### PR TITLE
Fix typo: replace o_neigh_xxx with o_neigh_op_xxx in ice40

### DIFF
--- a/ice40/arch/ice40-virt/arch.xml
+++ b/ice40/arch/ice40-virt/arch.xml
@@ -100,11 +100,11 @@
   <direct name="sp4_r2l" from_pin="PLB.o_sp4_l_v_b" to_pin="PLB.i_sp4_r_v_b" x_offset="1"  y_offset="0" z_offset="0"/>
   <direct name="sp4_l2r" from_pin="PLB.o_sp4_r_v_b" to_pin="PLB.i_sp4_l_v_b" x_offset="-1" y_offset="0" z_offset="0"/>
   <!-- Neighbourhood wires -->
-  <direct name="neigh_op_ob2it" from_pin="PLB.o_neigh_bot" to_pin="PLB.i_neigh_top" x_offset="0"  y_offset="-1" z_offset="0"/>
-  <direct name="neigh_op_ot2ib" from_pin="PLB.o_neigh_top" to_pin="PLB.i_neigh_bot" x_offset="0"  y_offset= "1" z_offset="0"/>
+  <direct name="neigh_op_ob2it" from_pin="PLB.o_neigh_op_bot" to_pin="PLB.i_neigh_op_top" x_offset="0"  y_offset="-1" z_offset="0"/>
+  <direct name="neigh_op_ot2ib" from_pin="PLB.o_neigh_op_top" to_pin="PLB.i_neigh_op_bot" x_offset="0"  y_offset= "1" z_offset="0"/>
 
-  <direct name="neigh_op_or2il" from_pin="PLB.o_neigh_rgt" to_pin="PLB.i_neigh_lft" x_offset="-1" y_offset="0"  z_offset="0"/>
-  <direct name="neigh_op_ol2ir" from_pin="PLB.o_neigh_lft" to_pin="PLB.i_neigh_rgt" x_offset= "1" y_offset="0"  z_offset="0"/>
+  <direct name="neigh_op_or2il" from_pin="PLB.o_neigh_op_rgt" to_pin="PLB.i_neigh_op_lft" x_offset="-1" y_offset="0"  z_offset="0"/>
+  <direct name="neigh_op_ol2ir" from_pin="PLB.o_neigh_op_lft" to_pin="PLB.i_neigh_op_rgt" x_offset= "1" y_offset="0"  z_offset="0"/>
  </directlist>
 
  <device>


### PR DESCRIPTION
This allows the FF test for the iCE40 to get to the placement stage, fixing the assert failure, but routing still fails with the below message:

```
Warning 1078: Empty heap occurred in get_heap_head.
Warning 1079: Some blocks are impossible to connect in this architecture.
Cannot route from PAD.inpad[0] (rr_node: 1 type: SOURCE ptc: 1 xlow: 1 ylow: 2) to PLB.o_neigh_op_rgt[2] (rr_node: 49 type: SINK ptc: 19 xlow: 2 ylow: 2) to -- no possible path
Failed to route connection from 'di' to 'D1' for net 'di'
Routing failed.

Attempting to route at 1832 channels (binary search bounds: [916, -1])
Routing took 13.52 seconds
Error 1: 
Type: Routing
File: /home/david/vtr-verilog-to-routing/vpr/src/base/place_and_route.cpp
Line: 165
Message: This circuit requires a channel width above 1000, probably is not going to route.
Aborting routing procedure.

make: *** [Makefile:47: ff.disp] Error 1
rm build/ice40/HX0K/ff.blif
````