### PR TITLE
make: `dist-clean` depends on `clean` now.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test:
 clean:
 	@true
 
-dist-clean:
+dist-clean: clean
 	@true
 
 .PHONY: clean dist-clean


### PR DESCRIPTION
Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>