### PR TITLE
Upgrade VPR arch: remove default_ prefix from <fc> attributes

### DIFF
--- a/artix7/blocks/clbll_l-int_l/pb_type.xml
+++ b/artix7/blocks/clbll_l-int_l/pb_type.xml
@@ -1,6 +1,6 @@
 <pb_type name="BLK_MB-CLBLL_L-INT_L" num_pb="1" width="2" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- Tile Interconnects -->
-  <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="0.5">
+  <fc in_type="frac" in_val="0.5" out_type="frac" out_val="0.5">
     <fc_override fc_type="abs" fc_val="0" port_name="CIN_N"/>
     <fc_override fc_type="abs" fc_val="0" port_name="COUT_N"/>
   </fc>

--- a/artix7/blocks/int_r-clbll_r/pb_type.xml
+++ b/artix7/blocks/int_r-clbll_r/pb_type.xml
@@ -1,6 +1,6 @@
 <pb_type name="BLK_MB-INT_R-CLBLL_R" num_pb="1" width="2" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- Tile Interconnects -->
-  <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="0.5">
+  <fc in_type="frac" in_val="0.5" out_type="frac" out_val="0.5">
     <fc_override fc_type="abs" fc_val="0" port_name="CIN_N"/>
     <fc_override fc_type="abs" fc_val="0" port_name="COUT_N"/>
   </fc>

--- a/artix7/devices/xc7a50t-roi-virt/dummy/dummy.sh
+++ b/artix7/devices/xc7a50t-roi-virt/dummy/dummy.sh
@@ -16,7 +16,7 @@ cat > $OUTPUT <<EOF
     <direct name="I" input="$NAME.I" output="DUMMY.I" />
     <direct name="O" input="DUMMY.O" output="$NAME.O" />
    </interconnect>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0">
     <fc_override fc_type="abs" fc_val="0" segment_name="global" />
    </fc>
    <pinlocations pattern="custom">

--- a/artix7/devices/xc7a50t-virt/arch.xml.unused
+++ b/artix7/devices/xc7a50t-virt/arch.xml.unused
@@ -309,7 +309,7 @@
     <loc side="left"  xoffset="0" yoffset="0">CLBLL_L.IN</loc>
     <loc side="right" xoffset="0" yoffset="0">CLBLL_L.OUT</loc>
    </pinlocations>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0">
      <fc_override fc_type="frac" fc_val="0.5" segment_name="long-span" />
      <fc_override fc_type="frac" fc_val="0.1" segment_name="global" />
    </fc>
@@ -337,7 +337,7 @@
     <loc side="right" xoffset="0" yoffset="0">CLBLL_R.IN</loc>
     <loc side="left"  xoffset="0" yoffset="0">CLBLL_R.OUT</loc>
    </pinlocations>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0">
      <fc_override fc_type="frac" fc_val="0.5" segment_name="long-span" />
      <fc_override fc_type="frac" fc_val="0.1" segment_name="global" />
    </fc>
@@ -365,7 +365,7 @@
     <loc side="left"  xoffset="0" yoffset="0">CLBLM_L.IN</loc>
     <loc side="right" xoffset="0" yoffset="0">CLBLM_L.OUT</loc>
    </pinlocations>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0">
      <fc_override fc_type="frac" fc_val="0.5" segment_name="long-span" />
      <fc_override fc_type="frac" fc_val="0.1" segment_name="global" />
    </fc>
@@ -398,7 +398,7 @@
     <loc side="left"   xoffset="0" yoffset="0">CLBLM_R.OUT</loc>
     <loc side="bottom" xoffset="0" yoffset="0">CLBLM_R.CARRY_OUT</loc>
    </pinlocations>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0">
      <fc_override fc_type="frac" fc_val="0.5" port_name="IN"  segment_name="long-span" />
      <fc_override fc_type="frac" fc_val="0.1" port_name="IN"  segment_name="global" />
      <fc_override fc_type="frac" fc_val="0.5" port_name="OUT" segment_name="global" />

--- a/artix7/dummy.xml
+++ b/artix7/dummy.xml
@@ -2,7 +2,7 @@
    <interconnect>
    </interconnect>
    <pinlocations pattern="spread_perimeter"/>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0">
      <fc_override fc_type="frac" fc_val="0.1" segment_name="global" />
      <fc_override fc_type="frac" fc_val="0.4" segment_name="long-span "/>
      <fc_override fc_type="frac" fc_val="1.0" segment_name="short-span "/>

--- a/artix7/empty.xml
+++ b/artix7/empty.xml
@@ -4,5 +4,5 @@
    <interconnect>
    </interconnect>
    <pinlocations pattern="spread_perimeter"/>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0" />
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0" />
 </empty>

--- a/ice40/cells/plb/plb.pb_type.xml
+++ b/ice40/cells/plb/plb.pb_type.xml
@@ -163,7 +163,7 @@
    </interconnect>
 
    <!--
-   <fc default_in_type="frac" default_in_val="0.0" default_out_type="frac" default_out_val="0.0">
+   <fc in_type="frac" in_val="0.0" out_type="frac" out_val="0.0">
     Connect all the ports to 2 local tracks
     <fc_override fc_type="abs" fc_val="2" port_name="I0"  segment_name="local" />
     <fc_override fc_type="abs" fc_val="2" port_name="I1"  segment_name="local" />

--- a/ice40/devices/ice4/arch.xml
+++ b/ice40/devices/ice4/arch.xml
@@ -96,7 +96,7 @@
      </direct>
     </interconnect>
    </mode>
-   <fc default_in_type="frac" default_in_val="1.0" default_out_type="frac" default_out_val="1.0"/>
+   <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0"/>
    <!-- IOs go on the periphery of the FPGA, for consistency,
         make it physically equivalent on all sides so that only one definition of I/Os is needed.
         If I do not make a physically equivalent definition, then I need to define 4 different I/Os, one for each side of the FPGA

--- a/ice40/tiles/pio-lr/pio-lr.pb_type.xml
+++ b/ice40/tiles/pio-lr/pio-lr.pb_type.xml
@@ -297,7 +297,7 @@ routing	span4_vert[19]  	span4_horz_r[3]
    -->
  </interconnect>
 
- <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="1.0">
+ <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
   <fc_override fc_type="frac" fc_val="0" port_name="OUTPUT_CLK" />
  </fc>
 

--- a/ice40/tiles/pio-tb/pio-tb.pb_type.xml
+++ b/ice40/tiles/pio-tb/pio-tb.pb_type.xml
@@ -230,7 +230,7 @@
     <complete name="OUTPUT_ENABLE"    input="PIO.OUTPUT_ENABLE"      output="IO[1:0].OUTPUT_ENABLE" />
    </interconnect>
 
-   <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
     <fc_override fc_type="abs" fc_val="2" port_name="OUTPUT_CLK" segment_name="local"/>
     <fc_override fc_type="abs" fc_val="2" port_name="INPUT_CLK" segment_name="local"/>
     <fc_override fc_type="abs" fc_val="2" port_name="CLOCK_ENABLE" segment_name="local"/>

--- a/ice40/tiles/plb/plb.pb_type.xml
+++ b/ice40/tiles/plb/plb.pb_type.xml
@@ -686,7 +686,7 @@
  </pinlocations>
  <switchblock_locations pattern="external_full_internal_straight"/>
 
- <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="1.0">
+ <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
 
   <fc_override fc_type="frac" fc_val="1.0" port_name="clk" segment_name="global" />
 

--- a/ice40/tiles/ramb/ramb.pb_type.xml
+++ b/ice40/tiles/ramb/ramb.pb_type.xml
@@ -110,7 +110,7 @@
     <direct name="WCLK"  input="RAMB.WCLK"        output="SB_RAM.WCLK" />
    </interconnect>
 
-   <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
     <fc_override fc_type="abs" fc_val="2" port_name="RDATAT" segment_name="local"/>
     <fc_override fc_type="abs" fc_val="2" port_name="RDATAB" segment_name="local"/>
     <fc_override fc_type="abs" fc_val="2" port_name="RADDR"  segment_name="local"/>

--- a/ice40/tiles/ramt/ramt.pb_type.xml
+++ b/ice40/tiles/ramt/ramt.pb_type.xml
@@ -110,7 +110,7 @@
     <direct name="WCLK"  input="RAMT.WCLK"        output="SB_RAM.WCLK" />
    </interconnect>
 
-   <fc default_in_type="frac" default_in_val="0.5" default_out_type="frac" default_out_val="1.0">
+   <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
     <fc_override fc_type="abs" fc_val="2" port_name="RDATAT" segment_name="local"/>
     <fc_override fc_type="abs" fc_val="2" port_name="RDATAB" segment_name="local"/>
     <fc_override fc_type="abs" fc_val="2" port_name="RADDR"  segment_name="local"/>

--- a/testarch/tile/ff-large/ff-large.pb_type.xml
+++ b/testarch/tile/ff-large/ff-large.pb_type.xml
@@ -55,7 +55,7 @@
   <loc side="left"></loc>
   <loc side="bottom"></loc>
  </pinlocations>
- <fc default_in_type="abs" default_in_val="1" default_out_type="abs" default_out_val="1">
+ <fc in_type="abs" in_val="1" out_type="abs" out_val="1">
   <fc_override fc_type="frac" fc_val="0.25" port_name="CLK"   />
  </fc>
 </pb_type>

--- a/testarch/tile/ff1/ff1.pb_type.xml
+++ b/testarch/tile/ff1/ff1.pb_type.xml
@@ -54,7 +54,7 @@
   <loc side="left"></loc>
   <loc side="bottom"></loc>
  </pinlocations>
- <fc default_in_type="abs" default_in_val="1" default_out_type="abs" default_out_val="1">
+ <fc in_type="abs" in_val="1" out_type="abs" out_val="1">
   <fc_override fc_type="frac" fc_val="0.25" port_name="CLK"   />
  </fc>
 </pb_type>

--- a/testarch/tile/lutff/lutff.pb_type.xml
+++ b/testarch/tile/lutff/lutff.pb_type.xml
@@ -94,7 +94,7 @@
   <loc side="right"></loc>
   <loc side="left"></loc>
  </pinlocations>
- <fc default_in_type="frac" default_in_val="0.1" default_out_type="frac" default_out_val="1.0">
+ <fc in_type="frac" in_val="0.1" out_type="frac" out_val="1.0">
   <fc_override fc_type="frac" fc_val="1.0" port_name="CLK"   />
  </fc>
 </pb_type>

--- a/testarch/tile/lutff3/lutff3.pb_type.xml
+++ b/testarch/tile/lutff3/lutff3.pb_type.xml
@@ -279,7 +279,7 @@
   <loc side="left">  BLK_TI-LUTFF3.IN[6] BLK_TI-LUTFF3.IN[7]  BLK_TI-LUTFF3.IN[8]   BLK_TI-LUTFF3.OUT[2] BLK_TI-LUTFF3.CLK[2] BLK_TI-LUTFF3.DUMMYI[0]</loc>
   <loc side="bottom">BLK_TI-LUTFF3.IN[9] BLK_TI-LUTFF3.IN[10] BLK_TI-LUTFF3.IN[11]  BLK_TI-LUTFF3.OUT[3] BLK_TI-LUTFF3.CLK[3] BLK_TI-LUTFF3.DUMMYO[0]</loc>
  </pinlocations>
- <fc default_in_type="frac" default_in_val="0.0" default_out_type="frac" default_out_val="0.0">
+ <fc in_type="frac" in_val="0.0" out_type="frac" out_val="0.0">
   <fc_override fc_type="frac" fc_val="1.0" port_name="DUMMYI" />
   <fc_override fc_type="frac" fc_val="1.0" port_name="DUMMYO" />
   <fc_override fc_type="frac" fc_val="1.0" port_name="CLK"   />

--- a/vpr/pad/pad.pb_type.xml
+++ b/vpr/pad/pad.pb_type.xml
@@ -30,7 +30,7 @@
  <!-- FIXME - Should have a IO operating as bi-directional -->
 
  <!-- IO pins are never connected to the fabric, they are connected to a platform specific IO tile -->
- <fc default_in_type="frac" default_in_val="1" default_out_type="frac" default_out_val="1"/>
+ <fc in_type="frac" in_val="1" out_type="frac" out_val="1"/>
 
  <!--
   IOs go on the periphery of the FPGA/


### PR DESCRIPTION
This is required as a result of the breaking change in verilog-to-routing/vtr-verilog-to-routing#308 (don't merge before the VTR PR is merged).