### PR TITLE
testarch: Adding a testarch with a longline in it.

### DIFF
--- a/testarch/devices/lutff-bidir-s4-g/arch.xml
+++ b/testarch/devices/lutff-bidir-s4-g/arch.xml
@@ -1,0 +1,16 @@
+<!-- set: ai sw=1 ts=1 sta et -->
+<architecture xmlns:xi="http://www.w3.org/2001/XInclude">
+ <models>
+  <xi:include href="../../tiles/lutff/lutff.model.xml" xpointer="xpointer(models/child::node())" />
+ </models>
+ <layout>
+   <xi:include href="../layouts/all.xml" xpointer="xpointer(layout/child::node())" />
+ </layout>
+ <complexblocklist>
+  <xi:include href="../../../vpr/ibuf/ibuf.pb_type.xml"/>
+  <xi:include href="../../../vpr/obuf/obuf.pb_type.xml"/>
+  <xi:include href="../../tiles/lutff/lutff.pb_type.xml"/>
+ </complexblocklist>
+
+ <xi:include href="../routing/bidir-s4-g.xml" xpointer="xpointer(architecture/child::node())" />
+</architecture>

--- a/testarch/devices/routing/bidir-s4-g.xml
+++ b/testarch/devices/routing/bidir-s4-g.xml
@@ -1,0 +1,44 @@
+<!-- set: ai sw=1 ts=1 sta et -->
+<architecture xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <!-- FIXME: Should this be in this file? -->
+ <device>
+  <sizing R_minW_nmos="6065.520020" R_minW_pmos="18138.500000" />
+  <area grid_logic_tile_area="14813.392"/>
+  <connection_block input_switch_name="1"/>
+  <switch_block type="wilton" fs="3"/>
+  <chan_width_distr>
+   <x distr="uniform" peak="1.000000"/>
+   <y distr="uniform" peak="1.000000"/>
+  </chan_width_distr>
+ </device>
+
+ <switchlist>
+  <switch type="mux" name="1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+ </switchlist>
+
+ <segmentlist>
+  <segment name="global" length="longline" freq="0.100000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
+   <sb type="pattern">1 1</sb>
+   <cb type="pattern">1</cb>
+   <mux name="1"/>
+   <wire_switch name="1"/>
+   <opin_switch name="1"/>
+  </segment>
+  <segment name="span" length="4" freq="0.200000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
+   <sb type="pattern">1 1 1 1 1</sb>
+   <cb type="pattern">1 1 1 1</cb>
+   <mux name="1"/>
+   <wire_switch name="1"/>
+   <opin_switch name="1"/>
+  </segment>
+  <segment name="local" length="1" freq="0.700000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
+   <sb type="pattern">1 1</sb>
+   <cb type="pattern">1</cb>
+   <mux name="1"/>
+   <wire_switch name="1"/>
+   <opin_switch name="1"/>
+  </segment>
+ </segmentlist>
+
+</architecture>

--- a/testarch/devices/routing/bidir-s4-g.xml
+++ b/testarch/devices/routing/bidir-s4-g.xml
@@ -1,17 +1,7 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <architecture xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <!-- FIXME: Should this be in this file? -->
- <device>
-  <sizing R_minW_nmos="6065.520020" R_minW_pmos="18138.500000" />
-  <area grid_logic_tile_area="14813.392"/>
-  <connection_block input_switch_name="1"/>
-  <switch_block type="wilton" fs="3"/>
-  <chan_width_distr>
-   <x distr="uniform" peak="1.000000"/>
-   <y distr="uniform" peak="1.000000"/>
-  </chan_width_distr>
- </device>
+ <xi:include href="device.xml"/>
 
  <switchlist>
   <switch type="mux" name="1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>

--- a/testarch/devices/routing/bidir-s4-g.xml
+++ b/testarch/devices/routing/bidir-s4-g.xml
@@ -9,21 +9,18 @@
 
  <segmentlist>
   <segment name="global" length="longline" freq="0.100000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
-   <mux name="1"/>
    <wire_switch name="1"/>
    <opin_switch name="1"/>
   </segment>
   <segment name="span" length="4" freq="0.200000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1</sb>
    <cb type="pattern">1 1 1 1</cb>
-   <mux name="1"/>
    <wire_switch name="1"/>
    <opin_switch name="1"/>
   </segment>
   <segment name="local" length="1" freq="0.700000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
    <sb type="pattern">1 1</sb>
    <cb type="pattern">1</cb>
-   <mux name="1"/>
    <wire_switch name="1"/>
    <opin_switch name="1"/>
   </segment>

--- a/testarch/devices/routing/bidir-s4-g.xml
+++ b/testarch/devices/routing/bidir-s4-g.xml
@@ -9,8 +9,6 @@
 
  <segmentlist>
   <segment name="global" length="longline" freq="0.100000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
-   <sb type="pattern">1 1</sb>
-   <cb type="pattern">1</cb>
    <mux name="1"/>
    <wire_switch name="1"/>
    <opin_switch name="1"/>

--- a/testarch/devices/routing/bidir-s4.xml
+++ b/testarch/devices/routing/bidir-s4.xml
@@ -1,17 +1,7 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <architecture xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <!-- FIXME: Should this be in this file? -->
- <device>
-  <sizing R_minW_nmos="6065.520020" R_minW_pmos="18138.500000" />
-  <area grid_logic_tile_area="14813.392"/>
-  <connection_block input_switch_name="1"/>
-  <switch_block type="wilton" fs="3"/>
-  <chan_width_distr>
-   <x distr="uniform" peak="1.000000"/>
-   <y distr="uniform" peak="1.000000"/>
-  </chan_width_distr>
- </device>
+ <xi:include href="device.xml"/>
 
  <switchlist>
   <switch type="mux" name="1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>

--- a/testarch/devices/routing/bidir-s4.xml
+++ b/testarch/devices/routing/bidir-s4.xml
@@ -11,14 +11,12 @@
   <segment name="span" length="4" freq="0.250000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1</sb>
    <cb type="pattern">1 1 1 1</cb>
-   <mux name="1"/>
    <wire_switch name="1"/>
    <opin_switch name="1"/>
   </segment>
   <segment name="local" length="1" freq="0.750000" type="bidir" Rmetal="101" Cmetal="22.5e-15">
    <sb type="pattern">1 1</sb>
    <cb type="pattern">1</cb>
-   <mux name="1"/>
    <wire_switch name="1"/>
    <opin_switch name="1"/>
   </segment>

--- a/testarch/devices/routing/device.xml
+++ b/testarch/devices/routing/device.xml
@@ -1,0 +1,11 @@
+<!-- set: ai sw=1 ts=1 sta et -->
+<device>
+ <sizing R_minW_nmos="6065.520020" R_minW_pmos="18138.500000" />
+ <area grid_logic_tile_area="14813.392"/>
+ <connection_block input_switch_name="1"/>
+ <switch_block type="wilton" fs="3"/>
+ <chan_width_distr>
+  <x distr="uniform" peak="1.000000"/>
+  <y distr="uniform" peak="1.000000"/>
+ </chan_width_distr>
+</device>

--- a/testarch/devices/routing/unidir-s4.xml
+++ b/testarch/devices/routing/unidir-s4.xml
@@ -1,17 +1,7 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <architecture xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <!-- FIXME: Should this be in this file? -->
- <device>
-  <sizing R_minW_nmos="6065.520020" R_minW_pmos="18138.500000" />
-  <area grid_logic_tile_area="14813.392"/>
-  <connection_block input_switch_name="1"/>
-  <switch_block type="wilton" fs="3"/>
-  <chan_width_distr>
-   <x distr="uniform" peak="1.000000"/>
-   <y distr="uniform" peak="1.000000"/>
-  </chan_width_distr>
- </device>
+ <xi:include href="device.xml"/>
 
  <switchlist>
   <switch type="mux" name="1" R="551" Cin=".77e-15" Cout="4e-15" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>


### PR DESCRIPTION
Longlines connect to every tile in the device. See;
https://docs.verilogtorouting.org/en/latest/arch/reference/#tag-wire-segments-segment

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>