### PR TITLE
PEP8:  Reorder imports, whitespace, rename shadowed names

### DIFF
--- a/utils/mux_gen.py
+++ b/utils/mux_gen.py
@@ -10,8 +10,6 @@ MUXes come in two types,
 import argparse
 import io
 import itertools
-import lxml.etree as ET
-import math
 import os
 import sys
 
@@ -19,105 +17,109 @@ from lib import mux as mux_lib
 from lib.argparse_extra import ActionStoreBool
 from lib.asserts import assert_eq
 
+import lxml.etree as ET
+
 parser = argparse.ArgumentParser(
-    description='Generate a MUX wrapper.',
-    fromfile_prefix_chars='@',
-    prefix_chars='-~')
+        description='Generate a MUX wrapper.',
+        fromfile_prefix_chars='@',
+        prefix_chars='-~')
 
 parser.add_argument(
-    '--verbose',
-    '--no-verbose',
-    action=ActionStoreBool,
-    default=os.environ.get('V', '') == '1',
-    help="Print lots of information about the generation.")
+        '--verbose',
+        '--no-verbose',
+        action=ActionStoreBool,
+        default=os.environ.get('V', '') == '1',
+        help="Print lots of information about the generation.")
 
-parser.add_argument('--width', type=int, default=8, help="Width of the MUX.")
-
-parser.add_argument(
-    '--data-width', type=int, default=1, help="data width of the MUX.")
+parser.add_argument('--width', type=int, default=1, help="Width of the MUX.")
 
 parser.add_argument(
-    '--type',
-    choices=['logic', 'routing'],
-    default='logic',
-    help="Type of MUX.")
+        '--type',
+        choices=['logic', 'routing'],
+        default='logic',
+        help="Type of MUX.")
 
 parser.add_argument(
-    '--split-inputs',
-    action=ActionStoreBool,
-    default=False,
-    help="Split the inputs into separate signals")
+        '--split-inputs',
+        action=ActionStoreBool,
+        default=False,
+        help="Split the inputs into separate signals")
 
 parser.add_argument(
-    '--split-selects',
-    action=ActionStoreBool,
-    default=False,
-    help="Split the selects into separate signals")
+        '--split-selects',
+        action=ActionStoreBool,
+        default=False,
+        help="Split the selects into separate signals")
 
 parser.add_argument(
-    '--name-mux', type=str, default='MUX', help="Name of the mux.")
+        '--name-mux', type=str, default='MUX', help="Name of the mux.")
 
 parser.add_argument(
-    '--name-input',
-    type=str,
-    default='I',
-    help="Name of the input values for the mux.")
+        '--name-input',
+        type=str,
+        default='I',
+        help="Name of the input values for the mux.")
 
 parser.name_inputs = parser.add_argument(
-    '--name-inputs',
-    type=str,
-    default=None,
-    help=
-    "Comma deliminator list for the name of each input to the mux (implies --split-inputs)."
-)
+        '--name-inputs',
+        type=str,
+        default=None,
+        help="Comma deliminator list for the name of each input "
+             "to the mux (implies --split-inputs).")
 
 parser.add_argument(
-    '--name-output',
-    type=str,
-    default='O',
-    help="Name of the output value for the mux.")
+        '--name-output',
+        type=str,
+        default='O',
+        help="Name of the output value for the mux.")
 
 parser.add_argument(
-    '--name-select',
-    type=str,
-    default='S',
-    help="Name of the select parameter for the mux.")
+        '--name-select',
+        type=str,
+        default='S',
+        help="Name of the select parameter for the mux.")
 
 parser.name_selects = parser.add_argument(
-    '--name-selects',
-    type=str,
-    default=None,
-    help=
-    "Comma deliminator list for the name of each select to the mux (implies --split-selects)."
+        '--name-selects',
+        type=str,
+        default=None,
+        help="Comma deliminator list for the name of each select "
+             "to the mux (implies --split-selects)."
 )
 
 parser.add_argument(
-    '--order',
-    choices=[''.join(x) for x in itertools.permutations('ios')] +
-    [''.join(x) for x in itertools.permutations('io')],
-    default='iso',
-    help=
-    """Order of the arguments for the MUX. (i - Inputs, o - Output, s - Select)"""
+        '--order',
+        choices=[''.join(x) for x in itertools.permutations('ios')] +
+                [''.join(x) for x in itertools.permutations('io')],
+        default='iso',
+        help=
+        """Order of the arguments for the MUX. (i - Inputs, o - Output, s - Select)"""
 )
 
 parser.add_argument(
-    '--outdir',
-    default=None,
-    help="""Directory to output generated content too.""")
+        '--outdir',
+        default=None,
+        help="""Directory to output generated content too.""")
 
 parser.add_argument(
-    '--outfilename',
-    default=None,
-    help="""Filename to output generated content too.""")
+        '--outfilename',
+        default=None,
+        help="""Filename to output generated content too.""")
 
 parser.add_argument(
-    '--comment', default=None, help="""Add some type of comment to the mux.""")
+        '--comment',
+        default=None,
+        help="""Add some type of comment to the mux.""")
 
 parser.add_argument(
-    '--num_pb', default=1, help="""Set the num_pb for the mux.""")
+        '--num_pb',
+        default=1,
+        help="""Set the num_pb for the mux.""")
 
 parser.add_argument(
-    '--subckt', default=None, help="""Override the subcircuit name.""")
+        '--subckt',
+        default=None,
+        help="""Override the subcircuit name.""")
 
 
 def main(argv):
@@ -125,10 +127,10 @@ def main(argv):
 
     args = parser.parse_args()
 
-    def output_block(name, s):
+    def output_block(name_, s):
         if args.verbose:
             print()
-            print(name, '-' * (75 - (len(name) + 1)))
+            print(name_, '-' * (75 - (len(name_) + 1)))
             print(s, end="")
             if s[-1] != '\n':
                 print()
@@ -155,8 +157,8 @@ def main(argv):
     mypath = normpath(mypath, to=outdir)
     mux_dir = normpath(os.path.join(mydir, '..', 'vpr', 'muxes'), to=outdir)
     buf_dir = normpath(os.path.join(mydir, '..', 'vpr', 'buf'), to=outdir)
-    mux_mk = normpath(
-        os.path.join(mydir, '..', 'common', 'make', 'mux.mk'), to=outdir)
+    mux_mk = normpath(os.path.join(mydir, '..', 'common', 'make', 'mux.mk'),
+                      to=outdir)
 
     if args.data_width > 1 and not args.split_inputs:
         assert False, "data_width(%d) > 1 requires using split_inputs" % (
@@ -172,9 +174,7 @@ def main(argv):
             names, args.width)
         args.name_inputs = names
     elif args.split_inputs:
-        args.name_inputs = [
-            args.name_input + str(i) for i in range(args.width)
-        ]
+        args.name_inputs = [args.name_input + str(i) for i in range(args.width)]
         parser.name_inputs.default = args.name_inputs
         assert_eq(parser.get_default("name_inputs"), args.name_inputs)
 
@@ -185,22 +185,18 @@ def main(argv):
 
         names = args.name_selects.split(',')
         assert len(
-            names) == args.width_bits, "%s select names, but %s needed." % (
-                names, args.width_bits)
+                names) == args.width_bits, "%s select names, but %s needed." % (
+            names, args.width_bits)
         args.name_selects = names
     elif args.split_selects:
-        args.name_selects = [
-            args.name_select + str(i) for i in range(args.width_bits)
-        ]
+        args.name_selects = [args.name_select + str(i) for i in range(args.width_bits)]
         parser.name_selects.default = args.name_selects
         assert_eq(parser.get_default("name_selects"), args.name_selects)
 
     os.makedirs(outdir, exist_ok=True)
 
     # Generated headers
-    generated_with = """
-Generated with %s
-""" % mypath
+    generated_with = """\nGenerated with %s\n""" % mypath
     if args.comment:
         generated_with = "\n".join([args.comment, generated_with])
 
@@ -242,9 +238,8 @@ Generated with %s
         if args.split_inputs:
             print("MUX_SPLIT_INPUTS = 1", file=f)
             if args.name_inputs != parser.get_default('name_inputs'):
-                print(
-                    "MUX_INPUTS = {}".format(",".join(args.name_inputs)),
-                    file=f)
+                print("MUX_INPUTS = {}".format(",".join(args.name_inputs)),
+                      file=f)
         else:
             if args.name_input != parser.get_default('name_input'):
                 print("MUX_INPUT = {}".format(args.name_input), file=f)
@@ -255,9 +250,8 @@ Generated with %s
         if args.split_selects:
             print("MUX_SPLIT_SELECTS = 1", file=f)
             if args.name_selects != parser.get_default('name_selects'):
-                print(
-                    "MUX_SELECTS = {}".format(",".join(args.name_selects)),
-                    file=f)
+                print("MUX_SELECTS = {}".format(",".join(args.name_selects)),
+                      file=f)
         else:
             if args.name_select != parser.get_default('name_select'):
                 print("MUX_SELECT = {}".format(args.name_select), file=f)
@@ -278,7 +272,8 @@ Generated with %s
         current_makefile_contents = open(makefile_file, "r").read()
 
     if current_makefile_contents != new_makefile_contents:
-        open(makefile_file, "w").write(new_makefile_contents)
+        with open(makefile_file, "w") as f:
+            f.write(new_makefile_contents)
 
     output_block("Makefile.mux", open(makefile_file).read())
 
@@ -311,13 +306,10 @@ Generated with %s
                 # verilog range bounds are inclusive and convention is [<width-1>:0]
                 assert args.name_select is not None
                 port_names.append(
-                    mux_lib.ModulePort(mux_lib.MuxPinType.SELECT,
-                                       args.name_select, args.width_bits,
-                                       '[%i:0]' % (args.width_bits - 1)))
+                        (mux_lib.MuxPinType.SELECT, args.name_select,
+                         args.width_bits, '[%i:0]' % (args.width_bits - 1)))
         elif i == 'o':
-            port_names.append(
-                mux_lib.ModulePort(mux_lib.MuxPinType.OUTPUT, args.name_output,
-                                   1, '', args.data_width))
+            port_names.append((mux_lib.MuxPinType.OUTPUT, args.name_output, 1, ''))
 
     # ------------------------------------------------------------------------
     # Generate the sim.v Verilog module
@@ -328,8 +320,8 @@ Generated with %s
     sim_pathname = os.path.join(outdir, sim_filename)
     with open(sim_pathname, "w") as f:
         module_args = []
-        for port in port_names:
-            if args.type == 'routing' and port.pin_type == mux_lib.MuxPinType.SELECT:
+        for pin_type, name, _, _ in port_names:
+            if args.type == 'routing' and pin_type == mux_lib.MuxPinType.SELECT:
                 continue
             module_args.append(port.name)
 
@@ -351,15 +343,21 @@ Generated with %s
         f.write('(* blackbox *) (* CLASS="%s" *)\n' % mux_class)
         f.write("module %s(%s);\n" % (args.name_mux, ", ".join(module_args)))
         previous_type = None
-        for port in port_names:
-            if previous_type != port.pin_type:
+        for pin_type, name, width, index in port_names:
+            if previous_type != pin_type:
                 f.write("\n")
-                previous_type = port.pin_type
-            if args.type == 'routing' and port.pin_type == mux_lib.MuxPinType.SELECT:
-                f.write(port.getParameterString())
+                previous_type = pin_type
+            if args.type == 'routing' and pin_type == mux_lib.MuxPinType.SELECT:
+                if width == 1:
+                    f.write('\tparameter [0:0] %s = 0;\n' % name)
+                else:
+                    f.write('\tparameter %s %s = 0;\n' % (index, name))
                 continue
+
+            if width == 1:
+                f.write('\t%s %s;\n' % (pin_type.verilog(), name))
             else:
-                f.write(port.getDefinition())
+                f.write('\t%s %s %s;\n' % (pin_type.verilog(), index, name))
 
         f.write("\n")
         if args.data_width > 1:
@@ -368,10 +366,10 @@ Generated with %s
                     (args.data_width))
 
         f.write('\tMUX%s mux (\n' % args.width)
-        for i in range(0, args.width):
+        for i in range(args.width):
             j = 0
-            for port in port_names:
-                if port.pin_type != mux_lib.MuxPinType.INPUT:
+            for pin_type, name, width, index in port_names:
+                if pin_type != mux_lib.MuxPinType.INPUT:
                     continue
                 if j + port.width <= i:
                     j += port.width
@@ -386,10 +384,10 @@ Generated with %s
             else:
                 f.write('\t\t.I%i(%s[%i]),\n' % (i, port.name, i - j))
 
-        for i in range(0, args.width_bits):
+        for i in range(args.width_bits):
             j = 0
-            for port in port_names:
-                if port.pin_type != mux_lib.MuxPinType.SELECT:
+            for pin_type, name, width, index in port_names:
+                if pin_type != mux_lib.MuxPinType.SELECT:
                     continue
                 if j + port.width < i:
                     j += port.width
@@ -401,8 +399,8 @@ Generated with %s
             else:
                 f.write('\t\t.S%i(%s[%i]),\n' % (i, port.name, i - j))
 
-        for port in port_names:
-            if port.pin_type != mux_lib.MuxPinType.OUTPUT:
+        for pin_type, name, width, index in port_names:
+            if pin_type != mux_lib.MuxPinType.OUTPUT:
                 continue
             break
         assert_eq(port.width, 1)
@@ -439,19 +437,17 @@ Generated with %s
 
         input_ports = ET.SubElement(model_xml, 'input_ports')
         output_ports = ET.SubElement(model_xml, 'output_ports')
-        for port in port_names:
-            if port.pin_type in (mux_lib.MuxPinType.INPUT,
-                                 mux_lib.MuxPinType.SELECT):
+        for pin_type, name, width, index in port_names:
+            if pin_type in (mux_lib.MuxPinType.INPUT, mux_lib.MuxPinType.SELECT):
                 ET.SubElement(
-                    input_ports, 'port', {
-                        'name':
-                        port.name,
-                        'combinational_sink_ports':
-                        ','.join(
-                            port.name for port in port_names
-                            if port.pin_type in (mux_lib.MuxPinType.OUTPUT, )),
-                    })
-            elif port.pin_type in (mux_lib.MuxPinType.OUTPUT, ):
+                        input_ports, 'port', {
+                            'name':
+                                name,
+                            'combinational_sink_ports':
+                                ','.join(n for t, n, w, i in port_names
+                                         if t in (mux_lib.MuxPinType.OUTPUT,)),
+                        })
+            elif pin_type in (mux_lib.MuxPinType.OUTPUT,):
                 ET.SubElement(output_ports, 'port', {'name': args.name_output})
 
         models_str = ET.tostring(models_xml, pretty_print=True).decode('utf-8')
@@ -467,12 +463,12 @@ Generated with %s
     # ------------------------------------------------------------------------
 
     pb_type_xml = mux_lib.pb_type_xml(
-        mux_lib.MuxType[args.type.upper()],
-        args.name_mux,
-        port_names,
-        subckt=subckt,
-        num_pb=args.num_pb,
-        comment=xml_comment_indent(4, xml_comment),
+            mux_lib.MuxType[args.type.upper()],
+            args.name_mux,
+            port_names,
+            subckt=subckt,
+            num_pb=args.num_pb,
+            comment=xml_comment_indent(4, xml_comment),
     )
 
     pb_type_str = ET.tostring(pb_type_xml, pretty_print=True).decode('utf-8')


### PR DESCRIPTION
This is in response to #13 

There are a few more issues with this file that I thought I should point out.  

1) It is my understanding that `ArgumentParser.add_argument()` doesn't return anything but it is used to assign to `parser.name_inputs` and `parser.name_selects`  I could be wrong and there may be some functionality I am not aware of.

2) On line 362 `width` & `name` is used outside of a for loop.  This can do unexpected things but will crash if `port_names` is empty.

2a) `subckt` also might be undefined but that is dependent on if there are args.type besides `logic` and `routing`.

3) There are is some unused code in this file:
[call_args](https://github.com/SymbiFlow/symbiflow-arch-defs/compare/master...Cabalist:master#diff-34e17609f3f75c0be9c4fadf8da04f46R126)
[buf_dir](https://github.com/SymbiFlow/symbiflow-arch-defs/compare/master...Cabalist:master#diff-34e17609f3f75c0be9c4fadf8da04f46R159)
[mux_mk](https://github.com/SymbiFlow/symbiflow-arch-defs/compare/master...Cabalist:master#diff-34e17609f3f75c0be9c4fadf8da04f46R160)
[remove_files](https://github.com/SymbiFlow/symbiflow-arch-defs/compare/master...Cabalist:master#diff-34e17609f3f75c0be9c4fadf8da04f46R218)
[defs](https://github.com/SymbiFlow/symbiflow-arch-defs/compare/master...Cabalist:master#diff-34e17609f3f75c0be9c4fadf8da04f46R306)
[mux_prefix](https://github.com/SymbiFlow/symbiflow-arch-defs/compare/master...Cabalist:master#diff-34e17609f3f75c0be9c4fadf8da04f46R316)
All of these look like they could be removed.
