### PR TITLE
make: Don't error on no outputs.

### DIFF
--- a/make/inc/func.mk
+++ b/make/inc/func.mk
@@ -139,7 +139,7 @@ $$(info $$(INC_ALL_TYPE)   OUTPUTS: $$(OUTPUTS))
 endif
 
 ifeq (0,$$(words $$(OUTPUTS)))
-$$(error No outputs generated for $$(INC_ALL_TYPE))
+$$(warning No outputs generated for $$(INC_ALL_TYPE))
 endif
 
 $$(call add_generated_files,$$(OUTPUTS))


### PR DESCRIPTION
Before you have the environment setup, `import icebox` will fail causing
no outputs to be found which prevents you from getting the environment
set up.