### PR TITLE
Rework the XML format for pb_type to better allow composition

### DIFF
--- a/common/xml/xmlsort.xsl
+++ b/common/xml/xmlsort.xsl
@@ -12,11 +12,55 @@
     <xsl:copy>
       <!-- Sort the attributes by name and remove the xml:base attribute -->
       <xsl:for-each select="@*[name()!='xml:base']">
-        <xsl:sort select="name( . )"/>
-        <xsl:attribute name="{local-name()}"><xsl:value-of select="normalize-space(.)"/></xsl:attribute>
+	<xsl:sort select="name( . )"/>
+	<xsl:attribute name="{local-name()}"><xsl:value-of select="normalize-space(.)"/></xsl:attribute>
       </xsl:for-each>
       <xsl:apply-templates/>
     </xsl:copy>
+  </xsl:template>
+
+  <!-- Allow from attribute which gives you a relative to a given pb_type -->
+  <xsl:template name="from-pb_type">
+    <xsl:choose>
+      <xsl:when test="@from='current'"><xsl:value-of select="ancestor::pb_type[1]/@name"/></xsl:when>
+      <xsl:when test="@from"><xsl:value-of select="@from"/></xsl:when>
+      <xsl:otherwise><xsl:value-of select="ancestor::pb_type[1]/@name"/></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!--
+    Convert
+     * <port name=XXX> 				to XXX
+     * <port name=XXX bit=Y> 			to XXX[Y]
+     * <port name=XXX bit_msb=M bit_lsb=L>	to XXX[M:L]
+    -->
+  <xsl:template name="port-value"><xsl:value-of select="@name"/><xsl:choose><xsl:when test="@bit">[<xsl:value-of select="@bit"/>]</xsl:when><xsl:when test="@bit-msb">[<xsl:value-of select="@bit-msb"/>:<xsl:value-of select="@bit-lsb"/>]</xsl:when><xsl:otherwise></xsl:otherwise></xsl:choose></xsl:template>
+
+  <!--
+    Convert
+      <interconnect><XXX><port type='input' ...><port type='output' ...></XXX><YYY../></interconnect>
+    to
+      <interconnect><XXX input='...' output='...'><YYY../></XXX></interconnect>
+    -->
+  <xsl:template match="interconnect/*/port[@type='input']">
+    <xsl:attribute name="input"><xsl:call-template name="from-pb_type"/>.<xsl:call-template name="port-value"/></xsl:attribute>
+  </xsl:template>
+  <xsl:template match="interconnect/*/port[@type='output']">
+    <xsl:attribute name="name"><xsl:call-template name="from-pb_type"/>-<xsl:call-template name="port-value"/></xsl:attribute>
+    <xsl:attribute name="output"><xsl:call-template name="from-pb_type"/>.<xsl:call-template name="port-value"/></xsl:attribute>
+  </xsl:template>
+  <!--
+    Convert
+      <loc ...><port ...><port ...></loc>
+    to
+      <loc ...>BLOCK.PORT BLOCK.PORT</loc>
+    -->
+  <xsl:template match="loc/port"><xsl:text>
+      </xsl:text><xsl:call-template name="from-pb_type"/>.<xsl:call-template name="port-value"/>
+  </xsl:template>
+  <xsl:template match="loc/port[last()]"><xsl:text>
+      </xsl:text><xsl:call-template name="from-pb_type"/>.<xsl:call-template name="port-value"/><xsl:text>
+    </xsl:text>
   </xsl:template>
 
   <!-- Remove duplicate model nodes -->

--- a/ice40/devices/top-routing-virt/tiles/dsp/dsp.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/dsp/dsp.pb_type.xml
@@ -6,7 +6,7 @@
  <input  name="DUMMY_IN"  num_pins="4"/>
  <output name="DUMMY_OUT" num_pins="4"/>
  <interconnect>
-  <direct input="BLK_TL-DSP.DUMMY_IN" output="BLK_TL-DSP.DUMMY_OUT" name="DUMMY"/>
+  <direct input="BLK_TL-DSP.DUMMY_IN" output="BLK_TL-DSP.DUMMY_OUT"/>
  </interconnect>
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2"/>
  <pinlocations pattern="custom">

--- a/ice40/devices/top-routing-virt/tiles/pio/pio.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/pio/pio.pb_type.xml
@@ -35,8 +35,8 @@
 
   <interconnect>
    <!-- SB_IO outputs -->
-   <direct name="D_OUT[0]" input="BLK_TL-PIO.D_OUT[0]" output="PAD.D_OUT[0]" />
-   <direct name="D_OUT[1]" input="BLK_TL-PIO.D_OUT[1]" output="PAD.D_OUT[1]" />
+   <direct input="BLK_TL-PIO.D_OUT[0]" output="PAD.D_OUT[0]" />
+   <direct input="BLK_TL-PIO.D_OUT[1]" output="PAD.D_OUT[1]" />
   </interconnect>
  </mode>
 
@@ -49,8 +49,8 @@
     <output name="inpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <direct name="D_IN[0]" input="input.inpad" output="PAD.D_IN[0]"/>
-    <direct name="PIN"    input="input.inpad" output="PAD.PIN"    />
+    <direct input="input.inpad" output="PAD.D_IN[0]"/>
+    <direct input="input.inpad" output="PAD.PIN"    />
    </interconnect>
    <metadata>
     <meta name="hlc_property">disable_pull_up</meta>
@@ -61,9 +61,9 @@
 
   <interconnect>
    <!-- SB_IO inputs -->
-   <direct name="D_IN[0]" input="PAD.D_IN[0]" output="BLK_TL-PIO.D_IN[0]"    />
-   <direct name="D_IN[1]" input="PAD.D_IN[1]" output="BLK_TL-PIO.D_IN[1]"    />
-   <direct name="PIN"    input="PAD.PIN"     output="BLK_TL-PIO.PACKAGE_PIN" />
+   <direct input="PAD.D_IN[0]" output="BLK_TL-PIO.D_IN[0]"    />
+   <direct input="PAD.D_IN[1]" output="BLK_TL-PIO.D_IN[1]"    />
+   <direct input="PAD.PIN"     output="BLK_TL-PIO.PACKAGE_PIN" />
   </interconnect>
 
  </mode>

--- a/ice40/devices/top-routing-virt/tiles/plb/plb.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/plb/plb.pb_type.xml
@@ -41,38 +41,38 @@
 
  <interconnect>
   <!-- LUT inputs -->
-  <direct name="lutff_0/in"       input="BLK_TL-PLB.lutff_0/in"       output="BLK_IG-PLB.I0"     />
-  <direct name="lutff_1/in"       input="BLK_TL-PLB.lutff_1/in"       output="BLK_IG-PLB.I1"     />
-  <direct name="lutff_2/in"       input="BLK_TL-PLB.lutff_2/in"       output="BLK_IG-PLB.I2"     />
-  <direct name="lutff_3/in"       input="BLK_TL-PLB.lutff_3/in"       output="BLK_IG-PLB.I3"     />
-  <direct name="lutff_4/in"       input="BLK_TL-PLB.lutff_4/in"       output="BLK_IG-PLB.I4"     />
-  <direct name="lutff_5/in"       input="BLK_TL-PLB.lutff_5/in"       output="BLK_IG-PLB.I5"     />
-  <direct name="lutff_6/in"       input="BLK_TL-PLB.lutff_6/in"       output="BLK_IG-PLB.I6"     />
-  <direct name="lutff_7/in"       input="BLK_TL-PLB.lutff_7/in"       output="BLK_IG-PLB.I7"     />
+  <direct input="BLK_TL-PLB.lutff_0/in"       output="BLK_IG-PLB.I0"     />
+  <direct input="BLK_TL-PLB.lutff_1/in"       output="BLK_IG-PLB.I1"     />
+  <direct input="BLK_TL-PLB.lutff_2/in"       output="BLK_IG-PLB.I2"     />
+  <direct input="BLK_TL-PLB.lutff_3/in"       output="BLK_IG-PLB.I3"     />
+  <direct input="BLK_TL-PLB.lutff_4/in"       output="BLK_IG-PLB.I4"     />
+  <direct input="BLK_TL-PLB.lutff_5/in"       output="BLK_IG-PLB.I5"     />
+  <direct input="BLK_TL-PLB.lutff_6/in"       output="BLK_IG-PLB.I6"     />
+  <direct input="BLK_TL-PLB.lutff_7/in"       output="BLK_IG-PLB.I7"     />
 
   <!-- D flip-flop controls -->
-  <direct name="lutff_global/clk" input="BLK_TL-PLB.lutff_global/clk" output="BLK_IG-PLB.CLK"    />
-  <direct name="lutff_global/s_r" input="BLK_TL-PLB.lutff_global/s_r" output="BLK_IG-PLB.SR"     />
-  <direct name="lutff_global/cen" input="BLK_TL-PLB.lutff_global/cen" output="BLK_IG-PLB.EN"     />
+  <direct input="BLK_TL-PLB.lutff_global/clk" output="BLK_IG-PLB.CLK"    />
+  <direct input="BLK_TL-PLB.lutff_global/s_r" output="BLK_IG-PLB.SR"     />
+  <direct input="BLK_TL-PLB.lutff_global/cen" output="BLK_IG-PLB.EN"     />
 
   <!-- D flip-flop outputs -->
-  <direct name="lutff_0/out"      input="BLK_IG-PLB.O0"         output="BLK_TL-PLB.lutff_0/out"  />
-  <direct name="lutff_1/out"      input="BLK_IG-PLB.O1"         output="BLK_TL-PLB.lutff_1/out"  />
-  <direct name="lutff_2/out"      input="BLK_IG-PLB.O2"         output="BLK_TL-PLB.lutff_2/out"  />
-  <direct name="lutff_3/out"      input="BLK_IG-PLB.O3"         output="BLK_TL-PLB.lutff_3/out"  />
-  <direct name="lutff_4/out"      input="BLK_IG-PLB.O4"         output="BLK_TL-PLB.lutff_4/out"  />
-  <direct name="lutff_5/out"      input="BLK_IG-PLB.O5"         output="BLK_TL-PLB.lutff_5/out"  />
-  <direct name="lutff_6/out"      input="BLK_IG-PLB.O6"         output="BLK_TL-PLB.lutff_6/out"  />
-  <direct name="lutff_7/out"      input="BLK_IG-PLB.O7"         output="BLK_TL-PLB.lutff_7/out"  />
+  <direct input="BLK_IG-PLB.O0"         output="BLK_TL-PLB.lutff_0/out"  />
+  <direct input="BLK_IG-PLB.O1"         output="BLK_TL-PLB.lutff_1/out"  />
+  <direct input="BLK_IG-PLB.O2"         output="BLK_TL-PLB.lutff_2/out"  />
+  <direct input="BLK_IG-PLB.O3"         output="BLK_TL-PLB.lutff_3/out"  />
+  <direct input="BLK_IG-PLB.O4"         output="BLK_TL-PLB.lutff_4/out"  />
+  <direct input="BLK_IG-PLB.O5"         output="BLK_TL-PLB.lutff_5/out"  />
+  <direct input="BLK_IG-PLB.O6"         output="BLK_TL-PLB.lutff_6/out"  />
+  <direct input="BLK_IG-PLB.O7"         output="BLK_TL-PLB.lutff_7/out"  />
 
   <!-- Fast Carry chain
-  <direct name="FCIN"  input="BLK_TL-PLB.FCIN"        output="BLK_IG-PLB.FCIN" />
-  <direct name="FCOUT" input="BLK_IG-PLB.FCOUT" output="BLK_TL-PLB.FCOUT"      />
+  <direct input="BLK_TL-PLB.FCIN"        output="BLK_IG-PLB.FCIN" />
+  <direct input="BLK_IG-PLB.FCOUT" output="BLK_TL-PLB.FCOUT"      />
        -->
-  <direct name="FCIN"  input="BLK_TL-PLB.FCIN"        output="BLK_IG-PLB.FCIN" >
+  <direct input="BLK_TL-PLB.FCIN"        output="BLK_IG-PLB.FCIN" >
    <pack_pattern name="CARRYCHAIN" in_port="BLK_TL-PLB.FCIN" out_port="BLK_IG-PLB.FCIN" />
   </direct>
-  <direct name="FCOUT" input="BLK_IG-PLB.FCOUT" output="BLK_TL-PLB.FCOUT"      >
+  <direct input="BLK_IG-PLB.FCOUT" output="BLK_TL-PLB.FCOUT"      >
    <pack_pattern name="CARRYCHAIN" in_port="BLK_IG-PLB.FCOUT" out_port="BLK_TL-PLB.FCOUT" />
   </direct>
 

--- a/ice40/devices/top-routing-virt/tiles/ram/ram.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/ram/ram.pb_type.xml
@@ -20,88 +20,88 @@
  <xi:include href="../../../../primitives/sb_ram/sb_ram.pb_type.xml"/>
 
  <interconnect>
-  <direct name="RDATA00" input="SB_RAM.RDATA[0]"  output="BLK_TL-RAM.RDATA[0]"/>
-  <direct name="RDATA01" input="SB_RAM.RDATA[1]"  output="BLK_TL-RAM.RDATA[1]"/>
-  <direct name="RDATA02" input="SB_RAM.RDATA[2]"  output="BLK_TL-RAM.RDATA[2]"/>
-  <direct name="RDATA03" input="SB_RAM.RDATA[3]"  output="BLK_TL-RAM.RDATA[3]"/>
-  <direct name="RDATA04" input="SB_RAM.RDATA[4]"  output="BLK_TL-RAM.RDATA[4]"/>
-  <direct name="RDATA05" input="SB_RAM.RDATA[5]"  output="BLK_TL-RAM.RDATA[5]"/>
-  <direct name="RDATA06" input="SB_RAM.RDATA[6]"  output="BLK_TL-RAM.RDATA[6]"/>
-  <direct name="RDATA07" input="SB_RAM.RDATA[7]"  output="BLK_TL-RAM.RDATA[7]"/>
-  <direct name="RDATA08" input="SB_RAM.RDATA[8]"  output="BLK_TL-RAM.RDATA[8]"/>
-  <direct name="RDATA09" input="SB_RAM.RDATA[9]"  output="BLK_TL-RAM.RDATA[9]"/>
-  <direct name="RDATA10" input="SB_RAM.RDATA[10]" output="BLK_TL-RAM.RDATA[10]"/>
-  <direct name="RDATA11" input="SB_RAM.RDATA[11]" output="BLK_TL-RAM.RDATA[11]"/>
-  <direct name="RDATA12" input="SB_RAM.RDATA[12]" output="BLK_TL-RAM.RDATA[12]"/>
-  <direct name="RDATA13" input="SB_RAM.RDATA[13]" output="BLK_TL-RAM.RDATA[13]"/>
-  <direct name="RDATA14" input="SB_RAM.RDATA[14]" output="BLK_TL-RAM.RDATA[14]"/>
-  <direct name="RDATA15" input="SB_RAM.RDATA[15]" output="BLK_TL-RAM.RDATA[15]"/>
+  <direct input="SB_RAM.RDATA[0]"  output="BLK_TL-RAM.RDATA[0]"/>
+  <direct input="SB_RAM.RDATA[1]"  output="BLK_TL-RAM.RDATA[1]"/>
+  <direct input="SB_RAM.RDATA[2]"  output="BLK_TL-RAM.RDATA[2]"/>
+  <direct input="SB_RAM.RDATA[3]"  output="BLK_TL-RAM.RDATA[3]"/>
+  <direct input="SB_RAM.RDATA[4]"  output="BLK_TL-RAM.RDATA[4]"/>
+  <direct input="SB_RAM.RDATA[5]"  output="BLK_TL-RAM.RDATA[5]"/>
+  <direct input="SB_RAM.RDATA[6]"  output="BLK_TL-RAM.RDATA[6]"/>
+  <direct input="SB_RAM.RDATA[7]"  output="BLK_TL-RAM.RDATA[7]"/>
+  <direct input="SB_RAM.RDATA[8]"  output="BLK_TL-RAM.RDATA[8]"/>
+  <direct input="SB_RAM.RDATA[9]"  output="BLK_TL-RAM.RDATA[9]"/>
+  <direct input="SB_RAM.RDATA[10]" output="BLK_TL-RAM.RDATA[10]"/>
+  <direct input="SB_RAM.RDATA[11]" output="BLK_TL-RAM.RDATA[11]"/>
+  <direct input="SB_RAM.RDATA[12]" output="BLK_TL-RAM.RDATA[12]"/>
+  <direct input="SB_RAM.RDATA[13]" output="BLK_TL-RAM.RDATA[13]"/>
+  <direct input="SB_RAM.RDATA[14]" output="BLK_TL-RAM.RDATA[14]"/>
+  <direct input="SB_RAM.RDATA[15]" output="BLK_TL-RAM.RDATA[15]"/>
 
-  <direct name="RADDR00" input="BLK_TL-RAM.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
-  <direct name="RADDR01" input="BLK_TL-RAM.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
-  <direct name="RADDR02" input="BLK_TL-RAM.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
-  <direct name="RADDR03" input="BLK_TL-RAM.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
-  <direct name="RADDR04" input="BLK_TL-RAM.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
-  <direct name="RADDR05" input="BLK_TL-RAM.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
-  <direct name="RADDR06" input="BLK_TL-RAM.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
-  <direct name="RADDR07" input="BLK_TL-RAM.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
-  <direct name="RADDR08" input="BLK_TL-RAM.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
-  <direct name="RADDR09" input="BLK_TL-RAM.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
-  <direct name="RADDR10" input="BLK_TL-RAM.RADDR[10]" output="SB_RAM.RADDR[10]"/>
+  <direct input="BLK_TL-RAM.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
+  <direct input="BLK_TL-RAM.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
+  <direct input="BLK_TL-RAM.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
+  <direct input="BLK_TL-RAM.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
+  <direct input="BLK_TL-RAM.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
+  <direct input="BLK_TL-RAM.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
+  <direct input="BLK_TL-RAM.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
+  <direct input="BLK_TL-RAM.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
+  <direct input="BLK_TL-RAM.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
+  <direct input="BLK_TL-RAM.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
+  <direct input="BLK_TL-RAM.RADDR[10]" output="SB_RAM.RADDR[10]"/>
 
-  <direct name="RE"      input="BLK_TL-RAM.RE"        output="SB_RAM.RE" />
-  <direct name="RCLKE"   input="BLK_TL-RAM.RCLKE"     output="SB_RAM.RCLKE" />
-  <direct name="RCLK"    input="BLK_TL-RAM.RCLK"      output="SB_RAM.RCLK" />
+  <direct input="BLK_TL-RAM.RE"        output="SB_RAM.RE" />
+  <direct input="BLK_TL-RAM.RCLKE"     output="SB_RAM.RCLKE" />
+  <direct input="BLK_TL-RAM.RCLK"      output="SB_RAM.RCLK" />
 
-  <direct name="WDATA00" input="BLK_TL-RAM.WDATA[0]" output="SB_RAM.WDATA[0]"/>
-  <direct name="WDATA01" input="BLK_TL-RAM.WDATA[1]" output="SB_RAM.WDATA[1]"/>
-  <direct name="WDATA02" input="BLK_TL-RAM.WDATA[2]" output="SB_RAM.WDATA[2]"/>
-  <direct name="WDATA03" input="BLK_TL-RAM.WDATA[3]" output="SB_RAM.WDATA[3]"/>
-  <direct name="WDATA04" input="BLK_TL-RAM.WDATA[4]" output="SB_RAM.WDATA[4]"/>
-  <direct name="WDATA05" input="BLK_TL-RAM.WDATA[5]" output="SB_RAM.WDATA[5]"/>
-  <direct name="WDATA06" input="BLK_TL-RAM.WDATA[6]" output="SB_RAM.WDATA[6]"/>
-  <direct name="WDATA07" input="BLK_TL-RAM.WDATA[7]" output="SB_RAM.WDATA[7]"/>
-  <direct name="WDATA08" input="BLK_TL-RAM.WDATA[8]" output="SB_RAM.WDATA[8]"/>
-  <direct name="WDATA09" input="BLK_TL-RAM.WDATA[9]" output="SB_RAM.WDATA[9]"/>
-  <direct name="WDATA10" input="BLK_TL-RAM.WDATA[10]" output="SB_RAM.WDATA[10]"/>
-  <direct name="WDATA11" input="BLK_TL-RAM.WDATA[11]" output="SB_RAM.WDATA[11]"/>
-  <direct name="WDATA12" input="BLK_TL-RAM.WDATA[12]" output="SB_RAM.WDATA[12]"/>
-  <direct name="WDATA13" input="BLK_TL-RAM.WDATA[13]" output="SB_RAM.WDATA[13]"/>
-  <direct name="WDATA14" input="BLK_TL-RAM.WDATA[14]" output="SB_RAM.WDATA[14]"/>
-  <direct name="WDATA15" input="BLK_TL-RAM.WDATA[15]" output="SB_RAM.WDATA[15]"/>
+  <direct input="BLK_TL-RAM.WDATA[0]" output="SB_RAM.WDATA[0]"/>
+  <direct input="BLK_TL-RAM.WDATA[1]" output="SB_RAM.WDATA[1]"/>
+  <direct input="BLK_TL-RAM.WDATA[2]" output="SB_RAM.WDATA[2]"/>
+  <direct input="BLK_TL-RAM.WDATA[3]" output="SB_RAM.WDATA[3]"/>
+  <direct input="BLK_TL-RAM.WDATA[4]" output="SB_RAM.WDATA[4]"/>
+  <direct input="BLK_TL-RAM.WDATA[5]" output="SB_RAM.WDATA[5]"/>
+  <direct input="BLK_TL-RAM.WDATA[6]" output="SB_RAM.WDATA[6]"/>
+  <direct input="BLK_TL-RAM.WDATA[7]" output="SB_RAM.WDATA[7]"/>
+  <direct input="BLK_TL-RAM.WDATA[8]" output="SB_RAM.WDATA[8]"/>
+  <direct input="BLK_TL-RAM.WDATA[9]" output="SB_RAM.WDATA[9]"/>
+  <direct input="BLK_TL-RAM.WDATA[10]" output="SB_RAM.WDATA[10]"/>
+  <direct input="BLK_TL-RAM.WDATA[11]" output="SB_RAM.WDATA[11]"/>
+  <direct input="BLK_TL-RAM.WDATA[12]" output="SB_RAM.WDATA[12]"/>
+  <direct input="BLK_TL-RAM.WDATA[13]" output="SB_RAM.WDATA[13]"/>
+  <direct input="BLK_TL-RAM.WDATA[14]" output="SB_RAM.WDATA[14]"/>
+  <direct input="BLK_TL-RAM.WDATA[15]" output="SB_RAM.WDATA[15]"/>
 
-  <direct name="MASK00" input="BLK_TL-RAM.MASK[0]" output="SB_RAM.MASK[0]"/>
-  <direct name="MASK01" input="BLK_TL-RAM.MASK[1]" output="SB_RAM.MASK[1]"/>
-  <direct name="MASK02" input="BLK_TL-RAM.MASK[2]" output="SB_RAM.MASK[2]"/>
-  <direct name="MASK03" input="BLK_TL-RAM.MASK[3]" output="SB_RAM.MASK[3]"/>
-  <direct name="MASK04" input="BLK_TL-RAM.MASK[4]" output="SB_RAM.MASK[4]"/>
-  <direct name="MASK05" input="BLK_TL-RAM.MASK[5]" output="SB_RAM.MASK[5]"/>
-  <direct name="MASK06" input="BLK_TL-RAM.MASK[6]" output="SB_RAM.MASK[6]"/>
-  <direct name="MASK07" input="BLK_TL-RAM.MASK[7]" output="SB_RAM.MASK[7]"/>
-  <direct name="MASK08" input="BLK_TL-RAM.MASK[8]" output="SB_RAM.MASK[8]"/>
-  <direct name="MASK09" input="BLK_TL-RAM.MASK[9]" output="SB_RAM.MASK[9]"/>
-  <direct name="MASK10" input="BLK_TL-RAM.MASK[10]" output="SB_RAM.MASK[10]"/>
-  <direct name="MASK11" input="BLK_TL-RAM.MASK[11]" output="SB_RAM.MASK[11]"/>
-  <direct name="MASK12" input="BLK_TL-RAM.MASK[12]" output="SB_RAM.MASK[12]"/>
-  <direct name="MASK13" input="BLK_TL-RAM.MASK[13]" output="SB_RAM.MASK[13]"/>
-  <direct name="MASK14" input="BLK_TL-RAM.MASK[14]" output="SB_RAM.MASK[14]"/>
-  <direct name="MASK15" input="BLK_TL-RAM.MASK[15]" output="SB_RAM.MASK[15]"/>
+  <direct input="BLK_TL-RAM.MASK[0]" output="SB_RAM.MASK[0]"/>
+  <direct input="BLK_TL-RAM.MASK[1]" output="SB_RAM.MASK[1]"/>
+  <direct input="BLK_TL-RAM.MASK[2]" output="SB_RAM.MASK[2]"/>
+  <direct input="BLK_TL-RAM.MASK[3]" output="SB_RAM.MASK[3]"/>
+  <direct input="BLK_TL-RAM.MASK[4]" output="SB_RAM.MASK[4]"/>
+  <direct input="BLK_TL-RAM.MASK[5]" output="SB_RAM.MASK[5]"/>
+  <direct input="BLK_TL-RAM.MASK[6]" output="SB_RAM.MASK[6]"/>
+  <direct input="BLK_TL-RAM.MASK[7]" output="SB_RAM.MASK[7]"/>
+  <direct input="BLK_TL-RAM.MASK[8]" output="SB_RAM.MASK[8]"/>
+  <direct input="BLK_TL-RAM.MASK[9]" output="SB_RAM.MASK[9]"/>
+  <direct input="BLK_TL-RAM.MASK[10]" output="SB_RAM.MASK[10]"/>
+  <direct input="BLK_TL-RAM.MASK[11]" output="SB_RAM.MASK[11]"/>
+  <direct input="BLK_TL-RAM.MASK[12]" output="SB_RAM.MASK[12]"/>
+  <direct input="BLK_TL-RAM.MASK[13]" output="SB_RAM.MASK[13]"/>
+  <direct input="BLK_TL-RAM.MASK[14]" output="SB_RAM.MASK[14]"/>
+  <direct input="BLK_TL-RAM.MASK[15]" output="SB_RAM.MASK[15]"/>
 
-  <direct name="WADDR00" input="BLK_TL-RAM.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
-  <direct name="WADDR01" input="BLK_TL-RAM.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
-  <direct name="WADDR02" input="BLK_TL-RAM.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
-  <direct name="WADDR03" input="BLK_TL-RAM.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
-  <direct name="WADDR04" input="BLK_TL-RAM.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
-  <direct name="WADDR05" input="BLK_TL-RAM.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
-  <direct name="WADDR06" input="BLK_TL-RAM.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
-  <direct name="WADDR07" input="BLK_TL-RAM.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
-  <direct name="WADDR08" input="BLK_TL-RAM.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
-  <direct name="WADDR09" input="BLK_TL-RAM.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
-  <direct name="WADDR10" input="BLK_TL-RAM.WADDR[10]" output="SB_RAM.WADDR[10]"/>
+  <direct input="BLK_TL-RAM.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
+  <direct input="BLK_TL-RAM.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
+  <direct input="BLK_TL-RAM.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
+  <direct input="BLK_TL-RAM.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
+  <direct input="BLK_TL-RAM.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
+  <direct input="BLK_TL-RAM.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
+  <direct input="BLK_TL-RAM.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
+  <direct input="BLK_TL-RAM.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
+  <direct input="BLK_TL-RAM.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
+  <direct input="BLK_TL-RAM.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
+  <direct input="BLK_TL-RAM.WADDR[10]" output="SB_RAM.WADDR[10]"/>
 
-  <direct name="WE"    input="BLK_TL-RAM.WE"          output="SB_RAM.WE" />
-  <direct name="WCLKE" input="BLK_TL-RAM.WCLKE"       output="SB_RAM.WCLKE" />
-  <direct name="WCLK"  input="BLK_TL-RAM.WCLK"        output="SB_RAM.WCLK" />
+  <direct input="BLK_TL-RAM.WE"          output="SB_RAM.WE" />
+  <direct input="BLK_TL-RAM.WCLKE"       output="SB_RAM.WCLKE" />
+  <direct input="BLK_TL-RAM.WCLK"        output="SB_RAM.WCLK" />
  </interconnect>
 
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2">

--- a/ice40/primitives/sb_ff/dff.pb_type.xml
+++ b/ice40/primitives/sb_ff/dff.pb_type.xml
@@ -17,9 +17,9 @@
    <T_clock_to_Q max="10e-12" port="VPR_FF.Q" clock="clk"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="DFF.C"    output="VPR_FF.clk" />
-   <direct name="D" input="DFF.D"    output="VPR_FF.D" />
-   <direct name="Q" input="VPR_FF.Q" output="DFF.Q" />
+   <direct input="DFF.C"    output="VPR_FF.clk" />
+   <direct input="DFF.D"    output="VPR_FF.D" />
+   <direct input="VPR_FF.Q" output="DFF.Q" />
   </interconnect>
  </mode>
 
@@ -33,9 +33,9 @@
    <T_setup    value="10e-12" port="SB_DFF.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFF.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"    output="SB_DFF.C" />
-   <direct name="D" input="DFF.D"    output="SB_DFF.D" />
+   <direct input="SB_DFF.Q" output="DFF.Q" />
+   <direct input="DFF.C"    output="SB_DFF.C" />
+   <direct input="DFF.D"    output="SB_DFF.D" />
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dff.pb_type.xml
+++ b/ice40/primitives/sb_ff/dff.pb_type.xml
@@ -17,9 +17,9 @@
    <T_clock_to_Q max="10e-12" port="VPR_FF.Q" clock="clk"/>
   </pb_type>
   <interconnect>
-   <direct input="DFF.C"    output="VPR_FF.clk" />
-   <direct input="DFF.D"    output="VPR_FF.D" />
-   <direct input="VPR_FF.Q" output="DFF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="VPR_FF" name="clk"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="VPR_FF" name="D"/></direct>
+   <direct><port type="input" from="VPR_FF" name="Q"/><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -33,9 +33,9 @@
    <T_setup    value="10e-12" port="SB_DFF.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFF.Q" output="DFF.Q" />
-   <direct input="DFF.C"    output="SB_DFF.C" />
-   <direct input="DFF.D"    output="SB_DFF.D" />
+   <direct><port type="input" from="SB_DFF" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFF" name="C"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFF" name="D"/></direct>
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dffe.pb_type.xml
+++ b/ice40/primitives/sb_ff/dffe.pb_type.xml
@@ -19,10 +19,10 @@
    <T_setup    value="10e-12" port="SB_DFFE.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFE.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"     output="SB_DFFE.C" />
-   <direct name="E" input="DFF.E"     output="SB_DFFE.E" />
-   <direct name="D" input="DFF.D"     output="SB_DFFE.D" />
+   <direct input="SB_DFFE.Q" output="DFF.Q" />
+   <direct input="DFF.C"     output="SB_DFFE.C" />
+   <direct input="DFF.E"     output="SB_DFFE.E" />
+   <direct input="DFF.D"     output="SB_DFFE.D" />
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dffe.pb_type.xml
+++ b/ice40/primitives/sb_ff/dffe.pb_type.xml
@@ -19,10 +19,10 @@
    <T_setup    value="10e-12" port="SB_DFFE.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFE.Q" output="DFF.Q" />
-   <direct input="DFF.C"     output="SB_DFFE.C" />
-   <direct input="DFF.E"     output="SB_DFFE.E" />
-   <direct input="DFF.D"     output="SB_DFFE.D" />
+   <direct><port type="input" from="SB_DFFE" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFE" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFE" name="E"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFE" name="D"/></direct>
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dffes.pb_type.xml
+++ b/ice40/primitives/sb_ff/dffes.pb_type.xml
@@ -21,11 +21,11 @@
    <T_setup    value="10e-12" port="SB_DFFESR.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFESR.Q" output="DFF.Q" />
-   <direct input="DFF.C"       output="SB_DFFESR.C" />
-   <direct input="DFF.E"       output="SB_DFFESR.E" />
-   <direct input="DFF.S"       output="SB_DFFESR.R" />
-   <direct input="DFF.D"       output="SB_DFFESR.D" />
+   <direct><port type="input" from="SB_DFFESR" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFESR" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFESR" name="E"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFESR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESR" name="D"/></direct>
   </interconnect>
  </mode>
 
@@ -43,11 +43,11 @@
    <T_setup    value="10e-12" port="SB_DFFER.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFER.Q" output="DFF.Q" />
-   <direct input="DFF.C"      output="SB_DFFER.C" />
-   <direct input="DFF.E"      output="SB_DFFER.E" />
-   <direct input="DFF.S"      output="SB_DFFER.R" />
-   <direct input="DFF.D"      output="SB_DFFER.D" />
+   <direct><port type="input" from="SB_DFFER" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFER" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFER" name="E"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFER" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFER" name="D"/></direct>
   </interconnect>
  </mode>
 
@@ -65,11 +65,11 @@
    <T_setup    value="10e-12" port="SB_DFFESS.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFESS.Q" output="DFF.Q" />
-   <direct input="DFF.C"       output="SB_DFFESS.C" />
-   <direct input="DFF.E"       output="SB_DFFESS.E" />
-   <direct input="DFF.S"       output="SB_DFFESS.S" />
-   <direct input="DFF.D"       output="SB_DFFESS.D" />
+   <direct><port type="input" from="SB_DFFESS" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFESS" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFESS" name="E"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFESS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESS" name="D"/></direct>
   </interconnect>
  </mode>
 
@@ -87,11 +87,11 @@
    <T_setup    value="10e-12" port="SB_DFFES.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFES.Q" output="DFF.Q" />
-   <direct input="DFF.C"      output="SB_DFFES.C" />
-   <direct input="DFF.E"      output="SB_DFFES.E" />
-   <direct input="DFF.S"      output="SB_DFFES.R" />
-   <direct input="DFF.D"      output="SB_DFFES.D" />
+   <direct><port type="input" from="SB_DFFES" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFES" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFES" name="E"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFES" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFES" name="D"/></direct>
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dffes.pb_type.xml
+++ b/ice40/primitives/sb_ff/dffes.pb_type.xml
@@ -21,11 +21,11 @@
    <T_setup    value="10e-12" port="SB_DFFESR.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFESR.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"       output="SB_DFFESR.C" />
-   <direct name="E" input="DFF.E"       output="SB_DFFESR.E" />
-   <direct name="S" input="DFF.S"       output="SB_DFFESR.R" />
-   <direct name="D" input="DFF.D"       output="SB_DFFESR.D" />
+   <direct input="SB_DFFESR.Q" output="DFF.Q" />
+   <direct input="DFF.C"       output="SB_DFFESR.C" />
+   <direct input="DFF.E"       output="SB_DFFESR.E" />
+   <direct input="DFF.S"       output="SB_DFFESR.R" />
+   <direct input="DFF.D"       output="SB_DFFESR.D" />
   </interconnect>
  </mode>
 
@@ -43,11 +43,11 @@
    <T_setup    value="10e-12" port="SB_DFFER.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFER.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"      output="SB_DFFER.C" />
-   <direct name="E" input="DFF.E"      output="SB_DFFER.E" />
-   <direct name="S" input="DFF.S"      output="SB_DFFER.R" />
-   <direct name="D" input="DFF.D"      output="SB_DFFER.D" />
+   <direct input="SB_DFFER.Q" output="DFF.Q" />
+   <direct input="DFF.C"      output="SB_DFFER.C" />
+   <direct input="DFF.E"      output="SB_DFFER.E" />
+   <direct input="DFF.S"      output="SB_DFFER.R" />
+   <direct input="DFF.D"      output="SB_DFFER.D" />
   </interconnect>
  </mode>
 
@@ -65,11 +65,11 @@
    <T_setup    value="10e-12" port="SB_DFFESS.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFESS.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"       output="SB_DFFESS.C" />
-   <direct name="E" input="DFF.E"       output="SB_DFFESS.E" />
-   <direct name="S" input="DFF.S"       output="SB_DFFESS.S" />
-   <direct name="D" input="DFF.D"       output="SB_DFFESS.D" />
+   <direct input="SB_DFFESS.Q" output="DFF.Q" />
+   <direct input="DFF.C"       output="SB_DFFESS.C" />
+   <direct input="DFF.E"       output="SB_DFFESS.E" />
+   <direct input="DFF.S"       output="SB_DFFESS.S" />
+   <direct input="DFF.D"       output="SB_DFFESS.D" />
   </interconnect>
  </mode>
 
@@ -87,11 +87,11 @@
    <T_setup    value="10e-12" port="SB_DFFES.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFES.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"      output="SB_DFFES.C" />
-   <direct name="E" input="DFF.E"      output="SB_DFFES.E" />
-   <direct name="S" input="DFF.S"      output="SB_DFFES.R" />
-   <direct name="D" input="DFF.D"      output="SB_DFFES.D" />
+   <direct input="SB_DFFES.Q" output="DFF.Q" />
+   <direct input="DFF.C"      output="SB_DFFES.C" />
+   <direct input="DFF.E"      output="SB_DFFES.E" />
+   <direct input="DFF.S"      output="SB_DFFES.R" />
+   <direct input="DFF.D"      output="SB_DFFES.D" />
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dffs.pb_type.xml
+++ b/ice40/primitives/sb_ff/dffs.pb_type.xml
@@ -19,10 +19,10 @@
    <T_setup    value="10e-12" port="SB_DFFSR.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFSR.Q" output="DFF.Q" />
-   <direct input="DFF.C"      output="SB_DFFSR.C" />
-   <direct input="DFF.S"      output="SB_DFFSR.R" />
-   <direct input="DFF.D"      output="SB_DFFSR.D" />
+   <direct><port type="input" from="SB_DFFSR" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFSR" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFSR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSR" name="D"/></direct>
   </interconnect>
  </mode>
 
@@ -38,10 +38,10 @@
    <T_setup    value="10e-12" port="SB_DFFR.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFR.Q" output="DFF.Q" />
-   <direct input="DFF.C"     output="SB_DFFR.C" />
-   <direct input="DFF.S"     output="SB_DFFR.R" />
-   <direct input="DFF.D"     output="SB_DFFR.D" />
+   <direct><port type="input" from="SB_DFFR" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFR" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFR" name="D"/></direct>
   </interconnect>
  </mode>
 
@@ -57,10 +57,10 @@
    <T_setup    value="10e-12" port="SB_DFFSS.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFSS.Q" output="DFF.Q" />
-   <direct input="DFF.C"      output="SB_DFFSS.C" />
-   <direct input="DFF.S"      output="SB_DFFSS.S" />
-   <direct input="DFF.D"      output="SB_DFFSS.D" />
+   <direct><port type="input" from="SB_DFFSS" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFSS" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFSS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSS" name="D"/></direct>
   </interconnect>
  </mode>
 
@@ -76,10 +76,10 @@
    <T_setup    value="10e-12" port="SB_DFFS.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="SB_DFFS.Q" output="DFF.Q" />
-   <direct input="DFF.C"     output="SB_DFFS.C" />
-   <direct input="DFF.S"     output="SB_DFFS.S" />
-   <direct input="DFF.D"     output="SB_DFFS.D" />
+   <direct><port type="input" from="SB_DFFS" name="Q"/><port type="output" name="Q"/></direct>
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFS" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFS" name="D"/></direct>
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/dffs.pb_type.xml
+++ b/ice40/primitives/sb_ff/dffs.pb_type.xml
@@ -19,10 +19,10 @@
    <T_setup    value="10e-12" port="SB_DFFSR.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFSR.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"      output="SB_DFFSR.C" />
-   <direct name="S" input="DFF.S"      output="SB_DFFSR.R" />
-   <direct name="D" input="DFF.D"      output="SB_DFFSR.D" />
+   <direct input="SB_DFFSR.Q" output="DFF.Q" />
+   <direct input="DFF.C"      output="SB_DFFSR.C" />
+   <direct input="DFF.S"      output="SB_DFFSR.R" />
+   <direct input="DFF.D"      output="SB_DFFSR.D" />
   </interconnect>
  </mode>
 
@@ -38,10 +38,10 @@
    <T_setup    value="10e-12" port="SB_DFFR.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFR.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"     output="SB_DFFR.C" />
-   <direct name="S" input="DFF.S"     output="SB_DFFR.R" />
-   <direct name="D" input="DFF.D"     output="SB_DFFR.D" />
+   <direct input="SB_DFFR.Q" output="DFF.Q" />
+   <direct input="DFF.C"     output="SB_DFFR.C" />
+   <direct input="DFF.S"     output="SB_DFFR.R" />
+   <direct input="DFF.D"     output="SB_DFFR.D" />
   </interconnect>
  </mode>
 
@@ -57,10 +57,10 @@
    <T_setup    value="10e-12" port="SB_DFFSS.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFSS.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"      output="SB_DFFSS.C" />
-   <direct name="S" input="DFF.S"      output="SB_DFFSS.S" />
-   <direct name="D" input="DFF.D"      output="SB_DFFSS.D" />
+   <direct input="SB_DFFSS.Q" output="DFF.Q" />
+   <direct input="DFF.C"      output="SB_DFFSS.C" />
+   <direct input="DFF.S"      output="SB_DFFSS.S" />
+   <direct input="DFF.D"      output="SB_DFFSS.D" />
   </interconnect>
  </mode>
 
@@ -76,10 +76,10 @@
    <T_setup    value="10e-12" port="SB_DFFS.D" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="Q" input="SB_DFFS.Q" output="DFF.Q" />
-   <direct name="C" input="DFF.C"     output="SB_DFFS.C" />
-   <direct name="S" input="DFF.S"     output="SB_DFFS.S" />
-   <direct name="D" input="DFF.D"     output="SB_DFFS.D" />
+   <direct input="SB_DFFS.Q" output="DFF.Q" />
+   <direct input="DFF.C"     output="SB_DFFS.C" />
+   <direct input="DFF.S"     output="SB_DFFS.S" />
+   <direct input="DFF.D"     output="SB_DFFS.D" />
   </interconnect>
  </mode>
 </pb_type>

--- a/ice40/primitives/sb_ff/sb_ff.pb_type.xml
+++ b/ice40/primitives/sb_ff/sb_ff.pb_type.xml
@@ -19,11 +19,11 @@
    <T_clock_to_Q max="10e-12" port="VPR_FF.Q" clock="clk"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="VPR_FF.clk"     />
-   <direct input="BEL_FF-SB_FF.D" output="VPR_FF.D"       >
+   <direct><port type="input" name="C"/><port type="output" from="VPR_FF" name="clk"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="VPR_FF" name="D"/>
     <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="VPR_FF.D" />
    </direct>
-   <direct input="VPR_FF.Q"       output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" from="VPR_FF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
   <metadata>
    <meta name="hlc_property">enable_dff</meta>
@@ -40,11 +40,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFF.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFF.C"       />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFF.D"        >
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFF" name="C"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFF" name="D"/>
     <!-- <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFF.D" /> -->
    </direct>
-   <direct input="SB_DFF.Q"       output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" from="SB_DFF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -60,10 +60,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFE.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFE.C"      />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFE.E"      />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFE.D"      />
-   <direct input="SB_DFFE.Q"      output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFE" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFE" name="E"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFE" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFE" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -81,11 +81,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFER.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFER.C"     />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFER.E"     />
-   <direct input="BEL_FF-SB_FF.R" output="SB_DFFER.R"     />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFER.D"     />
-   <direct input="SB_DFFER.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFER" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFER" name="E"/></direct>
+   <direct><port type="input" name="R"/><port type="output" from="SB_DFFER" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFER" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFER" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -103,11 +103,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFES.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFES.C"     />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFES.E"     />
-   <direct input="BEL_FF-SB_FF.R" output="SB_DFFES.R"     />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFES.D"     />
-   <direct input="SB_DFFES.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFES" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFES" name="E"/></direct>
+   <direct><port type="input" name="R"/><port type="output" from="SB_DFFES" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFES" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFES" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -125,11 +125,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFESR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFESR.C"    />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFESR.E"    />
-   <direct input="BEL_FF-SB_FF.R" output="SB_DFFESR.R"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFESR.D"    />
-   <direct input="SB_DFFESR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFESR" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFESR" name="E"/></direct>
+   <direct><port type="input" name="R"/><port type="output" from="SB_DFFESR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESR" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFESR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -147,11 +147,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFESS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFESS.C"    />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFESS.E"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFESS.S"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFESS.D"    />
-   <direct input="SB_DFFESS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFESS" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFESS" name="E"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFESS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESS" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFESS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -167,10 +167,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFR.C"     />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFR.R"     />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFR.D"     />
-   <direct input="SB_DFFR.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFR" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFR" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -186,10 +186,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFS.C"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFS.S"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFS.D"    />
-   <direct input="SB_DFFS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFS" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFS" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -205,10 +205,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFSR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFSR.C"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFSR.R"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFSR.D"    />
-   <direct input="SB_DFFSR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFSR" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFSR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSR" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFSR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -224,10 +224,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFSS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.C" output="SB_DFFSS.C"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFSS.S"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFSS.D"    />
-   <direct input="SB_DFFSS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="C"/><port type="output" from="SB_DFFSS" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFSS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSS" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFSS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -241,11 +241,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFN.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFN.C"       />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFN.D"        >
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFN" name="C" /></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFN" name="D" />
     <!-- <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFN.D" /> -->
    </direct>
-   <direct input="SB_DFFN.Q"       output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" from="SB_DFFN" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -261,10 +261,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNE.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNE.C"      />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNE.E"      />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNE.D"      />
-   <direct input="SB_DFFNE.Q"      output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNE" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFNE" name="E"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNE" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNE" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -282,11 +282,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNER.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNER.C"     />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNER.E"     />
-   <direct input="BEL_FF-SB_FF.R" output="SB_DFFNER.R"     />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNER.D"     />
-   <direct input="SB_DFFNER.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNER" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFNER" name="E"/></direct>
+   <direct><port type="input" name="R"/><port type="output" from="SB_DFFNER" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNER" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNER" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -304,11 +304,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNES.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNES.C"     />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNES.E"     />
-   <direct input="BEL_FF-SB_FF.R" output="SB_DFFNES.R"     />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNES.D"     />
-   <direct input="SB_DFFNES.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNES" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFNES" name="E"/></direct>
+   <direct><port type="input" name="R"/><port type="output" from="SB_DFFNES" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNES" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNES" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -326,11 +326,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNESR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNESR.C"    />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNESR.E"    />
-   <direct input="BEL_FF-SB_FF.R" output="SB_DFFNESR.R"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNESR.D"    />
-   <direct input="SB_DFFNESR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNESR" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESR" name="E"/></direct>
+   <direct><port type="input" name="R"/><port type="output" from="SB_DFFNESR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESR" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNESR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -348,11 +348,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNESS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNESS.C"    />
-   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNESS.E"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNESS.S"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNESS.D"    />
-   <direct input="SB_DFFNESS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNESS" name="C"/></direct>
+   <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESS" name="E"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFNESS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESS" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNESS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -368,10 +368,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNR.C"     />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNR.R"     />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNR.D"     />
-   <direct input="SB_DFFNR.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNR" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFNR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNR" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -387,10 +387,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNS.C"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNS.S"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNS.D"    />
-   <direct input="SB_DFFNS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNS" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFNS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNS" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -406,10 +406,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNSR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNSR.C"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNSR.R"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNSR.D"    />
-   <direct input="SB_DFFNSR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNSR" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSR" name="R"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSR" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNSR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 
@@ -425,10 +425,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNSS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNSS.C"    />
-   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNSS.S"    />
-   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNSS.D"    />
-   <direct input="SB_DFFNSS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct><port type="input" name="N"/><port type="output" from="SB_DFFNSS" name="C"/></direct>
+   <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSS" name="S"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSS" name="D"/></direct>
+   <direct><port type="input" from="SB_DFFNSS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
 

--- a/ice40/primitives/sb_ff/sb_ff.pb_type.xml
+++ b/ice40/primitives/sb_ff/sb_ff.pb_type.xml
@@ -19,11 +19,11 @@
    <T_clock_to_Q max="10e-12" port="VPR_FF.Q" clock="clk"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="VPR_FF.clk"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="VPR_FF.D"       >
+   <direct input="BEL_FF-SB_FF.C" output="VPR_FF.clk"     />
+   <direct input="BEL_FF-SB_FF.D" output="VPR_FF.D"       >
     <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="VPR_FF.D" />
    </direct>
-   <direct name="Q" input="VPR_FF.Q"       output="BEL_FF-SB_FF.Q" />
+   <direct input="VPR_FF.Q"       output="BEL_FF-SB_FF.Q" />
   </interconnect>
   <metadata>
    <meta name="hlc_property">enable_dff</meta>
@@ -40,11 +40,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFF.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFF.C"       />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFF.D"        >
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFF.C"       />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFF.D"        >
     <!-- <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFF.D" /> -->
    </direct>
-   <direct name="Q" input="SB_DFF.Q"       output="BEL_FF-SB_FF.Q" />
+   <direct input="SB_DFF.Q"       output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -60,10 +60,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFE.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFE.C"      />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFE.E"      />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFE.D"      />
-   <direct name="Q" input="SB_DFFE.Q"      output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFE.C"      />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFE.E"      />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFE.D"      />
+   <direct input="SB_DFFE.Q"      output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -81,11 +81,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFER.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFER.C"     />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFER.E"     />
-   <direct name="S" input="BEL_FF-SB_FF.R" output="SB_DFFER.R"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFER.D"     />
-   <direct name="Q" input="SB_DFFER.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFER.C"     />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFER.E"     />
+   <direct input="BEL_FF-SB_FF.R" output="SB_DFFER.R"     />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFER.D"     />
+   <direct input="SB_DFFER.Q"     output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -103,11 +103,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFES.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFES.C"     />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFES.E"     />
-   <direct name="S" input="BEL_FF-SB_FF.R" output="SB_DFFES.R"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFES.D"     />
-   <direct name="Q" input="SB_DFFES.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFES.C"     />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFES.E"     />
+   <direct input="BEL_FF-SB_FF.R" output="SB_DFFES.R"     />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFES.D"     />
+   <direct input="SB_DFFES.Q"     output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -125,11 +125,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFESR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFESR.C"    />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFESR.E"    />
-   <direct name="S" input="BEL_FF-SB_FF.R" output="SB_DFFESR.R"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFESR.D"    />
-   <direct name="Q" input="SB_DFFESR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFESR.C"    />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFESR.E"    />
+   <direct input="BEL_FF-SB_FF.R" output="SB_DFFESR.R"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFESR.D"    />
+   <direct input="SB_DFFESR.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -147,11 +147,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFESS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFESS.C"    />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFESS.E"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFESS.S"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFESS.D"    />
-   <direct name="Q" input="SB_DFFESS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFESS.C"    />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFESS.E"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFESS.S"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFESS.D"    />
+   <direct input="SB_DFFESS.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -167,10 +167,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFR.C"     />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFR.R"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFR.D"     />
-   <direct name="Q" input="SB_DFFR.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFR.C"     />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFR.R"     />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFR.D"     />
+   <direct input="SB_DFFR.Q"     output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -186,10 +186,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFS.C"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFS.S"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFS.D"    />
-   <direct name="Q" input="SB_DFFS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFS.C"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFS.S"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFS.D"    />
+   <direct input="SB_DFFS.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -205,10 +205,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFSR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFSR.C"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFSR.R"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFSR.D"    />
-   <direct name="Q" input="SB_DFFSR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFSR.C"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFSR.R"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFSR.D"    />
+   <direct input="SB_DFFSR.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -224,10 +224,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFSS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.C" output="SB_DFFSS.C"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFSS.S"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFSS.D"    />
-   <direct name="Q" input="SB_DFFSS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.C" output="SB_DFFSS.C"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFSS.S"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFSS.D"    />
+   <direct input="SB_DFFSS.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -241,11 +241,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFN.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFN.C"       />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFN.D"        >
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFN.C"       />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFN.D"        >
     <!-- <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFN.D" /> -->
    </direct>
-   <direct name="Q" input="SB_DFFN.Q"       output="BEL_FF-SB_FF.Q" />
+   <direct input="SB_DFFN.Q"       output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -261,10 +261,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNE.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNE.C"      />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFNE.E"      />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNE.D"      />
-   <direct name="Q" input="SB_DFFNE.Q"      output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNE.C"      />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNE.E"      />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNE.D"      />
+   <direct input="SB_DFFNE.Q"      output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -282,11 +282,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNER.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNER.C"     />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFNER.E"     />
-   <direct name="S" input="BEL_FF-SB_FF.R" output="SB_DFFNER.R"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNER.D"     />
-   <direct name="Q" input="SB_DFFNER.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNER.C"     />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNER.E"     />
+   <direct input="BEL_FF-SB_FF.R" output="SB_DFFNER.R"     />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNER.D"     />
+   <direct input="SB_DFFNER.Q"     output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -304,11 +304,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNES.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNES.C"     />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFNES.E"     />
-   <direct name="S" input="BEL_FF-SB_FF.R" output="SB_DFFNES.R"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNES.D"     />
-   <direct name="Q" input="SB_DFFNES.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNES.C"     />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNES.E"     />
+   <direct input="BEL_FF-SB_FF.R" output="SB_DFFNES.R"     />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNES.D"     />
+   <direct input="SB_DFFNES.Q"     output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -326,11 +326,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNESR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNESR.C"    />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFNESR.E"    />
-   <direct name="S" input="BEL_FF-SB_FF.R" output="SB_DFFNESR.R"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNESR.D"    />
-   <direct name="Q" input="SB_DFFNESR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNESR.C"    />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNESR.E"    />
+   <direct input="BEL_FF-SB_FF.R" output="SB_DFFNESR.R"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNESR.D"    />
+   <direct input="SB_DFFNESR.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -348,11 +348,11 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNESS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNESS.C"    />
-   <direct name="E" input="BEL_FF-SB_FF.E" output="SB_DFFNESS.E"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFNESS.S"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNESS.D"    />
-   <direct name="Q" input="SB_DFFNESS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNESS.C"    />
+   <direct input="BEL_FF-SB_FF.E" output="SB_DFFNESS.E"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNESS.S"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNESS.D"    />
+   <direct input="SB_DFFNESS.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -368,10 +368,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNR.C"     />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFNR.R"     />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNR.D"     />
-   <direct name="Q" input="SB_DFFNR.Q"     output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNR.C"     />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNR.R"     />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNR.D"     />
+   <direct input="SB_DFFNR.Q"     output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -387,10 +387,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNS.C"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFNS.S"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNS.D"    />
-   <direct name="Q" input="SB_DFFNS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNS.C"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNS.S"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNS.D"    />
+   <direct input="SB_DFFNS.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -406,10 +406,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNSR.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNSR.C"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFNSR.R"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNSR.D"    />
-   <direct name="Q" input="SB_DFFNSR.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNSR.C"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNSR.R"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNSR.D"    />
+   <direct input="SB_DFFNSR.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 
@@ -425,10 +425,10 @@
    <T_clock_to_Q max="10e-12" port="SB_DFFNSS.Q" clock="C"/>
   </pb_type>
   <interconnect>
-   <direct name="C" input="BEL_FF-SB_FF.N" output="SB_DFFNSS.C"    />
-   <direct name="S" input="BEL_FF-SB_FF.S" output="SB_DFFNSS.S"    />
-   <direct name="D" input="BEL_FF-SB_FF.D" output="SB_DFFNSS.D"    />
-   <direct name="Q" input="SB_DFFNSS.Q"    output="BEL_FF-SB_FF.Q" />
+   <direct input="BEL_FF-SB_FF.N" output="SB_DFFNSS.C"    />
+   <direct input="BEL_FF-SB_FF.S" output="SB_DFFNSS.S"    />
+   <direct input="BEL_FF-SB_FF.D" output="SB_DFFNSS.D"    />
+   <direct input="SB_DFFNSS.Q"    output="BEL_FF-SB_FF.Q" />
   </interconnect>
  </mode>
 

--- a/ice40/primitives/sb_io/sb_io.pb_type.xml
+++ b/ice40/primitives/sb_io/sb_io.pb_type.xml
@@ -16,12 +16,12 @@
     <output name="inpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <mux name="D_IN_0" input="input.inpad" output="PAD_IN-INPUT.D_IN[0]"/>
-    <mux name="D_IN_1" input="input.inpad" output="PAD_IN-INPUT.D_IN[1]"/>
+    <mux input="input.inpad" output="PAD_IN-INPUT.D_IN[0]"/>
+    <mux input="input.inpad" output="PAD_IN-INPUT.D_IN[1]"/>
    </interconnect>
   </pb_type>
   <interconnect>
-   <direct name="INPUT" input="PAD_IN-INPUT.D_IN" output="BLK_IG-IO.D_IN"/>
+   <direct input="PAD_IN-INPUT.D_IN" output="BLK_IG-IO.D_IN"/>
   </interconnect>
  </mode>
 
@@ -33,11 +33,11 @@
     <input name="outpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <mux name="D_OUT" input="PAD_IN-OUTPUT.D_OUT[0] PAD_IN-OUTPUT.D_OUT[1]" output="output.outpad"/>
+    <mux input="PAD_IN-OUTPUT.D_OUT[0] PAD_IN-OUTPUT.D_OUT[1]" output="output.outpad"/>
    </interconnect>
   </pb_type>
   <interconnect>
-   <direct name="D_OUT" input="BLK_IG-IO.D_OUT" output="PAD_IN-OUTPUT.D_OUT"/>
+   <direct input="BLK_IG-IO.D_OUT" output="PAD_IN-OUTPUT.D_OUT"/>
   </interconnect>
  </mode>
 

--- a/ice40/primitives/sb_io/sb_io.pb_type.xml
+++ b/ice40/primitives/sb_io/sb_io.pb_type.xml
@@ -16,12 +16,12 @@
     <output name="inpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <mux input="input.inpad" output="PAD_IN-INPUT.D_IN[0]"/>
-    <mux input="input.inpad" output="PAD_IN-INPUT.D_IN[1]"/>
+    <mux><port type="input" from="input" name="inpad"/><port type="output" from="PAD_IN-INPUT" name="D_IN[0]"/></mux>
+    <mux><port type="input" from="input" name="inpad"/><port type="output" from="PAD_IN-INPUT" name="D_IN[1]"/></mux>
    </interconnect>
   </pb_type>
   <interconnect>
-   <direct input="PAD_IN-INPUT.D_IN" output="BLK_IG-IO.D_IN"/>
+   <direct><port type="input" from="PAD_IN-INPUT" name="D_IN"/><port type="output" name="D_IN"/></direct>
   </interconnect>
  </mode>
 
@@ -33,11 +33,15 @@
     <input name="outpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <mux input="PAD_IN-OUTPUT.D_OUT[0] PAD_IN-OUTPUT.D_OUT[1]" output="output.outpad"/>
+    <mux>
+     <port type="input"  from="PAD_IN-OUTPUT" name="D_OUT[0]"/>
+     <port type="input"  from="PAD_IN-OUTPUT" name="D_OUT[1]"/>
+     <port type="output" from="output" name="outpad"/>
+    </mux>
    </interconnect>
   </pb_type>
   <interconnect>
-   <direct input="BLK_IG-IO.D_OUT" output="PAD_IN-OUTPUT.D_OUT"/>
+   <direct><port type="input" name="D_OUT"/><port type="output" from="PAD_IN-OUTPUT" name="D_OUT"/></direct>
   </interconnect>
  </mode>
 

--- a/ice40/primitives/sb_lut/sb_lut.pb_type.xml
+++ b/ice40/primitives/sb_lut/sb_lut.pb_type.xml
@@ -19,8 +19,8 @@
    </delay_matrix>
   </pb_type>
   <interconnect>
-   <direct input="BEL_LT-LUT.in"   output="BLK_IG-LUT4.in"  />
-   <direct input="BLK_IG-LUT4.out" output="BEL_LT-LUT.out"   >
+   <direct><port type="input" name="in"/><port type="output" from="BLK_IG-LUT4" name="in"/></direct>
+   <direct><port type="input" from="BLK_IG-LUT4" name="out"/><port type="output" name="out"/>
     <pack_pattern name="LUT+FF" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out" />
    </direct>
   </interconnect>
@@ -38,11 +38,11 @@
    <delay_constant max="10e-12" in_port="BLK_IG-SB_LUT4.I3" out_port="BLK_IG-SB_LUT4.O"/>
   </pb_type>
   <interconnect>
-   <direct input="BEL_LT-LUT.in[0]" output="BLK_IG-SB_LUT4.I0" />
-   <direct input="BEL_LT-LUT.in[1]" output="BLK_IG-SB_LUT4.I1" />
-   <direct input="BEL_LT-LUT.in[2]" output="BLK_IG-SB_LUT4.I2" />
-   <direct input="BEL_LT-LUT.in[3]" output="BLK_IG-SB_LUT4.I3" />
-   <direct input="BLK_IG-SB_LUT4.O" output="BEL_LT-LUT.out"     >
+   <direct><port type="input" name="in[0]"/><port type="output" from="BLK_IG-SB_LUT4" name="I0"/></direct>
+   <direct><port type="input" name="in[1]"/><port type="output" from="BLK_IG-SB_LUT4" name="I1"/></direct>
+   <direct><port type="input" name="in[2]"/><port type="output" from="BLK_IG-SB_LUT4" name="I2"/></direct>
+   <direct><port type="input" name="in[3]"/><port type="output" from="BLK_IG-SB_LUT4" name="I3"/></direct>
+   <direct><port type="input" from="BLK_IG-SB_LUT4" name="O"/><port type="output" name="out"/>
 	   <!-- <pack_pattern name="LUT+FF" in_port="BLK_IG-SB_LUT4" out_port="BEL_LT-LUT.out" /> -->
    </direct>
   </interconnect>

--- a/ice40/primitives/sb_lut/sb_lut.pb_type.xml
+++ b/ice40/primitives/sb_lut/sb_lut.pb_type.xml
@@ -19,8 +19,8 @@
    </delay_matrix>
   </pb_type>
   <interconnect>
-   <direct name="I"  input="BEL_LT-LUT.in"   output="BLK_IG-LUT4.in"  />
-   <direct name="O"  input="BLK_IG-LUT4.out" output="BEL_LT-LUT.out"   >
+   <direct input="BEL_LT-LUT.in"   output="BLK_IG-LUT4.in"  />
+   <direct input="BLK_IG-LUT4.out" output="BEL_LT-LUT.out"   >
     <pack_pattern name="LUT+FF" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out" />
    </direct>
   </interconnect>
@@ -38,11 +38,11 @@
    <delay_constant max="10e-12" in_port="BLK_IG-SB_LUT4.I3" out_port="BLK_IG-SB_LUT4.O"/>
   </pb_type>
   <interconnect>
-   <direct name="I0" input="BEL_LT-LUT.in[0]" output="BLK_IG-SB_LUT4.I0" />
-   <direct name="I1" input="BEL_LT-LUT.in[1]" output="BLK_IG-SB_LUT4.I1" />
-   <direct name="I2" input="BEL_LT-LUT.in[2]" output="BLK_IG-SB_LUT4.I2" />
-   <direct name="I3" input="BEL_LT-LUT.in[3]" output="BLK_IG-SB_LUT4.I3" />
-   <direct name="O"  input="BLK_IG-SB_LUT4.O" output="BEL_LT-LUT.out"     >
+   <direct input="BEL_LT-LUT.in[0]" output="BLK_IG-SB_LUT4.I0" />
+   <direct input="BEL_LT-LUT.in[1]" output="BLK_IG-SB_LUT4.I1" />
+   <direct input="BEL_LT-LUT.in[2]" output="BLK_IG-SB_LUT4.I2" />
+   <direct input="BEL_LT-LUT.in[3]" output="BLK_IG-SB_LUT4.I3" />
+   <direct input="BLK_IG-SB_LUT4.O" output="BEL_LT-LUT.out"     >
 	   <!-- <pack_pattern name="LUT+FF" in_port="BLK_IG-SB_LUT4" out_port="BEL_LT-LUT.out" /> -->
    </direct>
   </interconnect>

--- a/ice40/primitives/sb_ram/sb_ram.pb_type.xml
+++ b/ice40/primitives/sb_ram/sb_ram.pb_type.xml
@@ -79,89 +79,89 @@
       </pb_type>
       <interconnect>
        <!-- Read port -->
-       <direct input="SB_RAM256x16.RDATA[0]"  output="SB_RAM.RDATA[0]" />
-       <direct input="SB_RAM256x16.RDATA[1]"  output="SB_RAM.RDATA[1]" />
-       <direct input="SB_RAM256x16.RDATA[2]"  output="SB_RAM.RDATA[2]" />
-       <direct input="SB_RAM256x16.RDATA[3]"  output="SB_RAM.RDATA[3]" />
-       <direct input="SB_RAM256x16.RDATA[4]"  output="SB_RAM.RDATA[4]" />
-       <direct input="SB_RAM256x16.RDATA[5]"  output="SB_RAM.RDATA[5]" />
-       <direct input="SB_RAM256x16.RDATA[6]"  output="SB_RAM.RDATA[6]" />
-       <direct input="SB_RAM256x16.RDATA[7]"  output="SB_RAM.RDATA[7]" />
-       <direct input="SB_RAM256x16.RDATA[8]"  output="SB_RAM.RDATA[8]" />
-       <direct input="SB_RAM256x16.RDATA[9]"  output="SB_RAM.RDATA[9]" />
-       <direct input="SB_RAM256x16.RDATA[10]" output="SB_RAM.RDATA[10]" />
-       <direct input="SB_RAM256x16.RDATA[11]" output="SB_RAM.RDATA[11]" />
-       <direct input="SB_RAM256x16.RDATA[12]" output="SB_RAM.RDATA[12]" />
-       <direct input="SB_RAM256x16.RDATA[13]" output="SB_RAM.RDATA[13]" />
-       <direct input="SB_RAM256x16.RDATA[14]" output="SB_RAM.RDATA[14]" />
-       <direct input="SB_RAM256x16.RDATA[15]" output="SB_RAM.RDATA[15]" />
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[0]"/><port type="output" name="RDATA[0]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[1]"/><port type="output" name="RDATA[1]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[2]"/><port type="output" name="RDATA[2]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[3]"/><port type="output" name="RDATA[3]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[4]"/><port type="output" name="RDATA[4]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[5]"/><port type="output" name="RDATA[5]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[6]"/><port type="output" name="RDATA[6]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[7]"/><port type="output" name="RDATA[7]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[8]"/><port type="output" name="RDATA[8]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[9]"/><port type="output" name="RDATA[9]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[10]"/><port type="output" name="RDATA[10]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[11]"/><port type="output" name="RDATA[11]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[12]"/><port type="output" name="RDATA[12]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[13]"/><port type="output" name="RDATA[13]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[14]"/><port type="output" name="RDATA[14]"/></direct>
+       <direct><port type="input" from="SB_RAM256x16" name="RDATA[15]"/><port type="output" name="RDATA[15]"/></direct>
 
-       <direct input="SB_RAM.RCLK"  output="SB_RAM256x16.RCLK" />
-       <direct input="SB_RAM.RCLKE" output="SB_RAM256x16.RCLKE" />
-       <direct input="SB_RAM.RE"    output="SB_RAM256x16.RE" />
+       <direct><port type="input" name="RCLK"/><port type="output" from="SB_RAM256x16" name="RCLK"/></direct>
+       <direct><port type="input" name="RCLKE"/><port type="output" from="SB_RAM256x16" name="RCLKE"/></direct>
+       <direct><port type="input" name="RE"/><port type="output" from="SB_RAM256x16" name="RE"/></direct>
 
-       <direct input="SB_RAM.RADDR[0]"  output="SB_RAM256x16.RADDR[0]" />
-       <direct input="SB_RAM.RADDR[1]"  output="SB_RAM256x16.RADDR[1]" />
-       <direct input="SB_RAM.RADDR[2]"  output="SB_RAM256x16.RADDR[2]" />
-       <direct input="SB_RAM.RADDR[3]"  output="SB_RAM256x16.RADDR[3]" />
-       <direct input="SB_RAM.RADDR[4]"  output="SB_RAM256x16.RADDR[4]" />
-       <direct input="SB_RAM.RADDR[5]"  output="SB_RAM256x16.RADDR[5]" />
-       <direct input="SB_RAM.RADDR[6]"  output="SB_RAM256x16.RADDR[6]" />
-       <direct input="SB_RAM.RADDR[7]"  output="SB_RAM256x16.RADDR[7]" />
-       <direct input="SB_RAM.RADDR[8]"  output="SB_RAM256x16.RADDR[8]" />
-       <direct input="SB_RAM.RADDR[9]"  output="SB_RAM256x16.RADDR[9]" />
-       <direct input="SB_RAM.RADDR[10]" output="SB_RAM256x16.RADDR[10]" />
+       <direct><port type="input" name="RADDR[0]"/><port type="output" from="SB_RAM256x16" name="RADDR[0]"/></direct>
+       <direct><port type="input" name="RADDR[1]"/><port type="output" from="SB_RAM256x16" name="RADDR[1]"/></direct>
+       <direct><port type="input" name="RADDR[2]"/><port type="output" from="SB_RAM256x16" name="RADDR[2]"/></direct>
+       <direct><port type="input" name="RADDR[3]"/><port type="output" from="SB_RAM256x16" name="RADDR[3]"/></direct>
+       <direct><port type="input" name="RADDR[4]"/><port type="output" from="SB_RAM256x16" name="RADDR[4]"/></direct>
+       <direct><port type="input" name="RADDR[5]"/><port type="output" from="SB_RAM256x16" name="RADDR[5]"/></direct>
+       <direct><port type="input" name="RADDR[6]"/><port type="output" from="SB_RAM256x16" name="RADDR[6]"/></direct>
+       <direct><port type="input" name="RADDR[7]"/><port type="output" from="SB_RAM256x16" name="RADDR[7]"/></direct>
+       <direct><port type="input" name="RADDR[8]"/><port type="output" from="SB_RAM256x16" name="RADDR[8]"/></direct>
+       <direct><port type="input" name="RADDR[9]"/><port type="output" from="SB_RAM256x16" name="RADDR[9]"/></direct>
+       <direct><port type="input" name="RADDR[10]"/><port type="output" from="SB_RAM256x16" name="RADDR[10]"/></direct>
 
        <!-- Write port -->
-       <direct input="SB_RAM.WCLK"  output="SB_RAM256x16.WCLK" />
-       <direct input="SB_RAM.WCLKE" output="SB_RAM256x16.WCLKE" />
-       <direct input="SB_RAM.WE"    output="SB_RAM256x16.WE" />
+       <direct><port type="input" name="WCLK"/><port type="output" from="SB_RAM256x16" name="WCLK"/></direct>
+       <direct><port type="input" name="WCLKE"/><port type="output" from="SB_RAM256x16" name="WCLKE"/></direct>
+       <direct><port type="input" name="WE"/><port type="output" from="SB_RAM256x16" name="WE"/></direct>
 
-       <direct input="SB_RAM.WADDR[0]"  output="SB_RAM256x16.WADDR[0]" />
-       <direct input="SB_RAM.WADDR[1]"  output="SB_RAM256x16.WADDR[1]" />
-       <direct input="SB_RAM.WADDR[2]"  output="SB_RAM256x16.WADDR[2]" />
-       <direct input="SB_RAM.WADDR[3]"  output="SB_RAM256x16.WADDR[3]" />
-       <direct input="SB_RAM.WADDR[4]"  output="SB_RAM256x16.WADDR[4]" />
-       <direct input="SB_RAM.WADDR[5]"  output="SB_RAM256x16.WADDR[5]" />
-       <direct input="SB_RAM.WADDR[6]"  output="SB_RAM256x16.WADDR[6]" />
-       <direct input="SB_RAM.WADDR[7]"  output="SB_RAM256x16.WADDR[7]" />
-       <direct input="SB_RAM.WADDR[8]"  output="SB_RAM256x16.WADDR[8]" />
-       <direct input="SB_RAM.WADDR[9]"  output="SB_RAM256x16.WADDR[9]" />
-       <direct input="SB_RAM.WADDR[10]" output="SB_RAM256x16.WADDR[10]" />
+       <direct><port type="input" name="WADDR[0]"/><port type="output" from="SB_RAM256x16" name="WADDR[0]"/></direct>
+       <direct><port type="input" name="WADDR[1]"/><port type="output" from="SB_RAM256x16" name="WADDR[1]"/></direct>
+       <direct><port type="input" name="WADDR[2]"/><port type="output" from="SB_RAM256x16" name="WADDR[2]"/></direct>
+       <direct><port type="input" name="WADDR[3]"/><port type="output" from="SB_RAM256x16" name="WADDR[3]"/></direct>
+       <direct><port type="input" name="WADDR[4]"/><port type="output" from="SB_RAM256x16" name="WADDR[4]"/></direct>
+       <direct><port type="input" name="WADDR[5]"/><port type="output" from="SB_RAM256x16" name="WADDR[5]"/></direct>
+       <direct><port type="input" name="WADDR[6]"/><port type="output" from="SB_RAM256x16" name="WADDR[6]"/></direct>
+       <direct><port type="input" name="WADDR[7]"/><port type="output" from="SB_RAM256x16" name="WADDR[7]"/></direct>
+       <direct><port type="input" name="WADDR[8]"/><port type="output" from="SB_RAM256x16" name="WADDR[8]"/></direct>
+       <direct><port type="input" name="WADDR[9]"/><port type="output" from="SB_RAM256x16" name="WADDR[9]"/></direct>
+       <direct><port type="input" name="WADDR[10]"/><port type="output" from="SB_RAM256x16" name="WADDR[10]"/></direct>
 
-       <direct input="SB_RAM.MASK[0]"   output="SB_RAM256x16.MASK[0]" />
-       <direct input="SB_RAM.MASK[1]"   output="SB_RAM256x16.MASK[1]" />
-       <direct input="SB_RAM.MASK[2]"   output="SB_RAM256x16.MASK[2]" />
-       <direct input="SB_RAM.MASK[3]"   output="SB_RAM256x16.MASK[3]" />
-       <direct input="SB_RAM.MASK[4]"   output="SB_RAM256x16.MASK[4]" />
-       <direct input="SB_RAM.MASK[5]"   output="SB_RAM256x16.MASK[5]" />
-       <direct input="SB_RAM.MASK[6]"   output="SB_RAM256x16.MASK[6]" />
-       <direct input="SB_RAM.MASK[7]"   output="SB_RAM256x16.MASK[7]" />
-       <direct input="SB_RAM.MASK[8]"   output="SB_RAM256x16.MASK[8]" />
-       <direct input="SB_RAM.MASK[9]"   output="SB_RAM256x16.MASK[9]" />
-       <direct input="SB_RAM.MASK[10]"  output="SB_RAM256x16.MASK[10]" />
-       <direct input="SB_RAM.MASK[11]"  output="SB_RAM256x16.MASK[11]" />
-       <direct input="SB_RAM.MASK[12]"  output="SB_RAM256x16.MASK[12]" />
-       <direct input="SB_RAM.MASK[13]"  output="SB_RAM256x16.MASK[13]" />
-       <direct input="SB_RAM.MASK[14]"  output="SB_RAM256x16.MASK[14]" />
-       <direct input="SB_RAM.MASK[15]"  output="SB_RAM256x16.MASK[15]" />
+       <direct><port type="input" name="MASK[0]"/><port type="output" from="SB_RAM256x16" name="MASK[0]"/></direct>
+       <direct><port type="input" name="MASK[1]"/><port type="output" from="SB_RAM256x16" name="MASK[1]"/></direct>
+       <direct><port type="input" name="MASK[2]"/><port type="output" from="SB_RAM256x16" name="MASK[2]"/></direct>
+       <direct><port type="input" name="MASK[3]"/><port type="output" from="SB_RAM256x16" name="MASK[3]"/></direct>
+       <direct><port type="input" name="MASK[4]"/><port type="output" from="SB_RAM256x16" name="MASK[4]"/></direct>
+       <direct><port type="input" name="MASK[5]"/><port type="output" from="SB_RAM256x16" name="MASK[5]"/></direct>
+       <direct><port type="input" name="MASK[6]"/><port type="output" from="SB_RAM256x16" name="MASK[6]"/></direct>
+       <direct><port type="input" name="MASK[7]"/><port type="output" from="SB_RAM256x16" name="MASK[7]"/></direct>
+       <direct><port type="input" name="MASK[8]"/><port type="output" from="SB_RAM256x16" name="MASK[8]"/></direct>
+       <direct><port type="input" name="MASK[9]"/><port type="output" from="SB_RAM256x16" name="MASK[9]"/></direct>
+       <direct><port type="input" name="MASK[10]"/><port type="output" from="SB_RAM256x16" name="MASK[10]"/></direct>
+       <direct><port type="input" name="MASK[11]"/><port type="output" from="SB_RAM256x16" name="MASK[11]"/></direct>
+       <direct><port type="input" name="MASK[12]"/><port type="output" from="SB_RAM256x16" name="MASK[12]"/></direct>
+       <direct><port type="input" name="MASK[13]"/><port type="output" from="SB_RAM256x16" name="MASK[13]"/></direct>
+       <direct><port type="input" name="MASK[14]"/><port type="output" from="SB_RAM256x16" name="MASK[14]"/></direct>
+       <direct><port type="input" name="MASK[15]"/><port type="output" from="SB_RAM256x16" name="MASK[15]"/></direct>
 
-       <direct input="SB_RAM.WDATA[0]"  output="SB_RAM256x16.WDATA[0]" />
-       <direct input="SB_RAM.WDATA[1]"  output="SB_RAM256x16.WDATA[1]" />
-       <direct input="SB_RAM.WDATA[2]"  output="SB_RAM256x16.WDATA[2]" />
-       <direct input="SB_RAM.WDATA[3]"  output="SB_RAM256x16.WDATA[3]" />
-       <direct input="SB_RAM.WDATA[4]"  output="SB_RAM256x16.WDATA[4]" />
-       <direct input="SB_RAM.WDATA[5]"  output="SB_RAM256x16.WDATA[5]" />
-       <direct input="SB_RAM.WDATA[6]"  output="SB_RAM256x16.WDATA[6]" />
-       <direct input="SB_RAM.WDATA[7]"  output="SB_RAM256x16.WDATA[7]" />
-       <direct input="SB_RAM.WDATA[8]"  output="SB_RAM256x16.WDATA[8]" />
-       <direct input="SB_RAM.WDATA[9]"  output="SB_RAM256x16.WDATA[9]" />
-       <direct input="SB_RAM.WDATA[10]" output="SB_RAM256x16.WDATA[10]" />
-       <direct input="SB_RAM.WDATA[11]" output="SB_RAM256x16.WDATA[11]" />
-       <direct input="SB_RAM.WDATA[12]" output="SB_RAM256x16.WDATA[12]" />
-       <direct input="SB_RAM.WDATA[13]" output="SB_RAM256x16.WDATA[13]" />
-       <direct input="SB_RAM.WDATA[14]" output="SB_RAM256x16.WDATA[14]" />
-       <direct input="SB_RAM.WDATA[15]" output="SB_RAM256x16.WDATA[15]" />
+       <direct><port type="input" name="WDATA[0]"/><port type="output" from="SB_RAM256x16" name="WDATA[0]"/></direct>
+       <direct><port type="input" name="WDATA[1]"/><port type="output" from="SB_RAM256x16" name="WDATA[1]"/></direct>
+       <direct><port type="input" name="WDATA[2]"/><port type="output" from="SB_RAM256x16" name="WDATA[2]"/></direct>
+       <direct><port type="input" name="WDATA[3]"/><port type="output" from="SB_RAM256x16" name="WDATA[3]"/></direct>
+       <direct><port type="input" name="WDATA[4]"/><port type="output" from="SB_RAM256x16" name="WDATA[4]"/></direct>
+       <direct><port type="input" name="WDATA[5]"/><port type="output" from="SB_RAM256x16" name="WDATA[5]"/></direct>
+       <direct><port type="input" name="WDATA[6]"/><port type="output" from="SB_RAM256x16" name="WDATA[6]"/></direct>
+       <direct><port type="input" name="WDATA[7]"/><port type="output" from="SB_RAM256x16" name="WDATA[7]"/></direct>
+       <direct><port type="input" name="WDATA[8]"/><port type="output" from="SB_RAM256x16" name="WDATA[8]"/></direct>
+       <direct><port type="input" name="WDATA[9]"/><port type="output" from="SB_RAM256x16" name="WDATA[9]"/></direct>
+       <direct><port type="input" name="WDATA[10]"/><port type="output" from="SB_RAM256x16" name="WDATA[10]"/></direct>
+       <direct><port type="input" name="WDATA[11]"/><port type="output" from="SB_RAM256x16" name="WDATA[11]"/></direct>
+       <direct><port type="input" name="WDATA[12]"/><port type="output" from="SB_RAM256x16" name="WDATA[12]"/></direct>
+       <direct><port type="input" name="WDATA[13]"/><port type="output" from="SB_RAM256x16" name="WDATA[13]"/></direct>
+       <direct><port type="input" name="WDATA[14]"/><port type="output" from="SB_RAM256x16" name="WDATA[14]"/></direct>
+       <direct><port type="input" name="WDATA[15]"/><port type="output" from="SB_RAM256x16" name="WDATA[15]"/></direct>
 
       </interconnect>
      </mode>

--- a/ice40/primitives/sb_ram/sb_ram.pb_type.xml
+++ b/ice40/primitives/sb_ram/sb_ram.pb_type.xml
@@ -79,89 +79,89 @@
       </pb_type>
       <interconnect>
        <!-- Read port -->
-       <direct name="RDATA00" input="SB_RAM256x16.RDATA[0]"  output="SB_RAM.RDATA[0]" />
-       <direct name="RDATA01" input="SB_RAM256x16.RDATA[1]"  output="SB_RAM.RDATA[1]" />
-       <direct name="RDATA02" input="SB_RAM256x16.RDATA[2]"  output="SB_RAM.RDATA[2]" />
-       <direct name="RDATA03" input="SB_RAM256x16.RDATA[3]"  output="SB_RAM.RDATA[3]" />
-       <direct name="RDATA04" input="SB_RAM256x16.RDATA[4]"  output="SB_RAM.RDATA[4]" />
-       <direct name="RDATA05" input="SB_RAM256x16.RDATA[5]"  output="SB_RAM.RDATA[5]" />
-       <direct name="RDATA06" input="SB_RAM256x16.RDATA[6]"  output="SB_RAM.RDATA[6]" />
-       <direct name="RDATA07" input="SB_RAM256x16.RDATA[7]"  output="SB_RAM.RDATA[7]" />
-       <direct name="RDATA08" input="SB_RAM256x16.RDATA[8]"  output="SB_RAM.RDATA[8]" />
-       <direct name="RDATA09" input="SB_RAM256x16.RDATA[9]"  output="SB_RAM.RDATA[9]" />
-       <direct name="RDATA10" input="SB_RAM256x16.RDATA[10]" output="SB_RAM.RDATA[10]" />
-       <direct name="RDATA11" input="SB_RAM256x16.RDATA[11]" output="SB_RAM.RDATA[11]" />
-       <direct name="RDATA12" input="SB_RAM256x16.RDATA[12]" output="SB_RAM.RDATA[12]" />
-       <direct name="RDATA13" input="SB_RAM256x16.RDATA[13]" output="SB_RAM.RDATA[13]" />
-       <direct name="RDATA14" input="SB_RAM256x16.RDATA[14]" output="SB_RAM.RDATA[14]" />
-       <direct name="RDATA15" input="SB_RAM256x16.RDATA[15]" output="SB_RAM.RDATA[15]" />
+       <direct input="SB_RAM256x16.RDATA[0]"  output="SB_RAM.RDATA[0]" />
+       <direct input="SB_RAM256x16.RDATA[1]"  output="SB_RAM.RDATA[1]" />
+       <direct input="SB_RAM256x16.RDATA[2]"  output="SB_RAM.RDATA[2]" />
+       <direct input="SB_RAM256x16.RDATA[3]"  output="SB_RAM.RDATA[3]" />
+       <direct input="SB_RAM256x16.RDATA[4]"  output="SB_RAM.RDATA[4]" />
+       <direct input="SB_RAM256x16.RDATA[5]"  output="SB_RAM.RDATA[5]" />
+       <direct input="SB_RAM256x16.RDATA[6]"  output="SB_RAM.RDATA[6]" />
+       <direct input="SB_RAM256x16.RDATA[7]"  output="SB_RAM.RDATA[7]" />
+       <direct input="SB_RAM256x16.RDATA[8]"  output="SB_RAM.RDATA[8]" />
+       <direct input="SB_RAM256x16.RDATA[9]"  output="SB_RAM.RDATA[9]" />
+       <direct input="SB_RAM256x16.RDATA[10]" output="SB_RAM.RDATA[10]" />
+       <direct input="SB_RAM256x16.RDATA[11]" output="SB_RAM.RDATA[11]" />
+       <direct input="SB_RAM256x16.RDATA[12]" output="SB_RAM.RDATA[12]" />
+       <direct input="SB_RAM256x16.RDATA[13]" output="SB_RAM.RDATA[13]" />
+       <direct input="SB_RAM256x16.RDATA[14]" output="SB_RAM.RDATA[14]" />
+       <direct input="SB_RAM256x16.RDATA[15]" output="SB_RAM.RDATA[15]" />
 
-       <direct name="RCLK"  input="SB_RAM.RCLK"  output="SB_RAM256x16.RCLK" />
-       <direct name="RCLKE" input="SB_RAM.RCLKE" output="SB_RAM256x16.RCLKE" />
-       <direct name="RE"    input="SB_RAM.RE"    output="SB_RAM256x16.RE" />
+       <direct input="SB_RAM.RCLK"  output="SB_RAM256x16.RCLK" />
+       <direct input="SB_RAM.RCLKE" output="SB_RAM256x16.RCLKE" />
+       <direct input="SB_RAM.RE"    output="SB_RAM256x16.RE" />
 
-       <direct name="RADDR00" input="SB_RAM.RADDR[0]"  output="SB_RAM256x16.RADDR[0]" />
-       <direct name="RADDR01" input="SB_RAM.RADDR[1]"  output="SB_RAM256x16.RADDR[1]" />
-       <direct name="RADDR02" input="SB_RAM.RADDR[2]"  output="SB_RAM256x16.RADDR[2]" />
-       <direct name="RADDR03" input="SB_RAM.RADDR[3]"  output="SB_RAM256x16.RADDR[3]" />
-       <direct name="RADDR04" input="SB_RAM.RADDR[4]"  output="SB_RAM256x16.RADDR[4]" />
-       <direct name="RADDR05" input="SB_RAM.RADDR[5]"  output="SB_RAM256x16.RADDR[5]" />
-       <direct name="RADDR06" input="SB_RAM.RADDR[6]"  output="SB_RAM256x16.RADDR[6]" />
-       <direct name="RADDR07" input="SB_RAM.RADDR[7]"  output="SB_RAM256x16.RADDR[7]" />
-       <direct name="RADDR08" input="SB_RAM.RADDR[8]"  output="SB_RAM256x16.RADDR[8]" />
-       <direct name="RADDR09" input="SB_RAM.RADDR[9]"  output="SB_RAM256x16.RADDR[9]" />
-       <direct name="RADDR10" input="SB_RAM.RADDR[10]" output="SB_RAM256x16.RADDR[10]" />
+       <direct input="SB_RAM.RADDR[0]"  output="SB_RAM256x16.RADDR[0]" />
+       <direct input="SB_RAM.RADDR[1]"  output="SB_RAM256x16.RADDR[1]" />
+       <direct input="SB_RAM.RADDR[2]"  output="SB_RAM256x16.RADDR[2]" />
+       <direct input="SB_RAM.RADDR[3]"  output="SB_RAM256x16.RADDR[3]" />
+       <direct input="SB_RAM.RADDR[4]"  output="SB_RAM256x16.RADDR[4]" />
+       <direct input="SB_RAM.RADDR[5]"  output="SB_RAM256x16.RADDR[5]" />
+       <direct input="SB_RAM.RADDR[6]"  output="SB_RAM256x16.RADDR[6]" />
+       <direct input="SB_RAM.RADDR[7]"  output="SB_RAM256x16.RADDR[7]" />
+       <direct input="SB_RAM.RADDR[8]"  output="SB_RAM256x16.RADDR[8]" />
+       <direct input="SB_RAM.RADDR[9]"  output="SB_RAM256x16.RADDR[9]" />
+       <direct input="SB_RAM.RADDR[10]" output="SB_RAM256x16.RADDR[10]" />
 
        <!-- Write port -->
-       <direct name="WCLK"  input="SB_RAM.WCLK"  output="SB_RAM256x16.WCLK" />
-       <direct name="WCLKE" input="SB_RAM.WCLKE" output="SB_RAM256x16.WCLKE" />
-       <direct name="WE"    input="SB_RAM.WE"    output="SB_RAM256x16.WE" />
+       <direct input="SB_RAM.WCLK"  output="SB_RAM256x16.WCLK" />
+       <direct input="SB_RAM.WCLKE" output="SB_RAM256x16.WCLKE" />
+       <direct input="SB_RAM.WE"    output="SB_RAM256x16.WE" />
 
-       <direct name="WADDR00" input="SB_RAM.WADDR[0]"  output="SB_RAM256x16.WADDR[0]" />
-       <direct name="WADDR01" input="SB_RAM.WADDR[1]"  output="SB_RAM256x16.WADDR[1]" />
-       <direct name="WADDR02" input="SB_RAM.WADDR[2]"  output="SB_RAM256x16.WADDR[2]" />
-       <direct name="WADDR03" input="SB_RAM.WADDR[3]"  output="SB_RAM256x16.WADDR[3]" />
-       <direct name="WADDR04" input="SB_RAM.WADDR[4]"  output="SB_RAM256x16.WADDR[4]" />
-       <direct name="WADDR05" input="SB_RAM.WADDR[5]"  output="SB_RAM256x16.WADDR[5]" />
-       <direct name="WADDR06" input="SB_RAM.WADDR[6]"  output="SB_RAM256x16.WADDR[6]" />
-       <direct name="WADDR07" input="SB_RAM.WADDR[7]"  output="SB_RAM256x16.WADDR[7]" />
-       <direct name="WADDR08" input="SB_RAM.WADDR[8]"  output="SB_RAM256x16.WADDR[8]" />
-       <direct name="WADDR09" input="SB_RAM.WADDR[9]"  output="SB_RAM256x16.WADDR[9]" />
-       <direct name="WADDR10" input="SB_RAM.WADDR[10]" output="SB_RAM256x16.WADDR[10]" />
+       <direct input="SB_RAM.WADDR[0]"  output="SB_RAM256x16.WADDR[0]" />
+       <direct input="SB_RAM.WADDR[1]"  output="SB_RAM256x16.WADDR[1]" />
+       <direct input="SB_RAM.WADDR[2]"  output="SB_RAM256x16.WADDR[2]" />
+       <direct input="SB_RAM.WADDR[3]"  output="SB_RAM256x16.WADDR[3]" />
+       <direct input="SB_RAM.WADDR[4]"  output="SB_RAM256x16.WADDR[4]" />
+       <direct input="SB_RAM.WADDR[5]"  output="SB_RAM256x16.WADDR[5]" />
+       <direct input="SB_RAM.WADDR[6]"  output="SB_RAM256x16.WADDR[6]" />
+       <direct input="SB_RAM.WADDR[7]"  output="SB_RAM256x16.WADDR[7]" />
+       <direct input="SB_RAM.WADDR[8]"  output="SB_RAM256x16.WADDR[8]" />
+       <direct input="SB_RAM.WADDR[9]"  output="SB_RAM256x16.WADDR[9]" />
+       <direct input="SB_RAM.WADDR[10]" output="SB_RAM256x16.WADDR[10]" />
 
-       <direct name="MASK00"  input="SB_RAM.MASK[0]"   output="SB_RAM256x16.MASK[0]" />
-       <direct name="MASK01"  input="SB_RAM.MASK[1]"   output="SB_RAM256x16.MASK[1]" />
-       <direct name="MASK02"  input="SB_RAM.MASK[2]"   output="SB_RAM256x16.MASK[2]" />
-       <direct name="MASK03"  input="SB_RAM.MASK[3]"   output="SB_RAM256x16.MASK[3]" />
-       <direct name="MASK04"  input="SB_RAM.MASK[4]"   output="SB_RAM256x16.MASK[4]" />
-       <direct name="MASK05"  input="SB_RAM.MASK[5]"   output="SB_RAM256x16.MASK[5]" />
-       <direct name="MASK06"  input="SB_RAM.MASK[6]"   output="SB_RAM256x16.MASK[6]" />
-       <direct name="MASK07"  input="SB_RAM.MASK[7]"   output="SB_RAM256x16.MASK[7]" />
-       <direct name="MASK08"  input="SB_RAM.MASK[8]"   output="SB_RAM256x16.MASK[8]" />
-       <direct name="MASK09"  input="SB_RAM.MASK[9]"   output="SB_RAM256x16.MASK[9]" />
-       <direct name="MASK10"  input="SB_RAM.MASK[10]"  output="SB_RAM256x16.MASK[10]" />
-       <direct name="MASK11"  input="SB_RAM.MASK[11]"  output="SB_RAM256x16.MASK[11]" />
-       <direct name="MASK12"  input="SB_RAM.MASK[12]"  output="SB_RAM256x16.MASK[12]" />
-       <direct name="MASK13"  input="SB_RAM.MASK[13]"  output="SB_RAM256x16.MASK[13]" />
-       <direct name="MASK14"  input="SB_RAM.MASK[14]"  output="SB_RAM256x16.MASK[14]" />
-       <direct name="MASK15"  input="SB_RAM.MASK[15]"  output="SB_RAM256x16.MASK[15]" />
+       <direct input="SB_RAM.MASK[0]"   output="SB_RAM256x16.MASK[0]" />
+       <direct input="SB_RAM.MASK[1]"   output="SB_RAM256x16.MASK[1]" />
+       <direct input="SB_RAM.MASK[2]"   output="SB_RAM256x16.MASK[2]" />
+       <direct input="SB_RAM.MASK[3]"   output="SB_RAM256x16.MASK[3]" />
+       <direct input="SB_RAM.MASK[4]"   output="SB_RAM256x16.MASK[4]" />
+       <direct input="SB_RAM.MASK[5]"   output="SB_RAM256x16.MASK[5]" />
+       <direct input="SB_RAM.MASK[6]"   output="SB_RAM256x16.MASK[6]" />
+       <direct input="SB_RAM.MASK[7]"   output="SB_RAM256x16.MASK[7]" />
+       <direct input="SB_RAM.MASK[8]"   output="SB_RAM256x16.MASK[8]" />
+       <direct input="SB_RAM.MASK[9]"   output="SB_RAM256x16.MASK[9]" />
+       <direct input="SB_RAM.MASK[10]"  output="SB_RAM256x16.MASK[10]" />
+       <direct input="SB_RAM.MASK[11]"  output="SB_RAM256x16.MASK[11]" />
+       <direct input="SB_RAM.MASK[12]"  output="SB_RAM256x16.MASK[12]" />
+       <direct input="SB_RAM.MASK[13]"  output="SB_RAM256x16.MASK[13]" />
+       <direct input="SB_RAM.MASK[14]"  output="SB_RAM256x16.MASK[14]" />
+       <direct input="SB_RAM.MASK[15]"  output="SB_RAM256x16.MASK[15]" />
 
-       <direct name="WDATA00" input="SB_RAM.WDATA[0]"  output="SB_RAM256x16.WDATA[0]" />
-       <direct name="WDATA01" input="SB_RAM.WDATA[1]"  output="SB_RAM256x16.WDATA[1]" />
-       <direct name="WDATA02" input="SB_RAM.WDATA[2]"  output="SB_RAM256x16.WDATA[2]" />
-       <direct name="WDATA03" input="SB_RAM.WDATA[3]"  output="SB_RAM256x16.WDATA[3]" />
-       <direct name="WDATA04" input="SB_RAM.WDATA[4]"  output="SB_RAM256x16.WDATA[4]" />
-       <direct name="WDATA05" input="SB_RAM.WDATA[5]"  output="SB_RAM256x16.WDATA[5]" />
-       <direct name="WDATA06" input="SB_RAM.WDATA[6]"  output="SB_RAM256x16.WDATA[6]" />
-       <direct name="WDATA07" input="SB_RAM.WDATA[7]"  output="SB_RAM256x16.WDATA[7]" />
-       <direct name="WDATA08" input="SB_RAM.WDATA[8]"  output="SB_RAM256x16.WDATA[8]" />
-       <direct name="WDATA09" input="SB_RAM.WDATA[9]"  output="SB_RAM256x16.WDATA[9]" />
-       <direct name="WDATA10" input="SB_RAM.WDATA[10]" output="SB_RAM256x16.WDATA[10]" />
-       <direct name="WDATA11" input="SB_RAM.WDATA[11]" output="SB_RAM256x16.WDATA[11]" />
-       <direct name="WDATA12" input="SB_RAM.WDATA[12]" output="SB_RAM256x16.WDATA[12]" />
-       <direct name="WDATA13" input="SB_RAM.WDATA[13]" output="SB_RAM256x16.WDATA[13]" />
-       <direct name="WDATA14" input="SB_RAM.WDATA[14]" output="SB_RAM256x16.WDATA[14]" />
-       <direct name="WDATA15" input="SB_RAM.WDATA[15]" output="SB_RAM256x16.WDATA[15]" />
+       <direct input="SB_RAM.WDATA[0]"  output="SB_RAM256x16.WDATA[0]" />
+       <direct input="SB_RAM.WDATA[1]"  output="SB_RAM256x16.WDATA[1]" />
+       <direct input="SB_RAM.WDATA[2]"  output="SB_RAM256x16.WDATA[2]" />
+       <direct input="SB_RAM.WDATA[3]"  output="SB_RAM256x16.WDATA[3]" />
+       <direct input="SB_RAM.WDATA[4]"  output="SB_RAM256x16.WDATA[4]" />
+       <direct input="SB_RAM.WDATA[5]"  output="SB_RAM256x16.WDATA[5]" />
+       <direct input="SB_RAM.WDATA[6]"  output="SB_RAM256x16.WDATA[6]" />
+       <direct input="SB_RAM.WDATA[7]"  output="SB_RAM256x16.WDATA[7]" />
+       <direct input="SB_RAM.WDATA[8]"  output="SB_RAM256x16.WDATA[8]" />
+       <direct input="SB_RAM.WDATA[9]"  output="SB_RAM256x16.WDATA[9]" />
+       <direct input="SB_RAM.WDATA[10]" output="SB_RAM256x16.WDATA[10]" />
+       <direct input="SB_RAM.WDATA[11]" output="SB_RAM256x16.WDATA[11]" />
+       <direct input="SB_RAM.WDATA[12]" output="SB_RAM256x16.WDATA[12]" />
+       <direct input="SB_RAM.WDATA[13]" output="SB_RAM256x16.WDATA[13]" />
+       <direct input="SB_RAM.WDATA[14]" output="SB_RAM256x16.WDATA[14]" />
+       <direct input="SB_RAM.WDATA[15]" output="SB_RAM256x16.WDATA[15]" />
 
       </interconnect>
      </mode>

--- a/utils/vlog/vlog_to_pbtype.py
+++ b/utils/vlog/vlog_to_pbtype.py
@@ -300,7 +300,7 @@ def make_pb_type(mod):
     # Process IOs
     clocks = yosys.run.list_clocks(args.infiles, mod.name)
     for name, width, iodir in mod.ports:
-        ioattrs = {"name": name, "num_pins": str(width), "equivalent": "false"}
+        ioattrs = {"name": name, "num_pins": str(width)}
         pclass = mod.net_attr(name, "PORT_CLASS")
         if pclass is not None:
             ioattrs["port_class"] = pclass


### PR DESCRIPTION
 * Remove the equivalent property.
 * Use an alternative XML format which allows `<xi:include` to work.

The most important change is the following;
---
> Support a format for pb_type which doesn't require repeating the name
> many times. Use the xmlsort style sheet to generate the old XML version.
> 
> The changes are;
>  * Remove the requirement to give an interconnect a name.
>  * Moving from attributes for input/output to "port" tags.
>  * Decompose the old `PB_TYPE.PORT[BIT]` into attributes on "port" tag.
>  * "Port" tags have a `from` attribute. If left blank it defaults to the
>    current pb_type.
> 
> Before;
> ```xml
> <direct input="XXXX.CLOCK_ENABLE" output="in_cen.EN" name="XXXX">
> ```
> 
> After;
> ```xml
> <direct>
>   <port name="CLOCK_ENABLE" type="input"/>
>   <port name="EN" type="output" from="in_cen"/>
> </direct>
> ```
> 
> Disadvantages:
>  * This is more verbose.
> 
> Advantages:
>  * The 'default to current pb_type' means that you can do;
> ```xml
> <pb_type name="tristate" num_pb="1">
>   <xi:include href="../tri/io_tri.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
> </pb_type>
> ```
------