### PR TITLE
ice40/tests: Adding hx8k-b-evn support for blink and iceram

### DIFF
--- a/ice40/make/tests.mk
+++ b/ice40/make/tests.mk
@@ -32,6 +32,15 @@ $(PROG_TOOL):
 endif
 endif
 
+# iCE40-HX8K Breakout Board Evaluation Kit
+# iCE40-HX8K-CT256
+# ---------------------------------------------
+ifeq ($(BOARD),hx8k-b-evn)
+DEVICE=hx8k
+PACKAGE=ct256
+PROG_TOOL ?= $(ICEPROG_TOOL)
+endif
+
 # TinyFPGA B2
 # iCE40-LP8K-CM81
 # ---------------------------------------------

--- a/ice40/tests/blink/example_tb.v
+++ b/ice40/tests/blink/example_tb.v
@@ -13,7 +13,7 @@ module test;
 	wire ledB;
 	wire ledC;
 	wire ledD;
-	top uut (clk, ledA, ledB, ledC, ledD);
+	top uut (.clk(clk), .LED2(ledA), .LED3(ledB), .LED4(ledC), .LED5(ledD));
 
 	initial begin
 		$dumpfile(`VCDFILE);

--- a/ice40/tests/blink/hx8k-b-evn.pcf
+++ b/ice40/tests/blink/hx8k-b-evn.pcf
@@ -1,0 +1,9 @@
+#set_io LED0 B5
+#set_io LED1 B4
+set_io LED2 A2
+set_io LED3 A1
+set_io LED4 C5
+set_io LED5 C4
+#set_io LED6 B3
+#set_io LED7 C3
+set_io clk J3

--- a/ice40/tests/iceram/Makefile
+++ b/ice40/tests/iceram/Makefile
@@ -1,3 +1,3 @@
 BOARD ?= icestick
 ARCH=ice40
-include ../../make/test-common.mk
+include ../../../make/tests.mk

--- a/ice40/tests/iceram/hx8k-b-evn.pcf
+++ b/ice40/tests/iceram/hx8k-b-evn.pcf
@@ -1,0 +1,9 @@
+#set_io LED0 B5
+set_io LED1 B4
+set_io LED2 A2
+set_io LED3 A1
+set_io LED4 C5
+set_io LED5 C4
+#set_io LED6 B3
+#set_io LED7 C3
+set_io clk J3


### PR DESCRIPTION
Added BOARD=hx8k-b-evn and PCF files for blink and iceRAM.
 * fixed iceRAM test
 * fixed testbinch for blink (example_bit.v order not known)