### PR TITLE
ice40: Fixed <direct connections.

### DIFF
--- a/ice40/devices/top-routing-virt/tiles/dsp/dsp.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/dsp/dsp.pb_type.xml
@@ -6,7 +6,7 @@
  <input  name="DUMMY_IN"  num_pins="4"/>
  <output name="DUMMY_OUT" num_pins="4"/>
  <interconnect>
-  <direct input="BLK_TL-DSP.DUMMY_IN" output="BLK_TL-DSP.DUMMY_OUT"/>
+  <direct><port type="input" name="DUMMY_IN"/><port type="output" name="DUMMY_OUT"/></direct>
  </interconnect>
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2"/>
  <pinlocations pattern="custom">

--- a/ice40/devices/top-routing-virt/tiles/pio/pio.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/pio/pio.pb_type.xml
@@ -35,8 +35,8 @@
 
   <interconnect>
    <!-- SB_IO outputs -->
-   <direct input="BLK_TL-PIO.D_OUT[0]" output="PAD.D_OUT[0]" />
-   <direct input="BLK_TL-PIO.D_OUT[1]" output="PAD.D_OUT[1]" />
+   <direct><port type="input" name="D_OUT[0]"/><port type="output" name="D_OUT[0]" from="PAD" /></direct>
+   <direct><port type="input" name="D_OUT[1]"/><port type="output" name="D_OUT[1]" from="PAD" /></direct>
   </interconnect>
  </mode>
 
@@ -49,8 +49,8 @@
     <output name="inpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <direct input="input.inpad" output="PAD.D_IN[0]"/>
-    <direct input="input.inpad" output="PAD.PIN"    />
+    <direct><port type="input" name="inpad" from="input" /><port type="output" name="D_IN[0]" from="PAD" /></direct>
+    <direct><port type="input" name="inpad" from="input" /><port type="output" name="PIN" from="PAD" /></direct>
    </interconnect>
    <metadata>
     <meta name="hlc_property">disable_pull_up</meta>
@@ -61,9 +61,9 @@
 
   <interconnect>
    <!-- SB_IO inputs -->
-   <direct input="PAD.D_IN[0]" output="BLK_TL-PIO.D_IN[0]"    />
-   <direct input="PAD.D_IN[1]" output="BLK_TL-PIO.D_IN[1]"    />
-   <direct input="PAD.PIN"     output="BLK_TL-PIO.PACKAGE_PIN" />
+   <direct><port type="input" name="D_IN[0]" from="PAD" /><port type="output" name="D_IN[0]"/></direct>
+   <direct><port type="input" name="D_IN[1]" from="PAD" /><port type="output" name="D_IN[1]"/></direct>
+   <direct><port type="input" name="PIN" from="PAD" /><port type="output" name="PACKAGE_PIN"/></direct>
   </interconnect>
 
  </mode>

--- a/ice40/devices/top-routing-virt/tiles/plb/plb.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/plb/plb.pb_type.xml
@@ -37,42 +37,46 @@
  <output name="FCOUT"  num_pins="1"/>
 
  <!-- A BLK_IG-PLB contains the same 'cell' repeated 8 times. -->
- <xi:include href="../../../../cells/plb/plb.pb_type.xml"/>
+ <pb_type name="BLK_IG-PLB" num_pb="1">
+  <xi:include href="../../../../cells/plb/plb.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
+ </pb_type>
 
  <interconnect>
   <!-- LUT inputs -->
-  <direct input="BLK_TL-PLB.lutff_0/in"       output="BLK_IG-PLB.I0"     />
-  <direct input="BLK_TL-PLB.lutff_1/in"       output="BLK_IG-PLB.I1"     />
-  <direct input="BLK_TL-PLB.lutff_2/in"       output="BLK_IG-PLB.I2"     />
-  <direct input="BLK_TL-PLB.lutff_3/in"       output="BLK_IG-PLB.I3"     />
-  <direct input="BLK_TL-PLB.lutff_4/in"       output="BLK_IG-PLB.I4"     />
-  <direct input="BLK_TL-PLB.lutff_5/in"       output="BLK_IG-PLB.I5"     />
-  <direct input="BLK_TL-PLB.lutff_6/in"       output="BLK_IG-PLB.I6"     />
-  <direct input="BLK_TL-PLB.lutff_7/in"       output="BLK_IG-PLB.I7"     />
+  <direct><port type="input" name="lutff_0/in"/><port type="output" name="I0" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_1/in"/><port type="output" name="I1" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_2/in"/><port type="output" name="I2" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_3/in"/><port type="output" name="I3" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_4/in"/><port type="output" name="I4" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_5/in"/><port type="output" name="I5" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_6/in"/><port type="output" name="I6" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_7/in"/><port type="output" name="I7" from="BLK_IG-PLB"/></direct>
 
   <!-- D flip-flop controls -->
-  <direct input="BLK_TL-PLB.lutff_global/clk" output="BLK_IG-PLB.CLK"    />
-  <direct input="BLK_TL-PLB.lutff_global/s_r" output="BLK_IG-PLB.SR"     />
-  <direct input="BLK_TL-PLB.lutff_global/cen" output="BLK_IG-PLB.EN"     />
+  <direct><port type="input" name="lutff_global/clk"/><port type="output" name="CLK" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_global/s_r"/><port type="output" name="SR" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_global/cen"/><port type="output" name="EN" from="BLK_IG-PLB"/></direct>
 
   <!-- D flip-flop outputs -->
-  <direct input="BLK_IG-PLB.O0"         output="BLK_TL-PLB.lutff_0/out"  />
-  <direct input="BLK_IG-PLB.O1"         output="BLK_TL-PLB.lutff_1/out"  />
-  <direct input="BLK_IG-PLB.O2"         output="BLK_TL-PLB.lutff_2/out"  />
-  <direct input="BLK_IG-PLB.O3"         output="BLK_TL-PLB.lutff_3/out"  />
-  <direct input="BLK_IG-PLB.O4"         output="BLK_TL-PLB.lutff_4/out"  />
-  <direct input="BLK_IG-PLB.O5"         output="BLK_TL-PLB.lutff_5/out"  />
-  <direct input="BLK_IG-PLB.O6"         output="BLK_TL-PLB.lutff_6/out"  />
-  <direct input="BLK_IG-PLB.O7"         output="BLK_TL-PLB.lutff_7/out"  />
+  <direct><port type="input" name="O0" from="BLK_IG-PLB" /><port type="output" name="lutff_0/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O1" from="BLK_IG-PLB" /><port type="output" name="lutff_1/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O2" from="BLK_IG-PLB" /><port type="output" name="lutff_2/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O3" from="BLK_IG-PLB" /><port type="output" name="lutff_3/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O4" from="BLK_IG-PLB" /><port type="output" name="lutff_4/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O5" from="BLK_IG-PLB" /><port type="output" name="lutff_5/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O6" from="BLK_IG-PLB" /><port type="output" name="lutff_6/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O7" from="BLK_IG-PLB" /><port type="output" name="lutff_7/out" from="BLK_TL-PLB"/></direct>
 
   <!-- Fast Carry chain
-  <direct input="BLK_TL-PLB.FCIN"        output="BLK_IG-PLB.FCIN" />
-  <direct input="BLK_IG-PLB.FCOUT" output="BLK_TL-PLB.FCOUT"      />
+  <direct><port type="input" name="FCIN"/><port type="output" name="FCIN" from="BLK_IG-PLB" /></direct>
+  <direct><port type="input" name="FCOUT" from="BLK_IG-PLB" /><port type="output" name="FCOUT"/></direct>
        -->
-  <direct input="BLK_TL-PLB.FCIN"        output="BLK_IG-PLB.FCIN" >
+  <direct>
+   <port type="input" name="FCIN"/><port type="output" name="FCIN" from="BLK_IG-PLB" />
    <pack_pattern name="CARRYCHAIN" in_port="BLK_TL-PLB.FCIN" out_port="BLK_IG-PLB.FCIN" />
   </direct>
-  <direct input="BLK_IG-PLB.FCOUT" output="BLK_TL-PLB.FCOUT"      >
+  <direct>
+   <port type="input" name="FCOUT" from="BLK_IG-PLB" /><port type="output" name="FCOUT"/>
    <pack_pattern name="CARRYCHAIN" in_port="BLK_IG-PLB.FCOUT" out_port="BLK_TL-PLB.FCOUT" />
   </direct>
 

--- a/ice40/devices/top-routing-virt/tiles/ram/ram.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/ram/ram.pb_type.xml
@@ -20,102 +20,102 @@
  <xi:include href="../../../../primitives/sb_ram/sb_ram.pb_type.xml"/>
 
  <interconnect>
-  <direct input="SB_RAM.RDATA[0]"  output="BLK_TL-RAM.RDATA[0]"/>
-  <direct input="SB_RAM.RDATA[1]"  output="BLK_TL-RAM.RDATA[1]"/>
-  <direct input="SB_RAM.RDATA[2]"  output="BLK_TL-RAM.RDATA[2]"/>
-  <direct input="SB_RAM.RDATA[3]"  output="BLK_TL-RAM.RDATA[3]"/>
-  <direct input="SB_RAM.RDATA[4]"  output="BLK_TL-RAM.RDATA[4]"/>
-  <direct input="SB_RAM.RDATA[5]"  output="BLK_TL-RAM.RDATA[5]"/>
-  <direct input="SB_RAM.RDATA[6]"  output="BLK_TL-RAM.RDATA[6]"/>
-  <direct input="SB_RAM.RDATA[7]"  output="BLK_TL-RAM.RDATA[7]"/>
-  <direct input="SB_RAM.RDATA[8]"  output="BLK_TL-RAM.RDATA[8]"/>
-  <direct input="SB_RAM.RDATA[9]"  output="BLK_TL-RAM.RDATA[9]"/>
-  <direct input="SB_RAM.RDATA[10]" output="BLK_TL-RAM.RDATA[10]"/>
-  <direct input="SB_RAM.RDATA[11]" output="BLK_TL-RAM.RDATA[11]"/>
-  <direct input="SB_RAM.RDATA[12]" output="BLK_TL-RAM.RDATA[12]"/>
-  <direct input="SB_RAM.RDATA[13]" output="BLK_TL-RAM.RDATA[13]"/>
-  <direct input="SB_RAM.RDATA[14]" output="BLK_TL-RAM.RDATA[14]"/>
-  <direct input="SB_RAM.RDATA[15]" output="BLK_TL-RAM.RDATA[15]"/>
+  <direct><port type="input" name="RDATA[0]"  from="SB_RAM"/><port type="output" name="RDATA[0]" /></direct>
+  <direct><port type="input" name="RDATA[1]"  from="SB_RAM"/><port type="output" name="RDATA[1]" /></direct>
+  <direct><port type="input" name="RDATA[2]"  from="SB_RAM"/><port type="output" name="RDATA[2]" /></direct>
+  <direct><port type="input" name="RDATA[3]"  from="SB_RAM"/><port type="output" name="RDATA[3]" /></direct>
+  <direct><port type="input" name="RDATA[4]"  from="SB_RAM"/><port type="output" name="RDATA[4]" /></direct>
+  <direct><port type="input" name="RDATA[5]"  from="SB_RAM"/><port type="output" name="RDATA[5]" /></direct>
+  <direct><port type="input" name="RDATA[6]"  from="SB_RAM"/><port type="output" name="RDATA[6]" /></direct>
+  <direct><port type="input" name="RDATA[7]"  from="SB_RAM"/><port type="output" name="RDATA[7]" /></direct>
+  <direct><port type="input" name="RDATA[8]"  from="SB_RAM"/><port type="output" name="RDATA[8]" /></direct>
+  <direct><port type="input" name="RDATA[9]"  from="SB_RAM"/><port type="output" name="RDATA[9]" /></direct>
+  <direct><port type="input" name="RDATA[10]" from="SB_RAM"/><port type="output" name="RDATA[10]"/></direct>
+  <direct><port type="input" name="RDATA[11]" from="SB_RAM"/><port type="output" name="RDATA[11]"/></direct>
+  <direct><port type="input" name="RDATA[12]" from="SB_RAM"/><port type="output" name="RDATA[12]"/></direct>
+  <direct><port type="input" name="RDATA[13]" from="SB_RAM"/><port type="output" name="RDATA[13]"/></direct>
+  <direct><port type="input" name="RDATA[14]" from="SB_RAM"/><port type="output" name="RDATA[14]"/></direct>
+  <direct><port type="input" name="RDATA[15]" from="SB_RAM"/><port type="output" name="RDATA[15]"/></direct>
 
-  <direct input="BLK_TL-RAM.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
-  <direct input="BLK_TL-RAM.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
-  <direct input="BLK_TL-RAM.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
-  <direct input="BLK_TL-RAM.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
-  <direct input="BLK_TL-RAM.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
-  <direct input="BLK_TL-RAM.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
-  <direct input="BLK_TL-RAM.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
-  <direct input="BLK_TL-RAM.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
-  <direct input="BLK_TL-RAM.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
-  <direct input="BLK_TL-RAM.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
-  <direct input="BLK_TL-RAM.RADDR[10]" output="SB_RAM.RADDR[10]"/>
+  <direct><port type="input" name="RADDR[0]" /><port type="output" name="RADDR[0]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[1]" /><port type="output" name="RADDR[1]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[2]" /><port type="output" name="RADDR[2]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[3]" /><port type="output" name="RADDR[3]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[4]" /><port type="output" name="RADDR[4]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[5]" /><port type="output" name="RADDR[5]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[6]" /><port type="output" name="RADDR[6]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[7]" /><port type="output" name="RADDR[7]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[8]" /><port type="output" name="RADDR[8]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[9]" /><port type="output" name="RADDR[9]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="RADDR[10]"/><port type="output" name="RADDR[10]" from="SB_RAM"/></direct>
 
-  <direct input="BLK_TL-RAM.RE"        output="SB_RAM.RE" />
-  <direct input="BLK_TL-RAM.RCLKE"     output="SB_RAM.RCLKE" />
-  <direct input="BLK_TL-RAM.RCLK"      output="SB_RAM.RCLK" />
+  <direct><port type="input" name="RE"/><port type="output" name="RE" from="SB_RAM"/></direct>
+  <direct><port type="input" name="RCLKE"/><port type="output" name="RCLKE" from="SB_RAM"/></direct>
+  <direct><port type="input" name="RCLK"/><port type="output" name="RCLK" from="SB_RAM"/></direct>
 
-  <direct input="BLK_TL-RAM.WDATA[0]" output="SB_RAM.WDATA[0]"/>
-  <direct input="BLK_TL-RAM.WDATA[1]" output="SB_RAM.WDATA[1]"/>
-  <direct input="BLK_TL-RAM.WDATA[2]" output="SB_RAM.WDATA[2]"/>
-  <direct input="BLK_TL-RAM.WDATA[3]" output="SB_RAM.WDATA[3]"/>
-  <direct input="BLK_TL-RAM.WDATA[4]" output="SB_RAM.WDATA[4]"/>
-  <direct input="BLK_TL-RAM.WDATA[5]" output="SB_RAM.WDATA[5]"/>
-  <direct input="BLK_TL-RAM.WDATA[6]" output="SB_RAM.WDATA[6]"/>
-  <direct input="BLK_TL-RAM.WDATA[7]" output="SB_RAM.WDATA[7]"/>
-  <direct input="BLK_TL-RAM.WDATA[8]" output="SB_RAM.WDATA[8]"/>
-  <direct input="BLK_TL-RAM.WDATA[9]" output="SB_RAM.WDATA[9]"/>
-  <direct input="BLK_TL-RAM.WDATA[10]" output="SB_RAM.WDATA[10]"/>
-  <direct input="BLK_TL-RAM.WDATA[11]" output="SB_RAM.WDATA[11]"/>
-  <direct input="BLK_TL-RAM.WDATA[12]" output="SB_RAM.WDATA[12]"/>
-  <direct input="BLK_TL-RAM.WDATA[13]" output="SB_RAM.WDATA[13]"/>
-  <direct input="BLK_TL-RAM.WDATA[14]" output="SB_RAM.WDATA[14]"/>
-  <direct input="BLK_TL-RAM.WDATA[15]" output="SB_RAM.WDATA[15]"/>
+  <direct><port type="input" name="WDATA[0]" /><port type="output" name="WDATA[0]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[1]" /><port type="output" name="WDATA[1]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[2]" /><port type="output" name="WDATA[2]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[3]" /><port type="output" name="WDATA[3]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[4]" /><port type="output" name="WDATA[4]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[5]" /><port type="output" name="WDATA[5]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[6]" /><port type="output" name="WDATA[6]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[7]" /><port type="output" name="WDATA[7]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[8]" /><port type="output" name="WDATA[8]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[9]" /><port type="output" name="WDATA[9]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[10]"/><port type="output" name="WDATA[10]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[11]"/><port type="output" name="WDATA[11]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[12]"/><port type="output" name="WDATA[12]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[13]"/><port type="output" name="WDATA[13]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[14]"/><port type="output" name="WDATA[14]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WDATA[15]"/><port type="output" name="WDATA[15]" from="SB_RAM"/></direct>
 
-  <direct input="BLK_TL-RAM.MASK[0]" output="SB_RAM.MASK[0]"/>
-  <direct input="BLK_TL-RAM.MASK[1]" output="SB_RAM.MASK[1]"/>
-  <direct input="BLK_TL-RAM.MASK[2]" output="SB_RAM.MASK[2]"/>
-  <direct input="BLK_TL-RAM.MASK[3]" output="SB_RAM.MASK[3]"/>
-  <direct input="BLK_TL-RAM.MASK[4]" output="SB_RAM.MASK[4]"/>
-  <direct input="BLK_TL-RAM.MASK[5]" output="SB_RAM.MASK[5]"/>
-  <direct input="BLK_TL-RAM.MASK[6]" output="SB_RAM.MASK[6]"/>
-  <direct input="BLK_TL-RAM.MASK[7]" output="SB_RAM.MASK[7]"/>
-  <direct input="BLK_TL-RAM.MASK[8]" output="SB_RAM.MASK[8]"/>
-  <direct input="BLK_TL-RAM.MASK[9]" output="SB_RAM.MASK[9]"/>
-  <direct input="BLK_TL-RAM.MASK[10]" output="SB_RAM.MASK[10]"/>
-  <direct input="BLK_TL-RAM.MASK[11]" output="SB_RAM.MASK[11]"/>
-  <direct input="BLK_TL-RAM.MASK[12]" output="SB_RAM.MASK[12]"/>
-  <direct input="BLK_TL-RAM.MASK[13]" output="SB_RAM.MASK[13]"/>
-  <direct input="BLK_TL-RAM.MASK[14]" output="SB_RAM.MASK[14]"/>
-  <direct input="BLK_TL-RAM.MASK[15]" output="SB_RAM.MASK[15]"/>
+  <direct><port type="input" name="MASK[0]" /><port type="output" name="MASK[0]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[1]" /><port type="output" name="MASK[1]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[2]" /><port type="output" name="MASK[2]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[3]" /><port type="output" name="MASK[3]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[4]" /><port type="output" name="MASK[4]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[5]" /><port type="output" name="MASK[5]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[6]" /><port type="output" name="MASK[6]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[7]" /><port type="output" name="MASK[7]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[8]" /><port type="output" name="MASK[8]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[9]" /><port type="output" name="MASK[9]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[10]"/><port type="output" name="MASK[10]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[11]"/><port type="output" name="MASK[11]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[12]"/><port type="output" name="MASK[12]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[13]"/><port type="output" name="MASK[13]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[14]"/><port type="output" name="MASK[14]" from="SB_RAM"/></direct>
+  <direct><port type="input" name="MASK[15]"/><port type="output" name="MASK[15]" from="SB_RAM"/></direct>
 
-  <direct input="BLK_TL-RAM.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
-  <direct input="BLK_TL-RAM.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
-  <direct input="BLK_TL-RAM.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
-  <direct input="BLK_TL-RAM.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
-  <direct input="BLK_TL-RAM.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
-  <direct input="BLK_TL-RAM.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
-  <direct input="BLK_TL-RAM.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
-  <direct input="BLK_TL-RAM.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
-  <direct input="BLK_TL-RAM.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
-  <direct input="BLK_TL-RAM.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
-  <direct input="BLK_TL-RAM.WADDR[10]" output="SB_RAM.WADDR[10]"/>
+  <direct><port type="input" name="WADDR[0]" /><port type="output" name="WADDR[0]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[1]" /><port type="output" name="WADDR[1]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[2]" /><port type="output" name="WADDR[2]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[3]" /><port type="output" name="WADDR[3]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[4]" /><port type="output" name="WADDR[4]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[5]" /><port type="output" name="WADDR[5]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[6]" /><port type="output" name="WADDR[6]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[7]" /><port type="output" name="WADDR[7]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[8]" /><port type="output" name="WADDR[8]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[9]" /><port type="output" name="WADDR[9]"  from="SB_RAM"/></direct>
+  <direct><port type="input" name="WADDR[10]"/><port type="output" name="WADDR[10]" from="SB_RAM"/></direct>
 
-  <direct input="BLK_TL-RAM.WE"          output="SB_RAM.WE" />
-  <direct input="BLK_TL-RAM.WCLKE"       output="SB_RAM.WCLKE" />
-  <direct input="BLK_TL-RAM.WCLK"        output="SB_RAM.WCLK" />
+  <direct><port type="input" name="WE"/><port type="output" name="WE" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WCLKE"/><port type="output" name="WCLKE" from="SB_RAM"/></direct>
+  <direct><port type="input" name="WCLK"/><port type="output" name="WCLK" from="SB_RAM"/></direct>
  </interconnect>
 
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2">
   <fc_override fc_type="abs" fc_val="2" port_name="RDATA" segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="RADDR"  segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="RE"     segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="RCLKE"  segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="RCLK"   segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="RADDR" segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="RE"    segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="RCLKE" segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="RCLK"  segment_name="local"/>
   <fc_override fc_type="abs" fc_val="2" port_name="WDATA" segment_name="local"/>
   <fc_override fc_type="abs" fc_val="2" port_name="MASK"  segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="WADDR"  segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="WE"     segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="WCLKE"  segment_name="local"/>
-  <fc_override fc_type="abs" fc_val="2" port_name="WCLK"   segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="WADDR" segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="WE"    segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="WCLKE" segment_name="local"/>
+  <fc_override fc_type="abs" fc_val="2" port_name="WCLK"  segment_name="local"/>
  </fc>
 
  <pinlocations pattern="custom">


### PR DESCRIPTION
These were missed in #183.

Fixes the following from @elmsfu;
```
Error 1: ice40/build/ice40-top-routing-virt-up5k/arch.xml:1136 Expected 'name' attribute on node 'direct'

offending line 1136:
 <direct input="BLK_TL-PLB.lutff_0/in" output="BLK_IG-PLB.I0"/>
```