### PR TITLE
ecp5: Simulation model fixes

### DIFF
--- a/ecp5/primitives/slice/CCU2C/CCU2C.sim.v
+++ b/ecp5/primitives/slice/CCU2C/CCU2C.sim.v
@@ -8,8 +8,9 @@ module CCU2C(input CIN, A0, B0, C0, D0, A1, B1, C1, D1,
 	parameter INJECT1_1 = "YES";
 
 	// First half
-	wire LUT4_0 = INIT0[{D0, C0, B0, A0}];
-	wire LUT2_0 = INIT0[{2'b00, B0, A0}];
+	wire LUT4_0, LUT2_0;
+	LUT4 #(.INIT(INIT0)) lut4_0(.A(A0), .B(B0), .C(C0), .D(D0), .Z(LUT4_0));
+	LUT2 #(.INIT(INIT0[3:0])) lut2_0(.A(A0), .B(B0), .Z(LUT2_0));
 
 	wire gated_cin_0 = (INJECT1_0 == "YES") ? 1'b0 : CIN;
 	assign S0 = LUT4_0 ^ gated_cin_0;
@@ -18,8 +19,9 @@ module CCU2C(input CIN, A0, B0, C0, D0, A1, B1, C1, D1,
 	wire cout_0 = (~LUT4_0 & gated_lut2_0) | (LUT4_0 & CIN);
 
 	// Second half
-	wire LUT4_1 = INIT1[{D1, C1, B1, A1}];
-	wire LUT2_1 = INIT1[{2'b00, B1, A1}];
+	wire LUT4_1, LUT2_1;
+	LUT4 #(.INIT(INIT1)) lut4_1(.A(A1), .B(B1), .C(C1), .D(D1), .Z(LUT4_1));
+	LUT2 #(.INIT(INIT1[3:0])) lut2_1(.A(A1), .B(B1), .Z(LUT2_1));
 
 	wire gated_cin_1 = (INJECT1_1 == "YES") ? 1'b0 : cout_0;
 	assign S1 = LUT4_1 ^ gated_cin_1;

--- a/ecp5/primitives/slice/DPR16X4C/DPR16X4C.sim.v
+++ b/ecp5/primitives/slice/DPR16X4C/DPR16X4C.sim.v
@@ -43,7 +43,7 @@ module DPR16X4C (
 	integer i;
 	initial begin
 		for (i = 0; i < 15; i = i + 1) begin
-			ram[i] = conv_initval[4*i +: 4];
+			ram[i] <= conv_initval[4*i +: 4];
 		end
 	end
 

--- a/ecp5/primitives/slice/LUT2/LUT2.sim.v
+++ b/ecp5/primitives/slice/LUT2/LUT2.sim.v
@@ -1,0 +1,6 @@
+`default_nettype none
+module LUT2(input A, B, output Z);
+    parameter [3:0] INIT = 4'h0;
+    wire [1:0] s1 = B ?     INIT[ 3:2] :     INIT[1:0];
+    assign Z =      A ?          s1[1] :         s1[0];
+endmodule

--- a/ecp5/primitives/slice/LUT4/LUT4.sim.v
+++ b/ecp5/primitives/slice/LUT4/LUT4.sim.v
@@ -1,5 +1,8 @@
 `default_nettype none
 module LUT4(input A, B, C, D, output Z);
-	parameter [15:0] INIT = 16'h0000;
-	assign Z = INIT[{D, C, B, A}];
+    parameter [15:0] INIT = 16'h0000;
+    wire [7:0] s3 = D ?     INIT[15:8] :     INIT[7:0];
+    wire [3:0] s2 = C ?       s3[ 7:4] :       s3[3:0];
+    wire [1:0] s1 = B ?       s2[ 3:2] :       s2[1:0];
+    assign Z =      A ?          s1[1] :         s1[0];
 endmodule

--- a/ecp5/primitives/slice/TRELLIS_DPR16X4/TRELLIS_DPR16X4.sim.v
+++ b/ecp5/primitives/slice/TRELLIS_DPR16X4/TRELLIS_DPR16X4.sim.v
@@ -20,10 +20,14 @@ module TRELLIS_DPR16X4 (
 
 	wire muxwck = (WCKMUX == "INV") ? ~WCK : WCK;
 
-	wire muxwre = (WREMUX == "1") ? 1'b1 :
-							  (WREMUX == "0") ? 1'b0 :
-							  (WREMUX == "INV") ? ~WRE :
-							  WRE;
+	reg muxwre;
+	always @(*)
+		case (WREMUX)
+			"1": muxwre = 1'b1;
+			"0": muxwre = 1'b0;
+			"INV": muxwre = ~WRE;
+			default: muxwre = WRE;
+		endcase
 
 	always @(posedge muxwck)
 		if (muxwre)

--- a/ecp5/primitives/slice/TRELLIS_FF/TRELLIS_FF.sim.v
+++ b/ecp5/primitives/slice/TRELLIS_FF/TRELLIS_FF.sim.v
@@ -7,10 +7,14 @@ module TRELLIS_FF(input CLK, LSR, CE, DI, output reg Q);
 	parameter SRMODE = "LSR_OVER_CE";
 	parameter REGSET = "RESET";
 
-	wire muxce = (CEMUX == "1") ? 1'b1 :
-	             (CEMUX == "0") ? 1'b0 :
-							 (CEMUX == "INV") ? ~CE :
-							 CE;
+	reg muxce;
+	always @(*)
+		case (CEMUX)
+			"1": muxce = 1'b1;
+			"0": muxce = 1'b0;
+			"INV": muxce = ~CE;
+			default: muxce = CE;
+		endcase
 
 	wire muxlsr = (LSRMUX == "INV") ? ~LSR : LSR;
 	wire muxclk = (CLKMUX == "INV") ? ~CLK : CLK;
@@ -24,13 +28,13 @@ module TRELLIS_FF(input CLK, LSR, CE, DI, output reg Q);
 			always @(posedge muxclk, posedge muxlsr)
 				if (muxlsr)
 					Q <= srval;
-				else
+				else if (muxce)
 					Q <= DI;
 		end else begin
 			always @(posedge muxclk)
 				if (muxlsr)
 					Q <= srval;
-				else
+				else if (muxce)
 					Q <= DI;
 		end
 	endgenerate

--- a/ecp5/primitives/slice/TRELLIS_RAM16X2/TRELLIS_RAM16X2.sim.v
+++ b/ecp5/primitives/slice/TRELLIS_RAM16X2/TRELLIS_RAM16X2.sim.v
@@ -21,10 +21,15 @@ module TRELLIS_RAM16X2 (
 
 	wire muxwck = (WCKMUX == "INV") ? ~WCK : WCK;
 
-	wire muxwre = (WREMUX == "1") ? 1'b1 :
-							  (WREMUX == "0") ? 1'b0 :
-							  (WREMUX == "INV") ? ~WRE :
-							  WRE;
+	reg muxwre;
+	always @(*)
+		case (WREMUX)
+			"1": muxwre = 1'b1;
+			"0": muxwre = 1'b0;
+			"INV": muxwre = ~WRE;
+			default: muxwre = WRE;
+		endcase
+
 
 	always @(posedge muxwck)
 		if (muxwre)


### PR DESCRIPTION
 - Change how LUTs are implemented so that "don't care" inputs at 'X' don't force the output to 'X' 
 - Fix missing "cemux" conditional in TRELLIS_FF
 - Other small tweaks