### PR TITLE
ice40/tests: add support for TinyFPGA BX for blink and iceram

### DIFF
--- a/ice40/make/tests.mk
+++ b/ice40/make/tests.mk
@@ -53,7 +53,25 @@ PROG_TOOL=$(CONDA_DIR)/bin/tinyfpgab
 PROG_CMD ?= $(PROG_TOOL) --program
 
 $(PROG_TOOL):
-	pip install tinyfpgab
+	$(CONDA_PIP) install tinyfpgab
+
+endif
+endif
+
+
+# TinyFPGA BX
+# iCE40-LP8K-CM81
+# ---------------------------------------------
+ifeq ($(BOARD),tinyfpga-bx)
+DEVICE=hx8k
+PACKAGE=cm81
+
+ifeq ($(PROG_TOOL),)
+PROG_TOOL=$(CONDA_DIR)/bin/tinyprog
+PROG_CMD ?= $(PROG_TOOL) -p
+
+$(PROG_TOOL):
+	$(CONDA_PIP) install tinyprog
 
 endif
 endif

--- a/ice40/tests/blink/tinyfpga-bx.pcf
+++ b/ice40/tests/blink/tinyfpga-bx.pcf
@@ -1,0 +1,10 @@
+set_io --warn-no-port LED3 J9
+set_io --warn-no-port LED4 E8
+set_io --warn-no-port LED5 J2
+
+# LED
+set_io --warn-no-port LED2 B3
+
+# 16MHz clock
+set_io --warn-no-port clk B2 # input
+

--- a/ice40/tests/iceram/tinyfpga-bx.pcf
+++ b/ice40/tests/iceram/tinyfpga-bx.pcf
@@ -1,0 +1,11 @@
+set_io --warn-no-port LED2 G1
+set_io --warn-no-port LED3 J9
+set_io --warn-no-port LED4 E8
+set_io --warn-no-port LED5 J2
+
+# LED
+set_io --warn-no-port LED1 B3
+
+# 16MHz clock
+set_io --warn-no-port clk B2 # input
+


### PR DESCRIPTION
 * Add PCF files for blink and iceram (tested on hardware)
 * Add tinyfpga-bx to ice40 BOARD