### PR TITLE
ice40: Fixing the flip flop primitive

### DIFF
--- a/ice40/cells/lutff/lutff.pb_type.xml
+++ b/ice40/cells/lutff/lutff.pb_type.xml
@@ -7,14 +7,18 @@
  <output name="LCOUT" num_pins="1"/>
 
  <!-- FF -->
- <clock  name="PCLK"  num_pins="1"/>
- <clock  name="NCLK"  num_pins="1"/>
- <clock  name="PCEN"  num_pins="1"/>
- <clock  name="NCEN"  num_pins="1"/>
+ <clock  name="PCLK"        num_pins="1"/>
+ <clock  name="NCLK"        num_pins="1"/>
+ <clock  name="PCLK+CEN"    num_pins="1"/>
+ <clock  name="NCLK+CEN"    num_pins="1"/>
+ <clock  name="PCLK+SR"     num_pins="1"/>
+ <clock  name="NCLK+SR"     num_pins="1"/>
+ <clock  name="PCLK+CEN+SR" num_pins="1"/>
+ <clock  name="NCLK+CEN+SR" num_pins="1"/>
 
- <input  name="EN"    num_pins="1"/>
- <input  name="SR"    num_pins="1"/>
- <output name="O"     num_pins="1"/>
+ <input  name="EN" num_pins="1"/>
+ <input  name="SR" num_pins="1"/>
+ <output name="O"  num_pins="1"/>
 
  <!-- CARRY -->
  <input  name="FCIN"  num_pins="1"/>
@@ -56,14 +60,19 @@
   <direct name="LCOUT"    input="BEL_LT-LUT.out"                         output="BLK_IG-LUTFF.LCOUT" />
 
   <!-- LUT -->
-  <direct name="FF.PCLK[0]" input="BLK_IG-LUTFF.PCLK" output="BEL_FF-SB_FF.PCLK" />
-  <direct name="FF.NCLK[0]" input="BLK_IG-LUTFF.NCLK" output="BEL_FF-SB_FF.NCLK" />
-  <direct name="FF.PCEN[0]" input="BLK_IG-LUTFF.PCEN" output="BEL_FF-SB_FF.PCEN" />
-  <direct name="FF.NCEN[0]" input="BLK_IG-LUTFF.NCEN" output="BEL_FF-SB_FF.NCEN" />
-  <direct name="FF.E[0]"    input="BLK_IG-LUTFF.EN"   output="BEL_FF-SB_FF.E"    />
-  <direct name="FF.R[0]"    input="BLK_IG-LUTFF.SR"   output="BEL_FF-SB_FF.R"    />
-  <direct name="FF.S[0]"    input="BLK_IG-LUTFF.SR"   output="BEL_FF-SB_FF.S"    />
-  <direct name="FF.D[0]"    input="BEL_LT-LUT.out"    output="BEL_FF-SB_FF.D"     >
+  <direct name="FF.PCLK"        input="BLK_IG-LUTFF.PCLK"        output="BEL_FF-SB_FF.PCLK"        />
+  <direct name="FF.NCLK"        input="BLK_IG-LUTFF.NCLK"        output="BEL_FF-SB_FF.NCLK"        />
+  <direct name="FF.PCLK+CEN"    input="BLK_IG-LUTFF.PCLK+CEN"    output="BEL_FF-SB_FF.PCLK+CEN"    />
+  <direct name="FF.NCLK+CEN"    input="BLK_IG-LUTFF.NCLK+CEN"    output="BEL_FF-SB_FF.NCLK+CEN"    />
+  <direct name="FF.PCLK+SR"     input="BLK_IG-LUTFF.PCLK+SR"     output="BEL_FF-SB_FF.PCLK+SR"     />
+  <direct name="FF.NCLK+SR"     input="BLK_IG-LUTFF.NCLK+SR"     output="BEL_FF-SB_FF.NCLK+SR"     />
+  <direct name="FF.PCLK+CEN+SR" input="BLK_IG-LUTFF.PCLK+CEN+SR" output="BEL_FF-SB_FF.PCLK+CEN+SR" />
+  <direct name="FF.NCLK+CEN+SR" input="BLK_IG-LUTFF.NCLK+CEN+SR" output="BEL_FF-SB_FF.NCLK+CEN+SR" />
+
+  <direct name="FF.E"           input="BLK_IG-LUTFF.EN"          output="BEL_FF-SB_FF.E"           />
+  <direct name="FF.R"           input="BLK_IG-LUTFF.SR"          output="BEL_FF-SB_FF.R"           />
+  <direct name="FF.S"           input="BLK_IG-LUTFF.SR"          output="BEL_FF-SB_FF.S"           />
+  <direct name="FF.D"           input="BEL_LT-LUT.out"           output="BEL_FF-SB_FF.D"            >
    <pack_pattern name="LUT+FF" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
   </direct>
 

--- a/ice40/cells/lutff/lutff.pb_type.xml
+++ b/ice40/cells/lutff/lutff.pb_type.xml
@@ -73,7 +73,27 @@
   <direct name="FF.R"           input="BLK_IG-LUTFF.SR"          output="BEL_FF-SB_FF.R"           />
   <direct name="FF.S"           input="BLK_IG-LUTFF.SR"          output="BEL_FF-SB_FF.S"           />
   <direct name="FF.D"           input="BEL_LT-LUT.out"           output="BEL_FF-SB_FF.D"            >
-   <pack_pattern name="LUT+FF" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFA" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFB" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFC" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFD" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFE" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFF" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFG" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFH" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFI" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFJ" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFK" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFL" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFM" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFN" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFO" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFP" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFQ" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFR" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFS" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFT" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+   <pack_pattern name="LUT+FFU" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
   </direct>
 
   <direct name="DISABLE_FF" input="BEL_LT-LUT.out" output="BLK_IG-DISABLE_FF.I" />

--- a/ice40/cells/plb/plb.pb_type.xml
+++ b/ice40/cells/plb/plb.pb_type.xml
@@ -39,18 +39,22 @@
  <pb_type name="BLK_IG-MODE_CLK" num_pb="1">
   <input  name="I" num_pins="1"/>
 
-  <output name="PCLK" num_pins="1"/>
-  <output name="PCEN" num_pins="1"/>
+  <output name="PCLK"        num_pins="1"/>
+  <output name="PCLK+CEN"    num_pins="1"/>
+  <output name="PCLK+SR"     num_pins="1"/>
+  <output name="PCLK+CEN+SR" num_pins="1"/>
 
-  <output name="NCLK" num_pins="1"/>
-  <output name="NCEN" num_pins="1"/>
+  <output name="NCLK"        num_pins="1"/>
+  <output name="NCLK+CEN"    num_pins="1"/>
+  <output name="NCLK+SR"     num_pins="1"/>
+  <output name="NCLK+CEN+SR" num_pins="1"/>
 
   <mode name="BLK_IG-PCLK">
    <pb_type name="BLK_IG-BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property"># Positive Clk, CEN constant 1</meta>
+     <meta name="hlc_property"># PosClk, CEN constant 1, SR constant 0</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
@@ -64,13 +68,41 @@
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property"># Positive Clk, CEN in use</meta>
+     <meta name="hlc_property"># PosClk, CEN in use, SR constant 0</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
     <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCEN"/></direct>
+    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK+CEN"/></direct>
+   </interconnect>
+  </mode>
+  <mode name="BLK_IG-PCLK+SR">
+   <pb_type name="BLK_IG-BUF" num_pb="1">
+    <input  name="I" num_pins="1"/>
+    <output name="O" num_pins="1"/>
+    <metadata>
+     <meta name="hlc_property"># PosClk, CEN constant 0, SR in use</meta>
+    </metadata>
+    <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
+   </pb_type>
+   <interconnect>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
+    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK+SR"/></direct>
+   </interconnect>
+  </mode>
+  <mode name="BLK_IG-PCLK+CEN+SR">
+   <pb_type name="BLK_IG-BUF" num_pb="1">
+    <input  name="I" num_pins="1"/>
+    <output name="O" num_pins="1"/>
+    <metadata>
+     <meta name="hlc_property"># PosClk, CEN in use, SR in use</meta>
+    </metadata>
+    <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
+   </pb_type>
+   <interconnect>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
+    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK+CEN+SR"/></direct>
    </interconnect>
   </mode>
   <mode name="BLK_IG-NCLK">
@@ -78,7 +110,7 @@
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property">NegClk # CEN constant 1</meta>
+     <meta name="hlc_property">NegClk # CEN constant 1, SR constant 0</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
@@ -92,13 +124,41 @@
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property">NegClk # CEN in use</meta>
+     <meta name="hlc_property">NegClk # CEN in use, SR constant 0</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
     <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCEN"/></direct>
+    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK+CEN"/></direct>
+   </interconnect>
+  </mode>
+  <mode name="BLK_IG-NCLK+SR">
+   <pb_type name="BLK_IG-BUF" num_pb="1">
+    <input  name="I" num_pins="1"/>
+    <output name="O" num_pins="1"/>
+    <metadata>
+     <meta name="hlc_property">NegClk # CEN constant 0, SR in use</meta>
+    </metadata>
+    <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
+   </pb_type>
+   <interconnect>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
+    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK+SR"/></direct>
+   </interconnect>
+  </mode>
+  <mode name="BLK_IG-NCLK+CEN+SR">
+   <pb_type name="BLK_IG-BUF" num_pb="1">
+    <input  name="I" num_pins="1"/>
+    <output name="O" num_pins="1"/>
+    <metadata>
+     <meta name="hlc_property">NegClk # CEN in use, SR in use</meta>
+    </metadata>
+    <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
+   </pb_type>
+   <interconnect>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
+    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK+CEN+SR"/></direct>
    </interconnect>
   </mode>
  </pb_type>
@@ -192,10 +252,14 @@
   <direct name="I0[1]" input="BLK_IG-PLB.I0[1]"     output="BLK_IG-LUTFF[0].I[1]" />
   <direct name="I0[2]" input="BLK_IG-PLB.I0[2]"     output="BLK_IG-LUTFF[0].I[2]" />
   <direct name="I0[3]" input="BLK_IG-PLB.I0[3]"     output="BLK_IG-LUTFF[0].I[3]" />
-  <direct name="PC0"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[0].PCLK" />
-  <direct name="NC0"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[0].NCLK" />
-  <direct name="PCE0"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[0].PCEN" />
-  <direct name="NCE0"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[0].NCEN" />
+  <direct name="PC0"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[0].PCLK"        />
+  <direct name="NC0"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[0].NCLK"        />
+  <direct name="PCE0"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[0].PCLK+CEN"    />
+  <direct name="NCE0"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[0].NCLK+CEN"    />
+  <direct name="PCS0"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[0].PCLK+SR"     />
+  <direct name="NCS0"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[0].NCLK+SR"     />
+  <direct name="PCES0" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[0].PCLK+CEN+SR" />
+  <direct name="NCES0" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[0].NCLK+CEN+SR" />
   <direct name="E0"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[0].EN"   />
   <direct name="S0"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[0].SR"   />
   <direct name="O0"    input="BLK_IG-LUTFF[0].O"    output="BLK_IG-PLB.O0"        />
@@ -205,10 +269,14 @@
   <direct name="I1[1]" input="BLK_IG-PLB.I1[1]"     output="BLK_IG-LUTFF[1].I[1]" />
   <direct name="I1[2]" input="BLK_IG-PLB.I1[2]"     output="BLK_IG-LUTFF[1].I[2]" />
   <direct name="I1[3]" input="BLK_IG-PLB.I1[3]"     output="BLK_IG-LUTFF[1].I[3]" />
-  <direct name="PC1"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[1].PCLK" />
-  <direct name="NC1"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[1].NCLK" />
-  <direct name="PCE1"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[1].PCEN" />
-  <direct name="NCE1"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[1].NCEN" />
+  <direct name="PC1"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[1].PCLK"        />
+  <direct name="NC1"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[1].NCLK"        />
+  <direct name="PCE1"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[1].PCLK+CEN"    />
+  <direct name="NCE1"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[1].NCLK+CEN"    />
+  <direct name="PCS1"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[1].PCLK+SR"     />
+  <direct name="NCS1"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[1].NCLK+SR"     />
+  <direct name="PCES1" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[1].PCLK+CEN+SR" />
+  <direct name="NCES1" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[1].NCLK+CEN+SR" />
   <direct name="E1"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[1].EN"   />
   <direct name="S1"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[1].SR"   />
   <direct name="O1"    input="BLK_IG-LUTFF[1].O"    output="BLK_IG-PLB.O1"        />
@@ -218,10 +286,14 @@
   <direct name="I2[1]" input="BLK_IG-PLB.I2[1]"     output="BLK_IG-LUTFF[2].I[1]" />
   <direct name="I2[2]" input="BLK_IG-PLB.I2[2]"     output="BLK_IG-LUTFF[2].I[2]" />
   <direct name="I2[3]" input="BLK_IG-PLB.I2[3]"     output="BLK_IG-LUTFF[2].I[3]" />
-  <direct name="PC2"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[2].PCLK" />
-  <direct name="NC2"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[2].NCLK" />
-  <direct name="PCE2"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[2].PCEN" />
-  <direct name="NCE2"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[2].NCEN" />
+  <direct name="PC2"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[2].PCLK"        />
+  <direct name="NC2"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[2].NCLK"        />
+  <direct name="PCE2"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[2].PCLK+CEN"    />
+  <direct name="NCE2"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[2].NCLK+CEN"    />
+  <direct name="PCS2"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[2].PCLK+SR"     />
+  <direct name="NCS2"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[2].NCLK+SR"     />
+  <direct name="PCES2" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[2].PCLK+CEN+SR" />
+  <direct name="NCES2" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[2].NCLK+CEN+SR" />
   <direct name="E2"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[2].EN"   />
   <direct name="S2"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[2].SR"   />
   <direct name="O2"    input="BLK_IG-LUTFF[2].O"    output="BLK_IG-PLB.O2"        />
@@ -231,10 +303,14 @@
   <direct name="I3[1]" input="BLK_IG-PLB.I3[1]"     output="BLK_IG-LUTFF[3].I[1]" />
   <direct name="I3[2]" input="BLK_IG-PLB.I3[2]"     output="BLK_IG-LUTFF[3].I[2]" />
   <direct name="I3[3]" input="BLK_IG-PLB.I3[3]"     output="BLK_IG-LUTFF[3].I[3]" />
-  <direct name="PC3"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[3].PCLK" />
-  <direct name="NC3"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[3].NCLK" />
-  <direct name="PCE3"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[3].PCEN" />
-  <direct name="NCE3"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[3].NCEN" />
+  <direct name="PC3"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[3].PCLK"        />
+  <direct name="NC3"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[3].NCLK"        />
+  <direct name="PCE3"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[3].PCLK+CEN"    />
+  <direct name="NCE3"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[3].NCLK+CEN"    />
+  <direct name="PCS3"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[3].PCLK+SR"     />
+  <direct name="NCS3"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[3].NCLK+SR"     />
+  <direct name="PCES3" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[3].PCLK+CEN+SR" />
+  <direct name="NCES3" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[3].NCLK+CEN+SR" />
   <direct name="E3"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[3].EN"   />
   <direct name="S3"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[3].SR"   />
   <direct name="O3"    input="BLK_IG-LUTFF[3].O"    output="BLK_IG-PLB.O3"        />
@@ -244,10 +320,14 @@
   <direct name="I4[1]" input="BLK_IG-PLB.I4[1]"     output="BLK_IG-LUTFF[4].I[1]" />
   <direct name="I4[2]" input="BLK_IG-PLB.I4[2]"     output="BLK_IG-LUTFF[4].I[2]" />
   <direct name="I4[3]" input="BLK_IG-PLB.I4[3]"     output="BLK_IG-LUTFF[4].I[3]" />
-  <direct name="PC4"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[4].PCLK" />
-  <direct name="NC4"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[4].NCLK" />
-  <direct name="PCE4"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[4].PCEN" />
-  <direct name="NCE4"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[4].NCEN" />
+  <direct name="PC4"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[4].PCLK"        />
+  <direct name="NC4"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[4].NCLK"        />
+  <direct name="PCE4"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[4].PCLK+CEN"    />
+  <direct name="NCE4"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[4].NCLK+CEN"    />
+  <direct name="PCS4"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[4].PCLK+SR"     />
+  <direct name="NCS4"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[4].NCLK+SR"     />
+  <direct name="PCES4" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[4].PCLK+CEN+SR" />
+  <direct name="NCES4" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[4].NCLK+CEN+SR" />
   <direct name="E4"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[4].EN"   />
   <direct name="S4"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[4].SR"   />
   <direct name="O4"    input="BLK_IG-LUTFF[4].O"    output="BLK_IG-PLB.O4"        />
@@ -257,10 +337,14 @@
   <direct name="I5[1]" input="BLK_IG-PLB.I5[1]"     output="BLK_IG-LUTFF[5].I[1]" />
   <direct name="I5[2]" input="BLK_IG-PLB.I5[2]"     output="BLK_IG-LUTFF[5].I[2]" />
   <direct name="I5[3]" input="BLK_IG-PLB.I5[3]"     output="BLK_IG-LUTFF[5].I[3]" />
-  <direct name="PC5"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[5].PCLK" />
-  <direct name="NC5"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[5].NCLK" />
-  <direct name="PCE5"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[5].PCEN" />
-  <direct name="NCE5"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[5].NCEN" />
+  <direct name="PC5"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[5].PCLK"        />
+  <direct name="NC5"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[5].NCLK"        />
+  <direct name="PCE5"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[5].PCLK+CEN"    />
+  <direct name="NCE5"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[5].NCLK+CEN"    />
+  <direct name="PCS5"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[5].PCLK+SR"     />
+  <direct name="NCS5"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[5].NCLK+SR"     />
+  <direct name="PCES5" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[5].PCLK+CEN+SR" />
+  <direct name="NCES5" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[5].NCLK+CEN+SR" />
   <direct name="E5"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[5].EN"   />
   <direct name="S5"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[5].SR"   />
   <direct name="O5"    input="BLK_IG-LUTFF[5].O"    output="BLK_IG-PLB.O5"        />
@@ -270,10 +354,14 @@
   <direct name="I6[1]" input="BLK_IG-PLB.I6[1]"     output="BLK_IG-LUTFF[6].I[1]" />
   <direct name="I6[2]" input="BLK_IG-PLB.I6[2]"     output="BLK_IG-LUTFF[6].I[2]" />
   <direct name="I6[3]" input="BLK_IG-PLB.I6[3]"     output="BLK_IG-LUTFF[6].I[3]" />
-  <direct name="PC6"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[6].PCLK" />
-  <direct name="NC6"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[6].NCLK" />
-  <direct name="PCE6"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[6].PCEN" />
-  <direct name="NCE6"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[6].NCEN" />
+  <direct name="PC6"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[6].PCLK"        />
+  <direct name="NC6"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[6].NCLK"        />
+  <direct name="PCE6"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[6].PCLK+CEN"    />
+  <direct name="NCE6"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[6].NCLK+CEN"    />
+  <direct name="PCS6"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[6].PCLK+SR"     />
+  <direct name="NCS6"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[6].NCLK+SR"     />
+  <direct name="PCES6" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[6].PCLK+CEN+SR" />
+  <direct name="NCES6" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[6].NCLK+CEN+SR" />
   <direct name="E6"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[6].EN"   />
   <direct name="S6"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[6].SR"   />
   <direct name="O6"    input="BLK_IG-LUTFF[6].O"    output="BLK_IG-PLB.O6"        />
@@ -283,10 +371,14 @@
   <direct name="I7[1]" input="BLK_IG-PLB.I7[1]"     output="BLK_IG-LUTFF[7].I[1]" />
   <direct name="I7[2]" input="BLK_IG-PLB.I7[2]"     output="BLK_IG-LUTFF[7].I[2]" />
   <direct name="I7[3]" input="BLK_IG-PLB.I7[3]"     output="BLK_IG-LUTFF[7].I[3]" />
-  <direct name="PC7"   input="BLK_IG-MODE_CLK.PCLK" output="BLK_IG-LUTFF[7].PCLK" />
-  <direct name="NC7"   input="BLK_IG-MODE_CLK.NCLK" output="BLK_IG-LUTFF[7].NCLK" />
-  <direct name="PCE7"  input="BLK_IG-MODE_CLK.PCEN" output="BLK_IG-LUTFF[7].PCEN" />
-  <direct name="NCE7"  input="BLK_IG-MODE_CLK.NCEN" output="BLK_IG-LUTFF[7].NCEN" />
+  <direct name="PC7"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[7].PCLK"        />
+  <direct name="NC7"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[7].NCLK"        />
+  <direct name="PCE7"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[7].PCLK+CEN"    />
+  <direct name="NCE7"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[7].NCLK+CEN"    />
+  <direct name="PCS7"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[7].PCLK+SR"     />
+  <direct name="NCS7"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[7].NCLK+SR"     />
+  <direct name="PCES7" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[7].PCLK+CEN+SR" />
+  <direct name="NCES7" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[7].NCLK+CEN+SR" />
   <direct name="E7"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[7].EN"   />
   <direct name="S7"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[7].SR"   />
   <direct name="O7"    input="BLK_IG-LUTFF[7].O"    output="BLK_IG-PLB.O7"        />

--- a/ice40/make/tests.mk
+++ b/ice40/make/tests.mk
@@ -50,7 +50,7 @@ BIT_TIME_CMD = $(BIT_TIME) -v -t -p $(INPUT_IO_FILE) -d $(DEVICE) $(OUT_BITSTREA
 
 # For equivalence checking
 CELLS_SIM = ice40/cells_sim.v
-EQUIV_CHECK_SCRIPT = rename top gate; $(EQUIV_READ); rename top gold; hierarchy; proc; miter -equiv -flatten -ignore_gold_x -make_outputs -make_outcmp gold gate miter; sat -dump_vcd $(OUT_LOCAL)/out.vcd -verify-no-timeout -timeout 20 -seq 1000 -prove trigger 0 -prove-skip 1 -show-inputs -show-outputs miter
+EQUIV_CHECK_SCRIPT = rename top gate; $(EQUIV_READ); rename top gold; hierarchy; proc; clk2fflogic; miter -equiv -flatten -ignore_gold_x -make_outputs -make_outcmp gold gate miter; sat -dump_vcd $(OUT_LOCAL)/out.vcd -verify-no-timeout -timeout 600 -seq 1000 -prove trigger 0 -prove-skip 1 -show-inputs -show-outputs miter
 
 # Arachne for comparison
 # ------------------------------------------

--- a/ice40/primitives/sb_ff/README.md
+++ b/ice40/primitives/sb_ff/README.md
@@ -1,0 +1,81 @@
+
+## Tile Level Flip Flop Configuration
+
+ * `# PosClk` -- Flip flop uses positive edge clock (no actual value, so just uses a comment).
+ * `NegClk` -- Flip flop uses negative edge clock.
+
+ * Use a clock enable signal -- Any signal connected to the `CEN` input, otherwise `CEN` == 1.
+   - When a `CEN` input in use, the flip flop type name has `E` in it's name.
+
+ * Use a set/reset signal -- Any signal connected to the `S_R` input, otherwise `S_R` == 0.
+   - When a `S_R` input in use, the flip flop type name has either a `S` or `R` in the name.
+
+## Cell Level Flip Flop Configuration
+
+ * `enable_dff` / `DffEnable` - Use the flip flip -- Cell Level
+
+### Set/Reset Signal
+
+#### Set or Reset
+
+ * `Set_NoReset` - When `S_R` == 1, flip flop value is forced to `1'b1`
+ * `# Reset` - When `S_R` == 1, flip flop value is forced to `1'b0`
+
+#### Set/Reset Asynchronous
+
+ * `AsyncSetReset` - When set, the `S_R` is asynchronous to the clock.
+ * `# SyncSetReset` - When set, the `S_R` is synchronous to the clock
+   - Synchronous set/reset flip flops have an extra `S` in the name.
+
+## Naming
+
+### Lattice Naming
+
+ `DFF` (`N`) (`E`) (`S`<sub>1</sub>) (`R`|`S`<sub>2</sub>)
+
+  * `N`             -- Negative clock
+  * `E`             -- Clock enable signal used.
+  * `S`<sub>1</sub> -- Synchronous Set/Reset signal used.
+  * `R`             -- When Set/Reset signal asserted, value is set to zero.
+  * `S`<sub>2</sub> -- When Set/Reset signal asserted, value is set to one.
+
+### Yosys Internal Naming
+
+ `$_DFF` (`E`) (`SR`) `_` `N`|`P`<sub>1</sub> (`N`|`P`)<sub>2</sub> (`N0`|`N1`|`P0`|`P1`)<sub>3</sub> `_`
+
+  * `E` - Clock enable signal used.
+  * `SR` - Both Set and Reset signals.
+  * `N`<sub>1</sub> - Negative edge clock.
+  * `P`<sub>1</sub> - Positive edge clock.
+  * `N`<sub>2</sub> - Negative level clock enable.
+  * `P`<sub>2</sub> - Positive level clock enable.
+  * `N0`<sub>3</sub> - Negative level reset signal (on negative level, force contents to zero).
+  * `P0`<sub>3</sub> - Positive level reset signal (on positive level, force contents to zero).
+  * `N1`<sub>3</sub> - Negative level set signal (on negative level, force contents to one).
+  * `P1`<sub>3</sub> - Positive level set signal (on positive level, force contents to one).
+
+
+## Flip Flop Configuration Table
+
+NegClk |  cen | SR | async | set_norest | type name | packs if the same
+-------|------|----|-------|------------|-----------|------------------
+   0   |   0  |  0 |   X   |     X      | DFF       | A
+   0   |   1  |  0 |   X   |     X      | DFFE      | B
+   0   |   0  |  1 |   0   |     0      | DFFSR     | C
+   0   |   0  |  1 |   0   |     1      | DFFSS     | C
+   0   |   0  |  1 |   1   |     0      | DFFR      | C
+   0   |   0  |  1 |   1   |     1      | DFFS      | C
+   0   |   1  |  1 |   0   |     1      | DFFESS    | D
+   0   |   1  |  1 |   0   |     0      | DFFESR    | D
+   0   |   1  |  1 |   1   |     0      | DFFER     | D
+   0   |   1  |  1 |   1   |     1      | DFFES     | D
+   1   |   0  |  0 |   X   |     X      | DFFN      | a
+   1   |   1  |  0 |   X   |     X      | DFFNE     | b
+   1   |   0  |  1 |   0   |     0      | DFFNSR    | c
+   1   |   0  |  1 |   0   |     1      | DFFNSS    | c
+   1   |   0  |  1 |   1   |     0      | DFFNR     | c
+   1   |   0  |  1 |   1   |     1      | DFFNS     | c
+   1   |   1  |  1 |   0   |     1      | DFFNESS   | d
+   1   |   1  |  1 |   0   |     0      | DFFNESR   | d
+   1   |   1  |  1 |   1   |     0      | DFFNER    | d
+   1   |   1  |  1 |   1   |     1      | DFFNES    | d

--- a/ice40/primitives/sb_ff/sb_ff.pb_type.xml
+++ b/ice40/primitives/sb_ff/sb_ff.pb_type.xml
@@ -1,10 +1,14 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <!-- Flip flop found inside the iCE40 -->
 <pb_type name="BEL_FF-SB_FF" num_pb="1">
- <clock  name="PCLK" num_pins="1"/>
- <clock  name="NCLK" num_pins="1"/>
- <clock  name="PCEN" num_pins="1"/>
- <clock  name="NCEN" num_pins="1"/>
+ <clock  name="PCLK"        num_pins="1"/>
+ <clock  name="NCLK"        num_pins="1"/>
+ <clock  name="PCLK+CEN"    num_pins="1"/>
+ <clock  name="NCLK+CEN"    num_pins="1"/>
+ <clock  name="PCLK+SR"     num_pins="1"/>
+ <clock  name="NCLK+SR"     num_pins="1"/>
+ <clock  name="PCLK+CEN+SR" num_pins="1"/>
+ <clock  name="NCLK+CEN+SR" num_pins="1"/>
 
  <input  name="E" num_pins="1"/>
  <input  name="S" num_pins="1"/>
@@ -81,7 +85,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFE" name="C"/></direct>
+   <direct><port type="input" name="PCLK+CEN"/><port type="output" from="SB_DFFE" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFE" name="E"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFE" name="D"/></direct>
    <direct><port type="input" from="SB_DFFE" name="Q" /><port type="output" name="Q"/></direct>
@@ -111,7 +115,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFER" name="C"/></direct>
+   <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFER" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFER" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFER" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFER" name="D"/></direct>
@@ -142,7 +146,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFES" name="C"/></direct>
+   <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFES" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFES" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFES" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFES" name="D"/></direct>
@@ -173,7 +177,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFESR" name="C"/></direct>
+   <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFESR" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFESR" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFESR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFESR" name="D"/></direct>
@@ -204,7 +208,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFESS" name="C"/></direct>
+   <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFESS" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFESS" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFESS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFESS" name="D"/></direct>
@@ -233,7 +237,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFR" name="C"/></direct>
+   <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFR" name="D"/></direct>
    <direct><port type="input" from="SB_DFFR" name="Q" /><port type="output" name="Q"/></direct>
@@ -261,7 +265,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFS" name="C"/></direct>
+   <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFS" name="D"/></direct>
    <direct><port type="input" from="SB_DFFS" name="Q" /><port type="output" name="Q"/></direct>
@@ -289,7 +293,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFSR" name="C"/></direct>
+   <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFSR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFSR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFSR" name="D"/></direct>
    <direct><port type="input" from="SB_DFFSR" name="Q" /><port type="output" name="Q"/></direct>
@@ -317,7 +321,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFSS" name="C"/></direct>
+   <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFSS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFSS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFSS" name="D"/></direct>
    <direct><port type="input" from="SB_DFFSS" name="Q" /><port type="output" name="Q"/></direct>
@@ -372,7 +376,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNE" name="C"/></direct>
+   <direct><port type="input" name="NCLK+CEN"/><port type="output" from="SB_DFFNE" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNE" name="E"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNE" name="D"/></direct>
    <direct><port type="input" from="SB_DFFNE" name="Q" /><port type="output" name="Q"/></direct>
@@ -402,7 +406,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNER" name="C"/></direct>
+   <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNER" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNER" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNER" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNER" name="D"/></direct>
@@ -433,7 +437,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNES" name="C"/></direct>
+   <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNES" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNES" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNES" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNES" name="D"/></direct>
@@ -464,7 +468,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNESR" name="C"/></direct>
+   <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNESR" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESR" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNESR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESR" name="D"/></direct>
@@ -495,7 +499,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNESS" name="C"/></direct>
+   <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNESS" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESS" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNESS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESS" name="D"/></direct>
@@ -524,7 +528,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNR" name="C"/></direct>
+   <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNR" name="D"/></direct>
    <direct><port type="input" from="SB_DFFNR" name="Q" /><port type="output" name="Q"/></direct>
@@ -552,7 +556,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNS" name="C"/></direct>
+   <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNS" name="D"/></direct>
    <direct><port type="input" from="SB_DFFNS" name="Q" /><port type="output" name="Q"/></direct>
@@ -580,7 +584,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNSR" name="C"/></direct>
+   <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNSR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSR" name="D"/></direct>
    <direct><port type="input" from="SB_DFFNSR" name="Q" /><port type="output" name="Q"/></direct>
@@ -608,7 +612,7 @@
    </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNSS" name="C"/></direct>
+   <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNSS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSS" name="D"/></direct>
    <direct><port type="input" from="SB_DFFNSS" name="Q" /><port type="output" name="Q"/></direct>

--- a/ice40/primitives/sb_ff/sb_ff.pb_type.xml
+++ b/ice40/primitives/sb_ff/sb_ff.pb_type.xml
@@ -20,6 +20,9 @@
    <output name="Q"   num_pins="1" port_class="Q"     />
    <T_setup    value="10e-12" port="VPR_FF.D" clock="clk"/>
    <T_clock_to_Q max="10e-12" port="VPR_FF.Q" clock="clk"/>
+   <metadata>
+    <meta name="hlc_property"># VPR_FF - $_DFF_P_</meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="VPR_FF" name="clk"/></direct>
@@ -28,9 +31,6 @@
    </direct>
    <direct><port type="input" from="VPR_FF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">enable_dff</meta>
-  </metadata>
  </mode>
 
  <!-- module SB_DFF (output Q, input C, D); -->
@@ -41,6 +41,15 @@
    <output name="Q" num_pins="1"/>
    <T_setup    value="10e-12" port="SB_DFF.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFF.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFF - $_DFF_P_
+        # PosClk
+        # no_cen
+        # no_setreset
+        # --
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFF" name="C"/></direct>
@@ -61,6 +70,15 @@
    <T_setup    value="10e-12" port="SB_DFFE.E" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFE.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFE.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFE - $_DFFE_PN_
+        # PosClk
+        # use_cen
+        # no_setreset
+        # --
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFE" name="C"/></direct>
@@ -82,6 +100,15 @@
    <T_setup    value="10e-12" port="SB_DFFER.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFER.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFER.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFER - $_DFFE_PN0
+        # PosClk
+        # use_cen
+        async_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFER" name="C"/></direct>
@@ -104,6 +131,15 @@
    <T_setup    value="10e-12" port="SB_DFFES.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFES.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFES.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # SB_DFFES - $_DFFE_PN1
+        # PosClk
+        # use_cen
+        async_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFES" name="C"/></direct>
@@ -126,6 +162,15 @@
    <T_setup    value="10e-12" port="SB_DFFESR.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFESR.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFESR.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFESR
+        # PosClk
+        # use_cen
+        # sync_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFESR" name="C"/></direct>
@@ -148,6 +193,15 @@
    <T_setup    value="10e-12" port="SB_DFFESS.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFESS.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFESS.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFESS
+        # PosClk
+        # use_cen
+        # sync_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCEN"/><port type="output" from="SB_DFFESS" name="C"/></direct>
@@ -168,6 +222,15 @@
    <T_setup    value="10e-12" port="SB_DFFR.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFR.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFR.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFR
+        # PosClk
+        # no_cen
+        async_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFR" name="C"/></direct>
@@ -187,6 +250,15 @@
    <T_setup    value="10e-12" port="SB_DFFS.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFS.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFS.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFS
+        # PosClk
+        # no_cen
+        async_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFS" name="C"/></direct>
@@ -206,6 +278,15 @@
    <T_setup    value="10e-12" port="SB_DFFSR.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFSR.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFSR.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFSR
+        # PosClk
+        # no_cen
+        # sync_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFSR" name="C"/></direct>
@@ -225,6 +306,15 @@
    <T_setup    value="10e-12" port="SB_DFFSS.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFSS.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFSS.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFSS
+        # PosClk
+        # no_cen
+        # sync_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFFSS" name="C"/></direct>
@@ -242,6 +332,15 @@
    <output name="Q" num_pins="1"/>
    <T_setup    value="10e-12" port="SB_DFFN.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFN.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFN
+        # NegClk
+        # no_cen
+        # no_setreset
+        # --
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFN" name="C" /></direct>
@@ -262,6 +361,15 @@
    <T_setup    value="10e-12" port="SB_DFFNE.E" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNE.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNE.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNE
+        # NegClk
+        # use_cen
+        # no_setreset
+        # --
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNE" name="C"/></direct>
@@ -283,6 +391,15 @@
    <T_setup    value="10e-12" port="SB_DFFNER.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNER.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNER.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNER
+        # NegClk
+        # use_cen
+        async_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNER" name="C"/></direct>
@@ -305,6 +422,15 @@
    <T_setup    value="10e-12" port="SB_DFFNES.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNES.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNES.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNES
+        # NegClk
+        # use_cen
+        async_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNES" name="C"/></direct>
@@ -327,6 +453,15 @@
    <T_setup    value="10e-12" port="SB_DFFNESR.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNESR.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNESR.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNESR
+        # NegClk
+        # use_cen
+        # sync_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNESR" name="C"/></direct>
@@ -349,6 +484,15 @@
    <T_setup    value="10e-12" port="SB_DFFNESS.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNESS.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNESS.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNESS
+        # NegClk
+        # use_cen
+        # sync_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCEN"/><port type="output" from="SB_DFFNESS" name="C"/></direct>
@@ -369,6 +513,15 @@
    <T_setup    value="10e-12" port="SB_DFFNR.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNR.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNR.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNR
+        # NegClk
+        # no_cen
+        async_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNR" name="C"/></direct>
@@ -388,6 +541,15 @@
    <T_setup    value="10e-12" port="SB_DFFNS.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNS.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNS.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNS
+        # NegClk
+        # no_cen
+        async_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNS" name="C"/></direct>
@@ -407,6 +569,15 @@
    <T_setup    value="10e-12" port="SB_DFFNSR.R" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNSR.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNSR.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNSR
+        # NegClk
+        # no_cen
+        # sync_setreset
+        # reset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNSR" name="C"/></direct>
@@ -426,6 +597,15 @@
    <T_setup    value="10e-12" port="SB_DFFNSS.S" clock="C"/>
    <T_setup    value="10e-12" port="SB_DFFNSS.D" clock="C"/>
    <T_clock_to_Q max="10e-12" port="SB_DFFNSS.Q" clock="C"/>
+   <metadata>
+    <meta name="hlc_property">
+        # - SB_DFFNSS
+        # NegClk
+        # no_cen
+        # sync_setreset
+        set_noreset
+    </meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFNSS" name="C"/></direct>

--- a/ice40/primitives/sb_ff/sb_ff.pb_type.xml
+++ b/ice40/primitives/sb_ff/sb_ff.pb_type.xml
@@ -31,7 +31,7 @@
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="VPR_FF" name="clk"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="VPR_FF" name="D"/>
-    <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="VPR_FF.D" />
+    <pack_pattern name="LUT+FFA" in_port="BEL_FF-SB_FF.D" out_port="VPR_FF.D" />
    </direct>
    <direct><port type="input" from="VPR_FF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -58,7 +58,7 @@
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFF" name="C"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFF" name="D"/>
-    <!-- <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFF.D" /> -->
+    <pack_pattern name="LUT+FFB" in_port="BEL_FF-SB_FF.D" out_port="SB_DFF.D" />
    </direct>
    <direct><port type="input" from="SB_DFF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -87,7 +87,9 @@
   <interconnect>
    <direct><port type="input" name="PCLK+CEN"/><port type="output" from="SB_DFFE" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFE" name="E"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFE" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFE" name="D"/>
+    <pack_pattern name="LUT+FFC" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFE.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFE" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -118,7 +120,9 @@
    <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFER" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFER" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFER" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFER" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFER" name="D"/>
+    <pack_pattern name="LUT+FFD" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFER.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFER" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -149,7 +153,9 @@
    <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFES" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFES" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFES" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFES" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFES" name="D"/>
+    <pack_pattern name="LUT+FFE" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFES.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFES" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -180,7 +186,9 @@
    <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFESR" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFESR" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFESR" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESR" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESR" name="D"/>
+    <pack_pattern name="LUT+FFF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFESR.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFESR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -211,7 +219,9 @@
    <direct><port type="input" name="PCLK+CEN+SR"/><port type="output" from="SB_DFFESS" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFESS" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFESS" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESS" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFESS" name="D"/>
+    <pack_pattern name="LUT+FFG" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFESS.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFESS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -239,7 +249,9 @@
   <interconnect>
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFR" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFR" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFR" name="D"/>
+    <pack_pattern name="LUT+FFH" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFR.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -267,7 +279,9 @@
   <interconnect>
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFS" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFS" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFS" name="D"/>
+    <pack_pattern name="LUT+FFI" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFS.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -295,7 +309,9 @@
   <interconnect>
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFSR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFSR" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSR" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSR" name="D"/>
+    <pack_pattern name="LUT+FFJ" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFSR.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFSR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -323,7 +339,9 @@
   <interconnect>
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFSS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFSS" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSS" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFSS" name="D"/>
+    <pack_pattern name="LUT+FFK" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFSS.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFSS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -349,7 +367,7 @@
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFN" name="C" /></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFN" name="D" />
-    <!-- <pack_pattern name="LUT+FF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFN.D" /> -->
+    <pack_pattern name="LUT+FFL" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFN.D" />
    </direct>
    <direct><port type="input" from="SB_DFFN" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -378,7 +396,9 @@
   <interconnect>
    <direct><port type="input" name="NCLK+CEN"/><port type="output" from="SB_DFFNE" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNE" name="E"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNE" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNE" name="D"/>
+    <pack_pattern name="LUT+FFM" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNE.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNE" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -409,7 +429,9 @@
    <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNER" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNER" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNER" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNER" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNER" name="D"/>
+    <pack_pattern name="LUT+FFN" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNER.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNER" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -440,7 +462,9 @@
    <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNES" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNES" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNES" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNES" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNES" name="D"/>
+    <pack_pattern name="LUT+FFO" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNES.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNES" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -471,7 +495,9 @@
    <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNESR" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESR" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNESR" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESR" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESR" name="D"/>
+    <pack_pattern name="LUT+FFP" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNESR.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNESR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -502,7 +528,9 @@
    <direct><port type="input" name="NCLK+CEN+SR"/><port type="output" from="SB_DFFNESS" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESS" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNESS" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESS" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESS" name="D"/>
+    <pack_pattern name="LUT+FFQ" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNESS.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNESS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -530,7 +558,9 @@
   <interconnect>
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNR" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNR" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNR" name="D"/>
+    <pack_pattern name="LUT+FFR" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNR.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -558,7 +588,9 @@
   <interconnect>
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNS" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNS" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNS" name="D"/>
+    <pack_pattern name="LUT+FFS" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNS.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -586,7 +618,9 @@
   <interconnect>
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNSR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSR" name="R"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSR" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSR" name="D"/>
+    <pack_pattern name="LUT+FFT" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNSR.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNSR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
@@ -614,7 +648,9 @@
   <interconnect>
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNSS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSS" name="S"/></direct>
-   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSS" name="D"/></direct>
+   <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSS" name="D"/>
+    <pack_pattern name="LUT+FFU" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNSS.D" />
+   </direct>
    <direct><port type="input" from="SB_DFFNSS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>

--- a/ice40/primitives/sb_lut/sb_lut.pb_type.xml
+++ b/ice40/primitives/sb_lut/sb_lut.pb_type.xml
@@ -21,7 +21,27 @@
   <interconnect>
    <direct><port type="input" name="in"/><port type="output" from="BLK_IG-LUT4" name="in"/></direct>
    <direct><port type="input" from="BLK_IG-LUT4" name="out"/><port type="output" name="out"/>
-    <pack_pattern name="LUT+FF" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out" />
+    <pack_pattern name="LUT+FFA" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFB" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFC" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFD" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFE" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFF" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFG" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFH" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFI" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFJ" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFK" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFL" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFM" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFN" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFO" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFP" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFQ" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFR" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFS" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFT" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+    <pack_pattern name="LUT+FFU" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
    </direct>
   </interconnect>
  </mode>
@@ -43,7 +63,6 @@
    <direct><port type="input" name="in[2]"/><port type="output" from="BLK_IG-SB_LUT4" name="I2"/></direct>
    <direct><port type="input" name="in[3]"/><port type="output" from="BLK_IG-SB_LUT4" name="I3"/></direct>
    <direct><port type="input" from="BLK_IG-SB_LUT4" name="O"/><port type="output" name="out"/>
-	   <!-- <pack_pattern name="LUT+FF" in_port="BLK_IG-SB_LUT4" out_port="BEL_LT-LUT.out" /> -->
    </direct>
   </interconnect>
  </mode>

--- a/ice40/tests/ffpack/example_tb.v
+++ b/ice40/tests/ffpack/example_tb.v
@@ -58,6 +58,23 @@ module test;
       #1; // b
       #1; // pos
       #1; // b
+      in <= 4'b0010;
+      $display("reseting with cen and ina off");
+      
+      #1; // neg
+      if (out != 4'b1110) $error("clock to out %b", out);
+      #1; // b
+      in <= 4'b0111;
+      $display("reseting with cen and ina");
+      #1; // pos
+      #1; // b
+      if (vec0 != 5'b00000) $error("vec0 %b", vec0);
+      if (vec1 != 5'b11111) $error("vec1 %b", vec1);
+
+      #1; // neg
+      #1; // b
+      if (vec0 != 5'b00000) $error("vec0 %b", vec0);
+      if (vec1 != 5'b00001) $error("vec1 %b", vec1);
       
       $dumpflush;
       $finish;


### PR DESCRIPTION
 * Add a README file with description of the flip flop types.
 * Add `hlc_property` values for the different flip flop configurations.
 * Support proper packing of flip flop types (IE don't pack `cen` / non-`cen` and `sr` / non-`sr` flip flops together).
 * Improve testbench slightly.