### PR TITLE
xc7/tests/simple_ff: changed verilog primitive

### DIFF
--- a/xc7/tests/simple_ff/simple_ff.v
+++ b/xc7/tests/simple_ff/simple_ff.v
@@ -3,9 +3,7 @@ module top(
 	input [7:0] in,
 	output [7:0] out
 );
-  FDCE #(
-      .INIT(0),
-  ) fdse (
+  FDCE_ZINI #() fdce (
       .Q(out[0]),
       .C(clk),
       .CE(in[0]),


### PR DESCRIPTION
This PR is to fix the following error (produced in the master branch) by running the `simple_ff` test

```
...
Generating RTLIL representation for module `\ROM128X1'.
Generating RTLIL representation for module `\ROM256X1'.
Generating RTLIL representation for module `\ROM32X1'.
Generating RTLIL representation for module `\ROM64X1'.
Generating RTLIL representation for module `\SRL16E'.
Generating RTLIL representation for module `\SRLC32E'.
Generating RTLIL representation for module `\STARTUPE2'.
Generating RTLIL representation for module `\USR_ACCESSE2'.
Generating RTLIL representation for module `\XADC'.
Successfully finished Verilog frontend.

2.3. Executing Verilog-2005 frontend.
Parsing Verilog input from `/home/build/symbiflow-arch-defs/build/env/conda/bin/../share/yosys/xilinx/brams_bb.v' to AST representation.
Generating RTLIL representation for module `\RAMB18E1'.
Generating RTLIL representation for module `\RAMB36E1'.
Successfully finished Verilog frontend.

2.4. Executing HIERARCHY pass (managing design hierarchy).

2.4.1. Finding top of design hierarchy..
root of   0 design levels: top                 
Automatically selected top as design top module.

2.4.2. Analyzing design hierarchy..
ERROR: Module `\FDCE' referenced in module `\top' in cell `\fdse' is not part of the design.
xc7/tests/simple_ff/CMakeFiles/simple_ff_bin.dir/build.make:118: recipe for target 'xc7/tests/simple_ff/simple_ff/artix7-xc7a50t-roi-virt-xc7a50t-test/top.eblif' failed
make[3]: *** [xc7/tests/simple_ff/simple_ff/artix7-xc7a50t-roi-virt-xc7a50t-test/top.eblif] Error 1
CMakeFiles/Makefile2:35012: recipe for target 'xc7/tests/simple_ff/CMakeFiles/simple_ff_bin.dir/all' failed
make[2]: *** [xc7/tests/simple_ff/CMakeFiles/simple_ff_bin.dir/all] Error 2
CMakeFiles/Makefile2:35019: recipe for target 'xc7/tests/simple_ff/CMakeFiles/simple_ff_bin.dir/rule' failed
make[1]: *** [xc7/tests/simple_ff/CMakeFiles/simple_ff_bin.dir/rule] Error 2
Makefile:11184: recipe for target 'simple_ff_bin' failed
make: *** [simple_ff_bin] Error 2
```