### PR TITLE
Fix VPR_ARCH_ARGS

### DIFF
--- a/ice40/CMakeLists.txt
+++ b/ice40/CMakeLists.txt
@@ -12,6 +12,8 @@ define_arch(
   DEVICE_FULL_TEMPLATE \${DEVICE}-\${PACKAGE}
   VPR_ARCH_ARGS
     --clock_modeling route
+    --allow_unrelated_clustering off
+    --target_ext_pin_util 0.7
   RR_PATCH_TOOL
     ${symbiflow-arch-defs_SOURCE_DIR}/ice40/utils/ice40_import_routing_from_icebox.py
   RR_PATCH_CMD "\${QUIET_CMD} \${PYTHON3} \${RR_PATCH_TOOL} \

--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -135,6 +135,7 @@ function(DEFINE_ARCH)
     )
   set(DISALLOWED_ARGS "")
   set(OPTIONAL_ARGS
+    VPR_ARCH_ARGS
     CELLS_SIM
     )
 

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -24,6 +24,11 @@ function(ADD_XC7_ARCH_DEFINE)
     YOSYS_SCRIPT ${YOSYS_SCRIPT}
     DEVICE_FULL_TEMPLATE \${DEVICE}-\${PACKAGE}
     CELLS_SIM xilinx/cells_sim.v
+    VPR_ARCH_ARGS
+      --clock_modeling route
+      --place_algorithm bounding_box
+      --enable_timing_computations off
+      --allow_unrelated_clustering on
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \
@@ -63,12 +68,4 @@ function(ADD_XC7_ARCH_DEFINE)
     ROUTE_CHAN_WIDTH 500
   )
 
-  set(VPR_ARCH_ARGS
-   --clock_modeling route
-   --place_algorithm bounding_box
-   --enable_timing_computations off
-   --allow_unrelated_clustering on
-   )
-
-  set_target_properties(${ARCH} PROPERTIES VPR_ARCH_ARGS "${VPR_ARCH_ARGS}")
 endfunction()


### PR DESCRIPTION
VPR_ARCH_ARGS was being ignored in cmake define_arch()

ice40 tests should complete now.

Also added ability to specify conda package versions and builds. This was helpful in bisecting the failure and will be good for any release or milestone.