### PR TITLE
Fix BRAM test.

### DIFF
--- a/library/uart/uart_tx.v
+++ b/library/uart/uart_tx.v
@@ -10,6 +10,11 @@ module UART_TX(
     reg [2:0] data_counter;
     reg [3:0] state;
 
+    initial begin
+        tx <= 1;
+        data_accepted <= 0;
+    end
+
     always @(posedge clk) begin
         if(rst) begin
             state <= END;

--- a/xc7/techmap/cells_map.v
+++ b/xc7/techmap/cells_map.v
@@ -158,6 +158,13 @@ module RAMB18E1 (
   wire REGCLKA;
   wire REGCLKB;
 
+  wire [7:0] WEBWE_WIDE = {
+      WEBWE[3], WEBWE[3], WEBWE[2], WEBWE[2],
+      WEBWE[1], WEBWE[1], WEBWE[0], WEBWE[0]};
+
+  wire [3:0] WEA_WIDE = {WEA[1], WEA[1], WEA[0], WEA[0]};
+
+
   if (DOA_REG)
       assign REGCLKA = CLKARDCLK;
   else
@@ -301,8 +308,8 @@ module RAMB18E1 (
     .DIBDI(DIBDI),
     .DIPADIP(DIPADIP),
     .DIPBDIP(DIPBDIP),
-    .WEA(WEA),
-    .WEBWE(WEBWE),
+    .WEA(WEA_WIDE),
+    .WEBWE(WEBWE_WIDE),
 
     .DOADO(DOADO),
     .DOBDO(DOBDO),

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -79,6 +79,7 @@ def opposite_direction(direction):
         assert False, direction
 
 HCLK_CK_BUFHCLK_REGEX = re.compile('HCLK_CK_BUFHCLK[0-9]+')
+CASCOUT_REGEX = re.compile('BRAM_CASCOUT_ADDR((?:BWR)|(?:ARD))ADDRU([0-9]+)')
 
 def check_feature(feature):
     """ Check if enabling this feature requires other features to be enabled.
@@ -98,6 +99,14 @@ def check_feature(feature):
                 feature_path[-1])
 
         return ' '.join((feature, enable_buffer_feature))
+
+    m = CASCOUT_REGEX.fullmatch(feature_path[-2])
+    if m:
+        enable_cascout = '{}.CASCOUT_{}_ACTIVE'.format(
+                feature_path[0],
+                m.group(1))
+
+        return ' '.join((feature, enable_cascout))
 
     return feature
 


### PR DESCRIPTION
 - Correct WE signals for TDP BRAM.
 - Add loop count to result report
 - Explicitly initialize UART Tx output state.

BRAM INIT contents is still not handled correctly.