### PR TITLE
d_dram.pb_type: update xml definition to solve slicem issue

### DIFF
--- a/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
@@ -1,48 +1,128 @@
 <pb_type name="BLK_IG-D_DRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <clock  name="CLK" num_pins="1" />
   <input  name="A"   num_pins="6" />
+  <input  name="WA"  num_pins="6" />
   <input  name="WA7" num_pins="1" />
   <input  name="WA8" num_pins="1" />
   <input  name="DI1" num_pins="1" />
   <input  name="DI2" num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
+  <output name="DO6"  num_pins="1" />
+  <output name="DO6_32"  num_pins="1" />
   <output name="SO6"  num_pins="1" />
   <output name="SO6_32"  num_pins="1" />
   <output name="O6"  num_pins="1" />
   <output name="O5"  num_pins="1" />
 
- <!-- TODO: Missing modes: SRL. -->
- <mode name="64_SINGLE_PORT">
-   <xi:include href="spram64.pb_type.xml" />
-   <interconnect>
-     <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-SPRAM64.CLK" />
-     <direct name="A" input="BLK_IG-D_DRAM.A" output="BLK_MM-SPRAM64.A" />
-     <direct name="WA7" input="BLK_IG-D_DRAM.WA7" output="BLK_MM-SPRAM64.WA7" />
-     <direct name="WA8" input="BLK_IG-D_DRAM.WA8" output="BLK_MM-SPRAM64.WA8" />
-     <direct name="DI" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-SPRAM64.DI1" />
-     <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-SPRAM64.WE" />
+<!-- TODO: Missing modes: SRL. -->
+  <mode name="LUT">
+    <pb_type name="BEL_LT-D5LUT" num_pb="2" class="lut" blif_model=".names">
+      <input  name="in"  num_pins="5" port_class="lut_in" />
+      <output name="out" num_pins="1" port_class="lut_out" />
+      <delay_matrix type="max" in_port="BEL_LT-D5LUT.in" out_port="BEL_LT-D5LUT.out">
+        0.068e-9
+        0.068e-9
+        0.068e-9
+        0.068e-9
+        0.068e-9
+      </delay_matrix>
+    </pb_type>
+    <xi:include href="../../common_slice/muxes/f6mux/f6mux.pb_type.xml" />
 
-     <direct name="O6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-D_DRAM.O6" />
-     <direct name="SO6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-D_DRAM.SO6" />
-   </interconnect>
- </mode>
- <mode name="32_SINGLE_PORT">
-   <xi:include href="spram32.pb_type.xml" />
-   <interconnect>
-     <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-SPRAM32.CLK" />
-     <direct name="A" input="BLK_IG-D_DRAM.A[4:0]" output="BLK_MM-SPRAM32.A[4:0]" />
-     <direct name="DI1" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-SPRAM32.DI1" />
-     <direct name="DI2" input="BLK_IG-D_DRAM.DI2" output="BLK_MM-SPRAM32.DI2" />
-     <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-SPRAM32.WE" />
+    <interconnect>
+      <!-- LUT5 (upper) -> O6 -->
+      <direct name="DLUT_A5_0" input="BLK_IG-D_DRAM.A[4:0]" output="BEL_LT-D5LUT[0].in[4:0]"/>
 
-     <direct name="O6" input="BLK_MM-SPRAM32.O6" output="BLK_IG-D_DRAM.O6" />
-     <direct name="O5" input="BLK_MM-SPRAM32.O5" output="BLK_IG-D_DRAM.O5" />
-     <direct name="SO6_32" input="BLK_MM-SPRAM32.O6" output="BLK_IG-D_DRAM.SO6_32" />
-   </interconnect>
- </mode>
+      <!-- LUT5 (lower) -> O5 -->
+      <direct name="DLUT_A5_1" input="BLK_IG-D_DRAM.A[4:0]" output="BEL_LT-D5LUT[1].in[4:0]"/>
 
- <metadata>
-  <meta name="fasm_prefix">DLUT</meta>
- </metadata>
+      <!-- MUX used for LUT6 -->
+      <direct name="F6MUX_I0" input="BEL_LT-D5LUT[0].out" output="BEL_MX-F6MUX.I0">
+        <pack_pattern in_port="BEL_LT-D5LUT[0].out" name="LUT5toLUT6" out_port="BEL_MX-F6MUX.I0"/>
+      </direct>
+      <direct name="F6MUX_I1" input="BEL_LT-D5LUT[1].out" output="BEL_MX-F6MUX.I1">
+        <pack_pattern in_port="BEL_LT-D5LUT[1].out" name="LUT5toLUT6" out_port="BEL_MX-F6MUX.I1"/>
+      </direct>
+      <direct name="F6MUX_S"  input="BLK_IG-D_DRAM.A[5]" output="BEL_MX-F6MUX.S">
+      </direct>
+
+      <!-- LUT outputs -->
+      <direct name="O5" input="BEL_LT-D5LUT[0].out"                output="BLK_IG-D_DRAM.O5">
+        <pack_pattern in_port="BEL_LT-D5LUT[0].out" name="LUT5x2"     out_port="BLK_IG-D_DRAM.O5"/>
+      </direct>
+      <mux    name="O6" input="BEL_LT-D5LUT[1].out BEL_MX-F6MUX.O" output="BLK_IG-D_DRAM.O6">
+        <pack_pattern in_port="BEL_MX-F6MUX.O"        name="LUT5toLUT6" out_port="BLK_IG-D_DRAM.O6"/>
+        <pack_pattern in_port="BEL_LT-D5LUT[1].out" name="LUT5x2"     out_port="BLK_IG-D_DRAM.O6"/>
+      </mux>
+    </interconnect>
+    <metadata>
+      <meta name="fasm_type">SPLIT_LUT</meta>
+      <meta name="fasm_lut">
+        INIT[31:0] = BEL_LT-D5LUT[0]
+        INIT[63:32] = BEL_LT-D5LUT[1]
+      </meta>
+    </metadata>
+  </mode>
+  <mode name="64_SINGLE_PORT">
+    <xi:include href="spram64.pb_type.xml" />
+    <interconnect>
+      <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-SPRAM64.CLK" />
+      <direct name="A" input="BLK_IG-D_DRAM.A" output="BLK_MM-SPRAM64.A" />
+      <direct name="WA7" input="BLK_IG-D_DRAM.WA7" output="BLK_MM-SPRAM64.WA7" />
+      <direct name="WA8" input="BLK_IG-D_DRAM.WA8" output="BLK_MM-SPRAM64.WA8" />
+      <direct name="DI" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-SPRAM64.DI1" />
+      <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-SPRAM64.WE" />
+
+      <direct name="O6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-D_DRAM.O6" />
+      <direct name="SO6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-D_DRAM.SO6" />
+    </interconnect>
+  </mode>
+  <mode name="64_DUAL_PORT">
+    <xi:include href="dpram64.pb_type.xml" />
+    <interconnect>
+      <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-DPRAM64.CLK" />
+      <direct name="A" input="BLK_IG-D_DRAM.A" output="BLK_MM-DPRAM64.A" />
+      <direct name="WA" input="BLK_IG-D_DRAM.WA[5:0]" output="BLK_MM-DPRAM64.WA[5:0]" />
+      <direct name="WA7" input="BLK_IG-D_DRAM.WA7" output="BLK_MM-DPRAM64.WA7" />
+      <direct name="WA8" input="BLK_IG-D_DRAM.WA8" output="BLK_MM-DPRAM64.WA8" />
+      <direct name="DI" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-DPRAM64.DI1" />
+      <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-DPRAM64.WE" />
+
+      <direct name="O6" input="BLK_MM-DPRAM64.O6" output="BLK_IG-D_DRAM.O6" />
+      <direct name="DO6" input="BLK_MM-DPRAM64.O6" output="BLK_IG-D_DRAM.DO6" />
+    </interconnect>
+  </mode>
+  <mode name="32_DUAL_PORT">
+    <xi:include href="dpram32.pb_type.xml" />
+    <interconnect>
+      <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-DPRAM32.CLK" />
+      <direct name="A" input="BLK_IG-D_DRAM.A[4:0]" output="BLK_MM-DPRAM32.A[4:0]" />
+      <direct name="WA" input="BLK_IG-D_DRAM.WA[4:0]" output="BLK_MM-DPRAM32.WA[4:0]" />
+      <direct name="DI" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-DPRAM32.DI1" />
+      <direct name="DI2" input="BLK_IG-D_DRAM.DI2" output="BLK_MM-DPRAM32.DI2" />
+      <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-DPRAM32.WE" />
+
+      <direct name="O6" input="BLK_MM-DPRAM32.O6" output="BLK_IG-D_DRAM.O6" />
+      <direct name="DO6" input="BLK_MM-DPRAM32.O6" output="BLK_IG-D_DRAM.DO6_32" />
+      <direct name="O5" input="BLK_MM-DPRAM32.O5" output="BLK_IG-D_DRAM.O5" />
+    </interconnect>
+  </mode>
+  <mode name="32_SINGLE_PORT">
+    <xi:include href="spram32.pb_type.xml" />
+    <interconnect>
+      <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-SPRAM32.CLK" />
+      <direct name="A" input="BLK_IG-D_DRAM.A[4:0]" output="BLK_MM-SPRAM32.A[4:0]" />
+      <direct name="DI1" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-SPRAM32.DI1" />
+      <direct name="DI2" input="BLK_IG-D_DRAM.DI2" output="BLK_MM-SPRAM32.DI2" />
+      <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-SPRAM32.WE" />
+
+      <direct name="O6" input="BLK_MM-SPRAM32.O6" output="BLK_IG-D_DRAM.O6" />
+      <direct name="O5" input="BLK_MM-SPRAM32.O5" output="BLK_IG-D_DRAM.O5" />
+      <direct name="SO6_32" input="BLK_MM-SPRAM32.O6" output="BLK_IG-D_DRAM.SO6_32" />
+    </interconnect>
+  </mode>
+  <metadata>
+    <meta name="fasm_prefix">DLUT</meta>
+  </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/d_dram128.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/d_dram128.pb_type.xml
@@ -1,26 +1,45 @@
 <pb_type name="BLK_IG-D_DRAM128" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <clock  name="CLK" num_pins="1" />
   <input  name="A"   num_pins="6" />
+  <input  name="WA"  num_pins="6" />
   <input  name="WA7" num_pins="1" />
   <input  name="DI1" num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <output name="O6"  num_pins="1" />
+  <output name="DO6"  num_pins="1" />
+  <output name="SO6"  num_pins="1" />
+  <output name="O6"   num_pins="1" />
+  <output name="DI_OUT" num_pins="1" />
 
- <mode name="128_SINGLE_PORT">
-   <xi:include href="spram128.pb_type.xml" />
-   <interconnect>
-     <direct name="CLK" input="BLK_IG-D_DRAM128.CLK" output="BLK_MM-SPRAM128.CLK" />
-     <direct name="A" input="BLK_IG-D_DRAM128.A" output="BLK_MM-SPRAM128.A" />
-     <direct name="WA7" input="BLK_IG-D_DRAM128.WA7" output="BLK_MM-SPRAM128.WA7" />
-     <direct name="DI" input="BLK_IG-D_DRAM128.DI1" output="BLK_MM-SPRAM128.DI1" />
-     <direct name="WE" input="BLK_IG-D_DRAM128.WE" output="BLK_MM-SPRAM128.WE" />
+  <mode name="128_DUAL_PORT">
+    <xi:include href="dpram128.pb_type.xml" />
+      <interconnect>
+        <direct name="CLK" input="BLK_IG-D_DRAM128.CLK" output="BLK_MM-DPRAM128.CLK" />
+        <direct name="A" input="BLK_IG-D_DRAM128.A" output="BLK_MM-DPRAM128.A" />
+        <direct name="WA" input="BLK_IG-D_DRAM128.WA[5:0]" output="BLK_MM-DPRAM128.WA[5:0]" />
+        <direct name="WA7" input="BLK_IG-D_DRAM128.WA7" output="BLK_MM-DPRAM128.WA7" />
+        <direct name="DI" input="BLK_IG-D_DRAM128.DI1" output="BLK_MM-DPRAM128.DI1" />
+        <direct name="WE" input="BLK_IG-D_DRAM128.WE" output="BLK_MM-DPRAM128.WE" />
 
-     <direct name="O6" input="BLK_MM-SPRAM128.O6" output="BLK_IG-D_DRAM128.O6" />
-   </interconnect>
- </mode>
+        <direct name="DO6" input="BLK_MM-DPRAM128.O6" output="BLK_IG-D_DRAM128.DO6" />
+        <direct name="O6" input="BLK_MM-DPRAM128.O6" output="BLK_IG-D_DRAM128.O6" />
+        <direct name="DI_OUT" input="BLK_IG-D_DRAM128.DI1" output="BLK_IG-D_DRAM128.DI_OUT" />
+      </interconnect>
+  </mode>
+  <mode name="128_SINGLE_PORT">
+    <xi:include href="spram128.pb_type.xml" />
+    <interconnect>
+      <direct name="CLK" input="BLK_IG-D_DRAM128.CLK" output="BLK_MM-SPRAM128.CLK" />
+      <direct name="A" input="BLK_IG-D_DRAM128.A" output="BLK_MM-SPRAM128.A" />
+      <direct name="WA7" input="BLK_IG-D_DRAM128.WA7" output="BLK_MM-SPRAM128.WA7" />
+      <direct name="DI" input="BLK_IG-D_DRAM128.DI1" output="BLK_MM-SPRAM128.DI1" />
+      <direct name="WE" input="BLK_IG-D_DRAM128.WE" output="BLK_MM-SPRAM128.WE" />
 
- <metadata>
-  <meta name="fasm_prefix">DLUT</meta>
- </metadata>
+      <direct name="O6" input="BLK_MM-SPRAM128.O6" output="BLK_IG-D_DRAM128.O6" />
+    </interconnect>
+  </mode>
+
+  <metadata>
+    <meta name="fasm_prefix">DLUT</meta>
+  </metadata>
 </pb_type>

--- a/xc7/tests/chain_packing/basys3.pcf
+++ b/xc7/tests/chain_packing/basys3.pcf
@@ -6,4 +6,4 @@ set_io LED1 U16
 set_io LED2 E19
 set_io LED3 U19
 set_io LED4 V19
-# set_io LED5 W18
+set_io LED5 W18

--- a/xc7/tests/chain_packing/counter.v
+++ b/xc7/tests/chain_packing/counter.v
@@ -4,7 +4,7 @@ module top (
 	output LED2,
 	output LED3,
 	output LED4,
-	//output LED5
+	output LED5
 );
 
 	localparam LOG2DELAY = 8;
@@ -13,19 +13,19 @@ module top (
 	reg [LOG2DELAY-1:0] counter1 = 0;
 	reg [LOG2DELAY-1:0] counter2 = 0;
 	reg [LOG2DELAY-1:0] counter3 = 0;
-	//reg [LOG2DELAY-1:0] counter4 = 0;
+	reg [LOG2DELAY-1:0] counter4 = 0;
 
 	always @(posedge clk) begin
 		counter0 <= counter0 + 1;
 		counter1 <= counter1 + 1;
 		counter2 <= counter2 + 1;
 		counter3 <= counter3 + 1;
-		//counter4 <= counter4 + 1;
+		counter4 <= counter4 + 1;
 	end
 
 	assign LED1 = counter0[LOG2DELAY-1];
 	assign LED2 = counter1[LOG2DELAY-1];
 	assign LED3 = counter2[LOG2DELAY-1];
 	assign LED4 = counter3[LOG2DELAY-1];
-	//assign LED5 = counter4[LOG2DELAY-1];
+	assign LED5 = counter4[LOG2DELAY-1];
 endmodule


### PR DESCRIPTION
This PR addresses issue https://github.com/SymbiFlow/symbiflow-arch-defs/issues/372. I have been dealing with the `slicem` issue and found a solution that involved the modification and addition of the `dual port` modes for the `d_dram.pb_type.xml` and `d_dram.128.pb_type.xml`. Even though `DLUT` should not support `dual port` mode, its addition let me successfully compile the `chain_packing` test.

The test was modified as follows:
- LOGIC_DELAY: set to 4 because of https://github.com/SymbiFlow/vtr-verilog-to-routing/issues/8;
- Addition of the 5th counter to include also the usage of SLICEMs.

VPR version was the following: https://github.com/antmicro/vtr-verilog-to-routing/commit/b99b9941697f37a36134711884bde4d211cbcba7

I believe that being there a discrepancy between the `d_dram` and the `a/b/c_dram` the modes cannot be selected accordingly, provoking the following error during the `cluster_routing`:
- `Differing modes for block.  Got LUTs previously and DRAMs for interconnect DO6`.

IMHO the problem is not 100% fixed because there should be a mechanism during clustering in VPR to select the `mode` that can satisfy all the molecules, and this is not yet happening in the correct way.

I have also checked whether the tests in the `xc7/tests/dram` directory were working on HW as well. 
A note about the dram tests: I have compared the one produced by master branch of `arch-defs` (https://github.com/SymbiFlow/symbiflow-arch-defs/commit/477f9aee350f75073c58b76a832ba2c766c44f45) and the ones produced with this PR. They work exactly the same on `HW` and they both present (IMO) an error in `HW` for what regards `2_32x1d` and `4_32x1s` tests.

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>