### PR TITLE
arch_define.cmake: added round_robin option to arch definition

### DIFF
--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -29,6 +29,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --place_algorithm bounding_box
       --enable_timing_computations off
       --allow_unrelated_clustering on
+      --round_robin_prepacking on
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \


### PR DESCRIPTION
https://github.com/SymbiFlow/vtr-verilog-to-routing/pull/9 should be merged before this PR

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>