### PR TITLE
Remove tile level fasm_prefix

### DIFF
--- a/xc7/utils/prjxray_tile_import.py
+++ b/xc7/utils/prjxray_tile_import.py
@@ -481,11 +481,6 @@ def main():
                     'side': side.lower(),
             }).text = ' '.join(pins)
 
-    metadata_xml = ET.SubElement(pb_type_xml, 'metadata')
-    ET.SubElement(metadata_xml, 'meta', {
-            'name': 'fasm_prefix',
-    }).text = args.tile
-
     direct_pins = set()
     for direct in pin_assignments['direct_connections']:
         if direct['from_pin'].split('.')[0] == args.tile:


### PR DESCRIPTION
It was previously ignored does not match features in db

This should merge once genfasm conda package has https://github.com/SymbiFlow/vtr-verilog-to-routing/pull/12