### PR TITLE
ice40: Temp fix for build by running `abc` separately without -dress

### DIFF
--- a/ice40/yosys/synth.tcl
+++ b/ice40/yosys/synth.tcl
@@ -1,6 +1,8 @@
 yosys -import
 
-synth_ice40 -nocarry
+synth_ice40 -nocarry -noabc
+# TODO: revert when libblifparse fix propagates to vpr
+abc -lut 4
 ice40_opt
 ice40_unlut
 simplemap


### PR DESCRIPTION
When the fix for libblifparse is merged and propagated to VPR this can be reverted

Signed-off-by: Elms <elms@freshred.net>