### PR TITLE
Fix Travis CI.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genhlc genfasm
-  PACKAGE_SPEC "vtr 7.0.5 6716.1903060506.g4f2e935b9"
+  PACKAGE_SPEC "vtr 7.0.5 6718.1903061900.g6477cceff"
   )
 add_conda_package(
   NAME libxslt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genhlc genfasm
-  PACKAGE_SPEC "vtr 7.0.5 6718.1903061900.g6477cceff"
+  PACKAGE_SPEC "vtr 7.0.5 6722.1903062051.ga5e0a0ad4"
   )
 add_conda_package(
   NAME libxslt

--- a/testarch/CMakeLists.txt
+++ b/testarch/CMakeLists.txt
@@ -6,8 +6,6 @@ define_arch(
   ARCH testarch
   YOSYS_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/testarch/yosys/synth.tcl
   DEVICE_FULL_TEMPLATE \${DEVICE}
-  VPR_ARCH_ARGS
-    --cluster_seed_type timing
   RR_PATCH_TOOL
     ${symbiflow-arch-defs_SOURCE_DIR}/utils/testarch_graph.py
   RR_PATCH_CMD "\${PYTHON3} \${RR_PATCH_TOOL} \

--- a/testarch/CMakeLists.txt
+++ b/testarch/CMakeLists.txt
@@ -6,6 +6,8 @@ define_arch(
   ARCH testarch
   YOSYS_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/testarch/yosys/synth.tcl
   DEVICE_FULL_TEMPLATE \${DEVICE}
+  VPR_ARCH_ARGS
+    --cluster_seed_type timing
   RR_PATCH_TOOL
     ${symbiflow-arch-defs_SOURCE_DIR}/utils/testarch_graph.py
   RR_PATCH_CMD "\${PYTHON3} \${RR_PATCH_TOOL} \


### PR DESCRIPTION
Fixes #436

- Updates to VPR that includes HLC binary
- Updates to VPR that disables randomly failing placer cost check (see https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/485).  This is a workaround.