### PR TITLE
Initial SQLite3 XC7 routing graph implementation.

### DIFF
--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -1,0 +1,97 @@
+import enum
+from lib.rr_graph import graph2
+from lib.rr_graph import tracks
+
+class NodeClassification(enum.Enum):
+    NULL = 1
+    CHANNEL = 2
+    EDGES_TO_CHANNEL = 3
+    EDGE_WITH_MUX = 4
+
+def get_wire_pkey(conn, tile_name, wire):
+    c = conn.cursor()
+    c.execute("""
+WITH selected_tile(tile_pkey, tile_type_pkey) AS (SELECT pkey, tile_type_pkey FROM tile WHERE name = ?)
+    SELECT wire.pkey FROM wire WHERE
+        wire.tile_pkey = (SELECT selected_tile.tile_pkey FROM selected_tile) AND
+        wire.wire_in_tile_pkey = (SELECT wire_in_tile.pkey FROM wire_in_tile WHERE
+            wire_in_tile.name = ? AND wire_in_tile.tile_type_pkey = (SELECT tile_type_pkey FROM selected_tile)
+            );
+""", (tile_name, wire))
+
+    (wire_pkey,) = c.fetchone()
+    return wire_pkey
+
+def get_track_model(conn, track_pkey):
+    assert track_pkey is not None
+
+    track_list = []
+    track_nodes = []
+    c2 = conn.cursor()
+    graph_node_pkey = {}
+    for idx, (pkey, graph_node_type, x_low, x_high, y_low, y_high) in enumerate(c2.execute("""
+    SELECT pkey, graph_node_type, x_low, x_high, y_low, y_high
+        FROM graph_node WHERE track_pkey = ?""", (track_pkey,))):
+        node_type = graph2.NodeType(graph_node_type)
+        if node_type == graph2.NodeType.CHANX:
+            direction = 'X'
+        elif node_type == graph2.NodeType.CHANY:
+            direction = 'Y'
+
+        graph_node_pkey[pkey] = idx
+        track_nodes.append(pkey)
+        track_list.append(tracks.Track(
+            direction=direction,
+            x_low=x_low,
+            x_high=x_high,
+            y_low=y_low,
+            y_high=y_high))
+
+    track_connections = set()
+    for src_graph_node_pkey, dest_graph_node_pkey in c2.execute("""
+    SELECT src_graph_node_pkey, dest_graph_node_pkey
+        FROM graph_edge WHERE track_pkey = ?""", (track_pkey,)):
+
+        src_idx = graph_node_pkey[src_graph_node_pkey]
+        dest_idx = graph_node_pkey[dest_graph_node_pkey]
+
+        track_connections.add(tuple(sorted((src_idx, dest_idx))))
+
+    tracks_model = tracks.Tracks(track_list, list(track_connections))
+
+    return tracks_model, track_nodes
+
+def yield_wire_info_from_node(conn, node_pkey):
+    c2 = conn.cursor()
+    for tile, tile_type, wire in c2.execute("""
+WITH
+  wires_in_node(tile_pkey, wire_in_tile_pkey) AS (
+    SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE node_pkey = ?),
+  tile_for_wire(wire_in_tile_pkey, tile_name, tile_type_pkey) AS (
+    SELECT wires_in_node.wire_in_tile_pkey, tile.name, tile.tile_type_pkey
+    FROM tile INNER JOIN wires_in_node ON tile.pkey = wires_in_node.tile_pkey),
+  tile_type_for_wire(wire_in_tile_pkey, tile_name, tile_type_name) AS (
+  SELECT tile_for_wire.wire_in_tile_pkey, tile_for_wire.tile_name, tile_type.name
+  FROM tile_type INNER JOIN tile_for_wire ON tile_type.pkey = tile_for_wire.tile_type_pkey)
+
+  SELECT tile_type_for_wire.tile_name, tile_type_for_wire.tile_type_name, wire_in_tile.name
+    FROM wire_in_tile
+    INNER JOIN tile_type_for_wire
+    ON tile_type_for_wire.wire_in_tile_pkey = wire_in_tile.pkey;""",
+    (node_pkey,)):
+            yield tile, tile_type, wire
+
+def node_to_site_pins(conn, node_pkey):
+    FIND_WIRE_WITH_SITE_PIN = """
+WITH wires_in_node(pkey, tile_pkey, wire_in_tile_pkey) AS (
+    SELECT pkey, tile_pkey, wire_in_tile_pkey FROM wire WHERE node_pkey = ?)
+SELECT wires_in_node.pkey, wires_in_node.tile_pkey, wire_in_tile.pkey
+    FROM wires_in_node
+    INNER JOIN wire_in_tile
+    ON wires_in_node.wire_in_tile_pkey = wire_in_tile.pkey
+    WHERE wire_in_tile.site_pin_pkey IS NOT NULL;"""
+
+    c = conn.cursor()
+    for wire_pkey, tile_pkey, wire_in_tile_pkey in c.execute(
+            FIND_WIRE_WITH_SITE_PIN, (node_pkey,)):
+        yield wire_pkey, tile_pkey, wire_in_tile_pkey

--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -8,15 +8,198 @@ class NodeClassification(enum.Enum):
     EDGES_TO_CHANNEL = 3
     EDGE_WITH_MUX = 4
 
+
+def create_tables(conn):
+    """ Create connection database scheme. """
+    c = conn.cursor()
+
+    c.execute("""CREATE TABLE tile_type(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT
+    );""")
+    c.execute("""CREATE TABLE site_type(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT
+    );""")
+    c.execute("""CREATE TABLE tile(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      tile_type_pkey INT,
+      grid_x INT,
+      grid_y INT,
+      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+    );""")
+    c.execute("""CREATE TABLE site_pin(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      site_type_pkey INT,
+      direction TEXT,
+      FOREIGN KEY(site_type_pkey) REFERENCES site_type(pkey)
+    );""")
+    c.execute("""CREATE TABLE site(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      x_coord INT,
+      y_coord INT,
+      site_type_pkey INT,
+      FOREIGN KEY(site_type_pkey) REFERENCES site_type(pkey)
+    );""")
+    c.execute("""CREATE TABLE wire_in_tile(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      tile_type_pkey INT,
+      site_pkey INT,
+      site_pin_pkey INT,
+      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
+      FOREIGN KEY(site_pkey) REFERENCES site(pkey),
+      FOREIGN KEY(site_pin_pkey) REFERENCES site_pin(pkey)
+    );""")
+    c.execute("""CREATE TABLE pip_in_tile(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      tile_type_pkey INT,
+      src_wire_in_tile_pkey INT,
+      dest_wire_in_tile_pkey INT,
+      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
+      FOREIGN KEY(src_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey),
+      FOREIGN KEY(dest_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey)
+    );""")
+    c.execute("""CREATE TABLE track(
+      pkey INTEGER PRIMARY KEY,
+      alive BOOL
+    );""")
+    c.execute("""CREATE TABLE node(
+      pkey INTEGER PRIMARY KEY,
+      number_pips INT,
+      track_pkey INT,
+      site_wire_pkey INT,
+      classification INT,
+      FOREIGN KEY(track_pkey) REFERENCES track_pkey(pkey),
+      FOREIGN KEY(site_wire_pkey) REFERENCES wire(pkey)
+    );""")
+    c.execute("""CREATE TABLE edge_with_mux(
+      pkey INTEGER PRIMARY KEY,
+      src_wire_pkey INT,
+      dest_wire_pkey INT,
+      pip_in_tile_pkey INT,
+      FOREIGN KEY(src_wire_pkey) REFERENCES wire(pkey),
+      FOREIGN KEY(dest_wire_pkey) REFERENCES wire(pkey),
+      FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip_in_tile(pkey)
+    );""")
+    c.execute("""CREATE TABLE graph_node(
+      pkey INTEGER PRIMARY KEY,
+      graph_node_type INT,
+      track_pkey INT,
+      node_pkey INT,
+      x_low INT,
+      x_high INT,
+      y_low INT,
+      y_high INT,
+      ptc INT,
+      capacity INT,
+      FOREIGN KEY(track_pkey) REFERENCES track(pkey),
+      FOREIGN KEY(node_pkey) REFERENCES node(pkey)
+    );""")
+    c.execute("""CREATE TABLE wire(
+      pkey INTEGER PRIMARY KEY,
+      node_pkey INT,
+      tile_pkey INT,
+      wire_in_tile_pkey INT,
+      graph_node_pkey INT,
+      top_graph_node_pkey INT,
+      bottom_graph_node_pkey INT,
+      left_graph_node_pkey INT,
+      right_graph_node_pkey INT,
+      FOREIGN KEY(node_pkey) REFERENCES node(pkey),
+      FOREIGN KEY(tile_pkey) REFERENCES tile(pkey),
+      FOREIGN KEY(wire_in_tile_pkey) REFERENCES wire_in_grid(pkey)
+      FOREIGN KEY(graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(top_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(bottom_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(left_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(right_graph_node_pkey) REFERENCES graph_node(pkey)
+    );""")
+    c.execute("""CREATE TABLE switch(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT
+    );""")
+    c.execute("""CREATE TABLE graph_edge(
+      src_graph_node_pkey INT,
+      dest_graph_node_pkey INT,
+      switch_pkey INT,
+      track_pkey INT,
+      tile_pkey INT,
+      pip_in_tile_pkey INT,
+      FOREIGN KEY(src_graph_node_pkey) REFERENCES graph_node(pkey),
+      FOREIGN KEY(dest_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(track_pkey) REFERENCES track(pkey)
+      FOREIGN KEY(tile_pkey) REFERENCES tile(pkey)
+      FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip(pkey)
+    );""")
+    c.execute("""CREATE TABLE channel(
+      chan_width_max INT,
+      x_min INT,
+      y_min INT,
+      x_max INT,
+      y_max INT
+    );""")
+    c.execute("""CREATE TABLE x_list(
+        idx INT,
+        info INT
+    );""")
+    c.execute("""CREATE TABLE y_list(
+        idx INT,
+        info INT
+    );""")
+
+    conn.commit()
+
+    c.execute("""INSERT INTO switch(name) VALUES
+        ("__vpr_delayless_switch__"),
+        ("routing"),
+        ("short");
+        """)
+
+    conn.commit()
+
+
 def get_wire_pkey(conn, tile_name, wire):
     c = conn.cursor()
     c.execute("""
-WITH selected_tile(tile_pkey, tile_type_pkey) AS (SELECT pkey, tile_type_pkey FROM tile WHERE name = ?)
-    SELECT wire.pkey FROM wire WHERE
-        wire.tile_pkey = (SELECT selected_tile.tile_pkey FROM selected_tile) AND
-        wire.wire_in_tile_pkey = (SELECT wire_in_tile.pkey FROM wire_in_tile WHERE
-            wire_in_tile.name = ? AND wire_in_tile.tile_type_pkey = (SELECT tile_type_pkey FROM selected_tile)
-            );
+WITH selected_tile(tile_pkey, tile_type_pkey) AS (
+  SELECT
+    pkey,
+    tile_type_pkey
+  FROM
+    tile
+  WHERE
+    name = ?
+)
+SELECT
+  wire.pkey
+FROM
+  wire
+WHERE
+  wire.tile_pkey = (
+    SELECT
+      selected_tile.tile_pkey
+    FROM
+      selected_tile
+  )
+  AND wire.wire_in_tile_pkey = (
+    SELECT
+      wire_in_tile.pkey
+    FROM
+      wire_in_tile
+    WHERE
+      wire_in_tile.name = ?
+      AND wire_in_tile.tile_type_pkey = (
+        SELECT
+          tile_type_pkey
+        FROM
+          selected_tile
+      )
+  );
 """, (tile_name, wire))
 
     (wire_pkey,) = c.fetchone()
@@ -64,32 +247,72 @@ def get_track_model(conn, track_pkey):
 def yield_wire_info_from_node(conn, node_pkey):
     c2 = conn.cursor()
     for tile, tile_type, wire in c2.execute("""
-WITH
-  wires_in_node(tile_pkey, wire_in_tile_pkey) AS (
-    SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE node_pkey = ?),
-  tile_for_wire(wire_in_tile_pkey, tile_name, tile_type_pkey) AS (
-    SELECT wires_in_node.wire_in_tile_pkey, tile.name, tile.tile_type_pkey
-    FROM tile INNER JOIN wires_in_node ON tile.pkey = wires_in_node.tile_pkey),
-  tile_type_for_wire(wire_in_tile_pkey, tile_name, tile_type_name) AS (
-  SELECT tile_for_wire.wire_in_tile_pkey, tile_for_wire.tile_name, tile_type.name
-  FROM tile_type INNER JOIN tile_for_wire ON tile_type.pkey = tile_for_wire.tile_type_pkey)
-
-  SELECT tile_type_for_wire.tile_name, tile_type_for_wire.tile_type_name, wire_in_tile.name
-    FROM wire_in_tile
-    INNER JOIN tile_type_for_wire
-    ON tile_type_for_wire.wire_in_tile_pkey = wire_in_tile.pkey;""",
+WITH wires_in_node(tile_pkey, wire_in_tile_pkey) AS (
+  SELECT
+    tile_pkey,
+    wire_in_tile_pkey
+  FROM
+    wire
+  WHERE
+    node_pkey = ?
+),
+tile_for_wire(
+  wire_in_tile_pkey, tile_name, tile_type_pkey
+) AS (
+  SELECT
+    wires_in_node.wire_in_tile_pkey,
+    tile.name,
+    tile.tile_type_pkey
+  FROM
+    tile
+    INNER JOIN wires_in_node ON tile.pkey = wires_in_node.tile_pkey
+),
+tile_type_for_wire(
+  wire_in_tile_pkey, tile_name, tile_type_name
+) AS (
+  SELECT
+    tile_for_wire.wire_in_tile_pkey,
+    tile_for_wire.tile_name,
+    tile_type.name
+  FROM
+    tile_type
+    INNER JOIN tile_for_wire ON tile_type.pkey = tile_for_wire.tile_type_pkey
+)
+SELECT
+  tile_type_for_wire.tile_name,
+  tile_type_for_wire.tile_type_name,
+  wire_in_tile.name
+FROM
+  wire_in_tile
+  INNER JOIN tile_type_for_wire ON tile_type_for_wire.wire_in_tile_pkey = wire_in_tile.pkey;
+    """,
     (node_pkey,)):
             yield tile, tile_type, wire
 
 def node_to_site_pins(conn, node_pkey):
     FIND_WIRE_WITH_SITE_PIN = """
-WITH wires_in_node(pkey, tile_pkey, wire_in_tile_pkey) AS (
-    SELECT pkey, tile_pkey, wire_in_tile_pkey FROM wire WHERE node_pkey = ?)
-SELECT wires_in_node.pkey, wires_in_node.tile_pkey, wire_in_tile.pkey
-    FROM wires_in_node
-    INNER JOIN wire_in_tile
-    ON wires_in_node.wire_in_tile_pkey = wire_in_tile.pkey
-    WHERE wire_in_tile.site_pin_pkey IS NOT NULL;"""
+WITH wires_in_node(
+  pkey, tile_pkey, wire_in_tile_pkey
+) AS (
+  SELECT
+    pkey,
+    tile_pkey,
+    wire_in_tile_pkey
+  FROM
+    wire
+  WHERE
+    node_pkey = ?
+)
+SELECT
+  wires_in_node.pkey,
+  wires_in_node.tile_pkey,
+  wire_in_tile.pkey
+FROM
+  wires_in_node
+  INNER JOIN wire_in_tile ON wires_in_node.wire_in_tile_pkey = wire_in_tile.pkey
+WHERE
+  wire_in_tile.site_pin_pkey IS NOT NULL;
+"""
 
     c = conn.cursor()
     for wire_pkey, tile_pkey, wire_in_tile_pkey in c.execute(

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -185,17 +185,19 @@ class Graph(object):
 
         self.graph = graph2.Graph(**graph_input)
 
-    def serialize_to_xml(self, tool_version, tool_comment, pad_segment, pool=None):
+    def serialize_to_xml(self, tool_version, tool_comment, pad_segment, channels_obj=None, pool=None):
         output_xml = ET.Element('rr_graph', {
                 'tool_name': 'vpr',
                 'tool_version': tool_version,
                 'tool_comment': tool_comment,
         })
 
-        channels_obj = self.graph.create_channels(
-                pad_segment=pad_segment,
-                pool=pool,
-        )
+        if channels_obj is None:
+            channels_obj = self.graph.create_channels(
+                    pad_segment=pad_segment,
+                    pool=pool,
+            )
+
         self.graph.check_ptc()
 
         channels_xml = ET.SubElement(output_xml, 'channels')

--- a/xc7/make/device_define.cmake
+++ b/xc7/make/device_define.cmake
@@ -53,7 +53,7 @@ function(ADD_XC7_DEVICE_DEFINE)
     add_subdirectory(${DEVICE}-roi-virt)
 
     # SYNTH_TILES used in ROI.
-    set(CHANNELS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${ARCH}/channels.json)
+    set(CHANNELS ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE}-roi-virt/channels.db)
     set(SYNTH_TILES ${CMAKE_CURRENT_SOURCE_DIR}/${DEVICE}-roi-virt/synth_tiles.json)
     get_file_location(SYNTH_TILES_LOCATION ${SYNTH_TILES})
     get_file_location(CHANNELS_LOCATIONS ${CHANNELS})
@@ -68,7 +68,7 @@ function(ADD_XC7_DEVICE_DEFINE)
       ARCH ${ARCH}
       DEVICE_TYPE ${DEVICE}-roi-virt
       PACKAGES test
-      RR_PATCH_EXTRA_ARGS --synth_tiles ${SYNTH_TILES_LOCATION} --channels ${CHANNELS_LOCATIONS}
+      RR_PATCH_EXTRA_ARGS --synth_tiles ${SYNTH_TILES_LOCATION} --connection_database ${CHANNELS_LOCATIONS}
       RR_PATCH_DEPS ${DEVICE_RR_PATCH_DEPS}
       )
 

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -153,16 +153,10 @@ function(PROJECT_XRAY_ARCH)
     list(APPEND ARCH_INCLUDE_FILES ${MODEL_XML} ${INCLUDE_FILES})
   endforeach()
 
-  set(OUTPUTS arch.xml channels.db)
   set(ROI_ARG "")
+  set(ROI_ARG_FOR_CREATE_EDGES "")
+
   if(NOT "${PROJECT_XRAY_ARCH_USE_ROI}" STREQUAL "")
-    set(OUTPUTS arch.xml channels.db)
-    set(ROI_ARG --use_roi ${PROJECT_XRAY_ARCH_USE_ROI} --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json)
-    list(APPEND DEPS ${PROJECT_XRAY_ARCH_USE_ROI} synth_tiles.json)
-
-    set(ROI_ARG_FOR_CREATE_EDGES --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json)
-    list(APPEND CHANNELS_DEPS synth_tiles.json)
-
     add_custom_command(
       OUTPUT synth_tiles.json
       COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PRJXRAY_DIR}:${symbiflow-arch-defs_SOURCE_DIR}/utils
@@ -175,12 +169,17 @@ function(PROJECT_XRAY_ARCH)
         ${PROJECT_XRAY_ARCH_USE_ROI}
         ${PYTHON3} ${PYTHON3_TARGET}
         )
-    if(NOT "${PROJECT_XRAY_ARCH_USE_ROI}" STREQUAL "")
-      add_file_target(FILE synth_tiles.json GENERATED)
-      set_target_properties(${ARCH_TARGET} PROPERTIES USE_ROI TRUE)
-      set_target_properties(${ARCH_TARGET} PROPERTIES
-          SYNTH_TILES ${CMAKE_CURRENT_SOURCE_DIR}/synth_tiles.json)
-    endif()
+
+    add_file_target(FILE synth_tiles.json GENERATED)
+    set_target_properties(${ARCH_TARGET} PROPERTIES USE_ROI TRUE)
+    set_target_properties(${ARCH_TARGET} PROPERTIES
+        SYNTH_TILES ${CMAKE_CURRENT_SOURCE_DIR}/synth_tiles.json)
+
+    set(ROI_ARG --use_roi ${PROJECT_XRAY_ARCH_USE_ROI} --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json)
+    list(APPEND DEPS ${PROJECT_XRAY_ARCH_USE_ROI} synth_tiles.json)
+
+    set(ROI_ARG_FOR_CREATE_EDGES --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json)
+    list(APPEND CHANNELS_DEPS synth_tiles.json)
   endif()
 
   append_file_dependency(DEPS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/pin_assignments.json)
@@ -229,6 +228,7 @@ function(PROJECT_XRAY_ARCH)
     ${PYTHON3} ${PYTHON3_TARGET} ${CREATE_EDGES}
       ${CHANNELS_DEPS}
     )
+
   add_file_target(FILE channels.db GENERATED)
 endfunction()
 

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -147,17 +147,11 @@ def main():
     g = db.grid()
     x_min, x_max, y_min, y_max = g.dims()
 
-    # FIXME: There is an issue in the routing phase. (https://github.com/SymbiFlow/symbiflow-arch-defs/issues/353)
-    # if a zynq device is selected the grid must be expanded by 1
-    if args.device == 'xc7z010':
-        x_max += 1
-        y_max += 1
-
     name = '{}-test'.format(args.device)
     fixed_layout_xml = ET.SubElement(layout_xml, 'fixed_layout', {
             'name': name,
-            'height': str(y_max+1),
-            'width': str(x_max+1),
+            'height': str(y_max+2),
+            'width': str(x_max+2),
     })
 
     only_emit_roi = False

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -109,9 +109,9 @@ def main():
     parser.add_argument(
             '--use_roi', required=False)
     parser.add_argument(
-            '--synth_tiles', required=False)
-    parser.add_argument(
             '--device', required=True)
+    parser.add_argument(
+            '--synth_tiles', required=False)
 
     args = parser.parse_args()
 
@@ -161,8 +161,6 @@ def main():
     })
 
     only_emit_roi = False
-    roi_inputs = []
-    roi_outputs = []
 
     synth_tiles = {}
     synth_tiles['tiles'] = {}
@@ -171,6 +169,9 @@ def main():
         with open(args.use_roi) as f:
             j = json.load(f)
 
+        with open(args.synth_tiles) as f:
+            synth_tiles = json.load(f)
+
         roi = Roi(
                 db=db,
                 x1=j['info']['GRID_X_MIN'],
@@ -178,51 +179,6 @@ def main():
                 x2=j['info']['GRID_X_MAX'],
                 y2=j['info']['GRID_Y_MAX'],
                 )
-
-        synth_tiles['info'] = j['info']
-        for port in j['ports']:
-            if port['name'].startswith('dout['):
-                roi_outputs.append(port)
-                port_type = 'input'
-                is_clock = False
-            elif port['name'].startswith('din['):
-                roi_inputs.append(port)
-                is_clock = False
-                port_type = 'output'
-            elif port['name'].startswith('clk'):
-                roi_inputs.append(port)
-                port_type = 'output'
-                is_clock = True
-            else:
-                assert False, port
-
-            tile, wire = port['wire'].split('/')
-
-            # Make sure connecting wire is not in ROI!
-            loc = g.loc_of_tilename(tile)
-            if roi.tile_in_roi(loc):
-                # Or if in the ROI, make sure it has no sites.
-                gridinfo = g.gridinfo_at_tilename(tile)
-                assert len(db.get_tile_type(gridinfo.tile_type).get_sites()) == 0, tile
-
-
-
-            if tile not in synth_tiles['tiles']:
-                synth_tiles['tiles'][tile] = {
-                        'pins': [],
-                        'loc': g.loc_of_tilename(tile),
-                }
-
-            synth_tiles['tiles'][tile]['pins'].append({
-                    'roi_name': port['name'].replace('[', '_').replace(']','_'),
-                    'wire': wire,
-                    'pad': port['pin'],
-                    'port_type': port_type,
-                    'is_clock': is_clock,
-            })
-
-        with open(args.synth_tiles, 'w') as f:
-            json.dump(synth_tiles, f)
 
         synth_tile_map = add_synthetic_tile(complexblocklist_xml)
 

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -36,7 +36,8 @@ SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")):
         assert len(src_wire) == 1
         source_wire_pkey, src_tile_pkey, src_wire_in_tile_pkey = src_wire[0]
 
-        c2.execute("""SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?""",
+        c2.execute("""
+            SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?""",
                 (src_tile_pkey,))
         src_tile_type_pkey, source_loc_grid_x, source_loc_grid_y = c2.fetchone()
 
@@ -58,7 +59,8 @@ SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")):
         assert len(dest_wire) == 1
         destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = dest_wire[0]
 
-        c2.execute("""SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
+        c2.execute("""
+            SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
                 (dest_tile_pkey,))
         dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = c2.fetchone()
 
@@ -129,7 +131,8 @@ SELECT pkey, classification FROM node WHERE classification != ?;
                 """, (tile_pkey,))
             (tile_type,) = c3.fetchone()
 
-            c3.execute("""SELECT pkey, name, site_pin_pkey FROM wire_in_tile WHERE pkey = ?;""",
+            c3.execute("""
+SELECT pkey, name, site_pin_pkey FROM wire_in_tile WHERE pkey = ?;""",
                     (wire_in_tile_pkey,))
             (wire_in_tile_pkey, wire, site_pin_pkey) = c3.fetchone()
 
@@ -138,8 +141,16 @@ SELECT pkey, classification FROM node WHERE classification != ?;
                 continue
 
             for pip_pkey, pip, src_wire_in_tile_pkey, dest_wire_in_tile_pkey in c3.execute("""
-            SELECT pkey, name, src_wire_in_tile_pkey, dest_wire_in_tile_pkey FROM pip_in_tile WHERE
-                src_wire_in_tile_pkey = ? OR dest_wire_in_tile_pkey = ?;""", (wire_in_tile_pkey, wire_in_tile_pkey)):
+SELECT
+  pkey,
+  name,
+  src_wire_in_tile_pkey,
+  dest_wire_in_tile_pkey
+FROM
+  pip_in_tile
+WHERE
+  src_wire_in_tile_pkey = ?
+  OR dest_wire_in_tile_pkey = ?;""", (wire_in_tile_pkey, wire_in_tile_pkey)):
                 assert (
                     src_wire_in_tile_pkey == wire_in_tile_pkey or
                     dest_wire_in_tile_pkey == wire_in_tile_pkey), pip
@@ -153,9 +164,22 @@ SELECT pkey, classification FROM node WHERE classification != ?;
                 # to the node table and get track_pkey.
                 # other_wire_in_tile_pkey -> wire pkey -> node_pkey -> track_pkey
                 c4 = conn.cursor()
-                c4.execute("""SELECT track_pkey, classification FROM node WHERE pkey = (
-                    SELECT node_pkey FROM wire WHERE tile_pkey = ? AND wire_in_tile_pkey = ?
-                    );""", (tile_pkey, other_wire_in_tile_pkey))
+                c4.execute("""
+SELECT
+  track_pkey,
+  classification
+FROM
+  node
+WHERE
+  pkey = (
+    SELECT
+      node_pkey
+    FROM
+      wire
+    WHERE
+      tile_pkey = ?
+      AND wire_in_tile_pkey = ?
+  );""", (tile_pkey, other_wire_in_tile_pkey))
                 (track_pkey, classification) = c4.fetchone()
 
 

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -5,17 +5,178 @@ import prjxray.db
 import prjxray.tile
 import simplejson as json
 from lib.rr_graph import tracks
+from lib.connection_database import (NodeClassification,
+        yield_wire_info_from_node, get_track_model, node_to_site_pins)
 import progressbar
+import sqlite3
 import datetime
 
+now = datetime.datetime.now
 DirectConnection = namedtuple('DirectConnection', 'from_pin to_pin switch_name x_offset y_offset')
+
+def handle_direction_connections(conn, direct_connections, edge_assignments):
+    # Edges with mux should have one source tile and one destination_tile.
+    # The pin from the source_tile should face the destination_tile.
+    #
+    # It is expected that all edges_with_mux will lies in a line (e.g. X only or
+    # Y only).
+    c = conn.cursor()
+    for src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey in progressbar.progressbar(c.execute("""
+SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")):
+
+        c2 = conn.cursor()
+
+        # Get the node that is attached to the source.
+        c2.execute("""SELECT node_pkey FROM wire WHERE pkey = ?""",
+                (src_wire_pkey,))
+        (src_node_pkey,) = c2.fetchone()
+
+        # Find the wire connected to the source.
+        src_wire = list(node_to_site_pins(conn, src_node_pkey))
+        assert len(src_wire) == 1
+        source_wire_pkey, src_tile_pkey, src_wire_in_tile_pkey = src_wire[0]
+
+        c2.execute("""SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?""",
+                (src_tile_pkey,))
+        src_tile_type_pkey, source_loc_grid_x, source_loc_grid_y = c2.fetchone()
+
+        c2.execute("""SELECT name FROM tile_type WHERE pkey = ?""",
+                (src_tile_type_pkey,))
+        (source_tile_type,) = c2.fetchone()
+
+        c2.execute("""SELECT name FROM wire_in_tile WHERE pkey = ?""",
+                (src_wire_in_tile_pkey,))
+        (source_wire,) = c2.fetchone()
+
+        # Get the node that is attached to the sink.
+        c2.execute("""SELECT node_pkey FROM wire WHERE pkey = ?""",
+                (dest_wire_pkey,))
+        (dest_node_pkey,) = c2.fetchone()
+
+        # Find the wire connected to the sink.
+        dest_wire = list(node_to_site_pins(conn, dest_node_pkey))
+        assert len(dest_wire) == 1
+        destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = dest_wire[0]
+
+        c2.execute("""SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
+                (dest_tile_pkey,))
+        dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = c2.fetchone()
+
+        c2.execute("""SELECT name FROM tile_type WHERE pkey = ?""",
+                (dest_tile_type_pkey,))
+        (destination_tile_type,) = c2.fetchone()
+
+        c2.execute("""SELECT name FROM wire_in_tile WHERE pkey = ?""",
+                (dest_wire_in_tile_pkey,))
+        (destination_wire,) = c2.fetchone()
+
+        direct_connections.add(
+                DirectConnection(
+                        from_pin='{}.{}'.format(source_tile_type, source_wire),
+                        to_pin='{}.{}'.format(destination_tile_type, destination_wire),
+                        switch_name='routing',
+                        x_offset=destination_loc_grid_x-source_loc_grid_x,
+                        y_offset=destination_loc_grid_y-source_loc_grid_y,
+                )
+        )
+
+        if destination_loc_grid_x == source_loc_grid_x:
+            if destination_loc_grid_y > source_loc_grid_y:
+                source_dir = tracks.Direction.TOP
+                destination_dir = tracks.Direction.BOTTOM
+            else:
+                source_dir = tracks.Direction.BOTTOM
+                destination_dir = tracks.Direction.TOP
+        else:
+            if destination_loc_grid_x > source_loc_grid_x:
+                source_dir = tracks.Direction.RIGHT
+                destination_dir = tracks.Direction.LEFT
+            else:
+                source_dir = tracks.Direction.LEFT
+                destination_dir = tracks.Direction.RIGHT
+
+        edge_assignments[(source_tile_type, source_wire)].append((source_dir,))
+        edge_assignments[(destination_tile_type, destination_wire)].append((destination_dir,))
+
+
+def handle_edges_to_channels(conn, null_tile_wires, edge_assignments, channel_wires_to_tracks):
+    c = conn.cursor()
+
+    for node_pkey, classification in progressbar.progressbar(c.execute("""
+SELECT pkey, classification FROM node WHERE classification != ?;
+""", (NodeClassification.CHANNEL.value,))):
+        reason = NodeClassification(classification)
+
+        if reason == NodeClassification.NULL:
+            for (_, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
+                null_tile_wires.add((tile_type, wire))
+
+        if reason != NodeClassification.EDGES_TO_CHANNEL:
+            continue
+
+        c2 = conn.cursor()
+        for tile_pkey, wire_in_tile_pkey in c2.execute("""
+            SELECT tile_pkey, wire_in_tile_pkey
+                FROM wire WHERE node_pkey = ?;""",
+        (node_pkey,)):
+            c3 = conn.cursor()
+            c3.execute("""SELECT name, grid_x, grid_y FROM tile WHERE pkey = ?;
+                """, (tile_pkey,))
+            (tile, grid_x, grid_y) = c3.fetchone()
+
+            c3.execute("""SELECT name FROM tile_type
+                WHERE pkey = (SELECT tile_type_pkey FROM tile WHERE pkey = ?);
+                """, (tile_pkey,))
+            (tile_type,) = c3.fetchone()
+
+            c3.execute("""SELECT pkey, name, site_pin_pkey FROM wire_in_tile WHERE pkey = ?;""",
+                    (wire_in_tile_pkey,))
+            (wire_in_tile_pkey, wire, site_pin_pkey) = c3.fetchone()
+
+            # This node has no site pin, don't need to assign pin direction.
+            if site_pin_pkey is None:
+                continue
+
+            for pip_pkey, pip, src_wire_in_tile_pkey, dest_wire_in_tile_pkey in c3.execute("""
+            SELECT pkey, name, src_wire_in_tile_pkey, dest_wire_in_tile_pkey FROM pip_in_tile WHERE
+                src_wire_in_tile_pkey = ? OR dest_wire_in_tile_pkey = ?;""", (wire_in_tile_pkey, wire_in_tile_pkey)):
+                assert (
+                    src_wire_in_tile_pkey == wire_in_tile_pkey or
+                    dest_wire_in_tile_pkey == wire_in_tile_pkey), pip
+
+                if src_wire_in_tile_pkey == wire_in_tile_pkey:
+                    other_wire_in_tile_pkey = dest_wire_in_tile_pkey
+                else:
+                    other_wire_in_tile_pkey = src_wire_in_tile_pkey
+
+                # Need to walk from the wire_in_tile table, to the wire table,
+                # to the node table and get track_pkey.
+                # other_wire_in_tile_pkey -> wire pkey -> node_pkey -> track_pkey
+                c4 = conn.cursor()
+                c4.execute("""SELECT track_pkey, classification FROM node WHERE pkey = (
+                    SELECT node_pkey FROM wire WHERE tile_pkey = ? AND wire_in_tile_pkey = ?
+                    );""", (tile_pkey, other_wire_in_tile_pkey))
+                (track_pkey, classification) = c4.fetchone()
+
+
+                # Some pips do connect to a track at all, e.g. null node
+                if track_pkey is None:
+                    # TODO: Handle weird connections.
+                    #other_node_class = NodeClassification(classification)
+                    #assert other_node_class == NodeClassification.NULL, (
+                    #        node_pkey, pip_pkey, pip, other_node_class)
+                    continue
+
+                tracks_model = channel_wires_to_tracks[track_pkey]
+                available_pins = set(pin_dir for _, pin_dir in tracks_model.get_tracks_for_wire_at_coord((grid_x, grid_y)))
+                edge_assignments[(tile_type, wire)].append(available_pins)
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
             '--db_root', help='Project X-Ray Database', required=True)
     parser.add_argument(
-            '--channels', help='Input JSON defining channel assignments', required=True)
+            '--connection_database', help='Database of fabric connectivity', required=True)
     parser.add_argument(
             '--pin_assignments', help='Output JSON assigning pins to tile types and direction connections', required=True)
 
@@ -43,95 +204,26 @@ def main():
                 assert key not in edge_assignments, key
                 edge_assignments[key] = []
 
-    print('{} Reading channel data'.format(datetime.datetime.now()))
-    with open(args.channels) as f:
-        channels = json.load(f)
-    print('{} Done reading channel data'.format(datetime.datetime.now()))
+    conn = sqlite3.connect(args.connection_database)
 
     direct_connections = set()
-
-    # Edges with mux should have one source tile and one destination_tile.
-    # The pin from the source_tile should face the destination_tile.
-    #
-    # It is expected that all edges_with_mux will lies in a line (e.g. X only or
-    # Y only).
-    for edge_with_mux in progressbar.progressbar(channels['edges_with_mux']):
-        source_tile = None
-        source_tile_type = None
-        source_wire = None
-        destination_tile = None
-        destination_tile_type = None
-        destination_wire = None
-
-        for tile, wire in edge_with_mux['source_node']:
-            tileinfo = grid.gridinfo_at_tilename(tile)
-            tile_type = db.get_tile_type(tileinfo.tile_type)
-            wire_info = tile_type.get_wire_info(wire)
-
-            if len(wire_info.sites) == 1:
-                assert source_tile is None, (tile, wire, source_tile)
-                source_tile = tile
-                source_tile_type = tileinfo.tile_type
-                source_wire = wire
-
-        for tile, wire in edge_with_mux['destination_node']:
-            tileinfo = grid.gridinfo_at_tilename(tile)
-            tile_type = db.get_tile_type(tileinfo.tile_type)
-            wire_info = tile_type.get_wire_info(wire)
-
-            if len(wire_info.sites) == 1:
-                assert destination_tile is None, (tile, wire, destination_tile, wire_info)
-                destination_tile = tile
-                destination_tile_type = tileinfo.tile_type
-                destination_wire = wire
-
-        assert source_tile is not None
-        assert destination_tile is not None
-
-        source_loc = grid.loc_of_tilename(source_tile)
-        destination_loc = grid.loc_of_tilename(destination_tile)
-
-        assert source_loc.grid_x == destination_loc.grid_x or source_loc.grid_y == destination_loc.grid_y, (source_tile, destination_tile, edge_with_mux['pip'])
-
-        direct_connections.add(
-                DirectConnection(
-                        from_pin='{}.{}'.format(source_tile_type, source_wire),
-                        to_pin='{}.{}'.format(destination_tile_type, destination_wire),
-                        switch_name='routing',
-                        x_offset=destination_loc.grid_x-source_loc.grid_x,
-                        y_offset=destination_loc.grid_y-source_loc.grid_y,
-                )
-        )
-
-        if destination_loc.grid_x == source_loc.grid_x:
-            if destination_loc.grid_y > source_loc.grid_y:
-                source_dir = tracks.Direction.TOP
-                destination_dir = tracks.Direction.BOTTOM
-            else:
-                source_dir = tracks.Direction.BOTTOM
-                destination_dir = tracks.Direction.TOP
-        else:
-            if destination_loc.grid_x > source_loc.grid_x:
-                source_dir = tracks.Direction.RIGHT
-                destination_dir = tracks.Direction.LEFT
-            else:
-                source_dir = tracks.Direction.LEFT
-                destination_dir = tracks.Direction.RIGHT
-
-        edge_assignments[(source_tile_type, source_wire)].append((source_dir,))
-        edge_assignments[(destination_tile_type, destination_wire)].append((destination_dir,))
+    print('{} Processing direct connections.'.format(now()))
+    handle_direction_connections(conn, direct_connections, edge_assignments)
 
     wires_not_in_channels = {}
-    for node in progressbar.progressbar(channels['node_not_in_channels']):
-        reason = node['classification']
+    c = conn.cursor()
+    print('{} Processing non-channel nodes.'.format(now()))
+    for node_pkey, classification in progressbar.progressbar(c.execute("""
+SELECT pkey, classification FROM node WHERE classification != ?;
+""", (NodeClassification.CHANNEL.value,))):
+        reason = NodeClassification(classification)
 
-        for tile, wire in node['wires']:
-            tileinfo = grid.gridinfo_at_tilename(tile)
-            key = (tileinfo.tile_type, wire)
+        for (tile, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
+            key = (tile_type, wire)
 
             # Sometimes nodes in particular tile instances are disconnected,
             # disregard classification changes if this is the case.
-            if reason != 'NULL':
+            if reason != NodeClassification.NULL:
                 if key not in wires_not_in_channels:
                     wires_not_in_channels[key] = reason
                 else:
@@ -150,15 +242,17 @@ def main():
 
     # Generate track models and verify that wires are either in a channel
     # or not in a channel.
-    for channel in progressbar.progressbar(channels['channels']):
-        track_list = []
-        for track in channel['tracks']:
-            track_list.append(tracks.Track(**track))
+    print('{} Creating models from tracks.'.format(now()))
+    for node_pkey, track_pkey in progressbar.progressbar(c.execute("""
+SELECT pkey, track_pkey FROM node WHERE classification = ?;
+""", (NodeClassification.CHANNEL.value,))):
+        assert track_pkey is not None
 
-        tracks_model = tracks.Tracks(track_list, channel['track_connections'])
+        tracks_model, _ = get_track_model(conn, track_pkey)
         channel_nodes.append(tracks_model)
+        channel_wires_to_tracks[track_pkey] = tracks_model
 
-        for tile, wire in channel['wires']:
+        for (tile, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
             tileinfo = grid.gridinfo_at_tilename(tile)
             key = (tileinfo.tile_type, wire)
             # Make sure all wires in channels always are in channels
@@ -166,8 +260,6 @@ def main():
 
             if key in wires_in_tile_types:
                 wires_in_tile_types.remove(key)
-
-            channel_wires_to_tracks[(tile, wire)] = tracks_model
 
     # Make sure all wires appear to have been assigned.
     assert len(wires_in_tile_types) == 0
@@ -183,48 +275,20 @@ def main():
     #
     # If no live connections from the node are present, this node should've
     # been marked as NULL during channel formation.
-    for node in progressbar.progressbar(channels['node_not_in_channels']):
-        reason = node['classification']
+    print('{} Handling edges to channels.'.format(now()))
+    handle_edges_to_channels(conn, null_tile_wires, edge_assignments, channel_wires_to_tracks)
 
-        assert reason != 'EDGE_WITH_SHORT'
-
-        if reason == 'NULL':
-            for tile, wire in node['wires']:
-                tileinfo = grid.gridinfo_at_tilename(tile)
-                tile_type = db.get_tile_type(tileinfo.tile_type)
-                null_tile_wires.add((tileinfo.tile_type, wire))
-
-        if reason == 'EDGES_TO_CHANNEL':
-
-            num_sites = 0
-
-            for tile, wire in node['wires']:
-                tileinfo = grid.gridinfo_at_tilename(tile)
-                loc = grid.loc_of_tilename(tile)
-                tile_type = db.get_tile_type(tileinfo.tile_type)
-
-                wire_info = tile_type.get_wire_info(wire)
-                num_sites += len(wire_info.sites)
-                for pip in wire_info.pips:
-                    other_wire = prjxray.tile.get_other_wire_from_pip(tile_type.get_pip_by_name(pip), wire)
-
-                    key = (tile, other_wire)
-                    if key in channel_wires_to_tracks:
-                        tracks_model = channel_wires_to_tracks[key]
-
-                        if len(wire_info.sites) > 0:
-                            available_pins = set(pin_dir for _, pin_dir in tracks_model.get_tracks_for_wire_at_coord((loc.grid_x, loc.grid_y)))
-                            edge_assignments[(tileinfo.tile_type, wire)].append(available_pins)
-
+    print('{} Processing edge assignments.'.format(now()))
     final_edge_assignments = {}
-    for (tile_type, wire), available_pins in progressbar.progressbar(edge_assignments.items()):
+    for key, available_pins in progressbar.progressbar(edge_assignments.items()):
+        (tile_type, wire) = key
         if len(available_pins) == 0:
             if (tile_type, wire) not in null_tile_wires:
                 # TODO: Figure out what is going on with these wires.  Appear to
                 # tile internal connections sometimes?
                 print((tile_type, wire))
 
-            final_edge_assignments[(tile_type, wire)] = [tracks.Direction.RIGHT]
+            final_edge_assignments[key] = [tracks.Direction.RIGHT]
             continue
 
         pins = set(available_pins[0])
@@ -232,7 +296,7 @@ def main():
             pins &= set(p)
 
         if len(pins) > 0:
-            final_edge_assignments[(tile_type, wire)] = [list(pins)[0]]
+            final_edge_assignments[key] = [list(pins)[0]]
         else:
             # More than 2 pins are required, final the minimal number of pins
             pins = set()
@@ -264,17 +328,19 @@ def main():
                 if len(pins) == prev_len:
                     break
 
-            final_edge_assignments[(tile_type, wire)] = pins
+            final_edge_assignments[key] = pins
 
-    for (tile_type, wire), available_pins in edge_assignments.items():
-        pins = set(final_edge_assignments[(tile_type, wire)])
+    for key, available_pins in edge_assignments.items():
+        (tile_type, wire) = key
+        pins = set(final_edge_assignments[key])
 
         for required_pins in available_pins:
             assert len(pins & set(required_pins)) > 0, (
                     tile_type, wire, pins, required_pins)
 
     pin_directions = {}
-    for (tile_type, wire), pins in final_edge_assignments.items():
+    for key, pins in progressbar.progressbar(final_edge_assignments.items()):
+        (tile_type, wire) = key
         if tile_type not in pin_directions:
             pin_directions[tile_type] = {}
 

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -1,4 +1,18 @@
-""" Assign pin directions to all tile pins such that they point to the connecting channel or direct connection. """
+""" Assign pin directions to all tile pins.
+
+Tile pins are defined by one of two methods:
+ - Pins that are part of a direct connection (e.g. edge_with_mux) are assigned
+   based on the direction relationship between the two tiles, e.g. facing each
+   other.
+ - Pins that connect to a routing track face a routing track.
+
+Tile pins may end up with multiple edges if the routing tracks are formed
+differently throughout the grid.
+
+No connection database modifications are made in
+prjxray_assign_tile_pin_direction.
+
+"""
 import argparse
 from collections import namedtuple
 import prjxray.db

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -41,8 +41,8 @@ SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")):
         c2 = conn.cursor()
 
         # Get the node that is attached to the source.
-        c2.execute("""SELECT node_pkey FROM wire WHERE pkey = ?""",
-                (src_wire_pkey,))
+        c2.execute("""
+SELECT node_pkey FROM wire WHERE pkey = ?""", (src_wire_pkey,))
         (src_node_pkey,) = c2.fetchone()
 
         # Find the wire connected to the source.
@@ -51,20 +51,23 @@ SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")):
         source_wire_pkey, src_tile_pkey, src_wire_in_tile_pkey = src_wire[0]
 
         c2.execute("""
-            SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?""",
+SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?""",
                 (src_tile_pkey,))
         src_tile_type_pkey, source_loc_grid_x, source_loc_grid_y = c2.fetchone()
 
-        c2.execute("""SELECT name FROM tile_type WHERE pkey = ?""",
+        c2.execute("""
+SELECT name FROM tile_type WHERE pkey = ?""",
                 (src_tile_type_pkey,))
         (source_tile_type,) = c2.fetchone()
 
-        c2.execute("""SELECT name FROM wire_in_tile WHERE pkey = ?""",
+        c2.execute("""
+SELECT name FROM wire_in_tile WHERE pkey = ?""",
                 (src_wire_in_tile_pkey,))
         (source_wire,) = c2.fetchone()
 
         # Get the node that is attached to the sink.
-        c2.execute("""SELECT node_pkey FROM wire WHERE pkey = ?""",
+        c2.execute("""
+SELECT node_pkey FROM wire WHERE pkey = ?""",
                 (dest_wire_pkey,))
         (dest_node_pkey,) = c2.fetchone()
 
@@ -74,15 +77,17 @@ SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")):
         destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = dest_wire[0]
 
         c2.execute("""
-            SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
+SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
                 (dest_tile_pkey,))
         dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = c2.fetchone()
 
-        c2.execute("""SELECT name FROM tile_type WHERE pkey = ?""",
+        c2.execute("""
+SELECT name FROM tile_type WHERE pkey = ?""",
                 (dest_tile_type_pkey,))
         (destination_tile_type,) = c2.fetchone()
 
-        c2.execute("""SELECT name FROM wire_in_tile WHERE pkey = ?""",
+        c2.execute("""
+SELECT name FROM wire_in_tile WHERE pkey = ?""",
                 (dest_wire_in_tile_pkey,))
         (destination_wire,) = c2.fetchone()
 
@@ -132,16 +137,28 @@ SELECT pkey, classification FROM node WHERE classification != ?;
 
         c2 = conn.cursor()
         for tile_pkey, wire_in_tile_pkey in c2.execute("""
-            SELECT tile_pkey, wire_in_tile_pkey
-                FROM wire WHERE node_pkey = ?;""",
+SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE node_pkey = ?;""",
         (node_pkey,)):
             c3 = conn.cursor()
-            c3.execute("""SELECT name, grid_x, grid_y FROM tile WHERE pkey = ?;
-                """, (tile_pkey,))
+            c3.execute("""
+SELECT name, grid_x, grid_y FROM tile WHERE pkey = ?;""",
+                (tile_pkey,))
             (tile, grid_x, grid_y) = c3.fetchone()
 
-            c3.execute("""SELECT name FROM tile_type
-                WHERE pkey = (SELECT tile_type_pkey FROM tile WHERE pkey = ?);
+            c3.execute("""
+SELECT
+  name
+FROM
+  tile_type
+WHERE
+  pkey = (
+    SELECT
+      tile_type_pkey
+    FROM
+      tile
+    WHERE
+      pkey = ?
+  );
                 """, (tile_pkey,))
             (tile_type,) = c3.fetchone()
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -1,0 +1,635 @@
+#!/usr/bin/env python3
+""" Creates graph nodes and edges in connection database.
+
+For ROI configurations, pips that would intefer with the ROI are not emitted,
+and connections that lies outside the ROI are ignored.
+
+"""
+
+import argparse
+import prjxray.db
+from prjxray.roi import Roi
+import simplejson as json
+import progressbar
+import datetime
+import sqlite3
+import functools
+from collections import namedtuple
+from lib.rr_graph import tracks
+from lib.rr_graph import graph2
+from prjxray.site_type import SitePinDirection
+from lib.connection_database import get_track_model
+from lib.rr_graph.graph2 import NodeType
+
+now = datetime.datetime.now
+
+
+def add_graph_nodes_for_pins(conn, tile_type, wire, pin_directions):
+    """ Adds graph_node rows for each pin on a wire in a tile. """
+
+    # Find the generic wire_in_tile_pkey for the specified tile_type name and
+    # wire name.
+    c = conn.cursor()
+    c.execute("""
+SELECT pkey, site_pin_pkey FROM wire_in_tile
+WHERE name = ? and tile_type_pkey = (SELECT pkey FROM tile_type WHERE name = ?);
+""", (wire, tile_type))
+
+    (wire_in_tile_pkey, site_pin_pkey) = c.fetchone()
+
+    # Determine if this should be an IPIN or OPIN based on the site_pin
+    # direction.
+    c.execute("""
+        SELECT direction FROM site_pin WHERE pkey = ?;
+        """, (site_pin_pkey,))
+    (pin_direction,) = c.fetchone()
+
+    pin_direction = SitePinDirection(pin_direction)
+    if pin_direction == SitePinDirection.IN:
+        node_type = NodeType.IPIN
+    elif pin_direction == SitePinDirection.OUT:
+        node_type = NodeType.OPIN
+    else:
+        assert False, pin_direction
+
+    # Find all instances of this specific wire.
+    c.execute("""
+        SELECT pkey, node_pkey, tile_pkey
+            FROM wire WHERE wire_in_tile_pkey = ?;""",
+            (wire_in_tile_pkey,))
+
+    c2 = conn.cursor()
+    c3 = conn.cursor()
+    c2.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+
+    for wire_pkey, node_pkey, tile_pkey in c:
+        c3.execute("""
+            SELECT grid_x, grid_y FROM tile WHERE pkey = ?;""",
+            (tile_pkey,))
+
+        grid_x, grid_y = c3.fetchone()
+
+        updates = []
+        values = []
+
+        # Insert a graph_node per pin_direction.
+        for pin_direction in pin_directions:
+            c2.execute("""
+            INSERT INTO graph_node(
+                graph_node_type, node_pkey, x_low, x_high, y_low, y_high)
+                VALUES (?, ?, ?, ?, ?, ?)""", (
+                node_type.value, node_pkey, grid_x, grid_x, grid_y, grid_y,
+                ))
+
+            updates.append('{}_graph_node_pkey = ?'.format(pin_direction.name.lower()))
+            values.append(c2.lastrowid)
+
+        # Update the wire with the graph_nodes in each direction, if
+        # applicable.
+        c2.execute("""
+        UPDATE wire SET {updates} WHERE pkey = ?;""".format(
+            updates=','.join(updates)), values + [wire_pkey])
+
+    c2.execute("""COMMIT TRANSACTION;""")
+    c2.connection.commit()
+
+def create_find_pip(conn):
+    """ Returns a function that takes (tile_type, pip) and returns pip_in_tile_pkey. """
+    c = conn.cursor()
+
+    @functools.lru_cache(maxsize=None)
+    def find_pip(tile_type, pip):
+        c.execute("""SELECT pkey FROM pip_in_tile WHERE
+            name = ? AND
+            tile_type_pkey = (SELECT pkey FROM tile_type WHERE name = ?);""", (
+                pip, tile_type))
+
+        result = c.fetchone()
+        assert result is not None, (tile_type, pip)
+        return result[0]
+
+    return find_pip
+
+def create_find_wire(conn):
+    """ Returns a function finds a wire based on tile name and wire name.
+
+    Args:
+        conn: Database connection
+
+    Returns:
+        Function.  See find_wire below for signature.
+    """
+    c = conn.cursor()
+
+
+    @functools.lru_cache(maxsize=None)
+    def find_wire_in_tile(tile_type, wire):
+        c.execute("""SELECT pkey FROM wire_in_tile WHERE
+            name = ? AND
+            tile_type_pkey = (SELECT pkey FROM tile_type WHERE name = ?);""", (
+                wire, tile_type))
+
+        return c.fetchone()[0]
+
+
+    @functools.lru_cache(maxsize=None)
+    def find_wire(tile, tile_type, wire):
+        """ Finds a wire in the database.
+
+        Args:
+            tile (str): Tile name
+            tile_type (str): Type of tile name
+            wire (str): Wire name
+
+        Returns:
+            Tuple (wire_pkey, tile_pkey, node_pkey), where:
+                wire_pkey (int): Primary key of wire table
+                tile_pkey (int): Primary key of tile table that contains this
+                    wire.
+                node_pkey (int): Primary key of node table that is the node
+                    this wire belongs too.
+        """
+
+        wire_in_tile_pkey = find_wire_in_tile(tile_type, wire)
+        c.execute("""SELECT pkey, tile_pkey, node_pkey FROM wire WHERE
+            wire_in_tile_pkey = ? AND
+            tile_pkey = (SELECT pkey FROM tile WHERE name = ?);""", (
+                wire_in_tile_pkey, tile))
+
+        return c.fetchone()
+
+    return find_wire
+
+Pins = namedtuple('Pins', 'x y edge_map site_pin_direction')
+
+OPPOSITE_DIRECTIONS = {
+        tracks.Direction.TOP: tracks.Direction.BOTTOM,
+        tracks.Direction.BOTTOM: tracks.Direction.TOP,
+        tracks.Direction.LEFT: tracks.Direction.RIGHT,
+        tracks.Direction.RIGHT: tracks.Direction.LEFT,
+    }
+
+class Connector(object):
+    """ Connector is an object for joining two nodes.
+
+    Connector represents either a site pin within a specific tile or routing
+    channel made of one or more channel nodes.
+
+
+    """
+    def __init__(self, pins=None, tracks=None):
+        """ Create a Connector object.
+
+        Provide either pins or tracks, not both or neither.
+
+        Args:
+            pins (Pins namedtuple): If this Connector object represents a
+                site pin, provide the pins named arguments.
+            tracks (tuple of (tracks.Tracks, list of graph nodes)): If this
+                Connector object represents a routing channel, provide the
+                tracks named argument.
+
+                The tuple can most easily be constructed via
+                connection_database.get_track_model, which builds the Tracks
+                models and the graph node list.
+        """
+        self.pins = pins
+        self.tracks = tracks
+        assert (self.pins is not None) ^ (self.tracks is not None)
+
+    def connect_at(self, loc, other_connector):
+        """ Connect two Connector objects at a location within the grid.
+
+        Args:
+            loc (prjxray.grid_types.GridLoc): Location within grid to make
+                connection.
+            other_connector (Connector): Destination connection.
+
+        Returns:
+            Tuple of (src_graph_node_pkey, dest_graph_node_pkey)
+
+        """
+        if self.tracks and other_connector.tracks:
+            tracks_model, graph_nodes = self.tracks
+            idx1 = None
+            for idx1, _ in tracks_model.get_tracks_for_wire_at_coord(loc):
+                break
+
+            assert idx1 is not None
+
+            other_tracks_model, other_graph_nodes = other_connector.tracks
+            idx2 = None
+            for idx2, _ in other_tracks_model.get_tracks_for_wire_at_coord(loc):
+                break
+
+            assert idx2 is not None
+
+            return graph_nodes[idx1], other_graph_nodes[idx2]
+        elif self.pins and other_connector.tracks:
+            assert self.pins.site_pin_direction == SitePinDirection.OUT
+            assert self.pins.x == loc.grid_x
+            assert self.pins.y == loc.grid_y
+
+            tracks_model, graph_nodes = other_connector.tracks
+            for idx, pin_dir in tracks_model.get_tracks_for_wire_at_coord(loc):
+                if pin_dir in self.pins.edge_map:
+                    return self.pins.edge_map[pin_dir], graph_nodes[idx]
+        elif self.tracks and other_connector.pins:
+            assert other_connector.pins.site_pin_direction == SitePinDirection.IN
+            assert other_connector.pins.x == loc.grid_x
+            assert other_connector.pins.y == loc.grid_y
+
+            tracks_model, graph_nodes = self.tracks
+            for idx, pin_dir in tracks_model.get_tracks_for_wire_at_coord(loc):
+                if pin_dir in other_connector.pins.edge_map:
+                    return graph_nodes[idx], other_connector.pins.edge_map[pin_dir]
+        elif self.pins and other_connector.pins:
+            assert self.pins.site_pin_direction == SitePinDirection.OUT
+            assert other_connector.pins.site_pin_direction == SitePinDirection.IN
+
+            if len(self.pins.edge_map) == 1 and len(other_connector.pins.edge_map) == 1:
+                # If there is only one choice, make it.
+                return list(self.pins.edge_map.values())[0], list(other_connector.pins.edge_map.values())[0]
+
+            for pin_dir in self.pins.edge_map:
+                if OPPOSITE_DIRECTIONS[pin_dir] in other_connector.pins.edge_map:
+                    return (
+                        self.pins.edge_map[pin_dir],
+                        other_connector.pins.edge_map[OPPOSITE_DIRECTIONS[pin_dir]],
+                        )
+
+        assert False, (self.tracks, self.pins, other_connector.tracks, other_connector.pins)
+
+
+def create_find_connector(conn):
+    """ Returns a function returns a Connector object for a given wire and node.
+
+    Args:
+        conn: Database connection
+
+    Returns:
+        Function.  See find_connector below for signature.
+    """
+    c = conn.cursor()
+
+    @functools.lru_cache(maxsize=None)
+    def find_connector(wire_pkey, node_pkey):
+        """ Finds Connector for a wire and node in the database.
+
+        Args:
+            wire_pkey (int): Primary key into wire table of target wire
+            node_pkey (int): Primary key into node table of parent node of
+                specified wire.
+
+        Returns:
+            None if wire is disconnected, otherwise returns Connector objet.
+        """
+
+        # Find all graph_nodes for this node.
+        c.execute("""
+        SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high FROM graph_node
+        WHERE node_pkey = ?;""", (node_pkey,))
+
+        graph_nodes = c.fetchall()
+
+        # If there are no graph nodes, this wire is likely disconnected.
+        if len(graph_nodes) == 0:
+            return
+
+        # If this is a track (e.g. track_pkey is not NULL), then verify
+        # all graph_nodes for the specified node belong to the same track,
+        # and then retrieved and return the connector for the track.
+        track_pkey = graph_nodes[0][1]
+        if track_pkey is not None:
+            for node in graph_nodes:
+                assert node[1] == track_pkey
+
+            return Connector(tracks=get_track_model(conn, track_pkey))
+
+        # This is not a track, so it must be a site pin.  Make sure the
+        # graph_nodes share a type and verify that it is in fact a site pin.
+        node_type = graph2.NodeType(graph_nodes[0][2])
+        for node in graph_nodes:
+            assert node_type == graph2.NodeType(node[2])
+
+        assert node_type in [graph2.NodeType.IPIN, graph2.NodeType.OPIN]
+        if node_type == graph2.NodeType.IPIN:
+            site_pin_direction = SitePinDirection.IN
+        elif node_type == graph2.NodeType.OPIN:
+            site_pin_direction = SitePinDirection.OUT
+        else:
+            assert False, node_type
+
+        # Build the edge_map (map of edge direction to graph node).
+        c.execute("""
+        SELECT top_graph_node_pkey, bottom_graph_node_pkey,
+               left_graph_node_pkey, right_graph_node_pkey FROM wire WHERE pkey = ?;""",
+               (wire_pkey,))
+
+        all_graph_node_pkeys = c.fetchall()
+
+        assert len(all_graph_node_pkeys) == 1, wire_pkey
+
+        graph_node_pkeys = None
+        for keys in all_graph_node_pkeys:
+            if any(keys):
+                assert graph_node_pkeys is None
+                graph_node_pkeys = keys
+
+        # This wire may not have an connections, if so return now.
+        if graph_node_pkeys is None:
+            return
+
+        edge_map = {}
+
+        for edge, graph_node in zip(
+                (
+                    tracks.Direction.TOP,
+                    tracks.Direction.BOTTOM,
+                    tracks.Direction.LEFT,
+                    tracks.Direction.RIGHT,
+                    ), graph_node_pkeys,
+
+                ):
+            if graph_node is not None:
+                edge_map[edge] = graph_node
+
+        assert len(edge_map) == len(graph_nodes), (edge_map, graph_node_pkeys, graph_nodes)
+
+        # Make sure that all graph nodes for this wire are in the edge_map
+        # and at the same grid coordinate.
+        x = graph_nodes[0][3]
+        y = graph_nodes[0][5]
+        for pkey, _, _, x_low, x_high, y_low, y_high in graph_nodes:
+            assert x == x_low, (wire_pkey, node_pkey, x, x_low, x_high)
+            assert x == x_high, (wire_pkey, node_pkey, x, x_low, x_high)
+
+            assert y == y_low, (wire_pkey, node_pkey, y, y_low, y_high)
+            assert y == y_high, (wire_pkey, node_pkey, y, y_low, y_high)
+
+            assert pkey in edge_map.values(), (pkey, edge_map)
+
+        return Connector(pins=Pins(
+            edge_map=edge_map,
+            x=x,
+            y=y,
+            site_pin_direction=site_pin_direction,
+            ))
+
+    return find_connector
+
+def make_connection(conn, input_only_nodes, output_only_nodes,
+        find_wire, find_pip, find_connector,
+        tile_name, loc, tile_type, pip, switch_pkey):
+    """ Attempt to connect graph nodes on either side of a pip.
+
+    Args:
+        conn (sqlite3.Connection): Routing database
+        input_only_nodes (set of node_pkey): Nodes that can only be used as
+            sinks. This is because a synthetic tile will use this node as a
+            source.
+        output_only_nodes (set of node_pkey): Nodes that can only be used as
+            sources. This is because a synthetic tile will use this node as a
+            sink.
+        find_wire (function): Return value from create_find_wire.
+        find_pip (function): Return value from create_find_pip.
+        find_connector (function): Return value from create_find_connector.
+        tile_name (str): Name of tile pip belongs too.
+        loc (prjxray.grid_types.GridLoc): Location of tile.
+        pip (prjxray.tile.Pip): Pip being connected.
+        switch_pkey (int): Primary key to switch table of switch to be used
+            in this connection.
+
+    Returns:
+        None if connection cannot be made, otherwise returns tuple of:
+            src_graph_node_pkey (int) - Primary key into graph_node table of
+                source.
+            dest_graph_node_pkey (int) - Primary key into graph_node table of
+                destination.
+            switch_pkey (int) - Primary key into switch table of switch used
+                in connection.
+            tile_pkey (int) - Primary key into table of parent tile of pip.
+            pip_pkey (int) - Primary key into pip_in_tile table for this pip.
+
+    """
+
+    src_wire_pkey, tile_pkey, src_node_pkey = find_wire(tile_name, tile_type, pip.net_from)
+    sink_wire_pkey, tile_pkey2, sink_node_pkey = find_wire(tile_name, tile_type, pip.net_to)
+
+    assert tile_pkey == tile_pkey2
+
+    # Skip nodes that are reserved because of ROI
+    if src_node_pkey in input_only_nodes:
+        return
+
+    if sink_node_pkey in output_only_nodes:
+        return
+
+
+    src_connector = find_connector(src_wire_pkey, src_node_pkey)
+    if src_connector is None:
+        return
+
+    sink_connector = find_connector(sink_wire_pkey, sink_node_pkey)
+    if sink_connector is None:
+        return
+
+
+    pip_pkey = find_pip(tile_type, pip.name)
+
+    src_graph_node_pkey, dest_graph_node_pkey = src_connector.connect_at(loc, sink_connector)
+
+    return [(
+            src_graph_node_pkey,
+            dest_graph_node_pkey,
+            switch_pkey,
+            tile_pkey,
+            pip_pkey,
+            )]
+
+def mark_track_liveness(conn):
+    """ Checks tracks for liveness.
+
+    Iterates over all graph nodes that are routing tracks and determines if
+    at least one graph edge originates from or two the track.
+
+    Args:
+        conn (sqlite3.Connection): Connection database
+
+    """
+    alive_tracks = set()
+
+    c = conn.cursor()
+    c2 = conn.cursor()
+    for graph_node_pkey, track_pkey in c.execute("""SELECT pkey, track_pkey FROM graph_node WHERE track_pkey IS NOT NULL;"""):
+        if track_pkey in alive_tracks:
+            continue
+
+        c2.execute("""SELECT count(switch_pkey) FROM graph_edge WHERE
+            src_graph_node_pkey = ? OR
+            dest_graph_node_pkey = ?;""", (graph_node_pkey, graph_node_pkey,))
+
+        count = c2.fetchone()[0]
+
+        if count > 0:
+            alive_tracks.add(track_pkey)
+
+
+    c.execute("SELECT count(pkey) FROM track;")
+    track_count = c.fetchone()[0]
+    print("{} Alive tracks {} / {}".format(now(), len(alive_tracks), track_count))
+
+    c2.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+    for (track_pkey,) in c.execute("""SELECT pkey FROM track;"""):
+        c2.execute("UPDATE track SET alive = ? WHERE pkey = ?;", (
+            track_pkey in alive_tracks, track_pkey))
+    c2.execute("""COMMIT TRANSACTION;""")
+
+    print('{} Track aliveness committed'.format(now()))
+
+def direction_to_enum(pin):
+    """ Converts string to tracks.Direction. """
+    for direction in tracks.Direction:
+        if direction._name_ == pin:
+            return direction
+
+    assert False
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+            '--db_root', required=True, help='Project X-Ray Database')
+    parser.add_argument(
+            '--connection_database', help='Database of fabric connectivity', required=True)
+    parser.add_argument(
+            '--pin_assignments', help='Pin assignments JSON', required=True)
+    parser.add_argument(
+            '--synth_tiles', help='If using an ROI, synthetic tile defintion from prjxray-arch-import')
+
+    args = parser.parse_args()
+
+    db = prjxray.db.Database(args.db_root)
+    grid = db.grid()
+    conn = sqlite3.connect(args.connection_database)
+
+    with open(args.pin_assignments) as f:
+        pin_assignments = json.load(f)
+
+    tile_wires = []
+    for tile_type, wire_map in pin_assignments['pin_directions'].items():
+        for wire in wire_map:
+            tile_wires.append((tile_type, wire))
+
+    for tile_type, wire in progressbar.progressbar(tile_wires):
+        pins = [direction_to_enum(pin)
+                for pin in pin_assignments['pin_directions'][tile_type][wire]]
+        add_graph_nodes_for_pins(conn, tile_type, wire, pins)
+
+    if args.synth_tiles:
+        use_roi = True
+        with open(args.synth_tiles) as f:
+            synth_tiles = json.load(f)
+
+        roi = Roi(
+                db=db,
+                x1=synth_tiles['info']['GRID_X_MIN'],
+                y1=synth_tiles['info']['GRID_Y_MIN'],
+                x2=synth_tiles['info']['GRID_X_MAX'],
+                y2=synth_tiles['info']['GRID_Y_MAX'],
+                )
+
+        print('{} generating routing graph for ROI.'.format(now()))
+    else:
+        use_roi = False
+
+    output_only_nodes = set()
+    input_only_nodes = set()
+
+    find_pip = create_find_pip(conn)
+    find_wire = create_find_wire(conn)
+    find_connector = create_find_connector(conn)
+
+    print('{} Finding nodes belonging to ROI'.format(now()))
+    if use_roi:
+        for loc in progressbar.progressbar(grid.tile_locations()):
+            gridinfo = grid.gridinfo_at_loc(loc)
+            tile_name = grid.tilename_at_loc(loc)
+
+            if tile_name in synth_tiles['tiles']:
+                assert len(synth_tiles['tiles'][tile_name]['pins']) == 1
+                for pin in synth_tiles['tiles'][tile_name]['pins']:
+                    _, _, node_pkey = find_wire(tile_name, gridinfo.tile_type,
+                            pin['wire'])
+
+                    if pin['port_type'] == 'input':
+                        # This track can output be used as a sink.
+                        input_only_nodes |= set((node_pkey,))
+                    elif pin['port_type'] == 'output':
+                        # This track can output be used as a src.
+                        output_only_nodes |= set((node_pkey,))
+                    else:
+                        assert False, pin
+
+    c = conn.cursor()
+    c.execute('SELECT pkey FROM switch WHERE name = ?;', ('routing',))
+    switch_pkey = c.fetchone()[0]
+
+    edges = []
+
+    for loc in progressbar.progressbar(grid.tile_locations()):
+        gridinfo = grid.gridinfo_at_loc(loc)
+        tile_name = grid.tilename_at_loc(loc)
+
+        # Not a synth node, check if in ROI.
+        if use_roi and not roi.tile_in_roi(loc):
+            continue
+
+
+        tile_type = db.get_tile_type(gridinfo.tile_type)
+
+        for pip in tile_type.get_pips():
+            if pip.is_pseudo:
+                continue
+
+            if not pip.is_directional:
+                # TODO: Handle bidirectional pips?
+                continue
+
+            connections = make_connection(
+                    conn=conn,
+                    input_only_nodes=input_only_nodes,
+                    output_only_nodes=output_only_nodes,
+                    find_pip=find_pip,
+                    find_wire=find_wire,
+                    find_connector=find_connector,
+                    tile_name=tile_name,
+                    loc=loc,
+                    tile_type=gridinfo.tile_type,
+                    pip=pip,
+                    switch_pkey=switch_pkey)
+            if connections:
+                edges.extend(connections)
+
+    print('{} Created {} edges, inserting'.format(now(), len(edges)))
+
+    c.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+    for edge in progressbar.progressbar(edges):
+        c.execute("""
+                INSERT INTO graph_edge(
+                    src_graph_node_pkey, dest_graph_node_pkey, switch_pkey,
+                    tile_pkey, pip_in_tile_pkey)  VALUES (?, ?, ?, ?, ?)""",
+                    edge)
+
+    c.execute("""COMMIT TRANSACTION;""")
+
+    print('{} Inserted edges'.format(now()))
+
+    c.execute("""CREATE INDEX src_node_index ON graph_edge(src_graph_node_pkey);""")
+    c.execute("""CREATE INDEX dest_node_index ON graph_edge(dest_graph_node_pkey);""")
+    c.connection.commit()
+
+    print('{} Indices created, marking track liveness'.format(now()))
+    mark_track_liveness(conn)
+
+if __name__ == '__main__':
+    main()

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -4,6 +4,21 @@
 For ROI configurations, pips that would intefer with the ROI are not emitted,
 and connections that lies outside the ROI are ignored.
 
+Rough structure:
+
+Add graph_nodes for all IPIN's and OPIN's in the grid based on pin assignments.
+
+Collect tracks used by the ROI (if in used) to prevent tracks from being used
+twice.
+
+Make graph edges based on pips in every tile.
+
+Compute which routing tracks are alive based on whether they have at least one
+edge that sinks and one edge that sources the routing node.
+
+Build final channels based on alive tracks and insert dummy CHANX or CHANY to
+fill empty spaces.  This is required by VPR to allocate the right data.
+
 """
 
 import argparse

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -1,0 +1,77 @@
+from __future__ import print_function
+import argparse
+import prjxray.db
+from prjxray.roi import Roi
+import simplejson as json
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate synth_tiles.json")
+    parser.add_argument(
+            '--db_root', required=True)
+    parser.add_argument(
+            '--roi', required=True)
+    parser.add_argument(
+            '--synth_tiles', required=False)
+
+    args = parser.parse_args()
+
+    db = prjxray.db.Database(args.db_root)
+    g = db.grid()
+
+    synth_tiles = {}
+    synth_tiles['tiles'] = {}
+
+    with open(args.roi) as f:
+        j = json.load(f)
+
+    roi = Roi(
+            db=db,
+            x1=j['info']['GRID_X_MIN'],
+            y1=j['info']['GRID_Y_MIN'],
+            x2=j['info']['GRID_X_MAX'],
+            y2=j['info']['GRID_Y_MAX'],
+            )
+
+    synth_tiles['info'] = j['info']
+    for port in j['ports']:
+        if port['name'].startswith('dout['):
+            port_type = 'input'
+            is_clock = False
+        elif port['name'].startswith('din['):
+            is_clock = False
+            port_type = 'output'
+        elif port['name'].startswith('clk'):
+            port_type = 'output'
+            is_clock = True
+        else:
+            assert False, port
+
+        tile, wire = port['wire'].split('/')
+
+        # Make sure connecting wire is not in ROI!
+        loc = g.loc_of_tilename(tile)
+        if roi.tile_in_roi(loc):
+            # Or if in the ROI, make sure it has no sites.
+            gridinfo = g.gridinfo_at_tilename(tile)
+            assert len(db.get_tile_type(gridinfo.tile_type).get_sites()) == 0, tile
+
+        if tile not in synth_tiles['tiles']:
+            synth_tiles['tiles'][tile] = {
+                    'pins': [],
+                    'loc': g.loc_of_tilename(tile),
+            }
+
+        synth_tiles['tiles'][tile]['pins'].append({
+                'roi_name': port['name'].replace('[', '_').replace(']','_'),
+                'wire': wire,
+                'pad': port['pin'],
+                'port_type': port_type,
+                'is_clock': is_clock,
+        })
+
+    with open(args.synth_tiles, 'w') as f:
+        json.dump(synth_tiles, f)
+
+if __name__ == "__main__":
+    main()

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import argparse
 import prjxray.db
 from prjxray.roi import Roi

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -11,159 +11,7 @@ import sqlite3
 import datetime
 import os
 import os.path
-from lib.connection_database import NodeClassification
-
-def create_tables(conn):
-    c = conn.cursor()
-
-    c.execute("""CREATE TABLE tile_type(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT
-    );""")
-    c.execute("""CREATE TABLE site_type(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT
-    );""")
-    c.execute("""CREATE TABLE tile(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT,
-      tile_type_pkey INT,
-      grid_x INT,
-      grid_y INT,
-      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
-    );""")
-    c.execute("""CREATE TABLE site_pin(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT,
-      site_type_pkey INT,
-      direction TEXT,
-      FOREIGN KEY(site_type_pkey) REFERENCES site_type(pkey)
-    );""")
-    c.execute("""CREATE TABLE site(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT,
-      x_coord INT,
-      y_coord INT,
-      site_type_pkey INT,
-      FOREIGN KEY(site_type_pkey) REFERENCES site_type(pkey)
-    );""")
-    c.execute("""CREATE TABLE wire_in_tile(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT,
-      tile_type_pkey INT,
-      site_pkey INT,
-      site_pin_pkey INT,
-      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
-      FOREIGN KEY(site_pkey) REFERENCES site(pkey),
-      FOREIGN KEY(site_pin_pkey) REFERENCES site_pin(pkey)
-    );""")
-    c.execute("""CREATE TABLE pip_in_tile(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT,
-      tile_type_pkey INT,
-      src_wire_in_tile_pkey INT,
-      dest_wire_in_tile_pkey INT,
-      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
-      FOREIGN KEY(src_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey),
-      FOREIGN KEY(dest_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey)
-    );""")
-    c.execute("""CREATE TABLE track(
-      pkey INTEGER PRIMARY KEY,
-      alive BOOL
-    );""")
-    c.execute("""CREATE TABLE node(
-      pkey INTEGER PRIMARY KEY,
-      number_pips INT,
-      track_pkey INT,
-      site_wire_pkey INT,
-      classification INT,
-      FOREIGN KEY(track_pkey) REFERENCES track_pkey(pkey),
-      FOREIGN KEY(site_wire_pkey) REFERENCES wire(pkey)
-    );""")
-    c.execute("""CREATE TABLE edge_with_mux(
-      pkey INTEGER PRIMARY KEY,
-      src_wire_pkey INT,
-      dest_wire_pkey INT,
-      pip_in_tile_pkey INT,
-      FOREIGN KEY(src_wire_pkey) REFERENCES wire(pkey),
-      FOREIGN KEY(dest_wire_pkey) REFERENCES wire(pkey),
-      FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip_in_tile(pkey)
-    );""")
-    c.execute("""CREATE TABLE graph_node(
-      pkey INTEGER PRIMARY KEY,
-      graph_node_type INT,
-      track_pkey INT,
-      node_pkey INT,
-      x_low INT,
-      x_high INT,
-      y_low INT,
-      y_high INT,
-      ptc INT,
-      capacity INT,
-      FOREIGN KEY(track_pkey) REFERENCES track(pkey),
-      FOREIGN KEY(node_pkey) REFERENCES node(pkey)
-    );""")
-    c.execute("""CREATE TABLE wire(
-      pkey INTEGER PRIMARY KEY,
-      node_pkey INT,
-      tile_pkey INT,
-      wire_in_tile_pkey INT,
-      graph_node_pkey INT,
-      top_graph_node_pkey INT,
-      bottom_graph_node_pkey INT,
-      left_graph_node_pkey INT,
-      right_graph_node_pkey INT,
-      FOREIGN KEY(node_pkey) REFERENCES node(pkey),
-      FOREIGN KEY(tile_pkey) REFERENCES tile(pkey),
-      FOREIGN KEY(wire_in_tile_pkey) REFERENCES wire_in_grid(pkey)
-      FOREIGN KEY(graph_node_pkey) REFERENCES graph_node(pkey)
-      FOREIGN KEY(top_graph_node_pkey) REFERENCES graph_node(pkey)
-      FOREIGN KEY(bottom_graph_node_pkey) REFERENCES graph_node(pkey)
-      FOREIGN KEY(left_graph_node_pkey) REFERENCES graph_node(pkey)
-      FOREIGN KEY(right_graph_node_pkey) REFERENCES graph_node(pkey)
-    );""")
-    c.execute("""CREATE TABLE switch(
-      pkey INTEGER PRIMARY KEY,
-      name TEXT
-    );""")
-    c.execute("""CREATE TABLE graph_edge(
-      src_graph_node_pkey INT,
-      dest_graph_node_pkey INT,
-      switch_pkey INT,
-      track_pkey INT,
-      tile_pkey INT,
-      pip_in_tile_pkey INT,
-      FOREIGN KEY(src_graph_node_pkey) REFERENCES graph_node(pkey),
-      FOREIGN KEY(dest_graph_node_pkey) REFERENCES graph_node(pkey)
-      FOREIGN KEY(track_pkey) REFERENCES track(pkey)
-      FOREIGN KEY(tile_pkey) REFERENCES tile(pkey)
-      FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip(pkey)
-    );""")
-    c.execute("""CREATE TABLE channel(
-      chan_width_max INT,
-      x_min INT,
-      y_min INT,
-      x_max INT,
-      y_max INT
-    );""")
-    c.execute("""CREATE TABLE x_list(
-        idx INT,
-        info INT
-    );""")
-    c.execute("""CREATE TABLE y_list(
-        idx INT,
-        info INT
-    );""")
-
-    conn.commit()
-
-    c.execute("""INSERT INTO switch(name) VALUES
-        ("__vpr_delayless_switch__"),
-        ("routing"),
-        ("short");
-        """)
-
-    conn.commit()
+from lib.connection_database import NodeClassification, create_tables
 
 def import_site_type(db, c, site_types, site_type_name):
     assert site_type_name not in site_types
@@ -175,9 +23,11 @@ def import_site_type(db, c, site_types, site_type_name):
     for site_pin in site_type.get_site_pins():
         pin_info = site_type.get_site_pin(site_pin)
 
-        c.execute("""INSERT INTO site_pin(name, site_type_pkey, direction)
-             VALUES (?, ?, ?)""",
-             (pin_info.name, site_types[site_type_name], pin_info.direction.value))
+        c.execute("""
+INSERT INTO site_pin(name, site_type_pkey, direction)
+VALUES
+  (?, ?, ?)""", (
+      pin_info.name, site_types[site_type_name], pin_info.direction.value))
 
 def import_tile_type(db, c, tile_types, site_types, tile_type_name):
     assert tile_type_name not in tile_types
@@ -188,9 +38,10 @@ def import_tile_type(db, c, tile_types, site_types, tile_type_name):
 
     wires = {}
     for wire in tile_type.get_wires():
-        c.execute("""INSERT INTO wire_in_tile(name, tile_type_pkey)
-            VALUES (?, ?)""",
-            (wire, tile_types[tile_type_name]))
+        c.execute("""
+INSERT INTO wire_in_tile(name, tile_type_pkey)
+VALUES
+  (?, ?)""", (wire, tile_types[tile_type_name]))
         wires[wire] = c.lastrowid
 
     for pip in tile_type.get_pips():
@@ -201,9 +52,15 @@ def import_tile_type(db, c, tile_types, site_types, tile_type_name):
         if not pip.is_directional:
             continue
 
-        c.execute("""INSERT INTO pip_in_tile(name, tile_type_pkey, src_wire_in_tile_pkey, dest_wire_in_tile_pkey)
-            VALUES (?, ?, ?, ?)""",
-            (pip.name, tile_types[tile_type_name], wires[pip.net_from], wires[pip.net_to]))
+        c.execute("""
+INSERT INTO pip_in_tile(
+  name, tile_type_pkey, src_wire_in_tile_pkey,
+  dest_wire_in_tile_pkey
+)
+VALUES
+  (?, ?, ?, ?)""", (
+      pip.name, tile_types[tile_type_name], wires[pip.net_from],
+      wires[pip.net_to]))
 
     for site in tile_type.get_sites():
         if site.type not in site_types:
@@ -212,23 +69,39 @@ def import_tile_type(db, c, tile_types, site_types, tile_type_name):
 def add_wire_to_site_relation(db, c, tile_types, site_types, tile_type_name):
     tile_type = db.get_tile_type(tile_type_name)
     for site in tile_type.get_sites():
-        c.execute("""INSERT INTO site(name, x_coord, y_coord, site_type_pkey)
-            VALUES (?, ?, ?, ?)""", (site.name, site.x, site.y, site_types[site.type]))
+        c.execute("""
+INSERT INTO site(name, x_coord, y_coord, site_type_pkey)
+VALUES
+  (?, ?, ?, ?)""", (site.name, site.x, site.y, site_types[site.type]))
 
         site_pkey = c.lastrowid
 
         for site_pin in site.site_pins:
-            c.execute("""SELECT pkey FROM site_pin WHERE name = ? AND
-                    site_type_pkey = ?""", (site_pin.name, site_types[site.type]))
+            c.execute("""
+SELECT
+  pkey
+FROM
+  site_pin
+WHERE
+  name = ?
+  AND site_type_pkey = ?""", (site_pin.name, site_types[site.type]))
 
             result = c.fetchone()
             site_pin_pkey = result[0]
-            c.execute("""UPDATE wire_in_tile
-            SET site_pkey = ?,
-                site_pin_pkey = ?
-            WHERE name = ? and tile_type_pkey = ?;""", (
-                site_pkey, site_pin_pkey, site_pin.wire,
-                tile_types[tile_type_name]))
+            c.execute("""
+UPDATE
+  wire_in_tile
+SET
+  site_pkey = ?,
+  site_pin_pkey = ?
+WHERE
+  name = ?
+  and tile_type_pkey = ?;""", (
+                site_pkey,
+                site_pin_pkey,
+                site_pin.wire,
+                tile_types[tile_type_name]
+                ))
 
 def build_tile_type_indicies(c):
     c.execute("CREATE INDEX site_pin_index ON site_pin(name, site_type_pkey);")
@@ -269,9 +142,12 @@ def import_grid(db, grid, conn):
         gridinfo = grid.gridinfo_at_tilename(tile)
         loc = grid.loc_of_tilename(tile)
         # tile: pkey name tile_type_pkey grid_x grid_y
-        c.execute("""INSERT INTO tile(name, tile_type_pkey, grid_x, grid_y)
-            VALUES (?, ?, ?, ?)""",
-            (tile, tile_types[gridinfo.tile_type], loc.grid_x, loc.grid_y))
+        c.execute("""
+INSERT INTO tile(name, tile_type_pkey, grid_x, grid_y)
+VALUES
+  (?, ?, ?, ?)""", (
+      tile, tile_types[gridinfo.tile_type], loc.grid_x,
+      loc.grid_y))
 
     build_other_indicies(c)
     c.connection.commit()
@@ -297,13 +173,15 @@ def import_nodes(db, grid, conn):
 
         for wire in tile_type.get_wires():
             # pkey node_pkey tile_pkey wire_in_tile_pkey
-            c.execute("""SELECT pkey FROM wire_in_tile WHERE name = ? and tile_type_pkey = ?;""",
+            c.execute("""
+SELECT pkey FROM wire_in_tile WHERE name = ? and tile_type_pkey = ?;""",
                     (wire, tile_type_pkey))
             (wire_in_tile_pkey,) = c.fetchone()
 
             c2.execute("""
-            INSERT INTO wire(tile_pkey, wire_in_tile_pkey) VALUES
-            (?, ?);""", (tile_pkey, wire_in_tile_pkey))
+INSERT INTO wire(tile_pkey, wire_in_tile_pkey)
+VALUES
+  (?, ?);""", (tile_pkey, wire_in_tile_pkey))
 
             assert (tile, wire) not in tile_wire_map
             wire_pkey = c2.lastrowid
@@ -373,14 +251,22 @@ def count_sites_and_pips_on_nodes(conn):
 
     print("{}: Counting sites on nodes".format(datetime.datetime.now()))
     c.execute("""
-WITH
-  node_sites(node_pkey, number_site_pins) AS (
-   SELECT wire.node_pkey, count(wire_in_tile.site_pin_pkey) FROM wire_in_tile
-   INNER JOIN wire ON
-     wire.wire_in_tile_pkey = wire_in_tile.pkey
-     WHERE wire_in_tile.site_pin_pkey IS NOT NULL
-  GROUP BY wire.node_pkey)
-SELECT max(node_sites.number_site_pins) FROM node_sites;
+WITH node_sites(node_pkey, number_site_pins) AS (
+  SELECT
+    wire.node_pkey,
+    count(wire_in_tile.site_pin_pkey)
+  FROM
+    wire_in_tile
+    INNER JOIN wire ON wire.wire_in_tile_pkey = wire_in_tile.pkey
+  WHERE
+    wire_in_tile.site_pin_pkey IS NOT NULL
+  GROUP BY
+    wire.node_pkey
+)
+SELECT
+  max(node_sites.number_site_pins)
+FROM
+  node_sites;
 """)
 
     # Nodes are only expected to have 1 site
@@ -388,14 +274,26 @@ SELECT max(node_sites.number_site_pins) FROM node_sites;
 
     print("{}: Assigning site wires for nodes".format(datetime.datetime.now()))
     c.execute("""
-WITH
-  site_wires(wire_pkey, node_pkey) AS (
-    SELECT wire.pkey, wire.node_pkey FROM wire_in_tile
-    INNER JOIN wire ON
-      wire.wire_in_tile_pkey = wire_in_tile.pkey
-      WHERE wire_in_tile.site_pin_pkey IS NOT NULL)
-UPDATE node SET site_wire_pkey = (
-  SELECT site_wires.wire_pkey FROM site_wires WHERE site_wires.node_pkey = node.pkey
+WITH site_wires(wire_pkey, node_pkey) AS (
+  SELECT
+    wire.pkey,
+    wire.node_pkey
+  FROM
+    wire_in_tile
+    INNER JOIN wire ON wire.wire_in_tile_pkey = wire_in_tile.pkey
+  WHERE
+    wire_in_tile.site_pin_pkey IS NOT NULL
+)
+UPDATE
+  node
+SET
+  site_wire_pkey = (
+    SELECT
+      site_wires.wire_pkey
+    FROM
+      site_wires
+    WHERE
+      site_wires.node_pkey = node.pkey
   );
       """)
 
@@ -407,20 +305,40 @@ UPDATE node SET site_wire_pkey = (
       FOREIGN KEY(node_pkey) REFERENCES node(pkey)
     );""")
     c.execute("""
-    INSERT INTO node_pip_count(node_pkey, number_pips)
-    SELECT wire.node_pkey, count(pip_in_tile.pkey) FROM pip_in_tile
-    INNER JOIN wire WHERE
-        pip_in_tile.src_wire_in_tile_pkey = wire.wire_in_tile_pkey OR
-        pip_in_tile.dest_wire_in_tile_pkey = wire.wire_in_tile_pkey
-    GROUP BY wire.node_pkey;""");
+INSERT INTO node_pip_count(node_pkey, number_pips)
+SELECT
+  wire.node_pkey,
+  count(pip_in_tile.pkey)
+FROM
+  pip_in_tile
+  INNER JOIN wire
+WHERE
+  pip_in_tile.src_wire_in_tile_pkey = wire.wire_in_tile_pkey
+  OR pip_in_tile.dest_wire_in_tile_pkey = wire.wire_in_tile_pkey
+GROUP BY
+  wire.node_pkey;""");
     c.execute("CREATE INDEX pip_count_index ON node_pip_count(node_pkey);")
 
     print("{}: Inserting pip counts".format(datetime.datetime.now()))
     c.execute("""
-    UPDATE node SET number_pips = (
-        SELECT node_pip_count.number_pips FROM node_pip_count
-        WHERE node_pip_count.node_pkey = node.pkey
-    ) WHERE pkey IN (SELECT node_pkey FROM node_pip_count);""")
+UPDATE
+  node
+SET
+  number_pips = (
+    SELECT
+      node_pip_count.number_pips
+    FROM
+      node_pip_count
+    WHERE
+      node_pip_count.node_pkey = node.pkey
+  )
+WHERE
+  pkey IN (
+    SELECT
+      node_pkey
+    FROM
+      node_pip_count
+  );""")
 
     c.execute("""DROP TABLE node_pip_count;""")
 
@@ -451,28 +369,56 @@ UPDATE node SET classification = ?
     edge_with_mux = []
 
     c2 = conn.cursor()
-    c2.execute("SELECT count(pkey) FROM node WHERE number_pips == 1 AND site_wire_pkey IS NOT NULL;")
+    c2.execute("""
+SELECT
+  count(pkey)
+FROM
+  node
+WHERE
+  number_pips == 1
+  AND site_wire_pkey IS NOT NULL;""")
     num_nodes = c2.fetchone()[0]
     with progressbar.ProgressBar(max_value=num_nodes) as bar:
         bar.update(0)
         for idx, (node, site_wire_pkey) in enumerate(c2.execute("""
-SELECT pkey, site_wire_pkey FROM node WHERE number_pips == 1 AND site_wire_pkey IS NOT NULL;""")):
+SELECT
+  pkey,
+  site_wire_pkey
+FROM
+  node
+WHERE
+  number_pips == 1
+  AND site_wire_pkey IS NOT NULL;""")):
             bar.update(idx)
 
             c.execute("""
-WITH wire_in_node(wire_pkey, tile_pkey, wire_in_tile_pkey) AS (
-    SELECT wire.pkey, wire.tile_pkey, wire.wire_in_tile_pkey FROM wire
-    WHERE wire.node_pkey = ?)
-SELECT pip_in_tile.pkey,
-       pip_in_tile.src_wire_in_tile_pkey,
-       pip_in_tile.dest_wire_in_tile_pkey,
-       wire_in_node.wire_pkey,
-       wire_in_node.wire_in_tile_pkey,
-       wire_in_node.tile_pkey
-  FROM wire_in_node
+WITH wire_in_node(
+  wire_pkey, tile_pkey, wire_in_tile_pkey
+) AS (
+  SELECT
+    wire.pkey,
+    wire.tile_pkey,
+    wire.wire_in_tile_pkey
+  FROM
+    wire
+  WHERE
+    wire.node_pkey = ?
+)
+SELECT
+  pip_in_tile.pkey,
+  pip_in_tile.src_wire_in_tile_pkey,
+  pip_in_tile.dest_wire_in_tile_pkey,
+  wire_in_node.wire_pkey,
+  wire_in_node.wire_in_tile_pkey,
+  wire_in_node.tile_pkey
+FROM
+  wire_in_node
   INNER JOIN pip_in_tile
-  WHERE pip_in_tile.src_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey OR
-        pip_in_tile.dest_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey LIMIT 1;
+WHERE
+  pip_in_tile.src_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey
+  OR pip_in_tile.dest_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey
+LIMIT
+  1;
 """, (node,))
 
             (
@@ -539,13 +485,16 @@ SELECT pip_in_tile.pkey,
             (NodeClassification.EDGE_WITH_MUX.value, nodes[0], nodes[1]))
 
         c.execute("""
-        INSERT INTO edge_with_mux(src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey)
-            VALUES (?, ?, ?);""", (src_wire_pkey, dest_wire_pkey, pip_pkey))
+INSERT INTO edge_with_mux(src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey)
+VALUES
+  (?, ?, ?);""", (src_wire_pkey, dest_wire_pkey, pip_pkey))
 
     for node in progressbar.progressbar(edges_to_channel):
         c.execute("""
         UPDATE node SET classification = ?
-            WHERE pkey = ?;""", (NodeClassification.EDGES_TO_CHANNEL.value, node,))
+            WHERE pkey = ?;""", (
+                NodeClassification.EDGES_TO_CHANNEL.value,
+                node,))
 
     for null_node in progressbar.progressbar(null_nodes):
         c.execute("""
@@ -560,7 +509,8 @@ def insert_tracks(conn, tracks_to_insert):
     # TODO: Use short
     #c.execute('SELECT pkey FROM switch WHERE name = "short";')
     #short_pkey = c.fetchone()[0]
-    c.execute('SELECT pkey FROM switch WHERE name = "__vpr_delayless_switch__";')
+    c.execute("""
+SELECT pkey FROM switch WHERE name = "__vpr_delayless_switch__";""")
     short_pkey = c.fetchone()[0]
 
     track_graph_nodes = {}
@@ -581,9 +531,12 @@ def insert_tracks(conn, tracks_to_insert):
                 assert False, track.direction
 
             c.execute("""
-            INSERT INTO graph_node(
-                graph_node_type, track_pkey, node_pkey, x_low, x_high, y_low, y_high, capacity)
-                VALUES (?, ?, ?, ?, ?, ?, ?, 1)""", (
+INSERT INTO graph_node(
+  graph_node_type, track_pkey, node_pkey,
+  x_low, x_high, y_low, y_high, capacity
+)
+VALUES
+  (?, ?, ?, ?, ?, ?, ?, 1)""", (
                 node_type.value, track_pkey, node,
                 track.x_low, track.x_high, track.y_low, track.y_high
                 ))
@@ -593,8 +546,13 @@ def insert_tracks(conn, tracks_to_insert):
 
         for connection in track_connections:
             c.execute("""
-            INSERT INTO graph_edge(src_graph_node_pkey, dest_graph_node_pkey, switch_pkey, track_pkey)
-                VALUES (?, ?, ?, ?), (?, ?, ?, ?)""", (
+INSERT INTO graph_edge(
+  src_graph_node_pkey, dest_graph_node_pkey,
+  switch_pkey, track_pkey
+)
+VALUES
+  (?, ?, ?, ?),
+  (?, ?, ?, ?)""", (
                 track_graph_node_pkey[connection[0]],
                 track_graph_node_pkey[connection[1]],
                 short_pkey,
@@ -612,13 +570,22 @@ def insert_tracks(conn, tracks_to_insert):
         track_graph_node_pkey = track_graph_nodes[node]
 
         c.execute("""
-WITH
-    wires_from_node(wire_pkey, tile_pkey) AS (
-      SELECT pkey, tile_pkey FROM wire WHERE node_pkey = ?)
-SELECT wires_from_node.wire_pkey, tile.grid_x, tile.grid_y
-  FROM tile
-  INNER JOIN wires_from_node
-  ON tile.pkey = wires_from_node.tile_pkey;
+WITH wires_from_node(wire_pkey, tile_pkey) AS (
+  SELECT
+    pkey,
+    tile_pkey
+  FROM
+    wire
+  WHERE
+    node_pkey = ?
+)
+SELECT
+  wires_from_node.wire_pkey,
+  tile.grid_x,
+  tile.grid_y
+FROM
+  tile
+  INNER JOIN wires_from_node ON tile.pkey = wires_from_node.tile_pkey;
   """, (node,))
 
         wires = c.fetchall()
@@ -633,7 +600,7 @@ SELECT wires_from_node.wire_pkey, tile.grid_x, tile.grid_y
     for wire_pkey, graph_node_pkey in progressbar.progressbar(wire_to_graph.items()):
         c.execute("""
         UPDATE wire SET graph_node_pkey = ?
-                WHERE pkey = ?""", (graph_node_pkey, wire_pkey))
+            WHERE pkey = ?""", (graph_node_pkey, wire_pkey))
 
     conn.commit()
 
@@ -662,13 +629,22 @@ SELECT pkey FROM node WHERE classification == ?;
 
             unique_pos = set()
             for wire_pkey, grid_x, grid_y in c2.execute("""
-WITH
-    wires_from_node(wire_pkey, tile_pkey) AS (
-      SELECT pkey, tile_pkey FROM wire WHERE node_pkey = ?)
-SELECT wires_from_node.wire_pkey, tile.grid_x, tile.grid_y
-  FROM tile
-  INNER JOIN wires_from_node
-  ON tile.pkey = wires_from_node.tile_pkey;
+WITH wires_from_node(wire_pkey, tile_pkey) AS (
+  SELECT
+    pkey,
+    tile_pkey
+  FROM
+    wire
+  WHERE
+    node_pkey = ?
+)
+SELECT
+  wires_from_node.wire_pkey,
+  tile.grid_x,
+  tile.grid_y
+FROM
+  tile
+  INNER JOIN wires_from_node ON tile.pkey = wires_from_node.tile_pkey;
   """, (node,)):
                 unique_pos.add((grid_x, grid_y))
 

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -3,242 +3,834 @@
 
 import argparse
 import prjxray.db
-from collections import namedtuple
 import progressbar
-import simplejson as json
 from lib.rr_graph import points
 from lib.rr_graph import tracks
+from lib.rr_graph import graph2
+import sqlite3
+import datetime
+import os
+import os.path
+from lib.connection_database import NodeClassification
+import multiprocessing
 
-EdgeWithMux = namedtuple('EdgeWithMux', 'source_node pip destination_node')
-NodeClassification = namedtuple('NodeClassification', 'type edge_with_mux')
+def create_tables(conn):
+    c = conn.cursor()
 
-def full_wire_name(wire_in_grid):
-    return (wire_in_grid.tile, wire_in_grid.wire)
+    c.execute("""CREATE TABLE tile_type(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT
+    );""")
+    c.execute("""CREATE TABLE site_type(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT
+    );""")
+    c.execute("""CREATE TABLE tile(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      tile_type_pkey INT,
+      grid_x INT,
+      grid_y INT,
+      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+    );""")
+    c.execute("""CREATE TABLE site_pin(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      site_type_pkey INT,
+      direction TEXT,
+      FOREIGN KEY(site_type_pkey) REFERENCES site_type(pkey)
+    );""")
+    c.execute("""CREATE TABLE site(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      x_coord INT,
+      y_coord INT,
+      site_type_pkey INT,
+      FOREIGN KEY(site_type_pkey) REFERENCES site_type(pkey)
+    );""")
+    c.execute("""CREATE TABLE wire_in_tile(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      tile_type_pkey INT,
+      site_pkey INT,
+      site_pin_pkey INT,
+      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
+      FOREIGN KEY(site_pkey) REFERENCES site(pkey),
+      FOREIGN KEY(site_pin_pkey) REFERENCES site_pin(pkey)
+    );""")
+    c.execute("""CREATE TABLE pip_in_tile(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT,
+      tile_type_pkey INT,
+      src_wire_in_tile_pkey INT,
+      dest_wire_in_tile_pkey INT,
+      FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
+      FOREIGN KEY(src_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey),
+      FOREIGN KEY(dest_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey)
+    );""")
+    c.execute("""CREATE TABLE track(
+      pkey INTEGER PRIMARY KEY,
+      alive BOOL
+    );""")
+    c.execute("""CREATE TABLE node(
+      pkey INTEGER PRIMARY KEY,
+      number_pips INT,
+      track_pkey INT,
+      site_wire_pkey INT,
+      classification INT,
+      FOREIGN KEY(track_pkey) REFERENCES track_pkey(pkey),
+      FOREIGN KEY(site_wire_pkey) REFERENCES wire(pkey)
+    );""")
+    c.execute("""CREATE TABLE edge_with_mux(
+      pkey INTEGER PRIMARY KEY,
+      src_wire_pkey INT,
+      dest_wire_pkey INT,
+      pip_in_tile_pkey INT,
+      FOREIGN KEY(src_wire_pkey) REFERENCES wire(pkey),
+      FOREIGN KEY(dest_wire_pkey) REFERENCES wire(pkey),
+      FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip_in_tile(pkey)
+    );""")
+    c.execute("""CREATE TABLE graph_node(
+      pkey INTEGER PRIMARY KEY,
+      graph_node_type INT,
+      track_pkey INT,
+      node_pkey INT,
+      x_low INT,
+      x_high INT,
+      y_low INT,
+      y_high INT,
+      ptc INT,
+      capacity INT,
+      FOREIGN KEY(track_pkey) REFERENCES track(pkey),
+      FOREIGN KEY(node_pkey) REFERENCES node(pkey)
+    );""")
+    c.execute("""CREATE TABLE wire(
+      pkey INTEGER PRIMARY KEY,
+      node_pkey INT,
+      tile_pkey INT,
+      wire_in_tile_pkey INT,
+      graph_node_pkey INT,
+      top_graph_node_pkey INT,
+      bottom_graph_node_pkey INT,
+      left_graph_node_pkey INT,
+      right_graph_node_pkey INT,
+      FOREIGN KEY(node_pkey) REFERENCES node(pkey),
+      FOREIGN KEY(tile_pkey) REFERENCES tile(pkey),
+      FOREIGN KEY(wire_in_tile_pkey) REFERENCES wire_in_grid(pkey)
+      FOREIGN KEY(graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(top_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(bottom_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(left_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(right_graph_node_pkey) REFERENCES graph_node(pkey)
+    );""")
+    c.execute("""CREATE TABLE switch(
+      pkey INTEGER PRIMARY KEY,
+      name TEXT
+    );""")
+    c.execute("""CREATE TABLE graph_edge(
+      src_graph_node_pkey INT,
+      dest_graph_node_pkey INT,
+      switch_pkey INT,
+      track_pkey INT,
+      tile_pkey INT,
+      pip_in_tile_pkey INT,
+      FOREIGN KEY(src_graph_node_pkey) REFERENCES graph_node(pkey),
+      FOREIGN KEY(dest_graph_node_pkey) REFERENCES graph_node(pkey)
+      FOREIGN KEY(track_pkey) REFERENCES track(pkey)
+      FOREIGN KEY(tile_pkey) REFERENCES tile(pkey)
+      FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip(pkey)
+    );""")
+    c.execute("""CREATE TABLE channel(
+      chan_width_max INT,
+      x_min INT,
+      y_min INT,
+      x_max INT,
+      y_max INT
+    );""")
+    c.execute("""CREATE TABLE x_list(
+        idx INT,
+        info INT
+    );""")
+    c.execute("""CREATE TABLE y_list(
+        idx INT,
+        info INT
+    );""")
 
+    conn.commit()
 
-def make_connection(wires, connection):
-    wire_a = full_wire_name(connection.wire_a)
-    wire_b = full_wire_name(connection.wire_b)
+    c.execute("""INSERT INTO switch(name) VALUES
+        ("__vpr_delayless_switch__"),
+        ("routing"),
+        ("short");
+        """)
 
-    wire_a_set = wires[wire_a]
-    wire_b_set = wires[wire_b]
+    conn.commit()
 
-    if wire_a_set is wire_b_set:
-        return
+def import_site_type(db, c, site_types, site_type_name):
+    assert site_type_name not in site_types
+    site_type = db.get_site_type(site_type_name)
 
-    wire_a_set |= wire_b_set
+    c.execute("INSERT INTO site_type(name) VALUES (?)", (site_type_name,))
+    site_types[site_type_name] = c.lastrowid
 
-    for wire in wire_a_set:
-        wires[wire] = wire_a_set
+    for site_pin in site_type.get_site_pins():
+        pin_info = site_type.get_site_pin(site_pin)
 
+        c.execute("""INSERT INTO site_pin(name, site_type_pkey, direction)
+             VALUES (?, ?, ?)""",
+             (pin_info.name, site_types[site_type_name], pin_info.direction.value))
 
-def make_connections(db):
-    # Some nodes are just 1 wire, so start by enumerating all wires.
+def import_tile_type(db, c, tile_types, site_types, tile_type_name):
+    assert tile_type_name not in tile_types
+    tile_type = db.get_tile_type(tile_type_name)
+
+    c.execute("INSERT INTO tile_type(name) VALUES (?)", (tile_type_name,))
+    tile_types[tile_type_name] = c.lastrowid
+
     wires = {}
-    grid = db.grid()
+    for wire in tile_type.get_wires():
+        c.execute("""INSERT INTO wire_in_tile(name, tile_type_pkey)
+            VALUES (?, ?)""",
+            (wire, tile_types[tile_type_name]))
+        wires[wire] = c.lastrowid
+
+    for pip in tile_type.get_pips():
+        # Psuedo pips are not part of the routing fabric, so don't add them.
+        if pip.is_pseudo:
+            continue
+
+        if not pip.is_directional:
+            continue
+
+        c.execute("""INSERT INTO pip_in_tile(name, tile_type_pkey, src_wire_in_tile_pkey, dest_wire_in_tile_pkey)
+            VALUES (?, ?, ?, ?)""",
+            (pip.name, tile_types[tile_type_name], wires[pip.net_from], wires[pip.net_to]))
+
+    for site in tile_type.get_sites():
+        if site.type not in site_types:
+            import_site_type(db, c, site_types, site.type)
+
+def add_wire_to_site_relation(db, c, tile_types, site_types, tile_type_name):
+    tile_type = db.get_tile_type(tile_type_name)
+    for site in tile_type.get_sites():
+        c.execute("""INSERT INTO site(name, x_coord, y_coord, site_type_pkey)
+            VALUES (?, ?, ?, ?)""", (site.name, site.x, site.y, site_types[site.type]))
+
+        site_pkey = c.lastrowid
+
+        for site_pin in site.site_pins:
+            c.execute("""SELECT pkey FROM site_pin WHERE name = ? AND
+                    site_type_pkey = ?""", (site_pin.name, site_types[site.type]))
+
+            result = c.fetchone()
+            site_pin_pkey = result[0]
+            c.execute("""UPDATE wire_in_tile
+            SET site_pkey = ?,
+                site_pin_pkey = ?
+            WHERE name = ? and tile_type_pkey = ?;""", (
+                site_pkey, site_pin_pkey, site_pin.wire,
+                tile_types[tile_type_name]))
+
+def build_tile_type_indicies(c):
+    c.execute("CREATE INDEX site_pin_index ON site_pin(name, site_type_pkey);")
+    c.execute("CREATE INDEX wire_name_index ON wire_in_tile(name, tile_type_pkey);")
+    c.execute("CREATE INDEX wire_site_pin_index ON wire_in_tile(site_pin_pkey);")
+    c.execute("CREATE INDEX tile_type_index ON tile(tile_type_pkey);")
+    c.execute("CREATE INDEX pip_tile_type_index ON pip_in_tile(tile_type_pkey);")
+    c.execute("CREATE INDEX src_pip_index ON pip_in_tile(src_wire_in_tile_pkey);")
+    c.execute("CREATE INDEX dest_pip_index ON pip_in_tile(dest_wire_in_tile_pkey);")
+
+def build_other_indicies(c):
+    c.execute("CREATE INDEX tile_name_index ON tile(name);")
+    c.execute("CREATE INDEX tile_location_index ON tile(grid_x, grid_y);")
+
+def import_grid(db, grid, conn):
+    c = conn.cursor()
+
+    tile_types = {}
+    site_types = {}
+    for tile in grid.tiles():
+        gridinfo = grid.gridinfo_at_tilename(tile)
+
+        if gridinfo.tile_type not in tile_types:
+            if gridinfo.tile_type in tile_types:
+                continue
+
+            import_tile_type(db, c, tile_types, site_types, gridinfo.tile_type)
+
+    c.connection.commit()
+
+    build_tile_type_indicies(c)
+    c.connection.commit()
+
+    for tile_type in tile_types:
+        add_wire_to_site_relation(db, c, tile_types, site_types, tile_type)
+
+    for tile in grid.tiles():
+        gridinfo = grid.gridinfo_at_tilename(tile)
+        loc = grid.loc_of_tilename(tile)
+        # tile: pkey name tile_type_pkey grid_x grid_y
+        c.execute("""INSERT INTO tile(name, tile_type_pkey, grid_x, grid_y)
+            VALUES (?, ?, ?, ?)""",
+            (tile, tile_types[gridinfo.tile_type], loc.grid_x, loc.grid_y))
+
+    build_other_indicies(c)
+    c.connection.commit()
+
+def import_nodes(db, grid, conn):
+    # Some nodes are just 1 wire, so start by enumerating all wires.
+
+    c = conn.cursor()
+    c2 = conn.cursor()
+    c2.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+
+    tiles = {}
+    tile_wire_map = {}
+    wires = {}
     for tile in progressbar.progressbar(grid.tiles()):
         gridinfo = grid.gridinfo_at_tilename(tile)
         tile_type = db.get_tile_type(gridinfo.tile_type)
 
+        c.execute("""SELECT pkey, tile_type_pkey FROM tile WHERE name = ?;""",
+                (tile,))
+        tile_pkey, tile_type_pkey = c.fetchone()
+        tiles[tile] = (tile_pkey, tile_type_pkey)
+
         for wire in tile_type.get_wires():
-            key = (tile, wire)
-            wires[key] = set((key,))
+            # pkey node_pkey tile_pkey wire_in_tile_pkey
+            c.execute("""SELECT pkey FROM wire_in_tile WHERE name = ? and tile_type_pkey = ?;""",
+                    (wire, tile_type_pkey))
+            (wire_in_tile_pkey,) = c.fetchone()
 
-    c = db.connections()
+            c2.execute("""
+            INSERT INTO wire(tile_pkey, wire_in_tile_pkey) VALUES
+            (?, ?);""", (tile_pkey, wire_in_tile_pkey))
 
-    for connection in progressbar.progressbar(c.get_connections()):
-        make_connection(wires, connection)
+            assert (tile, wire) not in tile_wire_map
+            wire_pkey = c2.lastrowid
+            tile_wire_map[(tile, wire)] = wire_pkey
+            wires[wire_pkey] = None
+
+    c2.execute("""COMMIT TRANSACTION;""")
+
+    connections = db.connections()
+
+    for connection in progressbar.progressbar(connections.get_connections()):
+        a_pkey = tile_wire_map[(connection.wire_a.tile, connection.wire_a.wire)]
+        b_pkey = tile_wire_map[(connection.wire_b.tile, connection.wire_b.wire)]
+
+        a_node = wires[a_pkey]
+        b_node = wires[b_pkey]
+
+        if a_node is None:
+            a_node = set((a_pkey,))
+
+        if b_node is None:
+            b_node = set((b_pkey,))
+
+        if a_node is not b_node:
+            a_node |= b_node
+
+            for wire in a_node:
+                wires[wire] = a_node
 
     nodes = {}
+    for wire_pkey, node in wires.items():
+        if node is None:
+            node = set((wire_pkey,))
 
-    for wire_node in wires.values():
-        nodes[id(wire_node)] = wire_node
+        assert wire_pkey in node
 
-    return nodes.values()
+        nodes[id(node)] = node
 
-class Node(object):
-    def __init__(self, node):
-        self.node = node
-        self.tracks = []
-        self.track_connections = []
-        self.wire_connections = {}
+    wires_assigned = set()
+    for node in progressbar.progressbar(nodes.values()):
+        c.execute("""INSERT INTO node(number_pips) VALUES (0);""")
+        node_pkey = c.lastrowid
 
-        self.sites = []
-        self.pips = []
-        self.classification = None
+        for wire_pkey in node:
+            wires_assigned.add(wire_pkey)
+            c.execute("""
+            UPDATE wire
+                SET node_pkey = ?
+                WHERE pkey = ?
+            ;""", (node_pkey, wire_pkey))
 
-    def add_sites_and_pips_to_node(self, db, grid):
-        for tile, wire in self.node:
-            tileinfo = grid.gridinfo_at_tilename(tile)
+    assert len(set(wires.keys()) ^ wires_assigned) == 0
 
-            tile_type = db.get_tile_type(tileinfo.tile_type)
+    del tile_wire_map
+    del nodes
+    del wires
 
-            wire_info = tile_type.get_wire_info(wire)
+    c.execute("CREATE INDEX wire_in_tile_index ON wire(wire_in_tile_pkey);")
+    c.execute("CREATE INDEX wire_index ON wire(tile_pkey, wire_in_tile_pkey);")
+    c.execute("CREATE INDEX wire_node_index ON wire(node_pkey);")
 
-            for pip in wire_info.pips:
-                self.pips.append((tile, pip, wire))
+    c.connection.commit()
 
-            for site in wire_info.sites:
-                self.sites.append((tile,)+site)
 
-    def classify_node(self, db, grid, wire_to_nodes):
-        if len(self.pips) + len(self.sites) <= 1:
-            # Some nodes don't go anywhere.
-            return NodeClassification(type='NULL', edge_with_mux=None)
+def count_sites_and_pips_on_nodes(conn):
+    c = conn.cursor()
 
-        if len(self.pips) == 1 and len(self.sites) == 0:
-            # Some nodes don't go anywhere.
-            return NodeClassification(type='NULL', edge_with_mux=None)
+    print("{}: Counting sites on nodes".format(datetime.datetime.now()))
+    c.execute("""
+WITH
+  node_sites(node_pkey, number_site_pins) AS (
+   SELECT wire.node_pkey, count(wire_in_tile.site_pin_pkey) FROM wire_in_tile
+   INNER JOIN wire ON
+     wire.wire_in_tile_pkey = wire_in_tile.pkey
+     WHERE wire_in_tile.site_pin_pkey IS NOT NULL
+  GROUP BY wire.node_pkey)
+SELECT max(node_sites.number_site_pins) FROM node_sites;
+""")
 
-        if len(self.pips) > 1:
-            if len(self.sites) == 0:
-                return NodeClassification(type='CHANNEL', edge_with_mux=None)
+    # Nodes are only expected to have 1 site
+    assert c.fetchone()[0] == 1
+
+    print("{}: Assigning site wires for nodes".format(datetime.datetime.now()))
+    c.execute("""
+WITH
+  site_wires(wire_pkey, node_pkey) AS (
+    SELECT wire.pkey, wire.node_pkey FROM wire_in_tile
+    INNER JOIN wire ON
+      wire.wire_in_tile_pkey = wire_in_tile.pkey
+      WHERE wire_in_tile.site_pin_pkey IS NOT NULL)
+UPDATE node SET site_wire_pkey = (
+  SELECT site_wires.wire_pkey FROM site_wires WHERE site_wires.node_pkey = node.pkey
+  );
+      """)
+
+    print("{}: Counting pips on nodes".format(datetime.datetime.now()))
+    c.execute("""
+    CREATE TABLE node_pip_count(
+      node_pkey INT,
+      number_pips INT,
+      FOREIGN KEY(node_pkey) REFERENCES node(pkey)
+    );""")
+    c.execute("""
+    INSERT INTO node_pip_count(node_pkey, number_pips)
+    SELECT wire.node_pkey, count(pip_in_tile.pkey) FROM pip_in_tile
+    INNER JOIN wire WHERE
+        pip_in_tile.src_wire_in_tile_pkey = wire.wire_in_tile_pkey OR
+        pip_in_tile.dest_wire_in_tile_pkey = wire.wire_in_tile_pkey
+    GROUP BY wire.node_pkey;""");
+    c.execute("CREATE INDEX pip_count_index ON node_pip_count(node_pkey);")
+
+    print("{}: Inserting pip counts".format(datetime.datetime.now()))
+    c.execute("""
+    UPDATE node SET number_pips = (
+        SELECT node_pip_count.number_pips FROM node_pip_count
+        WHERE node_pip_count.node_pkey = node.pkey
+    ) WHERE pkey IN (SELECT node_pkey FROM node_pip_count);""")
+
+    c.execute("""DROP TABLE node_pip_count;""")
+
+    c.connection.commit()
+
+def classify_nodes(conn):
+    c = conn.cursor()
+
+    # Nodes are NULL if they they only have either a site pin or 1 pip, but
+    # nothing else.
+    c.execute("""
+UPDATE node SET classification = ?
+    WHERE (node.site_wire_pkey IS NULL AND node.number_pips <= 1) OR
+          (node.site_wire_pkey IS NOT NULL AND node.number_pips == 0)
+    ;""",
+    (NodeClassification.NULL.value,))
+    c.execute("""
+UPDATE node SET classification = ?
+    WHERE node.number_pips > 1 and node.site_wire_pkey IS NULL;""",
+    (NodeClassification.CHANNEL.value,))
+    c.execute("""
+UPDATE node SET classification = ?
+    WHERE node.number_pips > 1 and node.site_wire_pkey IS NOT NULL;""",
+    (NodeClassification.EDGES_TO_CHANNEL.value,))
+
+    null_nodes = []
+    edges_to_channel = []
+    edge_with_mux = []
+
+    c2 = conn.cursor()
+    c2.execute("SELECT count(pkey) FROM node WHERE number_pips == 1 AND site_wire_pkey IS NOT NULL;")
+    num_nodes = c2.fetchone()[0]
+    with progressbar.ProgressBar(max_value=num_nodes) as bar:
+        bar.update(0)
+        for idx, (node, site_wire_pkey) in enumerate(c2.execute("""
+SELECT pkey, site_wire_pkey FROM node WHERE number_pips == 1 AND site_wire_pkey IS NOT NULL;""")):
+            bar.update(idx)
+
+            c.execute("""
+WITH wire_in_node(wire_pkey, tile_pkey, wire_in_tile_pkey) AS (
+    SELECT wire.pkey, wire.tile_pkey, wire.wire_in_tile_pkey FROM wire
+    WHERE wire.node_pkey = ?)
+SELECT pip_in_tile.pkey,
+       pip_in_tile.src_wire_in_tile_pkey,
+       pip_in_tile.dest_wire_in_tile_pkey,
+       wire_in_node.wire_pkey,
+       wire_in_node.wire_in_tile_pkey,
+       wire_in_node.tile_pkey
+  FROM wire_in_node
+  INNER JOIN pip_in_tile
+  WHERE pip_in_tile.src_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey OR
+        pip_in_tile.dest_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey LIMIT 1;
+""", (node,))
+
+            (
+                    pip_pkey,
+                    src_wire_in_tile_pkey,
+                    dest_wire_in_tile_pkey,
+                    wire_in_node_pkey,
+                    wire_in_tile_pkey,
+                    tile_pkey) = c.fetchone()
+            assert c.fetchone() is None, node
+
+            assert (
+                    wire_in_tile_pkey == src_wire_in_tile_pkey or
+                    wire_in_tile_pkey == dest_wire_in_tile_pkey
+                    ), (wire_in_tile_pkey, pip_pkey)
+
+            if src_wire_in_tile_pkey == wire_in_tile_pkey:
+                other_wire = dest_wire_in_tile_pkey
             else:
-                if len(self.sites) == 1:
-                    return NodeClassification(type='EDGES_TO_CHANNEL', edge_with_mux=None)
+                other_wire = src_wire_in_tile_pkey
+
+            c.execute("""
+            SELECT node_pkey FROM wire WHERE
+                wire_in_tile_pkey = ? AND
+                tile_pkey = ?;
+                """, (other_wire, tile_pkey))
+
+            (other_node_pkey,) = c.fetchone()
+            assert c.fetchone() is None
+            assert other_node_pkey is not None, (other_wire, tile_pkey)
+
+            c.execute("""
+            SELECT site_wire_pkey, number_pips
+                FROM node WHERE pkey = ?;
+                """, (other_node_pkey,))
+
+            result = c.fetchone()
+            assert result is not None, other_node_pkey
+            other_site_wire_pkey, other_number_pips = result
+            assert c.fetchone() is None
+
+            if other_site_wire_pkey is not None and other_number_pips == 1:
+                if src_wire_in_tile_pkey == wire_in_tile_pkey:
+                    src_wire_pkey = site_wire_pkey
+                    dest_wire_pkey = other_site_wire_pkey
                 else:
-                    assert False, (self.pips, self.sites, self.node)
+                    src_wire_pkey = other_site_wire_pkey
+                    dest_wire_pkey = site_wire_pkey
 
+                edge_with_mux.append(((node, other_node_pkey),
+                    src_wire_pkey, dest_wire_pkey, pip_pkey))
+            elif other_site_wire_pkey is None and other_number_pips == 1:
+                null_nodes.append(node)
+                null_nodes.append(other_node_pkey)
+                pass
+            else:
+                edges_to_channel.append(node)
 
-        if len(self.sites) == 2 and len(self.pips) == 0:
-            return NodeClassification(type='EDGE_WITH_SHORT', edge_with_mux=None)
+    for nodes, src_wire_pkey, dest_wire_pkey, pip_pkey in progressbar.progressbar(edge_with_mux):
+        assert len(nodes) == 2
+        c.execute("""
+        UPDATE node SET classification = ?
+            WHERE pkey IN (?, ?);""",
+            (NodeClassification.EDGE_WITH_MUX.value, nodes[0], nodes[1]))
 
-        if len(self.sites) == 1 and len(self.pips) == 1:
-            # This could be a site pin -> pip -> site pin, check.
-            tile, pip, wire = self.pips[0]
+        c.execute("""
+        INSERT INTO edge_with_mux(src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey)
+            VALUES (?, ?, ?);""", (src_wire_pkey, dest_wire_pkey, pip_pkey))
 
-            tileinfo = grid.gridinfo_at_tilename(tile)
-            tile_type = db.get_tile_type(tileinfo.tile_type)
+    for node in progressbar.progressbar(edges_to_channel):
+        c.execute("""
+        UPDATE node SET classification = ?
+            WHERE pkey = ?;""", (NodeClassification.EDGES_TO_CHANNEL.value, node,))
 
-            for tile_pip in tile_type.get_pips():
-                if tile_pip.name == pip:
-                    if tile_pip.net_to == wire:
-                        other_wire = tile_pip.net_from
-                        other_node = wire_to_nodes[(tile, other_wire)]
+    for null_node in progressbar.progressbar(null_nodes):
+        c.execute("""
+        UPDATE node SET classification = ?
+            WHERE pkey = ?;""", (NodeClassification.NULL.value, null_node,))
 
-                        source_node = other_node.node
-                        destination_node = self.node
-                    elif tile_pip.net_from == wire:
-                        other_wire = tile_pip.net_to
-                        other_node = wire_to_nodes[(tile, other_wire)]
+    c.execute("CREATE INDEX node_type_index ON node(classification);")
+    c.connection.commit()
 
-                        source_node = self.node
-                        destination_node = other_node.node
-                    else:
-                        assert False, (tile, pip, wire, tile_pip)
+def insert_tracks(conn, tracks_to_insert):
+    c = conn.cursor()
+    # TODO: Use short
+    #c.execute('SELECT pkey FROM switch WHERE name = "short";')
+    #short_pkey = c.fetchone()[0]
+    c.execute('SELECT pkey FROM switch WHERE name = "__vpr_delayless_switch__";')
+    short_pkey = c.fetchone()[0]
 
-                    if len(other_node.sites) == 1 and len(other_node.pips) == 1:
-                        edge_with_mux = EdgeWithMux(
-                            source_node = tuple(sorted(source_node)),
-                            pip = pip,
-                            destination_node = tuple(sorted(destination_node)),
-                        )
-                        return NodeClassification(type='EDGE_WITH_MUX', edge_with_mux=edge_with_mux)
-                    elif len(other_node.sites) == 0 and len(other_node.pips) == 1:
-                        # Sometimes (e.g. top of carry chain) will end up with
-                        # site pin -> pip -> nothing.
-                        return NodeClassification(type='NULL', edge_with_mux=None)
-                    else:
-                        break
+    track_graph_nodes = {}
+    for node, tracks_list, track_connections, tracks_model in progressbar.progressbar(tracks_to_insert):
+        c.execute("""INSERT INTO track DEFAULT VALUES""")
+        track_pkey = c.lastrowid
 
-            # This node is an edge to/from a channel, but not a
-            # channel itself.
-            return NodeClassification(type='EDGES_TO_CHANNEL', edge_with_mux=None)
+        c.execute("""UPDATE node SET track_pkey = ? WHERE pkey = ?""",
+                (track_pkey, node))
 
-        assert False, (self.pips, self.sites, self.node)
+        track_graph_node_pkey = []
+        for track in tracks_list:
+            if track.direction == 'X':
+                node_type = graph2.NodeType.CHANX
+            elif track.direction == 'Y':
+                node_type = graph2.NodeType.CHANY
+            else:
+                assert False, track.direction
 
-    def form_tracks(self, grid):
-        connected_tiles = set()
-        for tile, wire in self.node:
-            connected_tiles.add(grid.loc_of_tilename(tile))
+            c.execute("""
+            INSERT INTO graph_node(
+                graph_node_type, track_pkey, node_pkey, x_low, x_high, y_low, y_high, capacity)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 1)""", (
+                node_type.value, track_pkey, node,
+                track.x_low, track.x_high, track.y_low, track.y_high
+                ))
+            track_graph_node_pkey.append(c.lastrowid)
 
-        unique_pos = set()
-        for tile, wire in self.node:
-            loc = grid.loc_of_tilename(tile)
-            unique_pos.add((loc.grid_x, loc.grid_y))
+        track_graph_nodes[node] = track_graph_node_pkey
 
-        xs, ys = points.decompose_points_into_tracks(unique_pos)
+        for connection in track_connections:
+            c.execute("""
+            INSERT INTO graph_edge(src_graph_node_pkey, dest_graph_node_pkey, switch_pkey, track_pkey)
+                VALUES (?, ?, ?, ?), (?, ?, ?, ?)""", (
+                track_graph_node_pkey[connection[0]],
+                track_graph_node_pkey[connection[1]],
+                short_pkey,
+                track_pkey,
+                track_graph_node_pkey[connection[1]],
+                track_graph_node_pkey[connection[0]],
+                short_pkey,
+                track_pkey,
+                ))
 
-        self.tracks, self.track_connections = tracks.make_tracks(xs, ys, unique_pos)
-        self.wire_connections = {}
-        self.tracks_model = tracks.Tracks(self.tracks, self.track_connections)
-        for tile, wire in self.node:
-            loc = grid.loc_of_tilename(tile)
-            connections = list(self.tracks_model.get_tracks_for_wire_at_coord((loc.grid_x, loc.grid_y)))
+    conn.commit()
+
+    wire_to_graph = {}
+    for node, tracks_list, track_connections, tracks_model in progressbar.progressbar(tracks_to_insert):
+        track_graph_node_pkey = track_graph_nodes[node]
+
+        c.execute("""
+WITH
+    wires_from_node(wire_pkey, tile_pkey) AS (
+      SELECT pkey, tile_pkey FROM wire WHERE node_pkey = ?)
+SELECT wires_from_node.wire_pkey, tile.grid_x, tile.grid_y
+  FROM tile
+  INNER JOIN wires_from_node
+  ON tile.pkey = wires_from_node.tile_pkey;
+  """, (node,))
+
+        wires = c.fetchall()
+
+        for wire_pkey, grid_x, grid_y in wires:
+            connections = list(tracks_model.get_tracks_for_wire_at_coord((grid_x, grid_y)))
             assert len(connections) > 0
-            self.wire_connections[(tile, wire)] = connections[0][0]
+            graph_node_pkey = track_graph_node_pkey[connections[0][0]]
 
-    def _get_track_idx(self, tilewire):
-        if self.wire_connections:
-            assert tilewire in self.wire_connections
-            assert self.wire_connections[tilewire] < len(self.tracks)
-            return self.wire_connections[tilewire]
+            wire_to_graph[wire_pkey] = graph_node_pkey
+
+    for wire_pkey, graph_node_pkey in progressbar.progressbar(wire_to_graph.items()):
+        c.execute("""
+        UPDATE wire SET graph_node_pkey = ?
+                WHERE pkey = ?""", (graph_node_pkey, wire_pkey))
+
+    conn.commit()
+
+
+def form_tracks(conn):
+    c = conn.cursor()
+
+    c.execute('SELECT count(pkey) FROM node WHERE classification == ?;',
+            (NodeClassification.CHANNEL.value,))
+    num_nodes = c.fetchone()[0]
+
+    tracks_to_insert = []
+    with progressbar.ProgressBar(max_value=num_nodes) as bar:
+        bar.update(0)
+        c2 = conn.cursor()
+        for idx, (node,) in enumerate(c.execute("""
+SELECT pkey FROM node WHERE classification == ?;
+""", (NodeClassification.CHANNEL.value,))):
+            bar.update(idx)
+
+            unique_pos = set()
+            for wire_pkey, grid_x, grid_y in c2.execute("""
+WITH
+    wires_from_node(wire_pkey, tile_pkey) AS (
+      SELECT pkey, tile_pkey FROM wire WHERE node_pkey = ?)
+SELECT wires_from_node.wire_pkey, tile.grid_x, tile.grid_y
+  FROM tile
+  INNER JOIN wires_from_node
+  ON tile.pkey = wires_from_node.tile_pkey;
+  """, (node,)):
+                unique_pos.add((grid_x, grid_y))
+
+            xs, ys = points.decompose_points_into_tracks(unique_pos)
+            tracks_list, track_connections = tracks.make_tracks(xs, ys, unique_pos)
+            tracks_model = tracks.Tracks(tracks_list, track_connections)
+
+            tracks_to_insert.append([node, tracks_list, track_connections, tracks_model])
+
+    insert_tracks(conn, tracks_to_insert)
+
+def build_channels(conn, pool):
+    c = conn.cursor()
+
+    xs = []
+    ys = []
+
+    x_tracks = {}
+    y_tracks = {}
+    for pkey, graph_node_type, x_low, x_high, y_low, y_high in c.execute("""
+SELECT pkey, graph_node_type, x_low, x_high, y_low, y_high FROM graph_node WHERE track_pkey IS NOT NULL;"""):
+        xs.append(x_low)
+        xs.append(x_high)
+        ys.append(y_low)
+        ys.append(y_high)
+
+        node_type = graph2.NodeType(graph_node_type)
+        if node_type == graph2.NodeType.CHANX:
+            assert y_low == y_high
+
+            if y_low not in x_tracks:
+                x_tracks[y_low] = []
+
+            x_tracks[y_low].append((
+                    x_low,
+                    x_high,
+                    pkey))
+        elif node_type == graph2.NodeType.CHANY:
+            assert x_low == x_high
+
+            if x_low not in y_tracks:
+                y_tracks[x_low] = []
+
+            y_tracks[x_low].append((
+                    y_low,
+                    y_high,
+                    pkey))
         else:
-            assert len(self.tracks) == 1
-            return 0
+            assert False, node_type
 
-    def verify_tracks(self, grid):
-        self.tracks_model.verify_tracks()
+    x_list = []
+    y_list = []
 
-        # Check that all wires can be connected to the track specified by
-        # _get_track.
-        for tile, wire in self.node:
-            track_idx = self._get_track_idx((tile, wire))
-            loc = grid.loc_of_tilename(tile)
-            assert self.tracks_model.is_wire_adjacent_to_track(track_idx, (loc.grid_x, loc.grid_y)) != tracks.Direction.NO_SIDE, (loc, track_idx, self.tracks[track_idx])
+    x_channel_models = {}
+    y_channel_models = {}
+
+    for y in x_tracks:
+        x_channel_models[y] = pool.apply_async(graph2.process_track, (x_tracks[y],))
+
+    for x in y_tracks:
+        y_channel_models[x] = pool.apply_async(graph2.process_track, (y_tracks[x],))
+
+    for y in progressbar.progressbar(range(max(x_tracks)+1)):
+        if y in x_tracks:
+            x_channel_models[y] = x_channel_models[y].get()
+
+            x_list.append(len(x_channel_models[y].trees))
+
+            for idx, tree in enumerate(x_channel_models[y].trees):
+                for i in tree:
+                    c.execute("""UPDATE graph_node SET ptc = ? WHERE pkey = ?;""",
+                            (idx, i[2]))
+        else:
+            x_list.append(0)
+
+    for x in progressbar.progressbar(range(max(y_tracks)+1)):
+        if x in y_tracks:
+            y_channel_models[x] = y_channel_models[x].get()
+
+            y_list.append(len(y_channel_models[x].trees))
+
+            for idx, tree in enumerate(y_channel_models[x].trees):
+                for i in tree:
+                    c.execute("""UPDATE graph_node SET ptc = ? WHERE pkey = ?;""",
+                            (idx, i[2]))
+        else:
+            y_list.append(0)
+
+    x_min=min(xs)
+    y_min=min(ys)
+    x_max=max(xs)
+    y_max=max(ys)
+
+    num_padding = 0
+    for chan, channel_model in x_channel_models.items():
+        for ptc, start, end in channel_model.fill_empty(x_min, x_max):
+            num_padding += 1
+            capacity = 0
+            c.execute("""
+            INSERT INTO
+                graph_node(graph_node_type, x_low, x_high, y_low, y_high, capacity, ptc)
+            VALUES
+                (?, ?, ?, ?, ?, ?, ?);
+                """, (graph2.NodeType.CHANX.value, start, chan, end, chan, capacity, ptc))
+
+    for chan, channel_model in y_channel_models.items():
+        for ptc, start, end in channel_model.fill_empty(y_min, y_max):
+            num_padding += 1
+            c.execute("""
+            INSERT INTO
+                graph_node(graph_node_type, x_low, x_high, y_low, y_high, capacity, ptc)
+            VALUES
+                (?, ?, ?, ?, ?, ?, ?);
+                """, (graph2.NodeType.CHANY.value, chan, start, chan, end, capacity, ptc))
+
+    print('Number padding nodes {}'.format(num_padding))
+
+    c.execute("""
+    INSERT INTO channel(chan_width_max, x_min, x_max, y_min, y_max) VALUES
+        (?, ?, ?, ?, ?);""", (
+            max(max(x_list), max(y_list)),
+            x_min, y_min, x_max, y_max))
+
+    for idx, info in enumerate(x_list):
+        c.execute("""
+        INSERT INTO x_list(idx, info) VALUES (?, ?);""", (idx, info))
+
+    for idx, info in enumerate(y_list):
+        c.execute("""
+        INSERT INTO y_list(idx, info) VALUES (?, ?);""", (idx, info))
+
+    c.execute("""CREATE INDEX graph_node_tracks ON graph_node(track_pkey);""")
+    c.execute("""CREATE INDEX graph_node_nodes ON graph_node(node_pkey);""")
+    c.execute("""CREATE INDEX graph_edge_tracks ON graph_edge(track_pkey);""")
+    c.connection.commit()
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
             '--db_root', help='Project X-Ray Database', required=True)
     parser.add_argument(
-            '--channels', help='Project X-Ray Database', required=True)
+            '--connection_database', help='Connection database', required=True)
+
+    pool = multiprocessing.Pool(20)
 
     args = parser.parse_args()
+    if os.path.exists(args.connection_database):
+        os.remove(args.connection_database)
 
+    conn = sqlite3.connect(args.connection_database)
+    create_tables(conn)
+
+    print("{}: About to load database".format(datetime.datetime.now()))
     db = prjxray.db.Database(args.db_root)
-    nodes = [Node(node) for node in make_connections(db)]
     grid = db.grid()
-    wire_to_nodes = {}
-    for node in progressbar.progressbar(nodes):
-        node.add_sites_and_pips_to_node(db, grid)
-        for wire in node.node:
-            wire_to_nodes[wire] = node
-
-    edges_with_mux = set()
-    node_not_in_channels = []
-    channels = []
-    num_tracks = 0
-    for node in progressbar.progressbar(nodes):
-        node.classification = node.classify_node(db, grid, wire_to_nodes)
-
-        if node.classification.type != 'CHANNEL':
-            node_not_in_channels.append({
-                    'classification': node.classification.type,
-                    'wires': list(node.node),
-            })
-        else:
-            node.form_tracks(grid)
-            node.verify_tracks(grid)
-            num_tracks += len(node.tracks)
-
-            channels.append({
-                    'wires': list(node.node),
-                    'tracks': [track._asdict() for track in node.tracks],
-                    'track_connections': node.track_connections,
-            })
-
-        if node.classification.type == 'EDGE_WITH_MUX':
-            edges_with_mux.add(node.classification.edge_with_mux)
-
-    print(num_tracks)
-
-    with open(args.channels, 'w') as f:
-        json.dump({
-                'node_not_in_channels': node_not_in_channels,
-                'edges_with_mux': [edge._asdict() for edge in list(edges_with_mux)],
-                'channels': channels,
-        }, f, indent=2)
+    import_grid(db, grid, conn)
+    print("{}: Initial database formed".format(datetime.datetime.now()))
+    import_nodes(db, grid, conn)
+    print("{}: Connections made".format(datetime.datetime.now()))
+    count_sites_and_pips_on_nodes(conn)
+    print("{}: Counted sites and pips".format(datetime.datetime.now()))
+    classify_nodes(conn)
+    print("{}: Nodes classified".format(datetime.datetime.now()))
+    form_tracks(conn)
+    print("{}: Tracks formed".format(datetime.datetime.now()))
+    build_channels(conn, pool)
+    print("{}: Built channels".format(datetime.datetime.now()))
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -1,5 +1,35 @@
 #!/usr/bin/env python3
-""" Classify 7-series nodes and generate channels for required nodes. """
+""" Classify 7-series nodes and generate channels for required nodes.
+
+Rough structure:
+
+Create initial database import by importing tile types, tile wires, tile pips,
+site types and site pins.  After importing tile types, imports the grid of
+tiles.  This uses tilegrid.json, tile_type_*.json and site_type_*.json.
+
+Once all tiles are imported, all wires in the grid are added and nodes are
+formed from the sea of wires based on the tile connections description
+(tileconn.json).
+
+In order to determine what each node is used for, site pins and pips are counted
+on each node (count_sites_and_pips_on_nodes).  Depending on the site pin and
+pip count, the nodes are classified into one of 4 buckets:
+
+    NULL - An unconnected node
+    CHANNEL - A routing node
+    EDGE_WITH_MUX - An edge between an IPIN and OPIN.
+    EDGES_TO_CHANNEL - An edge between an IPIN/OPIN and a CHANNEL.
+
+Then all CHANNEL are grouped into tracks (form_tracks) and graph nodes are
+created for the CHANNELs.  Graph edges are added to connect graph nodes that are
+part of the same track.
+
+Note that IPIN and OPIN graph nodes are not added yet, as pins have not been
+assigned sides of the VPR tiles yet.  This occurs in
+prjxray_assign_tile_pin_direction.
+
+
+"""
 
 import argparse
 import prjxray.db

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -9,74 +9,19 @@ node specified.
 import argparse
 import prjxray.db
 from prjxray.roi import Roi
+import prjxray.grid as grid
 from lib.rr_graph import graph2
 from lib.rr_graph import tracks
+from lib.connection_database import get_wire_pkey, get_track_model
 import lib.rr_graph_xml.graph2 as xml_graph2
 from lib.rr_graph_xml.utils import read_xml_file
 import simplejson as json
 import progressbar
 import datetime
-import multiprocessing
-import pickle
 import re
+import sqlite3
 
 now = datetime.datetime.now
-
-def find_nodes(graph, track_wire_map, loc, tile_name, tile_type, wire):
-    """ Finds nodes for the give tile, wire.  This can return multiple nodes.
-
-    Return type is (node_type, node, side)
-
-    For channels, multiple nodes means multiple adjacent channels that make
-    the tile/wire pair.
-
-    For site pins, multiple nodes means multiple sides of the tile have that
-    pin.
-    """
-
-    vpr_tile_name = 'BLK_TI-{}'.format(tile_type)
-
-    pin_name = graph.create_pin_name_from_tile_type_and_pin(vpr_tile_name, wire)
-
-    try:
-        site_pin_node = graph.get_nodes_for_pin(loc, pin_name)
-    except:
-        site_pin_node = None
-
-    if (tile_name, wire) in track_wire_map:
-        # This pair appears to be a channel.
-
-        # tile/wire pairs should not be both a channel and a site pin.
-        assert site_pin_node is None
-
-        tracks_model, track_nodes = track_wire_map[(tile_name, wire)]
-
-        for idx, pin_dir in tracks_model.get_tracks_for_wire_at_coord(loc):
-            node = track_nodes[idx]
-            node_type = graph.nodes[node].type
-
-            assert node_type in (graph2.NodeType.CHANX, graph2.NodeType.CHANY)
-            yield (node_type, node, pin_dir)
-    else:
-        if site_pin_node is None:
-            return
-
-        for node, pin_dir in site_pin_node:
-            node_type = graph.nodes[node].type
-            assert node_type in (graph2.NodeType.IPIN, graph2.NodeType.OPIN)
-            yield (node_type, node, pin_dir)
-
-def opposite_direction(direction):
-    if direction == tracks.Direction.LEFT:
-        return tracks.Direction.RIGHT
-    elif direction == tracks.Direction.RIGHT:
-        return tracks.Direction.LEFT
-    elif direction == tracks.Direction.TOP:
-        return tracks.Direction.BOTTOM
-    elif direction == tracks.Direction.BOTTOM:
-        return tracks.Direction.TOP
-    else:
-        assert False, direction
 
 HCLK_CK_BUFHCLK_REGEX = re.compile('HCLK_CK_BUFHCLK[0-9]+')
 CASCOUT_REGEX = re.compile('BRAM_CASCOUT_ADDR((?:BWR)|(?:ARD))ADDRU([0-9]+)')
@@ -110,99 +55,320 @@ def check_feature(feature):
 
     return feature
 
-def check_allowed(src_node, sink_node, output_only_nodes, input_only_nodes):
-    if src_node in input_only_nodes:
-        return False
-
-    if sink_node in output_only_nodes:
-        return False
-
-    return True
+# BLK_TI-CLBLL_L.CLBLL_LL_A1[0] -> (CLBLL_L, CLBLL_LL_A1)
+PIN_NAME_TO_PARTS = re.compile(r'^BLK_TI-([^\.]+)\.([^\]]+)\[0\]$')
 
 
-def make_connection(graph, track_wire_map, loc, tile_name, tile_type, pip, switch_id, edges_with_mux, grid, pip_set, output_only_nodes, input_only_nodes):
-    def add_edge(pip_name, src_node, sink_node, switch_id):
-        """ Add edge to graph, checking for duplicates and disabled PIPs.
+def import_graph_nodes(conn, graph, node_mapping):
+    c = conn.cursor()
+    tile_type_wire_to_pkey = {}
+    tile_loc_to_pkey = {}
 
-        Also handles adding addition featuers if required (e.g. check_feature).
-        """
-        if (src_node, sink_node, switch_id) in pip_set:
-            return
+    for node in progressbar.progressbar(graph.nodes):
+        if node.type not in (graph2.NodeType.IPIN, graph2.NodeType.OPIN):
+            continue
 
-        pip_set.add((src_node, sink_node, switch_id))
+        gridloc = graph.loc_map[(node.loc.x_low, node.loc.y_low)]
+        pin_name = graph.pin_ptc_to_name_map[(gridloc.block_type_id, node.loc.ptc)]
 
-        # Check if pip is allowed given synth tile usage.
-        if not check_allowed(src_node, sink_node,
-                output_only_nodes, input_only_nodes):
-            return
+        # Synthetic blocks are handled below.
+        if pin_name.startswith('BLK_SY-'):
+            continue
 
+        m = PIN_NAME_TO_PARTS.match(pin_name)
+        assert m is not None, pin_name
+
+        tile_type = m.group(1)
+        pin = m.group(2)
+
+        key = (tile_type, pin)
+
+        if key not in tile_type_wire_to_pkey:
+            c.execute("""
+            SELECT pkey FROM wire_in_tile WHERE
+                tile_type_pkey = (SELECT pkey FROM tile_type WHERE name = ?) AND
+                name = ?;""", (tile_type, pin))
+
+            result = c.fetchone()
+            assert result is not None, (tile_type, pin)
+            (wire_in_tile_pkey,) = result
+
+            tile_type_wire_to_pkey[key] = wire_in_tile_pkey
+        else:
+            wire_in_tile_pkey = tile_type_wire_to_pkey[key]
+
+        if gridloc not in tile_loc_to_pkey:
+            c.execute("""
+            SELECT pkey FROM tile WHERE grid_x = ? AND grid_y = ?;""",
+            (gridloc[0], gridloc[1]))
+
+            (tile_pkey,) = c.fetchone()
+            tile_loc_to_pkey[gridloc] = tile_pkey
+        else:
+            tile_pkey = tile_loc_to_pkey[gridloc]
+
+        c.execute("""
+        SELECT
+            top_graph_node_pkey, bottom_graph_node_pkey,
+            left_graph_node_pkey, right_graph_node_pkey FROM wire
+            WHERE
+              wire_in_tile_pkey = ? AND tile_pkey = ?;""",
+              (wire_in_tile_pkey, tile_pkey))
+
+        (
+            top_graph_node_pkey, bottom_graph_node_pkey,
+            left_graph_node_pkey, right_graph_node_pkey
+            ) = c.fetchone()
+
+        side = node.loc.side
+        if side == graph2.Direction.LEFT:
+            assert left_graph_node_pkey is not None, (tile_type, pin_name)
+            node_mapping[left_graph_node_pkey] = node.id
+        elif side == graph2.Direction.RIGHT:
+            assert right_graph_node_pkey is not None, (tile_type, pin_name)
+            node_mapping[right_graph_node_pkey] = node.id
+        elif side == graph2.Direction.TOP:
+            assert top_graph_node_pkey is not None, (tile_type, pin_name)
+            node_mapping[top_graph_node_pkey] = node.id
+        elif side == graph2.Direction.BOTTOM:
+            assert bottom_graph_node_pkey is not None, (tile_type, pin_name)
+            node_mapping[bottom_graph_node_pkey] = node.id
+        else:
+            assert False, side
+
+def is_track_alive(conn, tile_pkey, roi, synth_tiles):
+    c = conn.cursor()
+    c.execute("""SELECT name, grid_x, grid_y FROM tile WHERE pkey = ?;""", (tile_pkey,))
+    tile, grid_x, grid_y = c.fetchone()
+
+    return roi.tile_in_roi(grid.GridLoc(grid_x=grid_x, grid_y=grid_y)) or tile in synth_tiles['tiles']
+
+def import_tracks(conn, alive_tracks, node_mapping, graph, segment_id):
+    c2 = conn.cursor()
+    for (graph_node_pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high, ptc) in progressbar.progressbar(c2.execute("""
+    SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high, ptc FROM
+        graph_node WHERE track_pkey IS NOT NULL;""")):
+        if track_pkey not in alive_tracks:
+            continue
+
+        node_type = graph2.NodeType(graph_node_type)
+
+        if node_type == graph2.NodeType.CHANX:
+            direction = 'X'
+            x_low = max(x_low, 1)
+        elif node_type == graph2.NodeType.CHANY:
+            direction = 'Y'
+            y_low = max(y_low, 1)
+        else:
+            assert False, node_type
+
+        track = tracks.Track(
+                direction=direction,
+                x_low=x_low,
+                x_high=x_high,
+                y_low=y_low,
+                y_high=y_high,
+                )
+        assert graph_node_pkey not in node_mapping
+        node_mapping[graph_node_pkey] = graph.add_track(
+                track=track, segment_id=segment_id,
+                name='track_{}'.format(graph_node_pkey))
+        graph.set_track_ptc(node_mapping[graph_node_pkey], ptc)
+
+
+def create_track_rr_graph(conn, graph, node_mapping, use_roi, roi, synth_tiles, segment_id):
+    c = conn.cursor()
+    c.execute("""SELECT count(*) FROM track;""")
+    (num_channels,) = c.fetchone()
+
+    print('{} Import alive tracks'.format(now()))
+    alive_tracks = set()
+    for (track_pkey,) in c.execute("SELECT pkey FROM track WHERE alive = 1;"):
+        alive_tracks.add(track_pkey)
+
+    print('{} Importing alive tracks'.format(now()))
+    import_tracks(conn, alive_tracks, node_mapping, graph, segment_id)
+
+    print('original {} final {}'.format(num_channels, len(alive_tracks)))
+
+def add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles):
+    c = conn.cursor()
+    routing_switch = graph.get_switch_id('routing')
+
+    for loc in progressbar.progressbar(grid.tile_locations()):
+        tile_name = grid.tilename_at_loc(loc)
+
+        if tile_name in synth_tiles['tiles']:
+            assert len(synth_tiles['tiles'][tile_name]['pins']) == 1
+            for pin in synth_tiles['tiles'][tile_name]['pins']:
+                wire_pkey = get_wire_pkey(conn, tile_name, pin['wire'])
+                c.execute("""SELECT track_pkey FROM node WHERE pkey = (
+                    SELECT node_pkey FROM wire WHERE pkey = ?
+                    );""", (wire_pkey,))
+                (track_pkey,) = c.fetchone()
+                assert track_pkey is not None, (tile_name, pin['wire'], wire_pkey)
+                tracks_model, track_nodes = get_track_model(conn, track_pkey)
+
+                option = list(tracks_model.get_tracks_for_wire_at_coord(loc))
+                assert len(option) > 0
+
+                if pin['port_type'] == 'input':
+                    tile_type = 'BLK_SY-OUTPAD'
+                    wire = 'outpad'
+                elif pin['port_type'] == 'output':
+                    tile_type = 'BLK_SY-INPAD'
+                    wire = 'inpad'
+                else:
+                    assert False, pin
+
+                track_node = track_nodes[option[0][0]]
+                assert track_node in node_mapping, (track_node, track_pkey)
+                pin_name = graph.create_pin_name_from_tile_type_and_pin(
+                        tile_type,
+                        wire)
+
+                pin_node = graph.get_nodes_for_pin(loc, pin_name)
+
+                if pin['port_type'] == 'input':
+                    graph.add_edge(
+                            src_node=node_mapping[track_node],
+                            sink_node=pin_node[0][0],
+                            switch_id=routing_switch,
+                            name='synth_{}_{}'.format(tile_name, pin['wire']),
+                    )
+                elif pin['port_type'] == 'output':
+                    graph.add_edge(
+                            src_node=pin_node[0][0],
+                            sink_node=node_mapping[track_node],
+                            switch_id=routing_switch,
+                            name='synth_{}_{}'.format(tile_name, pin['wire']),
+                    )
+                else:
+                    assert False, pin
+
+def get_switch_name(conn, graph, switch_name_map, switch_pkey):
+    assert switch_pkey is not None
+    c2 = conn.cursor()
+    if switch_pkey not in switch_name_map:
+        c2.execute("""SELECT name FROM switch WHERE pkey = ?;""", (switch_pkey,))
+        (switch_name,) = c2.fetchone()
+        switch_id = graph.get_switch_id(switch_name)
+        switch_name_map[switch_pkey] = switch_id
+    else:
+        switch_id = switch_name_map[switch_pkey]
+
+    return switch_id
+
+def get_tile_name(conn, tile_name_cache, tile_pkey):
+    if tile_pkey in tile_name_cache:
+        return tile_name_cache[tile_pkey]
+    else:
+        c = conn.cursor()
+        c.execute("""
+        SELECT name FROM tile WHERE pkey = ?;
+        """, (tile_pkey,))
+        (tile_name,) = c.fetchone()
+
+        tile_name_cache[tile_pkey] = tile_name
+        return tile_name
+
+def get_pip_wire_names(conn, pip_cache, pip_pkey):
+    if pip_pkey in pip_cache:
+        return pip_cache[pip_pkey]
+    else:
+        c = conn.cursor()
+        c.execute("""SELECT src_wire_in_tile_pkey, dest_wire_in_tile_pkey
+            FROM pip_in_tile WHERE pkey = ?;""", (pip_pkey,))
+        src_wire_in_tile_pkey, dest_wire_in_tile_pkey = c.fetchone()
+
+        c.execute("""SELECT name FROM wire_in_tile WHERE pkey = ?;""",
+                (src_wire_in_tile_pkey,))
+        (src_net,) = c.fetchone()
+
+        c.execute("""SELECT name FROM wire_in_tile WHERE pkey = ?;""",
+                (dest_wire_in_tile_pkey,))
+        (dest_net,) = c.fetchone()
+
+        pip_cache[pip_pkey] = (src_net, dest_net)
+        return (src_net, dest_net)
+
+
+def make_fasm_feature(conn, tile_name_cache, pip_cache, tile_pkey, pip_pkey):
+    assert tile_pkey is not None
+
+    tile_name = get_tile_name(conn, tile_name_cache, tile_pkey)
+    src_net, dest_net = get_pip_wire_names(conn, pip_cache, pip_pkey)
+
+    return '{}.{}.{}'.format(tile_name, dest_net, src_net)
+
+def import_graph_edge(conn, graph, node_mapping, src_graph_node, dest_graph_node, switch_id, pip_name):
+    src_node = node_mapping[src_graph_node]
+    sink_node = node_mapping[dest_graph_node]
+
+    if pip_name is not None:
         graph.add_edge(
                 src_node=src_node, sink_node=sink_node, switch_id=switch_id,
                 name='fasm_features', value=check_feature(pip_name))
+    else:
+        graph.add_edge(
+                src_node=src_node, sink_node=sink_node, switch_id=switch_id)
 
-        return (src_node, sink_node, switch_id)
+def import_graph_edges(conn, graph, node_mapping):
+    c = conn.cursor()
 
-    src_pin = {}
-    src_node_type = None
-    sink_node_type = None
+    c.execute("SELECT count() FROM graph_edge;""")
+    (num_edges,) = c.fetchone()
 
-    pip_name = '{}.{}.{}'.format(tile_name, pip.net_to, pip.net_from)
+    tile_name_cache = {}
+    pip_cache = {}
+    switch_name_map = {}
+    with progressbar.ProgressBar(max_value=num_edges) as bar:
+        for idx, (src_graph_node, dest_graph_node, switch_pkey, tile_pkey, pip_pkey) in enumerate(c.execute("""
+    SELECT src_graph_node_pkey, dest_graph_node_pkey, switch_pkey, tile_pkey, pip_in_tile_pkey
+        FROM graph_edge;
+                """)):
+            if src_graph_node not in node_mapping:
+                continue
 
-    for src_node_type, src_node, src_pin_dir in find_nodes(graph, track_wire_map, loc, tile_name, tile_type, pip.net_from):
-        src_pin[src_pin_dir] = src_node
+            if dest_graph_node not in node_mapping:
+                continue
 
-    if src_node_type is None:
-        return
+            if pip_pkey is not None:
+                pip_name = make_fasm_feature(conn, tile_name_cache, pip_cache, tile_pkey, pip_pkey)
+            else:
+                pip_name = None
 
-    src_is_chan = src_node_type in (graph2.NodeType.CHANX, graph2.NodeType.CHANY)
+            switch_id = get_switch_name(conn, graph, switch_name_map, switch_pkey)
 
-    if pip.name in edges_with_mux:
-        if (tile_name, pip.net_from) in edges_with_mux[pip.name]:
-            # Found edge with mux!
-            assert not src_is_chan
+            import_graph_edge(conn, graph, node_mapping, src_graph_node, dest_graph_node, switch_id, pip_name)
+            bar.update(idx)
 
-            for target_tile, target_wire in edges_with_mux[pip.name][(tile_name, pip.net_from)]:
-                gridinfo = grid.gridinfo_at_tilename(target_tile)
-                target_loc = grid.loc_of_tilename(target_tile)
+def create_channels(conn):
+    c = conn.cursor()
 
+    c.execute("""
+    SELECT chan_width_max, x_min, x_max, y_min, y_max FROM channel;""")
+    chan_width_max, x_min, x_max, y_min, y_max = c.fetchone()
 
-                for sink_node_type, sink_node, sink_pin_dir in find_nodes(
-                        graph=graph,
-                        track_wire_map=track_wire_map,
-                        loc=target_loc,
-                        tile_name=target_tile,
-                        tile_type=gridinfo.tile_type,
-                        wire=target_wire):
+    c.execute('SELECT idx, info FROM x_list;')
+    x_list = []
+    for idx, info in c:
+        x_list.append(graph2.ChannelList(idx, info))
 
-                    node_type = graph.nodes[sink_node].type
-                    if node_type != graph2.NodeType.IPIN:
-                        continue
+    c.execute('SELECT idx, info FROM y_list;')
+    y_list = []
+    for idx, info in c:
+        y_list.append(graph2.ChannelList(idx, info))
 
-                    return add_edge(
-                            pip_name=pip_name,
-                            src_node=src_pin[opposite_direction(sink_pin_dir)],
-                            sink_node=sink_node,
-                            switch_id=switch_id)
-
-    for sink_node_type, sink_node, sink_pin_dir in find_nodes(graph, track_wire_map, loc, tile_name, tile_type, pip.net_to):
-        sink_is_chan = sink_node_type in (graph2.NodeType.CHANX, graph2.NodeType.CHANY)
-
-        if (src_is_chan and sink_is_chan) or (not src_is_chan and not sink_is_chan):
-            return add_edge(
-                    pip_name=pip_name,
-                    src_node=src_node,
-                    sink_node=sink_node,
-                    switch_id=switch_id)
-
-        if sink_pin_dir in src_pin:
-            return add_edge(
-                    pip_name=pip_name,
-                    src_node=src_pin[sink_pin_dir],
-                    sink_node=sink_node,
-                    switch_id=switch_id)
-
-    if sink_node_type is not None:
-        assert False, (tile_name, pip)
+    return graph2.Channels(
+            chan_width_max=chan_width_max,
+            x_min=x_min,
+            y_min=y_min,
+            x_max=x_max,
+            y_max=y_max,
+            x_list=x_list,
+            y_list=y_list,
+    )
 
 def main():
     parser = argparse.ArgumentParser()
@@ -213,7 +379,7 @@ def main():
     parser.add_argument(
             '--write_rr_graph', required=True, help='Output rr_graph file')
     parser.add_argument(
-            '--channels', required=True, help='Channel definitions from prjxray_form_channels')
+            '--connection_database', help='Database of fabric connectivity', required=True)
     parser.add_argument(
             '--synth_tiles', help='If using an ROI, synthetic tile defintion from prjxray-arch-import')
 
@@ -238,7 +404,6 @@ def main():
         print('{} generating routing graph for ROI.'.format(now()))
     else:
         use_roi = False
-        roi = None
 
     # Convert input rr graph into graph2.Graph object.
     input_rr_graph = read_xml_file(args.read_rr_graph)
@@ -252,184 +417,38 @@ def main():
     tool_version = input_rr_graph.getroot().attrib['tool_version']
     tool_comment = input_rr_graph.getroot().attrib['tool_comment']
 
-    delayless_switch = graph.get_delayless_switch_id()
+    conn = sqlite3.connect(args.connection_database)
 
-    print('{} reading channels definitions.'.format(now()))
-    with open(args.channels) as f:
-        channels = json.load(f)
+    # Mapping of graph_node.pkey to rr node id.
+    node_mapping = {}
 
+    # Match site pins rr nodes with graph_node's in the connection_database.
+    print('{} Importing graph nodes'.format(now()))
+    import_graph_nodes(conn, graph, node_mapping)
+
+    # Walk all track graph nodes and add them.
+    print('{} Creating tracks'.format(now()))
     segment_id = graph.get_segment_id_from_name('dummy')
-
-    track_wire_map = {}
-
-    print('{} add nodes for all channels.'.format(now()))
-    used_channels = 0
-    for idx, channel in progressbar.progressbar(enumerate(channels['channels'])):
-        # Don't use dead channels if using an ROI.
-        # Consider a channel alive if at least 1 wire in the node is part of a
-        # live tile.
-        if use_roi:
-            alive = False
-            for tile, wire in channel['wires']:
-                loc = grid.loc_of_tilename(tile)
-                if roi.tile_in_roi(loc) or tile in synth_tiles['tiles']:
-                    alive = True
-                    break
-
-            if not alive:
-                continue
-
-        used_channels += 1
-        nodes = []
-        track_list = []
-        for idx2, track_dict in enumerate(channel['tracks']):
-            if track_dict['direction'] == 'X':
-                track_dict['x_low'] = max(track_dict['x_low'], 1)
-            elif track_dict['direction'] == 'Y':
-                track_dict['y_low'] = max(track_dict['y_low'], 1)
-            track = tracks.Track(**track_dict)
-            track_list.append(track)
-
-            nodes.append(graph.add_track(track=track, segment_id=segment_id, name='track_{}_{}'.format(idx, idx2)))
-
-        for a_idx, b_idx in channel['track_connections']:
-            graph.add_edge(nodes[a_idx], nodes[b_idx], delayless_switch, 'track_{}_to_{}'.format(a_idx, b_idx))
-            graph.add_edge(nodes[b_idx], nodes[a_idx], delayless_switch, 'track_{}_to_{}'.format(b_idx, a_idx))
-
-        tracks_model = tracks.Tracks(track_list, channel['track_connections'])
-
-        for tile, wire in channel['wires']:
-            track_wire_map[(tile, wire)] = (tracks_model, nodes)
-
-    print('original {} final {}'.format(len(channels['channels']), used_channels))
-
-    routing_switch = graph.get_switch_id('routing')
-
-    pip_map = {}
-
-    edges_with_mux = {}
-    for idx, edge_with_mux in progressbar.progressbar(enumerate(channels['edges_with_mux'])):
-        if edge_with_mux['pip'] not in edges_with_mux:
-            edges_with_mux[edge_with_mux['pip']] = {}
-
-        assert len(edge_with_mux['source_node']) == 1
-        edges_with_mux[edge_with_mux['pip']][tuple(edge_with_mux['source_node'][0])] = edge_with_mux['destination_node']
+    create_track_rr_graph(conn, graph, node_mapping, use_roi, roi, synth_tiles, segment_id)
 
     # Set of (src, sink, switch_id) tuples that pip edges have been sent to
     # VPR.  VPR cannot handle duplicate paths with the same switch id.
-    pip_set = set()
-
-    output_only_nodes = set()
-    input_only_nodes = set()
-
-    print('{} Adding edges'.format(now()))
     if use_roi:
-        for loc in progressbar.progressbar(grid.tile_locations()):
-            gridinfo = grid.gridinfo_at_loc(loc)
-            tile_name = grid.tilename_at_loc(loc)
+        print('{} Adding synthetic edges'.format(now()))
+        add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles)
 
-            if tile_name in synth_tiles['tiles']:
-                assert len(synth_tiles['tiles'][tile_name]['pins']) == 1
-                for pin in synth_tiles['tiles'][tile_name]['pins']:
-                    tracks_model, track_nodes = track_wire_map[(tile_name, pin['wire'])]
+    print('{} Importing edges from database.'.format(now()))
+    import_graph_edges(conn, graph, node_mapping)
 
-                    option = list(tracks_model.get_tracks_for_wire_at_coord(loc))
-                    assert len(option) > 0
+    print('{} Creating channels.'.format(now()))
+    channels_obj = create_channels(conn)
 
-                    if pin['port_type'] == 'input':
-                        tile_type = 'BLK_SY-OUTPAD'
-                        wire = 'outpad'
-                    elif pin['port_type'] == 'output':
-                        tile_type = 'BLK_SY-INPAD'
-                        wire = 'inpad'
-                    else:
-                        assert False, pin
-
-                    track_node = track_nodes[option[0][0]]
-                    pin_name = graph.create_pin_name_from_tile_type_and_pin(
-                            tile_type,
-                            wire)
-
-                    pin_node = graph.get_nodes_for_pin(loc, pin_name)
-
-                    if pin['port_type'] == 'input':
-                        graph.add_edge(
-                                src_node=track_node,
-                                sink_node=pin_node[0][0],
-                                switch_id=routing_switch,
-                                name='synth_{}_{}'.format(tile_name, pin['wire']),
-                        )
-
-                        # This track can output be used as a sink.
-                        input_only_nodes |= set(track_nodes)
-                    elif pin['port_type'] == 'output':
-                        graph.add_edge(
-                                src_node=pin_node[0][0],
-                                sink_node=track_node,
-                                switch_id=routing_switch,
-                                name='synth_{}_{}'.format(tile_name, pin['wire']),
-                        )
-
-                        # This track can output be used as a src.
-                        output_only_nodes |= set(track_nodes)
-                    else:
-                        assert False, pin
-
-    for loc in progressbar.progressbar(grid.tile_locations()):
-        gridinfo = grid.gridinfo_at_loc(loc)
-        tile_name = grid.tilename_at_loc(loc)
-
-        # Not a synth node, check if in ROI.
-        if use_roi and not roi.tile_in_roi(loc):
-            continue
-
-        tile_type = db.get_tile_type(gridinfo.tile_type)
-
-        for pip in tile_type.get_pips():
-            if pip.is_pseudo:
-                continue
-
-            if not pip.is_directional:
-                # TODO: Handle bidirectional pips?
-                continue
-
-            edge_node = make_connection(graph, track_wire_map, loc, tile_name,
-                    gridinfo.tile_type, pip, routing_switch, edges_with_mux,
-                    grid, pip_set, output_only_nodes, input_only_nodes)
-
-            if edge_node is not None:
-                pip_map[(tile_name, pip.name)] = edge_node
-
-    print('{} Writing node mapping.'.format(now()))
-    node_mapping = {
-            'pips': [],
-            'tracks': []
-        }
-
-    for (tile, pip_name), edge in pip_map.items():
-        node_mapping['pips'].append({
-                'tile': tile,
-                'pip': pip_name,
-                'edge': edge
-        })
-
-    for (tile, wire), (_, nodes) in track_wire_map.items():
-        node_mapping['tracks'].append({
-                'tile': tile,
-                'wire': wire,
-                'nodes': nodes,
-        })
-
-    with open('node_mapping.pickle', 'wb') as f:
-        pickle.dump(node_mapping, f)
-
-    print('{} Create channels and serializing.'.format(now()))
-    pool = multiprocessing.Pool(10)
+    print('{} Serializing.'.format(now()))
     serialized_rr_graph = xml_graph.serialize_to_xml(
             tool_version=tool_version,
             tool_comment=tool_comment,
             pad_segment=segment_id,
-            pool=pool,
+            channels_obj=channels_obj,
     )
 
     print('{} Writing to disk.'.format(now()))

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -206,7 +206,8 @@ def import_dummy_tracks(conn, graph, segment_id):
 
         inode = graph.add_track(
                 track=track, segment_id=segment_id,
-                name='dummy_track_{}'.format(graph_node_pkey))
+                name='dummy_track_{}'.format(graph_node_pkey),
+                capacity=0)
         graph.set_track_ptc(inode, ptc)
         num_dummy += 1
 

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -227,10 +227,10 @@ def create_track_rr_graph(conn, graph, node_mapping, use_roi, roi, synth_tiles, 
     import_tracks(conn, alive_tracks, node_mapping, graph, segment_id)
 
     print('{} Importing dummy tracks'.format(now()))
-    dummy = import_dummy_tracks(conn, graph, segment_id)
+    num_dummy = import_dummy_tracks(conn, graph, segment_id)
 
     print('original {} final {} dummy {}'.format(
-        num_channels, len(alive_tracks), dummy))
+        num_channels, len(alive_tracks), num_dummy))
 
 def add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles):
     c = conn.cursor()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -4,6 +4,19 @@
 For ROI configurations, this also connects the synthetic IO tiles to the routing
 node specified.
 
+Rough structure:
+
+Add rr_nodes for CHANX and CHANY from the database.  IPIN and OPIN rr_nodes
+should already be present from the input rr_graph.
+
+Create a mapping between database graph_nodes and IPIN, OPIN, CHANX and CHANY
+rr_node ids in the rr_graph.
+
+Add rr_edge for each row in the graph_edge table.
+
+Import channel XML node from connection database and serialize output to
+rr_graph XML.
+
 """
 
 import argparse


### PR DESCRIPTION
This converts the xc7 routing graph import from using channels.json to channels.db, a sqlite3 database.  This was done for several reasons:
 - Certain operations (e.g. pruning dead nodes) was fairly difficult in the previous data structure and layout.
 - Memory usage was very high as a side affect of keeping all data in memory
 - Parse times of channels.json (~800 MB) was high.
 - It was hard to see what was taking time, because database-like operations were in the code.  Now data lookup is explicit and can be optimized via SQL indicies or denormalized tables if shown to be required.

In addition, by moving to a database to keep relations between tiles, wires, nodes (prjxray node), graph_node (VTR rr_node), and graph_edges (VTR rr_edge) to the database, it should be easier to do optimizations on the graph, like merge nodes or splitting tiles (ala #415).

This also fixes #292 by avoiding recomputing the graph every time a pb_type XML is changed.  Instead the graph is computed only when prjxray DB changes.

This is fairly large rework of the routing import, but hopefully it is more understandable than the previous incarnation.