### PR TITLE
Yosys log and statistics

### DIFF
--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -830,7 +830,7 @@ function(ADD_FPGA_TARGET)
       COMMAND
         ${CMAKE_COMMAND} -E make_directory ${OUT_LOCAL}
       COMMAND
-        ${CMAKE_COMMAND} -E env symbiflow-arch-defs_SOURCE_DIR=${symbiflow-arch-defs_SOURCE_DIR} ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SCRIPT}" ${SOURCE_FILES}
+        ${CMAKE_COMMAND} -E env symbiflow-arch-defs_SOURCE_DIR=${symbiflow-arch-defs_SOURCE_DIR} ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SCRIPT}" -l ${OUT_EBLIF}.log ${SOURCE_FILES}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       VERBATIM
     )

--- a/xc7/yosys/synth.tcl
+++ b/xc7/yosys/synth.tcl
@@ -14,3 +14,4 @@ opt_expr -undriven
 opt_clean
 
 setundef -zero -params
+stat


### PR DESCRIPTION
Added generation of Yosys log in the build system. Added printing of primitive usage statistics to Yosys script for XC7 (`xc7/yosys/synth.tcl`). Very useful for debugging.
