### PR TITLE
SQLite database cache

### DIFF
--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -101,7 +101,7 @@ function(PROJECT_XRAY_TILE)
     DEPENDS
     ${TILE_IMPORT}
       ${DEPS}
-      ${PYTHON3} ${PYTHON3_TARGET}
+      ${PYTHON3} ${PYTHON3_TARGET} simplejson
     )
 
   add_file_target(FILE ${TILE}.pb_type.xml GENERATED)
@@ -167,7 +167,7 @@ function(PROJECT_XRAY_ARCH)
       DEPENDS
         ${CREATE_SYNTH_TILES}
         ${PROJECT_XRAY_ARCH_USE_ROI}
-        ${PYTHON3} ${PYTHON3_TARGET}
+        ${PYTHON3} ${PYTHON3_TARGET} simplejson intervaltree
         )
 
     add_file_target(FILE synth_tiles.json GENERATED)
@@ -200,7 +200,7 @@ function(PROJECT_XRAY_ARCH)
     DEPENDS
     ${ARCH_IMPORT}
     ${DEPS}
-    ${PYTHON3} ${PYTHON3_TARGET}
+    ${PYTHON3} ${PYTHON3_TARGET} simplejson
     )
 
   add_file_target(FILE arch.xml GENERATED)
@@ -279,7 +279,7 @@ function(PROJECT_XRAY_PREPARE_DATABASE)
     DEPENDS
     ${ASSIGN_PINS}
     ${DEPS} ${DEPS2} ${CHANNELS}
-    ${PYTHON3} ${PYTHON3_TARGET}
+    ${PYTHON3} ${PYTHON3_TARGET} simplejson progressbar2
     )
 
   add_file_target(FILE ${PIN_ASSIGNMENTS} GENERATED)

--- a/xc7/tests/chain_packing/counter.v
+++ b/xc7/tests/chain_packing/counter.v
@@ -3,7 +3,7 @@ module top (
 	output [7:0] out
 );
 
-	localparam LOG2DELAY = 8;
+	localparam LOG2DELAY = 22;
 
 	reg [LOG2DELAY-1:0] counter0 = 0;
 	reg [LOG2DELAY-1:0] counter1 = 0;

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -25,6 +25,8 @@ import progressbar
 import sqlite3
 import datetime
 
+from prjxray_db_cache import DatabaseCache
+
 now = datetime.datetime.now
 DirectConnection = namedtuple('DirectConnection', 'from_pin to_pin switch_name x_offset y_offset')
 
@@ -259,7 +261,8 @@ def main():
                 assert key not in edge_assignments, key
                 edge_assignments[key] = []
 
-    conn = sqlite3.connect(args.connection_database)
+    db_cache = DatabaseCache(args.connection_database)
+    conn = db_cache.get_connection()
 
     direct_connections = set()
     print('{} Processing direct connections.'.format(now()))
@@ -406,6 +409,9 @@ SELECT pkey, track_pkey FROM node WHERE classification = ?;
             'pin_directions': pin_directions,
             'direct_connections': [d._asdict() for d in direct_connections],
         }, f, indent=2)
+
+    print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
+    db_cache.close()
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -261,7 +261,7 @@ def main():
                 assert key not in edge_assignments, key
                 edge_assignments[key] = []
 
-    db_cache = DatabaseCache(args.connection_database)
+    db_cache = DatabaseCache(args.connection_database, read_only=True)
     conn = db_cache.get_connection()
 
     direct_connections = set()

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -261,156 +261,155 @@ def main():
                 assert key not in edge_assignments, key
                 edge_assignments[key] = []
 
-    db_cache = DatabaseCache(args.connection_database, read_only=True)
-    conn = db_cache.get_connection()
+    with DatabaseCache(args.connection_database, read_only=True) as conn:
 
-    direct_connections = set()
-    print('{} Processing direct connections.'.format(now()))
-    handle_direction_connections(conn, direct_connections, edge_assignments)
+        direct_connections = set()
+        print('{} Processing direct connections.'.format(now()))
+        handle_direction_connections(conn, direct_connections, edge_assignments)
 
-    wires_not_in_channels = {}
-    c = conn.cursor()
-    print('{} Processing non-channel nodes.'.format(now()))
-    for node_pkey, classification in progressbar.progressbar(c.execute("""
-SELECT pkey, classification FROM node WHERE classification != ?;
-""", (NodeClassification.CHANNEL.value,))):
-        reason = NodeClassification(classification)
+        wires_not_in_channels = {}
+        c = conn.cursor()
+        print('{} Processing non-channel nodes.'.format(now()))
+        for node_pkey, classification in progressbar.progressbar(c.execute("""
+    SELECT pkey, classification FROM node WHERE classification != ?;
+    """, (NodeClassification.CHANNEL.value,))):
+            reason = NodeClassification(classification)
 
-        for (tile, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
-            key = (tile_type, wire)
+            for (tile, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
+                key = (tile_type, wire)
 
-            # Sometimes nodes in particular tile instances are disconnected,
-            # disregard classification changes if this is the case.
-            if reason != NodeClassification.NULL:
-                if key not in wires_not_in_channels:
-                    wires_not_in_channels[key] = reason
-                else:
-                    other_reason = wires_not_in_channels[key]
-                    assert reason == other_reason, (tile, wire, reason, other_reason)
+                # Sometimes nodes in particular tile instances are disconnected,
+                # disregard classification changes if this is the case.
+                if reason != NodeClassification.NULL:
+                    if key not in wires_not_in_channels:
+                        wires_not_in_channels[key] = reason
+                    else:
+                        other_reason = wires_not_in_channels[key]
+                        assert reason == other_reason, (tile, wire, reason, other_reason)
 
-            if key in wires_in_tile_types:
-                wires_in_tile_types.remove(key)
+                if key in wires_in_tile_types:
+                    wires_in_tile_types.remove(key)
 
-    # List of nodes that are channels.
-    channel_nodes = []
+        # List of nodes that are channels.
+        channel_nodes = []
 
-    # Map of (tile, wire) to track.  This will be used to find channels for pips
-    # that come from EDGES_TO_CHANNEL.
-    channel_wires_to_tracks = {}
+        # Map of (tile, wire) to track.  This will be used to find channels for pips
+        # that come from EDGES_TO_CHANNEL.
+        channel_wires_to_tracks = {}
 
-    # Generate track models and verify that wires are either in a channel
-    # or not in a channel.
-    print('{} Creating models from tracks.'.format(now()))
-    for node_pkey, track_pkey in progressbar.progressbar(c.execute("""
-SELECT pkey, track_pkey FROM node WHERE classification = ?;
-""", (NodeClassification.CHANNEL.value,))):
-        assert track_pkey is not None
+        # Generate track models and verify that wires are either in a channel
+        # or not in a channel.
+        print('{} Creating models from tracks.'.format(now()))
+        for node_pkey, track_pkey in progressbar.progressbar(c.execute("""
+    SELECT pkey, track_pkey FROM node WHERE classification = ?;
+    """, (NodeClassification.CHANNEL.value,))):
+            assert track_pkey is not None
 
-        tracks_model, _ = get_track_model(conn, track_pkey)
-        channel_nodes.append(tracks_model)
-        channel_wires_to_tracks[track_pkey] = tracks_model
+            tracks_model, _ = get_track_model(conn, track_pkey)
+            channel_nodes.append(tracks_model)
+            channel_wires_to_tracks[track_pkey] = tracks_model
 
-        for (tile, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
-            tileinfo = grid.gridinfo_at_tilename(tile)
-            key = (tileinfo.tile_type, wire)
-            # Make sure all wires in channels always are in channels
-            assert key not in wires_not_in_channels
+            for (tile, tile_type, wire) in yield_wire_info_from_node(conn, node_pkey):
+                tileinfo = grid.gridinfo_at_tilename(tile)
+                key = (tileinfo.tile_type, wire)
+                # Make sure all wires in channels always are in channels
+                assert key not in wires_not_in_channels
 
-            if key in wires_in_tile_types:
-                wires_in_tile_types.remove(key)
+                if key in wires_in_tile_types:
+                    wires_in_tile_types.remove(key)
 
-    # Make sure all wires appear to have been assigned.
-    assert len(wires_in_tile_types) == 0
+        # Make sure all wires appear to have been assigned.
+        assert len(wires_in_tile_types) == 0
 
-    # Verify that all tracks are sane.
-    for node in channel_nodes:
-        node.verify_tracks()
+        # Verify that all tracks are sane.
+        for node in channel_nodes:
+            node.verify_tracks()
 
-    null_tile_wires = set()
+        null_tile_wires = set()
 
-    # Verify that all nodes that are classified as edges to channels have at
-    # least one site, and at least one live connection to a channel.
-    #
-    # If no live connections from the node are present, this node should've
-    # been marked as NULL during channel formation.
-    print('{} Handling edges to channels.'.format(now()))
-    handle_edges_to_channels(conn, null_tile_wires, edge_assignments, channel_wires_to_tracks)
+        # Verify that all nodes that are classified as edges to channels have at
+        # least one site, and at least one live connection to a channel.
+        #
+        # If no live connections from the node are present, this node should've
+        # been marked as NULL during channel formation.
+        print('{} Handling edges to channels.'.format(now()))
+        handle_edges_to_channels(conn, null_tile_wires, edge_assignments, channel_wires_to_tracks)
 
-    print('{} Processing edge assignments.'.format(now()))
-    final_edge_assignments = {}
-    for key, available_pins in progressbar.progressbar(edge_assignments.items()):
-        (tile_type, wire) = key
-        if len(available_pins) == 0:
-            if (tile_type, wire) not in null_tile_wires:
-                # TODO: Figure out what is going on with these wires.  Appear to
-                # tile internal connections sometimes?
-                print((tile_type, wire))
+        print('{} Processing edge assignments.'.format(now()))
+        final_edge_assignments = {}
+        for key, available_pins in progressbar.progressbar(edge_assignments.items()):
+            (tile_type, wire) = key
+            if len(available_pins) == 0:
+                if (tile_type, wire) not in null_tile_wires:
+                    # TODO: Figure out what is going on with these wires.  Appear to
+                    # tile internal connections sometimes?
+                    print((tile_type, wire))
 
-            final_edge_assignments[key] = [tracks.Direction.RIGHT]
-            continue
+                final_edge_assignments[key] = [tracks.Direction.RIGHT]
+                continue
 
-        pins = set(available_pins[0])
-        for p in available_pins[1:]:
-            pins &= set(p)
+            pins = set(available_pins[0])
+            for p in available_pins[1:]:
+                pins &= set(p)
 
-        if len(pins) > 0:
-            final_edge_assignments[key] = [list(pins)[0]]
-        else:
-            # More than 2 pins are required, final the minimal number of pins
-            pins = set()
-            for p in available_pins:
-                pins |= set(p)
+            if len(pins) > 0:
+                final_edge_assignments[key] = [list(pins)[0]]
+            else:
+                # More than 2 pins are required, final the minimal number of pins
+                pins = set()
+                for p in available_pins:
+                    pins |= set(p)
 
-            while len(pins) > 2:
-                pins = list(pins)
+                while len(pins) > 2:
+                    pins = list(pins)
 
-                prev_len = len(pins)
+                    prev_len = len(pins)
 
-                for idx in range(len(pins)):
-                    pins_subset = list(pins)
-                    del pins_subset[idx]
+                    for idx in range(len(pins)):
+                        pins_subset = list(pins)
+                        del pins_subset[idx]
 
-                    pins_subset = set(pins_subset)
+                        pins_subset = set(pins_subset)
 
-                    bad_subset = False
-                    for p in available_pins:
-                        if len(pins_subset & set(p)) == 0:
-                            bad_subset = True
+                        bad_subset = False
+                        for p in available_pins:
+                            if len(pins_subset & set(p)) == 0:
+                                bad_subset = True
+                                break
+
+                        if not bad_subset:
+                            pins = list(pins_subset)
                             break
 
-                    if not bad_subset:
-                        pins = list(pins_subset)
+                    # Failed to remove any pins, stop.
+                    if len(pins) == prev_len:
                         break
 
-                # Failed to remove any pins, stop.
-                if len(pins) == prev_len:
-                    break
+                final_edge_assignments[key] = pins
 
-            final_edge_assignments[key] = pins
+        for key, available_pins in edge_assignments.items():
+            (tile_type, wire) = key
+            pins = set(final_edge_assignments[key])
 
-    for key, available_pins in edge_assignments.items():
-        (tile_type, wire) = key
-        pins = set(final_edge_assignments[key])
+            for required_pins in available_pins:
+                assert len(pins & set(required_pins)) > 0, (
+                        tile_type, wire, pins, required_pins)
 
-        for required_pins in available_pins:
-            assert len(pins & set(required_pins)) > 0, (
-                    tile_type, wire, pins, required_pins)
+        pin_directions = {}
+        for key, pins in progressbar.progressbar(final_edge_assignments.items()):
+            (tile_type, wire) = key
+            if tile_type not in pin_directions:
+                pin_directions[tile_type] = {}
 
-    pin_directions = {}
-    for key, pins in progressbar.progressbar(final_edge_assignments.items()):
-        (tile_type, wire) = key
-        if tile_type not in pin_directions:
-            pin_directions[tile_type] = {}
+            pin_directions[tile_type][wire] = [pin._name_ for pin in pins]
 
-        pin_directions[tile_type][wire] = [pin._name_ for pin in pins]
+        with open(args.pin_assignments, 'w') as f:
+            json.dump({
+                'pin_directions': pin_directions,
+                'direct_connections': [d._asdict() for d in direct_connections],
+            }, f, indent=2)
 
-    with open(args.pin_assignments, 'w') as f:
-        json.dump({
-            'pin_directions': pin_directions,
-            'direct_connections': [d._asdict() for d in direct_connections],
-        }, f, indent=2)
-
-    print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
+        print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -411,7 +411,6 @@ SELECT pkey, track_pkey FROM node WHERE classification = ?;
         }, f, indent=2)
 
     print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
-    db_cache.close()
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -885,7 +885,6 @@ def main():
     mark_track_liveness(conn, pool, input_only_nodes, output_only_nodes)
 
     print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
-    db_cache.close()
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -37,6 +37,8 @@ from lib.connection_database import get_track_model
 from lib.rr_graph.graph2 import NodeType
 import multiprocessing
 
+from prjxray_db_cache import DatabaseCache
+
 now = datetime.datetime.now
 
 
@@ -748,7 +750,9 @@ def main():
 
     db = prjxray.db.Database(args.db_root)
     grid = db.grid()
-    conn = sqlite3.connect(args.connection_database)
+
+    db_cache = DatabaseCache(args.connection_database)
+    conn = db_cache.get_connection()
 
     with open(args.pin_assignments) as f:
         pin_assignments = json.load(f)
@@ -879,6 +883,9 @@ def main():
 
     print('{} Indices created, marking track liveness'.format(now()))
     mark_track_liveness(conn, pool, input_only_nodes, output_only_nodes)
+
+    print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
+    db_cache.close()
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_db_cache.py
+++ b/xc7/utils/prjxray_db_cache.py
@@ -1,0 +1,53 @@
+"""
+This is a database cache. Its a kind of proxy object for Python sqlite3 connection
+which operates on a memory copy of the database.
+
+Upon object creation the database is "backed up" to memory. All subsequent
+operations are then pefromed on this copy which yields in performance increase.
+
+It is important to explicitly call the close() method once database connection
+is no longer needed. The method "backs up" the database back to disk.
+"""
+import sqlite3
+
+# =============================================================================
+
+class DatabaseCache(object):
+
+    def __init__(self, file_name):
+
+        self.file_name         = file_name
+        self.memory_connection = sqlite3.connect(":memory:")
+        self.file_connection   = sqlite3.connect(file_name)
+
+        print("Loading database from '{}'".format(self.file_name))
+        self.file_connection.backup(self.memory_connection, pages=1, progress=self._progress)
+        print("")
+
+    def close(self):
+
+        print("Dumping database to '{}'".format(self.file_name))
+        self.memory_connection.backup(self.file_connection, pages=1, progress=self._progress)
+        print("")
+
+        self.memory_connection.close()
+        self.file_connection.close()
+
+    def _progress(self, status, remaining, total):
+        """
+        Prints database copy progress.
+        """
+
+        if total > 0:
+            percent = 100.0 * (total-remaining) / total
+        else:
+            percent = 100.0
+
+        print("\r%.2f%%" % percent, end="")
+
+    def get_connection(self):
+        """
+        Returns connection to the database copy in memory
+        """
+        return self.memory_connection
+

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -43,6 +43,8 @@ import os
 import os.path
 from lib.connection_database import NodeClassification, create_tables
 
+from prjxray_db_cache import DatabaseCache
+
 def import_site_type(db, c, site_types, site_type_name):
     assert site_type_name not in site_types
     site_type = db.get_site_type(site_type_name)
@@ -697,7 +699,9 @@ def main():
     if os.path.exists(args.connection_database):
         os.remove(args.connection_database)
 
-    conn = sqlite3.connect(args.connection_database)
+    db_cache = DatabaseCache(args.connection_database)
+    conn = db_cache.get_connection()
+
     create_tables(conn)
 
     print("{}: About to load database".format(datetime.datetime.now()))
@@ -713,6 +717,9 @@ def main():
     print("{}: Nodes classified".format(datetime.datetime.now()))
     form_tracks(conn)
     print("{}: Tracks formed".format(datetime.datetime.now()))
+
+    print('{} Flushing database back to file "{}"'.format(datetime.datetime.now(), args.connection_database))
+    db_cache.close()
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -699,26 +699,25 @@ def main():
     if os.path.exists(args.connection_database):
         os.remove(args.connection_database)
 
-    db_cache = DatabaseCache(args.connection_database)
-    conn = db_cache.get_connection()
+    with DatabaseCache(args.connection_database) as conn:
 
-    create_tables(conn)
+        create_tables(conn)
 
-    print("{}: About to load database".format(datetime.datetime.now()))
-    db = prjxray.db.Database(args.db_root)
-    grid = db.grid()
-    import_grid(db, grid, conn)
-    print("{}: Initial database formed".format(datetime.datetime.now()))
-    import_nodes(db, grid, conn)
-    print("{}: Connections made".format(datetime.datetime.now()))
-    count_sites_and_pips_on_nodes(conn)
-    print("{}: Counted sites and pips".format(datetime.datetime.now()))
-    classify_nodes(conn)
-    print("{}: Nodes classified".format(datetime.datetime.now()))
-    form_tracks(conn)
-    print("{}: Tracks formed".format(datetime.datetime.now()))
+        print("{}: About to load database".format(datetime.datetime.now()))
+        db = prjxray.db.Database(args.db_root)
+        grid = db.grid()
+        import_grid(db, grid, conn)
+        print("{}: Initial database formed".format(datetime.datetime.now()))
+        import_nodes(db, grid, conn)
+        print("{}: Connections made".format(datetime.datetime.now()))
+        count_sites_and_pips_on_nodes(conn)
+        print("{}: Counted sites and pips".format(datetime.datetime.now()))
+        classify_nodes(conn)
+        print("{}: Nodes classified".format(datetime.datetime.now()))
+        form_tracks(conn)
+        print("{}: Tracks formed".format(datetime.datetime.now()))
 
-    print('{} Flushing database back to file "{}"'.format(datetime.datetime.now(), args.connection_database))
+        print('{} Flushing database back to file "{}"'.format(datetime.datetime.now(), args.connection_database))
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -719,7 +719,6 @@ def main():
     print("{}: Tracks formed".format(datetime.datetime.now()))
 
     print('{} Flushing database back to file "{}"'.format(datetime.datetime.now(), args.connection_database))
-    db_cache.close()
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -547,9 +547,6 @@ def main():
         xml_graph.serialize_edges(import_graph_edges(conn, graph, node_mapping))
 
     print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
-    db_cache.close()
-
-    print('{} Done.'.format(now()))
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -510,43 +510,42 @@ def main():
     tool_version = input_rr_graph.getroot().attrib['tool_version']
     tool_comment = input_rr_graph.getroot().attrib['tool_comment']
 
-    db_cache = DatabaseCache(args.connection_database)
-    conn = db_cache.get_connection()
+    with DatabaseCache(args.connection_database) as conn:
 
-    # Mapping of graph_node.pkey to rr node id.
-    node_mapping = {}
+        # Mapping of graph_node.pkey to rr node id.
+        node_mapping = {}
 
-    # Match site pins rr nodes with graph_node's in the connection_database.
-    print('{} Importing graph nodes'.format(now()))
-    import_graph_nodes(conn, graph, node_mapping)
+        # Match site pins rr nodes with graph_node's in the connection_database.
+        print('{} Importing graph nodes'.format(now()))
+        import_graph_nodes(conn, graph, node_mapping)
 
-    # Walk all track graph nodes and add them.
-    print('{} Creating tracks'.format(now()))
-    segment_id = graph.get_segment_id_from_name('dummy')
-    create_track_rr_graph(conn, graph, node_mapping, use_roi, roi, synth_tiles, segment_id)
+        # Walk all track graph nodes and add them.
+        print('{} Creating tracks'.format(now()))
+        segment_id = graph.get_segment_id_from_name('dummy')
+        create_track_rr_graph(conn, graph, node_mapping, use_roi, roi, synth_tiles, segment_id)
 
-    # Set of (src, sink, switch_id) tuples that pip edges have been sent to
-    # VPR.  VPR cannot handle duplicate paths with the same switch id.
-    if use_roi:
-        print('{} Adding synthetic edges'.format(now()))
-        add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles)
+        # Set of (src, sink, switch_id) tuples that pip edges have been sent to
+        # VPR.  VPR cannot handle duplicate paths with the same switch id.
+        if use_roi:
+            print('{} Adding synthetic edges'.format(now()))
+            add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles)
 
 
-    print('{} Creating channels.'.format(now()))
-    channels_obj = create_channels(conn)
+        print('{} Creating channels.'.format(now()))
+        channels_obj = create_channels(conn)
 
-    print('{} Serializing to disk.'.format(now()))
-    with xml_graph:
-        xml_graph.start_serialize_to_xml(
-            tool_version=tool_version,
-            tool_comment=tool_comment,
-            channels_obj=channels_obj,
-            )
+        print('{} Serializing to disk.'.format(now()))
+        with xml_graph:
+            xml_graph.start_serialize_to_xml(
+                tool_version=tool_version,
+                tool_comment=tool_comment,
+                channels_obj=channels_obj,
+                )
 
-        xml_graph.serialize_nodes(yield_nodes(xml_graph.graph.nodes))
-        xml_graph.serialize_edges(import_graph_edges(conn, graph, node_mapping))
+            xml_graph.serialize_nodes(yield_nodes(xml_graph.graph.nodes))
+            xml_graph.serialize_edges(import_graph_edges(conn, graph, node_mapping))
 
-    print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
+        print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -35,6 +35,8 @@ import re
 import sqlite3
 import functools
 
+from prjxray_db_cache import DatabaseCache
+
 now = datetime.datetime.now
 
 HCLK_CK_BUFHCLK_REGEX = re.compile('HCLK_CK_BUFHCLK[0-9]+')
@@ -508,7 +510,8 @@ def main():
     tool_version = input_rr_graph.getroot().attrib['tool_version']
     tool_comment = input_rr_graph.getroot().attrib['tool_comment']
 
-    conn = sqlite3.connect(args.connection_database)
+    db_cache = DatabaseCache(args.connection_database)
+    conn = db_cache.get_connection()
 
     # Mapping of graph_node.pkey to rr node id.
     node_mapping = {}
@@ -542,6 +545,9 @@ def main():
 
         xml_graph.serialize_nodes(yield_nodes(xml_graph.graph.nodes))
         xml_graph.serialize_edges(import_graph_edges(conn, graph, node_mapping))
+
+    print('{} Flushing database back to file "{}"'.format(now(), args.connection_database))
+    db_cache.close()
 
     print('{} Done.'.format(now()))
 


### PR DESCRIPTION
While working with arch defs I've noticed that recent changes regarding SQLite introduction dramatically slowed down process of prjxray database import. I've narrowed it down to problem with frequent writing of small chunks of data to the SQL database on disk. So I've created a wrapper which creates a temporary copy of the database in memory and all subsequent operations are performed on it.

I also added missing Python dependencies to the CMake build scripts.