### PR TITLE
connection_database: fixing bug in table_create

### DIFF
--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -1,4 +1,5 @@
 import enum
+import os
 from lib.rr_graph import graph2
 from lib.rr_graph import tracks
 
@@ -13,9 +14,9 @@ def create_tables(conn):
     """ Create connection database scheme. """
     connection_database_sql_file = os.path.join(
         os.path.dirname(__file__), "connection_database.sql")
-    with open(connection_database_sql_file, 'r'):
+    with open(connection_database_sql_file, 'r') as f:
         c = conn.cursor()
-        c.execute(f.read())
+        c.executescript(f.read())
         conn.commit()
 
     c = conn.cursor()


### PR DESCRIPTION
This PR is to fix a few bugs in `connection_database.py`:

- with `c.execute()` the following warning was produced (which ended up in a fatal error) `sqlite3.Warning: You can only execute one statement at a time`

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>