### PR TITLE
WIP: Use all pins when using ROI.

### DIFF
--- a/xc7/tests/bram_init_test/top.v
+++ b/xc7/tests/bram_init_test/top.v
@@ -26,7 +26,9 @@ endmodule
 module top (
     input clk,
     input rx,
-    output tx
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
 );
     reg nrst = 0;
     wire tx_baud_edge;
@@ -40,6 +42,9 @@ module top (
     wire tx_data_ready;
     wire tx_data_accepted;
     wire [7:0] tx_data;
+
+    assign led[14:0] = sw[14:0];
+    assign led[15] = rx_data_ready_wire ^ sw[15];
 
     UART #(
         .COUNTER(25),

--- a/xc7/tests/bram_sdp_init_test/top.v
+++ b/xc7/tests/bram_sdp_init_test/top.v
@@ -26,7 +26,9 @@ endmodule
 module top (
     input clk,
     input rx,
-    output tx
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
 );
     reg nrst = 0;
     wire tx_baud_edge;
@@ -40,6 +42,9 @@ module top (
     wire tx_data_ready;
     wire tx_data_accepted;
     wire [7:0] tx_data;
+
+    assign led[14:0] = sw[14:0];
+    assign led[15] = rx_data_ready_wire ^ sw[15];
 
     UART #(
         .COUNTER(25),

--- a/xc7/tests/bram_sdp_test/top.v
+++ b/xc7/tests/bram_sdp_test/top.v
@@ -40,7 +40,9 @@ endmodule
 module top (
     input  clk,
     input rx,
-    output tx
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
 );
     reg nrst = 0;
     wire tx_baud_edge;
@@ -54,6 +56,9 @@ module top (
     wire tx_data_ready;
     wire tx_data_accepted;
     wire [7:0] tx_data;
+
+    assign led[14:0] = sw[14:0];
+    assign led[15] = rx_data_ready_wire ^ sw[15];
 
     UART #(
         .COUNTER(25),

--- a/xc7/tests/bram_test/top.v
+++ b/xc7/tests/bram_test/top.v
@@ -29,7 +29,9 @@ endmodule
 module top (
     input  clk,
     input rx,
-    output tx
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
 );
     reg nrst = 0;
     wire tx_baud_edge;
@@ -43,6 +45,9 @@ module top (
     wire tx_data_ready;
     wire tx_data_accepted;
     wire [7:0] tx_data;
+
+    assign led[14:0] = sw[14:0];
+    assign led[15] = rx_data_ready_wire ^ sw[15];
 
     UART #(
         .COUNTER(25),

--- a/xc7/tests/common/basys3.pcf
+++ b/xc7/tests/common/basys3.pcf
@@ -3,3 +3,39 @@ set_io clk W5
 
 set_io tx A18
 set_io rx B18
+#
+# in[0:15] correspond with SW0-SW15 on the basys3
+set_io sw[0] V17
+set_io sw[1] V16
+set_io sw[2] W16
+set_io sw[3] W17
+set_io sw[4] W15
+set_io sw[5] V15
+set_io sw[6] W14
+set_io sw[7] W13
+set_io sw[8] V2
+set_io sw[9] T3
+set_io sw[10] T2
+set_io sw[11] R3
+set_io sw[12] W2
+set_io sw[13] U1
+set_io sw[14] T1
+set_io sw[15] R2
+
+# out[0:15] correspond with LD0-LD15 on the basys3
+set_io led[0] U16
+set_io led[1] E19
+set_io led[2] U19
+set_io led[3] V19
+set_io led[4] W18
+set_io led[5] U15
+set_io led[6] U14
+set_io led[7] V14
+set_io led[8] V13
+set_io led[9] V3
+set_io led[10] W3
+set_io led[11] U3
+set_io led[12] P3
+set_io led[13] N3
+set_io led[14] P1
+set_io led[15] L1

--- a/xc7/tests/dram_test/top.v
+++ b/xc7/tests/dram_test/top.v
@@ -1,7 +1,9 @@
 module top (
     input  clk,
     input rx,
-    output tx
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
 );
     reg nrst = 0;
     wire tx_baud_edge;
@@ -15,6 +17,9 @@ module top (
     wire tx_data_ready;
     wire tx_data_accepted;
     wire [7:0] tx_data;
+
+    assign led[14:0] = sw[14:0];
+    assign led[15] = rx_data_ready_wire ^ sw[15];
 
     UART #(
         .COUNTER(25),


### PR DESCRIPTION
This is required to allow the [fasm2bels](https://github.com/SymbiFlow/symbiflow-arch-defs/pull/473) tool to work without significant work arounds.

This PR causes the BRAM tests to fail per #491.