### PR TITLE
xc7: Switch to xc7frames2bit for bitstream generation

### DIFF
--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -58,8 +58,8 @@ function(ADD_XC7_ARCH_DEFINE)
         --sparse \
         \${FASM_TO_BIT_EXTRA_ARGS} \
     \${OUT_FASM} \${OUT_BITSTREAM}"
-    BIT_TO_BIN xc7patch
-    BIT_TO_BIN_CMD "xc7patch \
+    BIT_TO_BIN xc7frames2bit
+    BIT_TO_BIN_CMD "xc7frames2bit \
         --frm_file \${OUT_BITSTREAM} \
         --output_file \${OUT_BIN} \
         \${BIT_TO_BIN_EXTRA_ARGS}"

--- a/xc7/make/device_define.cmake
+++ b/xc7/make/device_define.cmake
@@ -32,7 +32,6 @@ function(ADD_XC7_DEVICE_DEFINE_TYPE)
   ")
   set_target_properties(${ARCH}_${DEVICE}_${NAME}
       PROPERTIES BIT_TO_BIN_EXTRA_ARGS " \
-    --bitstream_file ${ROI_DIR}/design.bit \
     --part_name ${ROI_PART} \
     --part_file ${PRJXRAY_DB_DIR}/${ARCH}/${ROI_PART}.yaml \
   ")


### PR DESCRIPTION
This PR is to solve the last thing on the todo list in #418.
Namelly: Use tool from SymbiFlow/prjxray#694 to create bitstream from frames, rather than patching design.bit with xc7patch.