### PR TITLE
WIP: Fixes for based FASM output found via fasm2bels.

### DIFF
--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -70,8 +70,9 @@ WHERE
   );
 """, (tile_name, wire))
 
-    (wire_pkey,) = c.fetchone()
-    return wire_pkey
+    results = c.fetchone()
+    assert results is not None, (tile_name, wire)
+    return results[0]
 
 def get_track_model(conn, track_pkey):
     assert track_pkey is not None

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -23,7 +23,6 @@ function(ADD_XC7_ARCH_DEFINE)
       --place_algorithm bounding_box
       --enable_timing_computations off
       --allow_unrelated_clustering on
-      --round_robin_prepacking on
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \

--- a/xc7/primitives/common_slice/common_slice.pb_type.xml
+++ b/xc7/primitives/common_slice/common_slice.pb_type.xml
@@ -308,16 +308,5 @@
     <direct name="CK" input="BLK_IG-COMMON_SLICE.CLK" output="BLK_BB-SLICE_FF.CK"/>
     <direct name="CE" input="BLK_IG-COMMON_SLICE.CE"  output="BLK_BB-SLICE_FF.CE"/>
     <direct name="SR" input="BLK_IG-COMMON_SLICE.SR"  output="BLK_BB-SLICE_FF.SR"/>
-
   </interconnect>
-  <metadata>
-    <meta name="fasm_features">
-      <!-- Because VPR cannot understand muxes that either tied to a  -->
-      <!-- constant or a port, VPR always connects CE and SR.  -->
-      <!-- Once VPR can understand the CEUSEDMUX and SRUSEDMUX, it can choose -->
-      <!-- whether CEUSEDMUX and SRUSEDMUX should be set or not.  -->
-      CEUSEDMUX
-      SRUSEDMUX
-    </meta>
-  </metadata>
 </pb_type>

--- a/xc7/primitives/ff/ff.model.xml
+++ b/xc7/primitives/ff/ff.model.xml
@@ -1,10 +1,10 @@
 <models>
   <model name="FDRE_ZINI">
     <input_ports>
-    <port name="C"  is_clock="1" />
-    <port name="CE" clock="C" />
-    <port name="R"  clock="C" />
-    <port name="D"  clock="C" />
+      <port name="C"  is_clock="1" />
+      <port name="CE" clock="C" />
+      <port name="R"  clock="C" />
+      <port name="D"  clock="C" />
     </input_ports>
     <output_ports>
     <port name="Q" clock="C"  />
@@ -34,35 +34,40 @@
   </model>
   <model name="FDCE_ZINI">
     <input_ports>
-    <port name="C"  is_clock="1" />
-    <port name="CE" clock="C" />
-    <port name="CLR"  clock="C" />
-    <port name="D"  clock="C" />
+      <port name="C"  is_clock="1" />
+      <port name="CE" clock="C" />
+      <port name="CLR"  clock="C" />
+      <port name="D"  clock="C" />
     </input_ports>
     <output_ports>
-    <port name="Q" clock="C"  />
+      <port name="Q" clock="C"  />
     </output_ports>
   </model>
   <model name="LDPE_ZINI">
     <input_ports>
-    <port name="G"  is_clock="1" />
-    <port name="GE" clock="G" />
-    <port name="PRE"  clock="G" />
-    <port name="D"  clock="G" />
+      <port name="G"  is_clock="1" />
+      <port name="GE" clock="G" />
+      <port name="PRE"  clock="G" />
+      <port name="D"  clock="G" />
     </input_ports>
     <output_ports>
-    <port name="Q" clock="G"  />
+      <port name="Q" clock="G"  />
     </output_ports>
   </model>
   <model name="LDCE_ZINI">
     <input_ports>
-    <port name="G"  is_clock="1" />
-    <port name="GE" clock="G" />
-    <port name="CLR"  clock="G" />
-    <port name="D"  clock="G" />
+      <port name="G"  is_clock="1" />
+      <port name="GE" clock="G" />
+      <port name="CLR"  clock="G" />
+      <port name="D"  clock="G" />
     </input_ports>
     <output_ports>
-    <port name="Q" clock="G"  />
+      <port name="Q" clock="G"  />
     </output_ports>
+  </model>
+  <model name="NO_FF">
+    <input_ports>
+      <port name="D" />
+    </input_ports>
   </model>
 </models>

--- a/xc7/primitives/ff/ff.pb_type.xml
+++ b/xc7/primitives/ff/ff.pb_type.xml
@@ -17,6 +17,14 @@
   <!-- |FDCE  |      |     |  X  | -->
   <!-- |LDPE  |      |  X  |     | -->
   <!-- |LDCE  |      |  X  |  X  | -->
+  <mode name="NO_FF">
+    <pb_type name="BEL_FF-NO_FF" num_pb="4" blif_model=".subckt NO_FF">
+      <input  name="D" num_pins="1"/>
+    </pb_type>
+    <interconnect>
+      <direct name="D" input="BLK_BB-SLICE_FF.D" output="BEL_FF-NO_FF.D"/>
+    </interconnect>
+  </mode>
   <mode name="FDSE_or_FDRE">
     <pb_type name="BEL_FF-FDSE_or_FDRE" num_pb="8">
       <input  name="D" num_pins="1"/>

--- a/xc7/primitives/slicel/ntemplate.slicelN.pb_type.xml
+++ b/xc7/primitives/slicel/ntemplate.slicelN.pb_type.xml
@@ -150,8 +150,20 @@
 
     <!-- Clock, Clock Enable and Reset -->
     <direct name="CK" input="BLK_IG-SLICEL{N}.CLK" output="BLK_IG-COMMON_SLICE.CLK"/>
-    <direct name="CE" input="BLK_IG-SLICEL{N}.CE"  output="BLK_IG-COMMON_SLICE.CE"/>
-    <direct name="SR" input="BLK_IG-SLICEL{N}.SR"  output="BLK_IG-COMMON_SLICE.SR"/>
+    <direct name="CE" input="BLK_IG-SLICEL{N}.CE"  output="BLK_IG-COMMON_SLICE.CE">
+      <metadata>
+        <meta name="fasm_mux">
+          BLK_IG-SLICEL{N}.CE = CEUSEDMUX
+        </meta>
+      </metadata>
+    </direct>
+    <direct name="SR" input="BLK_IG-SLICEL{N}.SR"  output="BLK_IG-COMMON_SLICE.SR">
+      <metadata>
+        <meta name="fasm_mux">
+          BLK_IG-SLICEL{N}.SR = SRUSEDMUX
+        </meta>
+      </metadata>
+    </direct>
 
   </interconnect>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
@@ -13,6 +13,14 @@
   <output name="O5"  num_pins="1" />
 
  <!-- TODO: Missing modes: SRL. -->
+ <mode name="NO_DRAM">
+  <pb_type name="BEL_NULL-NO_DRAM" num_pb="1" blif_model=".subckt NO_DRAM">
+    <input  name="A" num_pins="6"/>
+  </pb_type>
+  <interconnect>
+    <direct name="A" input="BLK_IG-D_DRAM.A" output="BEL_NULL-NO_DRAM.A" />
+  </interconnect>
+ </mode>
  <mode name="64_SINGLE_PORT">
    <xi:include href="spram64.pb_type.xml" />
    <interconnect>

--- a/xc7/primitives/slicem/Ndram/ntemplate.N_dram.model.xml
+++ b/xc7/primitives/slicem/Ndram/ntemplate.N_dram.model.xml
@@ -1,5 +1,11 @@
 <!-- vim: set ai sw=1 ts=1 sta et: -->
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
+ <model name="NO_DRAM">
+  <input_ports>
+   <port                name="A" />
+  </input_ports>
+  <output_ports/>
+ </model>
  <model name="DPRAM128">
   <input_ports>
    <port is_clock="1"   name="CLK"  />

--- a/xc7/primitives/slicem/slicem.pb_type.xml
+++ b/xc7/primitives/slicem/slicem.pb_type.xml
@@ -184,10 +184,10 @@
       </interconnect>
     </mode>
     <mode name="DRAMs">
-      <xi:include href="Ndram/a_dram.pb_type.xml"/>
-      <xi:include href="Ndram/b_dram.pb_type.xml"/>
-      <xi:include href="Ndram/c_dram.pb_type.xml"/>
       <xi:include href="Ndram/d_dram.pb_type.xml"/>
+      <xi:include href="Ndram/c_dram.pb_type.xml"/>
+      <xi:include href="Ndram/b_dram.pb_type.xml"/>
+      <xi:include href="Ndram/a_dram.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f7amux/f7amux.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f7bmux/f7bmux.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f8mux/f8mux.pb_type.xml"/>
@@ -219,10 +219,10 @@
       </pb_type>
 
       <interconnect>
-        <direct name="AMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-A_DRAM.CLK"/>
-        <direct name="BMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-B_DRAM.CLK"/>
-        <direct name="CMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-C_DRAM.CLK"/>
-        <direct name="DMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-D_DRAM.CLK"/>
+        <direct name="AMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-A_DRAM.CLK" />
+        <direct name="BMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-B_DRAM.CLK" />
+        <direct name="CMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-C_DRAM.CLK" />
+        <direct name="DMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-D_DRAM.CLK" />
 
         <direct name="D1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-D_DRAM.A[0]" />
         <direct name="D2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-D_DRAM.A[1]" />
@@ -432,18 +432,12 @@
         <direct name="F8MUX_O"   input="BEL_MX-F8MUX.O" output="BLK_IG-SLICEM_MODES.F8MUX_O" />
 
       </interconnect>
-      <!-- The DLUT must be in RAM-mode for an of the RAM's to work. -->
-      <metadata>
-        <meta name="fasm_features">
-          DLUT.RAM
-        </meta>
-      </metadata>
     </mode>
     <mode name="DRAM128">
-      <xi:include href="Ndram/a_dram128.pb_type.xml"/>
-      <xi:include href="Ndram/b_dram128.pb_type.xml"/>
-      <xi:include href="Ndram/c_dram128.pb_type.xml"/>
       <xi:include href="Ndram/d_dram128.pb_type.xml"/>
+      <xi:include href="Ndram/c_dram128.pb_type.xml"/>
+      <xi:include href="Ndram/b_dram128.pb_type.xml"/>
+      <xi:include href="Ndram/a_dram128.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f7amux/f7amux.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f7bmux/f7bmux.pb_type.xml"/>
       <xi:include href="dram_2_output_stub.pb_type.xml"/>
@@ -582,12 +576,6 @@
         <mux name="F7AMUX_O"   input="BEL_MX-F7AMUX.O BEL_BB-DRAM_2_OUTPUT_STUB.DPO_OUT" output="BLK_IG-SLICEM_MODES.F7AMUX_O" />
         <mux name="F7BMUX_O"   input="BEL_MX-F7BMUX.O BEL_BB-DRAM_2_OUTPUT_STUB.SPO_OUT" output="BLK_IG-SLICEM_MODES.F7BMUX_O" />
       </interconnect>
-      <!-- The DLUT must be in RAM-mode for an of the RAM's to work. -->
-      <metadata>
-        <meta name="fasm_features">
-          DLUT.RAM
-        </meta>
-      </metadata>
     </mode>
   </pb_type>
 
@@ -629,7 +617,17 @@
     <direct name="A5" input="BLK_IG-SLICEM.A5" output="BLK_IG-SLICEM_MODES.A5" />
     <direct name="A6" input="BLK_IG-SLICEM.A6" output="BLK_IG-SLICEM_MODES.A6" />
 
-    <direct name="CK2" input="BLK_IG-SLICEM.CLK" output="BLK_IG-SLICEM_MODES.CLK"/>
+    <direct name="CK2" input="BLK_IG-SLICEM.CLK" output="BLK_IG-SLICEM_MODES.CLK">
+        <!-- The DLUT must be in RAM-mode for an of the RAM's to work.
+             As a corrolary, a DRAM requires the clock, so only turn on the
+             DRAM if the clock is also connected.
+        -->
+      <metadata>
+        <meta name="fasm_mux">
+          BLK_IG-SLICEM.CLK = DLUT.RAM
+        </meta>
+      </metadata>
+    </direct>
     <direct name="CE2" input="BLK_IG-SLICEM.CE"  output="BLK_IG-SLICEM_MODES.CE"/>
     <direct name="WE2" input="BLK_IG-SLICEM.WE"  output="BLK_IG-SLICEM_MODES.WE"/>
 
@@ -680,8 +678,20 @@
 
     <!-- Clock, Clock Enable and Reset -->
     <direct name="CK" input="BLK_IG-SLICEM.CLK" output="BLK_IG-COMMON_SLICE.CLK"/>
-    <direct name="CE" input="BLK_IG-SLICEM.CE"  output="BLK_IG-COMMON_SLICE.CE"/>
-    <direct name="SR" input="BLK_IG-SLICEM.SR"  output="BLK_IG-COMMON_SLICE.SR"/>
+    <direct name="CE" input="BLK_IG-SLICEM.CE"  output="BLK_IG-COMMON_SLICE.CE">
+      <metadata>
+        <meta name="fasm_mux">
+          BLK_IG-SLICEM.CE = CEUSEDMUX
+        </meta>
+      </metadata>
+    </direct>
+    <direct name="SR" input="BLK_IG-SLICEM.SR"  output="BLK_IG-COMMON_SLICE.SR">
+      <metadata>
+        <meta name="fasm_mux">
+          BLK_IG-SLICEM.SR = SRUSEDMUX
+        </meta>
+      </metadata>
+    </direct>
 
     <!-- WA7 and WA8 -->
     <direct name="WA7"  input="BLK_IG-SLICEM.CX" output="BLK_IG-SLICEM_MODES.WA7">


### PR DESCRIPTION
- Output CEUSEDMUX and SRUSEDMUX only when required (e.g. CE or SR
  signal is used).
- Only output FFSYNC if FDSE or FDRE is used.
- Only output DLUT.RAM if a DRAM is actually used.
- Change order of DRAM packing to pack into DLUT before CLUT, etc.
