### PR TITLE
fasm2bels implementation.

### DIFF
--- a/xc7/fasm2bels/__main__.py
+++ b/xc7/fasm2bels/__main__.py
@@ -1,0 +1,4 @@
+from .fasm2bels import main
+
+if __name__ == "__main__":
+    main()

--- a/xc7/fasm2bels/bram_models.py
+++ b/xc7/fasm2bels/bram_models.py
@@ -1,0 +1,431 @@
+import fasm
+from .verilog_modeling import Bel, Site
+
+def get_init(features, target_feature, invert, width):
+    """ Returns INIT argument for specified feature.
+
+    features: List of fasm.SetFeature objects
+    target_feature (str): Target feature prefix (e.g. INIT_A or INITP_0).
+    invert (bool): Controls whether output value should be bit inverted.
+    width (int): Bit width of INIT value.
+
+    Returns int
+
+    """
+    init = 0
+
+    for f in features:
+        if f.feature.startswith(target_feature):
+            for canon_f in fasm.canonical_features(f):
+                if canon_f.start is None:
+                    init |= 1
+                else:
+                    init |= (1 << canon_f.start)
+
+    if invert:
+        init ^= (2**width)-1
+
+    return "{width}'b{init:0b}".format(width=width, init=init)
+
+
+def get_bram_site(db, grid, tile, site):
+    """ Return the prjxray.tile.Site object for the given BRAM site. """
+    gridinfo = grid.gridinfo_at_tilename(tile)
+    tile_type = db.get_tile_type(gridinfo.tile_type)
+
+    if site == 'RAMB18_Y0':
+        target_type = 'FIFO18E1'
+    elif site == 'RAMB18_Y1':
+        target_type = 'RAMB18E1'
+    else:
+        assert False, site
+
+    sites = tile_type.get_instance_sites(gridinfo)
+    for site in sites:
+        if site.type == target_type:
+            return site
+
+    assert False, sites
+
+
+def process_bram_site(top, features, set_features):
+    if 'IN_USE' not in set_features:
+        return
+
+    aparts = features[0].feature.split('.')
+    bram_site = get_bram_site(top.db, top.grid, aparts[0], aparts[1])
+    site = Site(features, bram_site)
+
+    bel = Bel('RAMB18E1')
+    site.add_bel(bel)
+
+    # Parameters
+
+    def make_target_feature(feature):
+        return '{}.{}.{}'.format(aparts[0], aparts[1], feature)
+
+    parameter_binds = [
+        ('INIT_A', 'ZINIT_A', True, 18),
+        ('INIT_B', 'ZINIT_B', True, 18),
+        ('SRVAL_A', 'ZSRVAL_A', True, 18),
+        ('SRVAL_B', 'ZSRVAL_B', True, 18),
+        ]
+
+    for pidx in range(8):
+        parameter_binds.append(('INITP_0{}'.format(pidx), 'INITP_0{}'.format(pidx), False, 256))
+
+    for idx in range(0x40):
+        parameter_binds.append(('INIT_{:02X}'.format(idx), 'INIT_{:02X}'.format(idx), False, 256))
+
+    for vparam, fparam, invert, width in parameter_binds:
+        bel.parameters[vparam] = get_init(features, make_target_feature(fparam), invert=invert, width=width)
+
+    bel.parameters['DOA_REG'] = int('DOA_REG' in set_features)
+    bel.parameters['DOB_REG'] = int('DOB_REG' in set_features)
+
+    """
+     SDP_READ_WIDTH_36 = SDP_READ_WIDTH_36
+     READ_WIDTH_A_18 = READ_WIDTH_A_18
+     READ_WIDTH_A_9 = READ_WIDTH_A_9
+     READ_WIDTH_A_4 = READ_WIDTH_A_4
+     READ_WIDTH_A_2 = READ_WIDTH_A_2
+     READ_WIDTH_A_1 = READ_WIDTH_A_1
+     READ_WIDTH_B_18 = READ_WIDTH_B_18
+     READ_WIDTH_B_9 = READ_WIDTH_B_9
+     READ_WIDTH_B_4 = READ_WIDTH_B_4
+     READ_WIDTH_B_2 = READ_WIDTH_B_2
+     READ_WIDTH_B_1 = READ_WIDTH_B_1
+    """
+
+    RAM_MODE = '"TDP"'
+    if 'SDP_READ_WIDTH_36' in set_features:
+        assert 'READ_WIDTH_A_1' in set_features
+        assert 'READ_WIDTH_B_18' in set_features
+        READ_WIDTH_A = 36
+        READ_WIDTH_B = 0
+        RAM_MODE = '"SDP"'
+    else:
+        if 'READ_WIDTH_A_1' in set_features:
+            READ_WIDTH_A = 1
+        elif 'READ_WIDTH_A_2' in set_features:
+            READ_WIDTH_A = 2
+        elif 'READ_WIDTH_A_4' in set_features:
+            READ_WIDTH_A = 4
+        elif 'READ_WIDTH_A_9' in set_features:
+            READ_WIDTH_A = 9
+        elif 'READ_WIDTH_A_18' in set_features:
+            READ_WIDTH_A = 18
+        else:
+            assert False
+
+        if 'READ_WIDTH_B_1' in set_features:
+            READ_WIDTH_B = 1
+        elif 'READ_WIDTH_B_2' in set_features:
+            READ_WIDTH_B = 2
+        elif 'READ_WIDTH_B_4' in set_features:
+            READ_WIDTH_B = 4
+        elif 'READ_WIDTH_B_9' in set_features:
+            READ_WIDTH_B = 9
+        elif 'READ_WIDTH_B_18' in set_features:
+            READ_WIDTH_B = 18
+        else:
+            assert False
+
+    """
+     SDP_WRITE_WIDTH_36 = SDP_WRITE_WIDTH_36
+     WRITE_WIDTH_A_18 = WRITE_WIDTH_A_18
+     WRITE_WIDTH_A_9 = WRITE_WIDTH_A_9
+     WRITE_WIDTH_A_4 = WRITE_WIDTH_A_4
+     WRITE_WIDTH_A_2 = WRITE_WIDTH_A_2
+     WRITE_WIDTH_A_1 = WRITE_WIDTH_A_1
+     WRITE_WIDTH_B_18 = WRITE_WIDTH_B_18
+     WRITE_WIDTH_B_9 = WRITE_WIDTH_B_9
+     WRITE_WIDTH_B_4 = WRITE_WIDTH_B_4
+     WRITE_WIDTH_B_2 = WRITE_WIDTH_B_2
+     WRITE_WIDTH_B_1 = WRITE_WIDTH_B_1
+    """
+
+    if 'SDP_WRITE_WIDTH_36' in set_features:
+        assert 'WRITE_WIDTH_A_18' in set_features
+        assert 'WRITE_WIDTH_B_18' in set_features
+        WRITE_WIDTH_A = 0
+        WRITE_WIDTH_B = 36
+        RAM_MODE = '"SDP"'
+        wea_width = 0
+        webwe_width = 4
+    else:
+        wea_width = 1
+        webwe_width = 1
+
+        if 'WRITE_WIDTH_A_1' in set_features:
+            WRITE_WIDTH_A = 1
+        elif 'WRITE_WIDTH_A_2' in set_features:
+            WRITE_WIDTH_A = 2
+        elif 'WRITE_WIDTH_A_4' in set_features:
+            WRITE_WIDTH_A = 4
+        elif 'WRITE_WIDTH_A_9' in set_features:
+            WRITE_WIDTH_A = 9
+        elif 'WRITE_WIDTH_A_18' in set_features:
+            wea_width = 2
+            WRITE_WIDTH_A = 18
+        else:
+            assert False
+
+        if 'WRITE_WIDTH_B_1' in set_features:
+            WRITE_WIDTH_B = 1
+        elif 'WRITE_WIDTH_B_2' in set_features:
+            WRITE_WIDTH_B = 2
+        elif 'WRITE_WIDTH_B_4' in set_features:
+            WRITE_WIDTH_B = 4
+        elif 'WRITE_WIDTH_B_9' in set_features:
+            WRITE_WIDTH_B = 9
+        elif 'WRITE_WIDTH_B_18' in set_features:
+            webwe_width = 2
+            WRITE_WIDTH_B = 18
+        else:
+            assert False
+
+    bel.parameters['RAM_MODE'] = RAM_MODE
+    bel.parameters['READ_WIDTH_A'] = READ_WIDTH_A
+    bel.parameters['READ_WIDTH_B'] = READ_WIDTH_B
+    bel.parameters['WRITE_WIDTH_A'] = WRITE_WIDTH_A
+    bel.parameters['WRITE_WIDTH_B'] = WRITE_WIDTH_B
+
+    """
+     ZINV_CLKARDCLK = ZINV_CLKARDCLK
+     ZINV_CLKBWRCLK = ZINV_CLKBWRCLK
+     ZINV_ENARDEN = ZINV_ENARDEN
+     ZINV_ENBWREN = ZINV_ENBWREN
+     ZINV_RSTRAMARSTRAM = ZINV_RSTRAMARSTRAM
+     ZINV_RSTRAMB = ZINV_RSTRAMB
+     ZINV_RSTREGARSTREG = ZINV_RSTREGARSTREG
+     ZINV_RSTREGB = ZINV_RSTREGB
+     ZINV_REGCLKARDRCLK = ZINV_REGCLKARDRCLK
+     ZINV_REGCLKB = ZINV_REGCLKB
+    """
+    for wire in (
+            'CLKARDCLK', 'CLKBWRCLK',
+            'ENARDEN', 'ENBWREN',
+            'RSTRAMARSTRAM', 'RSTRAMB',
+            'RSTREGARSTREG', 'RSTREGB',
+            ):
+        bel.parameters['IS_{}_INVERTED'.format(wire)] = int(not 'ZINV_{}'.format(wire) in set_features)
+
+    """
+     WRITE_MODE_A_NO_CHANGE = WRITE_MODE_A_NO_CHANGE
+     WRITE_MODE_A_READ_FIRST = WRITE_MODE_A_READ_FIRST
+     WRITE_MODE_B_NO_CHANGE = WRITE_MODE_B_NO_CHANGE
+     WRITE_MODE_B_READ_FIRST = WRITE_MODE_B_READ_FIRST
+    """
+    if 'WRITE_MODE_A_NO_CHANGE' in set_features:
+        bel.parameters['WRITE_MODE_A'] = '"NO_CHANGE"'
+    elif 'WRITE_MODE_A_READ_FIRST' in set_features:
+        bel.parameters['WRITE_MODE_A'] = '"READ_FIRST"'
+    else:
+        bel.parameters['WRITE_MODE_A'] = '"WRITE_FIRST"'
+
+    if 'WRITE_MODE_B_NO_CHANGE' in set_features:
+        bel.parameters['WRITE_MODE_B'] = '"NO_CHANGE"'
+    elif 'WRITE_MODE_B_READ_FIRST' in set_features:
+        bel.parameters['WRITE_MODE_B'] = '"READ_FIRST"'
+    else:
+        bel.parameters['WRITE_MODE_B'] = '"WRITE_FIRST"'
+
+
+    fifo_site = bram_site.type == 'FIFO18E1'
+
+    fifo_site_wire_map = {
+            'REGCEAREGCE': 'REGCE',
+            'REGCLKARDRCLK': 'RDRCLK',
+            'RSTRAMARSTRAM': 'RST',
+            'RSTREGARSTREG': 'RSTREG',
+            'ENBWREN': 'WREN',
+            'CLKBWRCLK': 'WRCLK',
+            'ENARDEN': 'RDEN',
+            'CLKARDCLK': 'RDCLK',
+            }
+
+    for idx in range(16):
+        fifo_site_wire_map['DOADO{}'.format(idx)] = 'DO{}'.format(idx)
+        fifo_site_wire_map['DOBDO{}'.format(idx)] = 'DO{}'.format(idx+16)
+
+    for idx in range(2):
+        fifo_site_wire_map['DOPADOP{}'.format(idx)] = 'DOP{}'.format(idx)
+        fifo_site_wire_map['DOPBDOP{}'.format(idx)] = 'DOP{}'.format(idx+2)
+
+    def make_wire(wire_name):
+        if fifo_site and wire_name in fifo_site_wire_map:
+            return fifo_site_wire_map[wire_name]
+        else:
+            return wire_name
+
+
+    for input_wire in [
+            "CLKARDCLK",
+            "CLKBWRCLK",
+            "ENARDEN",
+            "ENBWREN",
+            "REGCEAREGCE",
+            "REGCEB",
+            "RSTRAMARSTRAM",
+            "RSTRAMB",
+            "RSTREGARSTREG",
+            "RSTREGB",
+            ]:
+        wire_name = make_wire(input_wire)
+        site.add_sink(bel, input_wire, wire_name)
+
+    for input_wire, width in [
+            # TODO: Add RAMB36 support.
+            # Detect when ADDRATIEHIGH and ADDRBTIEHIGH are not tied high,
+            # emit RAMB36 in that case.
+            #("ADDRATIEHIGH", 2),
+            #("ADDRBTIEHIGH", 2),
+            ("ADDRARDADDR", 14),
+            ("ADDRBWRADDR", 14),
+            ("DIADI", 16),
+            ("DIBDI", 16),
+            ("DIPADIP", 2),
+            ("DIPBDIP", 2),
+            ]:
+        for idx in range(width):
+            wire_name = make_wire('{}{}'.format(input_wire, idx))
+            site.add_sink(bel, '{}[{}]'.format(input_wire, idx), wire_name)
+
+    # TODO: Add RAMB36 support.
+    # In RAMB36, WEA and WEBWE don't double up like this
+    for input_wire, width in [
+            ("WEA", wea_width*2),
+            ("WEBWE", webwe_width*2),
+            ]:
+        for idx in range(0, width, 2):
+            wire_name = make_wire('{}{}'.format(input_wire, idx))
+            site.add_sink(bel, '{}[{}]'.format(input_wire, idx//2), wire_name)
+
+    for output_wire, width in [
+            ('DOADO', 16),
+            ('DOPADOP', 2),
+            ('DOBDO', 16),
+            ('DOPBDOP', 2),
+            ]:
+        for idx in range(width):
+            wire_name = make_wire('{}{}'.format(output_wire, idx))
+            pin_name = '{}[{}]'.format(output_wire, idx)
+            site.add_source(bel, pin_name, wire_name)
+
+    top.add_site(site)
+
+
+def process_bram(conn, top, tile, features):
+    tile_features = set()
+
+    brams = {
+            'RAMB18_Y0': [],
+            'RAMB18_Y1': []
+            }
+
+    bram_features = {
+            'RAMB18_Y0': set(),
+            'RAMB18_Y1': set()
+            }
+
+    for f in features:
+        if f.value == 0:
+            continue
+
+        parts = f.feature.split('.')
+
+        tile_features.add('.'.join(parts[1:]))
+
+        if parts[1] in brams:
+            bram_features[parts[1]].add('.'.join(parts[2:]))
+            brams[parts[1]].append(f)
+
+    """
+    FIFO config:
+
+    EN_SYN 27_171
+    FIRST_WORD_FALL_THROUGH 27_170
+    ZALMOST_EMPTY_OFFSET[12:0] 27_288
+    ZALMOST_FULL_OFFSET[12:0] 27_32
+
+    RAMB18 config:
+
+    RAMB18_Y[01].FIFO_MODE 27_169
+    RAMB18_Y[01].IN_USE 27_220 27_221
+
+    RAMB18_Y[01].DOA_REG 27_251
+    RAMB18_Y[01].DOB_REG 27_248
+    RAMB18_Y[01].RDADDR_COLLISION_HWCONFIG_DELAYED_WRITE !27_224
+    RAMB18_Y[01].RDADDR_COLLISION_HWCONFIG_PERFORMANCE 27_224
+    RAMB18_Y[01].READ_WIDTH_A_1 !27_283 !27_284 !27_285
+    RAMB18_Y[01].READ_WIDTH_A_2 !27_283 !27_284 27_285
+    RAMB18_Y[01].READ_WIDTH_A_4 !27_283 27_284 !27_285
+    RAMB18_Y[01].READ_WIDTH_A_9 !27_283 27_284 27_285
+    RAMB18_Y[01].READ_WIDTH_A_18 27_283 !27_284 !27_285
+    RAMB18_Y[01].READ_WIDTH_B_1 !27_275 !27_276 !27_277
+    RAMB18_Y[01].READ_WIDTH_B_2 !27_275 !27_276 27_277
+    RAMB18_Y[01].READ_WIDTH_B_4 !27_275 27_276 !27_277
+    RAMB18_Y[01].READ_WIDTH_B_9 !27_275 27_276 27_277
+    RAMB18_Y[01].READ_WIDTH_B_18 27_275 !27_276 !27_277
+    RAMB18_Y[01].RSTREG_PRIORITY_A_REGCE 27_196
+    RAMB18_Y[01].RSTREG_PRIORITY_A_RSTREG !27_196
+    RAMB18_Y[01].RSTREG_PRIORITY_B_REGCE 27_195
+    RAMB18_Y[01].RSTREG_PRIORITY_B_RSTREG !27_195
+
+    RAMB18_Y[01].ZINV_CLKARDCLK 27_213
+    RAMB18_Y[01].ZINV_CLKBWRCLK 27_211
+    RAMB18_Y[01].ZINV_ENARDEN 27_208
+    RAMB18_Y[01].ZINV_ENBWREN 27_205
+    RAMB18_Y[01].ZINV_REGCLKARDRCLK 27_216
+    RAMB18_Y[01].ZINV_REGCLKB 27_212
+    RAMB18_Y[01].ZINV_RSTRAMARSTRAM 27_204
+    RAMB18_Y[01].ZINV_RSTRAMB 27_203
+    RAMB18_Y[01].ZINV_RSTREGARSTREG 27_200
+    RAMB18_Y[01].ZINV_RSTREGB 27_197
+    RAMB18_Y[01].ZINIT_A[17:0] 27_249
+    RAMB18_Y[01].ZINIT_B[17:0] 27_255
+    RAMB18_Y[01].ZSRVAL_A[17:0]
+    RAMB18_Y[01].ZSRVAL_B[17:0]
+    RAMB18_Y[01].SDP_READ_WIDTH_36 27_272
+    RAMB18_Y[01].SDP_WRITE_WIDTH_36 27_280
+    RAMB18_Y[01].WRITE_MODE_A_NO_CHANGE 27_256
+    RAMB18_Y[01].WRITE_MODE_A_READ_FIRST 27_264
+    RAMB18_Y[01].WRITE_MODE_B_NO_CHANGE 27_252
+    RAMB18_Y[01].WRITE_MODE_B_READ_FIRST 27_253
+    RAMB18_Y[01].WRITE_WIDTH_A_1 !27_267 !27_268 !27_269
+    RAMB18_Y[01].WRITE_WIDTH_A_2 !27_267 !27_268 27_269
+    RAMB18_Y[01].WRITE_WIDTH_A_4 !27_267 27_268 !27_269
+    RAMB18_Y[01].WRITE_WIDTH_A_9 !27_267 27_268 27_269
+    RAMB18_Y[01].WRITE_WIDTH_A_18 27_267 !27_268 !27_269
+    RAMB18_Y[01].WRITE_WIDTH_B_1 !27_259 !27_260 !27_261
+    RAMB18_Y[01].WRITE_WIDTH_B_2 !27_259 !27_260 27_261
+    RAMB18_Y[01].WRITE_WIDTH_B_4 !27_259 27_260 !27_261
+    RAMB18_Y[01].WRITE_WIDTH_B_9 !27_259 27_260 27_261
+    RAMB18_Y[01].WRITE_WIDTH_B_18 27_259 !27_260 !27_261
+
+    RAMB36 config:
+
+    RAMB36.EN_ECC_READ
+    RAMB36.EN_ECC_WRITE
+    RAMB36.RAM_EXTENSION_A_LOWER
+    RAMB36.RAM_EXTENSION_A_NONE_OR_UPPER
+    RAMB36.RAM_EXTENSION_B_LOWER
+    RAMB36.RAM_EXTENSION_B_NONE_OR_UPPER
+    """
+
+    for features in bram_features.values():
+        # TODO: Add support for FIFO mode
+        assert 'FIFO_MODE' not in features
+
+    # TODO: Add support for data cascade.
+    assert 'RAMB36.RAM_EXTENSION_A_NONE_OR_UPPER' in tile_features
+    assert 'RAMB36.RAM_EXTENSION_B_NONE_OR_UPPER' in tile_features
+
+    # TODO: Add support for RAMB36.
+    assert 'RAMB36.EN_ECC_READ' not in tile_features
+    assert 'RAMB36.EN_ECC_WRITE' not in tile_features
+
+
+    for bram in brams:
+        process_bram_site(top, brams[bram], bram_features[bram])

--- a/xc7/fasm2bels/clb_models.py
+++ b/xc7/fasm2bels/clb_models.py
@@ -1,0 +1,736 @@
+import fasm
+from .verilog_modeling import Bel, Site
+
+def get_clb_site(db, grid, tile, site):
+    """ Return the prjxray.tile.Site object for the given CLB site. """
+    gridinfo = grid.gridinfo_at_tilename(tile)
+    tile_type = db.get_tile_type(gridinfo.tile_type)
+
+    sites = sorted(tile_type.get_instance_sites(gridinfo), key=lambda x: x.x)
+
+    return sites[int(site[-1])]
+
+
+def get_lut_init(features, tile_name, slice_name, lut):
+    """ Return the INIT value for the specified LUT. """
+    target_feature = '{}.{}.{}LUT.INIT'.format(tile_name, slice_name, lut)
+
+    init = 0
+
+    for f in features:
+        if f.feature.startswith(target_feature):
+            for canon_f in fasm.canonical_features(f):
+                if canon_f.start is None:
+                    init |= 1
+                else:
+                    init |= (1 << canon_f.start)
+
+    return "64'b{:064b}".format(init)
+
+
+def create_lut(site, lut):
+    """ Create the BEL for the specified LUT. """
+    bel = Bel('LUT6_2', lut + 'LUT')
+    bel.set_bel(lut + '6LUT')
+
+    for idx in range(6):
+        site.add_sink(bel, 'I{}'.format(idx), '{}{}'.format(lut, idx+1))
+
+    site.add_internal_source(bel, 'O6', lut + 'O6')
+    site.add_internal_source(bel, 'O5', lut + 'O5')
+
+    return bel
+
+
+def decode_dram(site):
+    """ Decode the modes of each LUT in the slice based on set features.
+
+    Returns dictionary of lut position (e.g. 'A') to lut mode.
+    """
+    lut_ram = {}
+    for lut in 'ABCD':
+        lut_ram[lut] = site.has_feature('{}LUT.RAM'.format(lut))
+
+    di = {}
+    for lut in 'ABC':
+        di[lut] = site.has_feature('{}LUT.DI1MUX.{}I'.format(lut, lut))
+
+    lut_modes = {}
+    if site.has_feature('WA8USED'):
+        assert site.has_feature('WA7USED')
+        assert lut_ram['A']
+        assert lut_ram['B']
+        assert lut_ram['C']
+        assert lut_ram['D']
+
+        lut_modes['A'] = 'RAM256X1S'
+        lut_modes['B'] = 'RAM256X1S'
+        lut_modes['C'] = 'RAM256X1S'
+        lut_modes['D'] = 'RAM256X1S'
+        return lut_modes
+
+    if site.has_feature('WA7USED'):
+        if not lut_ram['A']:
+            assert not lut_ram['B']
+            assert lut_ram['C']
+            assert lut_ram['D']
+            lut_modes['A'] = 'LUT'
+            lut_modes['B'] = 'LUT'
+            lut_modes['C'] = 'RAM128X1S'
+            lut_modes['D'] = 'RAM128X1S'
+
+            return lut_modes
+
+        assert lut_ram['B']
+
+        if di['B']:
+            lut_modes['A'] = 'RAM128X1S'
+            lut_modes['B'] = 'RAM128X1S'
+            lut_modes['C'] = 'RAM128X1S'
+            lut_modes['D'] = 'RAM128X1S'
+        else:
+            assert lut_ram['B']
+            assert lut_ram['C']
+            assert lut_ram['D']
+
+            lut_modes['A'] = 'RAM128X1D'
+            lut_modes['B'] = 'RAM128X1D'
+            lut_modes['C'] = 'RAM128X1D'
+            lut_modes['D'] = 'RAM128X1D'
+
+        return lut_modes
+
+    # Remaining modes:
+    # RAM32X1S, RAM32X1D, RAM64X1S, RAM64X1D
+
+    remaining = set('ABCD')
+
+    for lut in 'AC':
+        if lut_ram[lut] and di[lut]:
+            remaining.remove(lut)
+
+            if site.has_feature('{}LUT.SMALL'.format(lut)):
+                lut_modes[lut] = 'RAM32X2S'
+            else:
+                lut_modes[lut] = 'RAM64X1S'
+
+    for lut in 'BD':
+        if not lut_ram[lut]:
+            continue
+
+        minus_one = chr(ord(lut)-1)
+        if minus_one in remaining:
+            if lut_ram[minus_one]:
+                remaining.remove(lut)
+                remaining.remove(minus_one)
+                if site.has_feature('{}LUT.SMALL'.format(lut)):
+                    lut_modes[lut] = 'RAM32X1D'
+                    lut_modes[minus_one] = 'RAM32X1D'
+                else:
+                    lut_modes[lut] = 'RAM64X1D'
+                    lut_modes[minus_one] = 'RAM64X1D'
+
+        if lut in remaining:
+            remaining.remove(lut)
+            if site.has_feature('{}LUT.SMALL'.format(lut)):
+                lut_modes[lut] = 'RAM32X2S'
+            else:
+                lut_modes[lut] = 'RAM64X1S'
+
+    for lut in remaining:
+        lut_modes[lut] = 'LUT'
+
+    return lut_modes
+
+
+def ff_bel(site, lut, ff5):
+    """ Returns FF information for given FF.
+
+    site (Site): Site object
+    lut (str): FF in question (e.g. 'A')
+    ff5 (bool): True if the 5FF versus the FF.
+
+    Returns tuple of (module name, clock pin, clock enable pin, reset pin,
+        init parameter).
+
+    """
+    ffsync = site.has_feature('FFSYNC')
+    latch = site.has_feature('LATCH') and not ff5
+    zrst = site.has_feature('{}{}FF.ZRST'.format(lut, '5' if ff5 else ''))
+    zini = site.has_feature('{}{}FF.ZINI'.format(lut, '5' if ff5 else ''))
+    init = int(not zini)
+
+    if latch:
+        assert not ffsync
+
+    return {
+            (False, False, False) : ('FDPE', 'C', 'CE', 'PRE', init),
+            (True, False, False) : ('FDSE', 'C', 'CE', 'S', init),
+            (True, False, True) : ('FDRE', 'C', 'CE', 'R', init),
+            (False, False, True) : ('FDCE', 'C', 'CE', 'CLR', init),
+            (False, True, True) : ('LDCE', 'G', 'GE', 'CLR', init),
+            (False, True, False) : ('LDPE', 'G', 'GE', 'PRE', init),
+            }[(ffsync, latch, zrst)]
+
+def cleanup_slice(top, site):
+    """ Perform post-routing cleanups required for SLICE.
+
+    Cleanups:
+     - Detect if CARRY4 is required.  If not, remove from site.
+
+    """
+    carry4 = site.maybe_get_bel('CARRY4')
+
+    if carry4 is None:
+        return
+
+    # Simplest check is if the CARRY4 has output in used by either the OUTMUX
+    # or the FFMUX, if any of these muxes are enable, CARRY4 must remain.
+    for lut in 'ABCD':
+        if site.has_feature('{}FFMUX.XOR'.format(lut)):
+            return
+
+        if site.has_feature('{}FFMUX.CY'.format(lut)):
+            return
+
+        if site.has_feature('{}OUTMUX.XOR'.format(lut)):
+            return
+
+        if site.has_feature('{}OUTMUX.CY'.format(lut)):
+            return
+
+    # No outputs in the SLICE use CARRY4, check if the COUT line is in use.
+    for sink in top.find_sinks_from_source(site, 'COUT'):
+        return
+
+    top.remove_bel(site, carry4)
+
+def process_slice(top, s):
+    """ Convert SLICE features in Bel and Site objects.
+
+    Note: Does not handle SRL option.
+
+    """
+
+    """
+    Available options:
+
+    LUT/DRAM/SRL:
+    SLICE[LM]_X[01].[ABCD]LUT.INIT[63:0]
+    SLICEM_X0.[ABCD]LUT.RAM
+    SLICEM_X0.[ABCD]LUT.SMALL
+    SLICEM_X0.[ABCD]LUT.SRL
+
+    FF:
+    SLICE[LM]_X[01].[ABCD]5?FF.ZINI
+    SLICE[LM]_X[01].[ABCD]5?FF.ZRST
+    SLICE[LM]_X[01].CLKINV
+    SLICE[LM]_X[01].FFSYNC
+    SLICE[LM]_X[01].LATCH
+    SLICE[LM]_X[01].CEUSEDMUX
+    SLICE[LM]_X[01].SRUSEDMUX
+
+    CARRY4:
+    SLICE[LM]_X[01].PRECYINIT = AX|CIN|C0|C1
+
+    Muxes:
+    SLICE[LM]_X[01].CARRY4.ACY0
+    SLICE[LM]_X[01].CARRY4.BCY0
+    SLICE[LM]_X[01].CARRY4.CCY0
+    SLICE[LM]_X[01].CARRY4.DCY0
+    SLICE[LM]_X[01].[ABCD]5FFMUX.IN_[AB]
+    SLICE[LM]_X[01].[ABCD]AFFMUX = [ABCD]X|CY|XOR|F[78]|O5|O6
+    SLICE[LM]_X[01].[ABCD]OUTMUX = CY|XOR|F[78]|O5|O6|[ABCD]5Q
+    SLICEM_X0.WA7USED
+    SLICEM_X0.WA8USED
+    SLICEM_X0.WEMUX.CE
+    """
+
+    aparts = s[0].feature.split('.')
+    site = Site(s, get_clb_site(top.db, top.grid, tile=aparts[0], site=aparts[1]))
+
+    mlut = aparts[1].startswith('SLICEM')
+
+    def connect_ce_sr(bel, ce, sr):
+        if site.has_feature('CEUSEDMUX'):
+            site.add_sink(bel, ce, 'CE')
+        else:
+            bel.connections[ce] = 1
+
+        if site.has_feature('SRUSEDMUX'):
+            site.add_sink(bel, sr, 'SR')
+        else:
+            bel.connections[sr] = 0
+
+    IS_C_INVERTED = int(site.has_feature('CLKINV'))
+
+    if mlut:
+        if site.has_feature('WEMUX.CE'):
+            WE = 'CE'
+        else:
+            WE = 'WE'
+
+    if site.has_feature('DLUT.RAM'):
+        # Must be a SLICEM to have RAM set.
+        assert mlut
+    else:
+        for row in 'ABC':
+            assert not site.has_feature('{}LUT.RAM')
+
+    # SRL not currently supported
+    for row in 'ABCD':
+        assert not site.has_feature('{}LUT.SRL')
+
+    muxes = set(('F7AMUX', 'F7BMUX', 'F8MUX'))
+
+    luts = {}
+    # Add BELs for LUTs/RAMs
+    if not site.has_feature('DLUT.RAM'):
+        for lut in 'ABCD':
+            luts[lut] = create_lut(site, lut)
+            luts[lut].parameters['INIT'] = get_lut_init(s, aparts[0], aparts[1], lut)
+            site.add_bel(luts[lut])
+    else:
+        # DRAM is active.  Determine what BELs are in use.
+        lut_modes = decode_dram(site)
+
+        if lut_modes['D'] == 'RAM256X1S':
+            ram256 = Bel('RAM256X1S')
+            site.add_sink(ram256, 'WE', WE)
+            site.add_sink(ram256, 'WCLK', 'CLK')
+            site.add_sink(ram256, 'D', 'DI')
+
+            for idx in range(6):
+                site.add_sink(ram256, 'A[{}]'.format(idx), "D{}".format(idx+1))
+
+            site.add_sink(ram256, 'A[6]', "CX")
+            site.add_sink(ram256, 'A[7]', "BX")
+            site.add_internal_source(ram256, 'O', 'F8MUX_O')
+
+            ram256.parameters['INIT'] = (
+                    get_lut_init(s, aparts[0], aparts[1], 'D') |
+                    (get_lut_init(s, aparts[0], aparts[1], 'C') << 64) |
+                    (get_lut_init(s, aparts[0], aparts[1], 'B') << 128) |
+                    (get_lut_init(s, aparts[0], aparts[1], 'A') << 192)
+                    )
+
+            site.add_bel(ram256)
+
+            muxes = set()
+
+            del lut_modes['A']
+            del lut_modes['B']
+            del lut_modes['C']
+            del lut_modes['D']
+        elif lut_modes['D'] == 'RAM128X1S':
+            ram128 = Bel('RAM128X1S')
+            site.add_sink(ram128, 'WE', WE)
+            site.add_sink(ram128, 'WCLK', "CLK")
+            site.add_sink(ram128, 'D', "DI")
+
+            for idx in range(6):
+                site.add_sink(ram128, 'A{}'.format(idx), "D{}".format(idx+1))
+
+            site.add_sink(ram128, 'A6', "CX")
+            site.add_internal_source(ram128, 'O', 'F7BMUX_O')
+
+            ram128.parameters['INIT'] = (
+                    get_lut_init(s, aparts[0], aparts[1], 'D') |
+                    (get_lut_init(s, aparts[0], aparts[1], 'C') << 64))
+
+            site.add_bel(ram128)
+            muxes.remove('F7BMUX')
+
+            del lut_modes['C']
+            del lut_modes['D']
+
+            if lut_modes['B'] == 'RAM128X1S':
+                ram128 = Bel('RAM128X1S')
+                site.add_sink(ram128, 'WE', WE)
+                site.add_sink(ram128, 'WCLK', "CLK")
+                site.add_sink(ram128, 'D', "BI")
+
+                for idx in range(6):
+                    site.adD_sink(ram128, 'A{}'.format(idx), "B{}".format(idx+1))
+
+                site.add_sink(ram128, 'A6', "AX")
+
+                site.add_internal_source(ram128, 'O', 'F7AMUX_O')
+
+                ram128.parameters['INIT'] = (
+                        get_lut_init(s, aparts[0], aparts[1], 'B') |
+                        (get_lut_init(s, aparts[0], aparts[1], 'A') << 64))
+
+                site.add_bel(ram128)
+
+                muxes.remove('F7AMUX')
+
+                del lut_modes['A']
+                del lut_modes['B']
+
+        elif lut_modes['D'] == 'RAM128X1D':
+            ram128 = Bel('RAM128X1D')
+
+            site.add_sink(ram128, 'WE', WE)
+            site.add_sink(ram128, 'WCLK', "CLK")
+            site.add_sink(ram128, 'D', "DI")
+
+            for idx in range(6):
+                site.add_sink(ram128, 'A[{}]'.format(idx), "D{}".format(idx+1))
+                site.add_sink(ram128, 'DPRA[{}]'.format(idx), "C{}".format(idx+1))
+
+            site.add_sink(ram128, 'A[6]', "CX")
+            site.add_sink(ram128, 'DPRA[6]', "AX")
+
+            site.add_internal_source(ram128, 'SPO', 'F7AMUX_O')
+            site.add_internal_source(ram128, 'DPO', 'F7BMUX_O')
+
+            ram128.parameters['INIT'] = (
+                    get_lut_init(s, aparts[0], aparts[1], 'D') |
+                    (get_lut_init(s, aparts[0], aparts[1], 'C') << 64))
+
+            other_init = (
+                    get_lut_init(s, aparts[0], aparts[1], 'B') |
+                    (get_lut_init(s, aparts[0], aparts[1], 'A') << 64))
+
+            assert ram128.parameters['INIT'] == other_init
+
+            site.add_bel(ram128)
+
+            muxes.remove('F7AMUX')
+            muxes.remove('F7BMUX')
+
+            del lut_modes['A']
+            del lut_modes['B']
+            del lut_modes['C']
+            del lut_modes['D']
+
+        for lut in 'BD':
+            minus_one = chr(ord(lut)-1)
+
+            if lut_modes[lut] == 'RAM64X1D':
+                assert lut_modes[minus_one] == lut_modes[lut]
+
+                ram64 = Bel('RAM64X1D')
+
+                site.add_sink(ram64, 'WE', WE)
+                site.add_sink(ram64, 'WCLK', "CLK")
+                site.add_sink(ram64, 'D', lut + "I")
+
+                for idx in range(6):
+                    site.add_sink(ram64, 'A{}'.format(idx), "{}{}".format(lut, idx+1))
+                    site.add_sink(ram64, 'DPRA{}'.format(idx), "{}{}".format(minus_one, idx+1))
+
+                site.add_internal_source(ram64, 'SPO', lut + "O6")
+                site.add_internal_source(ram64, 'DPO', minus_one + "O6")
+
+                ram64.parameters['INIT'] = get_lut_init(s, aparts[0], aparts[1], lut)
+                other_init = get_lut_init(s, aparts[0], aparts[1], minus_one)
+
+                assert ram64.parameters['INIT'] == other_init
+
+                site.add_bel(ram64)
+
+                del lut_modes[lut]
+                del lut_modes[minus_one]
+            elif lut_modes[lut] == 'RAM32X1D':
+                ram32 = Bel('RAM32X1D')
+
+                site.add_sink(ram32, 'WE', WE)
+                site.add_sink(ram32, 'WCLK', "CLK")
+                site.add_sink(ram32, 'D', lut + "I")
+
+                for idx in range(5):
+                    site.add_sink(ram64, 'A{}'.format(idx), "{}{}".format(lut, idx+1))
+                    site.add_sink(ram64, 'DPRA{}'.format(idx), "{}{}".format(minus_one, idx+1))
+
+                site.add_sink(ram32, 'SPO', lut + "O6")
+                site.add_sink(ram32, 'DPO', minus_one + "O6")
+
+                ram32.parameters['INIT'] = get_lut_init(s, aparts[0], aparts[1], lut)
+                other_init = get_lut_init(s, aparts[0], aparts[1], minus_one)
+
+                site.add_bel(ram32)
+
+                del lut_modes[lut]
+                del lut_modes[minus_one]
+
+        for lut in 'ABCD':
+            if lut not in lut_modes:
+                continue
+
+            if lut_modes[lut] == 'LUT':
+                luts[lut] = create_lut(site, lut)
+                luts[lut].parameters['INIT'] = get_lut_init(s, aparts[0], aparts[1], lut)
+                site.add_bel(luts[lut])
+            elif lut_modes[lut] == 'RAM64X1S':
+                ram64 = Bel('RAM64X1S')
+
+                site.add_sink(ram64, 'WE', WE)
+                site.add_sink(ram64, 'WCLK', "CLK")
+                site.add_sink(ram64, 'D', lut + "I")
+
+                for idx in range(6):
+                    site.add_sink(ram64, 'A{}'.format(idx), "{}{}".format(lut, idx+1))
+
+                site.add_internal_source(ram64, 'O', lut + "O6")
+
+                ram64.parameters['INIT'] = get_lut_init(s, aparts[0], aparts[1], lut)
+
+                site.add_bel(ram64)
+            elif lut_modes[lut] == 'RAM32X2S':
+                ram32 = Bel('RAM32X1S')
+
+                site.add_sink(ram32, 'WE', WE)
+                site.add_sink(ram32, 'WCLK', "CLK")
+                site.add_sink(ram32, 'D', lut + "I")
+
+                for idx in range(5):
+                    site.add_sink(ram32, 'A{}'.format(idx), "{}{}".format(lut, idx+1))
+
+                site.add_internal_source(ram32 ,'O', lut + "O6")
+
+                ram32.parameters['INIT'] = get_lut_init(s, aparts[0], aparts[1], lut)
+
+                site.add_bel(ram32)
+            else:
+                assert False, lut_modes[lut]
+
+    need_f8 = site.has_feature('BFFMUX.F8') or site.has_feature('BOUTMUX.F8')
+    need_f7a = site.has_feature('AFFMUX.F7') or site.has_feature('AOUTMUX.F7')
+    need_f7b = site.has_feature('CFFMUX.F7') or site.has_feature('COUTMUX.F7')
+
+    for mux in sorted(muxes):
+        if mux == 'F7AMUX':
+            if not need_f8 and not need_f7a:
+                continue
+            else:
+                bel_type = 'MUXF7'
+                opin = 'O'
+
+            f7amux = Bel(bel_type, 'MUXF7A')
+            f7amux.set_bel('F7AMUX')
+
+            site.connect_internal(f7amux, 'I0', 'BO6')
+            site.connect_internal(f7amux, 'I1', 'AO6')
+            site.add_sink(f7amux, 'S', 'AX')
+
+            site.add_internal_source(f7amux, opin, 'F7AMUX_O')
+
+            site.add_bel(f7amux)
+        elif mux == 'F7BMUX':
+            if not need_f8 and not need_f7b:
+                continue
+            else:
+                bel_type = 'MUXF7'
+                opin = 'O'
+
+            f7bmux = Bel(bel_type, 'MUXF7B')
+            f7bmux.set_bel('F7BMUX')
+
+            site.connect_internal(f7bmux, 'I0', 'DO6')
+            site.connect_internal(f7bmux, 'I1', 'CO6')
+            site.add_sink(f7bmux, 'S', 'CX')
+
+            site.add_internal_source(f7bmux, opin, 'F7BMUX_O')
+
+            site.add_bel(f7bmux)
+        elif mux == 'F8MUX':
+            if not need_f8:
+                continue
+            else:
+                bel_type = 'MUXF8'
+                opin = 'O'
+
+            f8mux = Bel(bel_type)
+
+            site.connect_internal(f8mux, 'I0', 'F7BMUX_O')
+            site.connect_internal(f8mux, 'I1', 'F7AMUX_O')
+            site.add_sink(f8mux, 'S', 'BX')
+
+            site.add_internal_source(f8mux, opin, 'F8MUX_O')
+
+            site.add_bel(f8mux)
+        else:
+            assert False, mux
+
+    can_have_carry4 = True
+    for lut in 'ABCD':
+        if site.has_feature(lut + 'O6'):
+            can_have_carry4 = False
+            break
+
+    if can_have_carry4:
+        bel = Bel('CARRY4')
+
+        for idx in range(4):
+            lut = chr(ord('A') + idx)
+            if site.has_feature('CARRY4.{}CY0'.format(lut)):
+                source = lut + 'O5'
+                site.connect_internal(bel, 'DI[{}]'.format(idx), source)
+            else:
+                site.add_sink(bel, 'DI[{}]'.format(idx), lut + 'X')
+
+            source = lut + 'O6'
+
+            site.connect_internal(bel, 'S[{}]'.format(idx), source)
+
+            site.add_internal_source(bel, 'O[{}]'.format(idx), lut + '_XOR')
+
+            co_pin = 'CO[{}]'.format(idx)
+            if idx == 3:
+                site.add_source(bel, co_pin, 'COUT')
+            else:
+                site.add_internal_source(bel, co_pin, lut + '_CY')
+
+        if site.has_feature('PRECYINIT.AX'):
+            site.add_sink(bel, 'CYINIT', 'AX')
+            bel.unused_connections.add('CI')
+
+        elif site.has_feature('PRECYINIT.C0'):
+            bel.connections['CYINIT'] = 0
+            bel.unused_connections.add('CI')
+
+        elif site.has_feature('PRECYINIT.C1'):
+            bel.connections['CYINIT'] = 1
+            bel.unused_connections.add('CI')
+
+        elif site.has_feature('PRECYINIT.CIN'):
+            bel.unused_connections.add('CYINIT')
+            site.add_sink(bel, 'CI', 'CIN')
+
+        else:
+            assert False
+
+        site.add_bel(bel, name='CARRY4')
+
+    ff5_bels = {}
+    for lut in 'ABCD':
+        if site.has_feature('{}OUTMUX.{}5Q'.format(lut, lut)):
+            # 5FF in use, emit
+            name, clk, ce, sr, init = ff_bel(site, lut, ff5=True)
+            ff5 = Bel(name, "{}5_{}".format(lut, name))
+            ff5_bels[lut] = ff5
+            ff5.set_bel(lut + '5FF')
+
+            if site.has_feature('{}5FFMUX.IN_A'.format(lut)):
+                site.connect_internal(ff5, 'D', lut + 'O5')
+            elif site.has_feature('{}5FFMUX.IN_B'.format(lut)):
+                site.add_sink(ff5, 'D', lut + 'X')
+
+            site.add_sink(ff5, clk, "CLK")
+
+            connect_ce_sr(ff5, ce, sr)
+
+            site.add_internal_source(ff5, 'Q', lut + '5Q')
+            ff5.parameters['INIT'] = init
+            ff5.parameters['IS_C_INVERTED'] = IS_C_INVERTED
+
+            site.add_bel(ff5)
+
+    for lut in 'ABCD':
+        name, clk, ce, sr, init = ff_bel(site, lut, ff5=False)
+        ff = Bel(name, "{}_{}".format(lut, name))
+        ff.set_bel(lut + 'FF')
+
+        if site.has_feature('{}FFMUX.{}X'.format(lut, lut)):
+            site.add_sink(ff, 'D', lut + 'X')
+
+        elif lut == 'A' and site.has_feature('AFFMUX.F7'):
+            site.connect_internal(ff, 'D', 'F7AMUX_O')
+
+        elif lut == 'C' and site.has_feature('CFFMUX.F7'):
+            site.connect_internal(ff, 'D', 'F7BMUX_O')
+
+        elif lut == 'B' and site.has_feature('BFFMUX.F8'):
+            site.connect_internal(ff, 'D', 'F8MUX_O')
+
+        elif site.has_feature('{}FFMUX.O5'.format(lut)):
+            site.connect_internal(ff, 'D', lut + 'O5')
+
+        elif site.has_feature('{}FFMUX.O6'.format(lut)):
+            site.connect_internal(ff, 'D', lut + 'O6')
+
+        elif site.has_feature('{}FFMUX.CY'.format(lut)):
+            assert can_have_carry4
+            if lut != 'D':
+                site.connect_internal(ff, 'D', lut + '_CY')
+            else:
+                ff.connections['D'] = 'COUT'
+        elif site.has_feature('{}FFMUX.XOR'.format(lut)):
+            assert can_have_carry4
+            site.connect_internal(ff, 'D', lut + '_XOR')
+        else:
+            continue
+
+        site.add_source(ff, 'Q', lut + 'Q')
+        site.add_sink(ff, clk, "CLK")
+
+        connect_ce_sr(ff, ce, sr)
+
+        ff.parameters['INIT'] = init
+        ff.parameters['IS_C_INVERTED'] = IS_C_INVERTED
+
+        site.add_bel(ff)
+
+    for lut in 'ABCD':
+        if lut + 'O6' in site.internal_sources:
+            site.add_output_from_internal(lut, lut + 'O6')
+
+    for lut in 'ABCD':
+        output_wire = lut + 'MUX'
+        if site.has_feature('{}OUTMUX.{}5Q'.format(lut, lut)):
+            site.add_output_from_internal(output_wire, lut + '5Q')
+
+        elif lut == 'A' and site.has_feature('AOUTMUX.F7'):
+            site.add_output_from_internal(output_wire, 'F7AMUX_O')
+
+        elif lut == 'C' and site.has_feature('COUTMUX.F7'):
+            site.add_output_from_internal(output_wire, 'F7BMUX_O')
+
+        elif lut == 'B' and site.has_feature('BOUTMUX.F8'):
+            site.add_output_from_internal(output_wire, 'F8MUX_O')
+
+        elif site.has_feature('{}OUTMUX.O5'.format(lut)):
+            site.add_output_from_internal(output_wire, lut + 'O5')
+
+        elif site.has_feature('{}OUTMUX.O6'.format(lut)):
+            # Note: There is a dedicated O6 output.  Fixed routing requires
+            # treating xMUX.O6 as a routing connection.
+            site.add_output_from_output(output_wire, lut)
+
+        elif site.has_feature('{}OUTMUX.CY'.format(lut)):
+            assert can_have_carry4
+            if lut != 'D':
+                site.add_output_from_internal(output_wire, lut + '_CY')
+            else:
+                site.add_output_from_output(output_wire, 'COUT')
+
+        elif site.has_feature('{}OUTMUX.XOR'.format(lut)):
+            assert can_have_carry4
+            site.add_output_from_internal(output_wire, lut + '_XOR')
+        else:
+            continue
+
+    site.set_post_route_cleanup_function(cleanup_slice)
+    top.add_site(site)
+
+
+def process_clb(conn, top, tile_name, features):
+    slices = {
+            '0': [],
+            '1': [],
+            }
+
+    for f in features:
+        parts = f.feature.split('.')
+
+        if not parts[1].startswith('SLICE'):
+            continue
+
+        slices[parts[1][-1]].append(f)
+
+    for s in slices:
+        if len(slices[s]) > 0:
+            process_slice(top, slices[s])
+

--- a/xc7/fasm2bels/clk_models.py
+++ b/xc7/fasm2bels/clk_models.py
@@ -1,0 +1,146 @@
+import re
+
+from .verilog_modeling import Bel, Site
+
+BUFHCE_RE = re.compile('BUFHCE_X([0-9]+)Y([0-9]+)')
+
+
+def get_bufg_site(db, grid, tile, generic_site):
+    y = int(generic_site[generic_site.find('Y')+1:])
+    if '_TOP_' in tile:
+        y += 16
+
+    site_name = 'BUFGCTRL_X0Y{}'.format(y)
+
+    gridinfo = grid.gridinfo_at_tilename(tile)
+
+    tile = db.get_tile_type(gridinfo.tile_type)
+
+    for site in tile.get_instance_sites(gridinfo):
+        if site.name == site_name:
+            return site
+
+    assert False, (tile, generic_site)
+
+
+def bufhce_xy(site):
+    m = BUFHCE_RE.fullmatch(site)
+    assert m is not None, site
+
+    return int(m.group(1)), int(m.group(2))
+
+def get_bufhce_site(db, grid, tile, generic_site):
+    x, y = bufhce_xy(generic_site)
+
+    gridinfo = grid.gridinfo_at_tilename(tile)
+
+    tile = db.get_tile_type(gridinfo.tile_type)
+
+    for site in tile.get_instance_sites(gridinfo):
+        instance_x, instance_y = bufhce_xy(site.name)
+
+        if instance_x == x and y == (instance_y % 12):
+            return site
+
+    assert False, (tile, generic_site)
+
+def process_bufg(conn, top, tile, features):
+    bufgs = {}
+    for f in features:
+        parts = f.feature.split('.')
+
+        if parts[1] != 'BUFGCTRL':
+            continue
+
+        if parts[2] not in bufgs:
+            bufgs[parts[2]] = []
+
+        bufgs[parts[2]].append(f)
+
+    for bufg, features in bufgs.items():
+        set_features = set()
+
+        for f in features:
+            if f.value == 0:
+                continue
+
+            parts = f.feature.split('.')
+
+            set_features.add('.'.join(parts[3:]))
+
+        if 'IN_USE' not in set_features:
+            continue
+
+        bufg_site = get_bufg_site(top.db, top.grid, tile, features[0].feature.split('.')[2])
+        site = Site(
+                features,
+                site=bufg_site)
+
+        bel = Bel('BUFGCTRL')
+        bel.parameters['IS_IGNORE0_INVERTED'] = int(not 'IS_IGNORE0_INVERTED' in set_features)
+        bel.parameters['IS_IGNORE1_INVERTED'] = int(not 'IS_IGNORE1_INVERTED' in set_features)
+        bel.parameters['IS_CE0_INVERTED'] = int('ZINV_CE0' not in set_features)
+        bel.parameters['IS_CE1_INVERTED'] = int('ZINV_CE1' not in set_features)
+        bel.parameters['IS_S0_INVERTED'] = int('ZINV_S0' not in set_features)
+        bel.parameters['IS_S1_INVERTED'] = int('ZINV_S1' not in set_features)
+        bel.parameters['PRESELECT_I0'] = int('ZPRESELECT_I0' not in set_features)
+        bel.parameters['PRESELECT_I1'] = int('PRESELECT_I1' in set_features)
+        bel.parameters['INIT_OUT'] = int('INIT_OUT' in set_features)
+
+        for sink in ('I0', 'I1', 'S0', 'S1', 'CE0', 'CE1', 'IGNORE0', 'IGNORE1'):
+            site.add_sink(bel, sink, sink)
+
+        site.add_source(bel,'O', 'O')
+
+        site.add_bel(bel)
+
+        top.add_site(site)
+
+
+def process_hrow(conn, top, tile, features):
+    bufhs = {}
+    for f in features:
+        parts = f.feature.split('.')
+
+        if parts[1] != 'BUFHCE':
+            continue
+
+        if parts[2] not in bufhs:
+            bufhs[parts[2]] = []
+
+        bufhs[parts[2]].append(f)
+
+    for bufh, features in bufhs.items():
+        set_features = set()
+
+        for f in features:
+            if f.value == 0:
+                continue
+
+            parts = f.feature.split('.')
+
+            set_features.add('.'.join(parts[3:]))
+
+        if 'IN_USE' not in set_features:
+            continue
+
+        bufhce_site = get_bufhce_site(top.db, top.grid, tile,
+                features[0].feature.split('.')[2])
+        site = Site(features, site=bufhce_site)
+
+        bel = Bel('BUFHCE')
+        if 'CE_TYPE.ASYNC' in set_features:
+            bel.parameters['CE_TYPE'] = '"ASYNC"'
+        else:
+            bel.parameters['CE_TYPE'] = '"SYNC"'
+        bel.parameters['IS_CE_INVERTED'] = int('ZINV_CE' not in set_features)
+        bel.parameters['INIT_OUT'] = int('INIT_OUT' in set_features)
+
+        for sink in ('I', 'CE'):
+            site.add_sink(bel, sink, sink)
+
+        site.add_source(bel, 'O', 'O')
+
+        site.add_bel(bel)
+
+        top.add_site(site)

--- a/xc7/fasm2bels/connection_db_utils.py
+++ b/xc7/fasm2bels/connection_db_utils.py
@@ -1,0 +1,127 @@
+import functools
+
+def create_maybe_get_wire(conn):
+    c = conn.cursor()
+
+    @functools.lru_cache(maxsize=None)
+    def get_tile_type_pkey(tile):
+        c.execute('SELECT pkey, tile_type_pkey FROM tile WHERE name = ?',
+                (tile,))
+        return c.fetchone()
+
+    @functools.lru_cache(maxsize=None)
+    def maybe_get_wire(tile, wire):
+        tile_pkey, tile_type_pkey = get_tile_type_pkey(tile)
+
+        c.execute('SELECT pkey FROM wire_in_tile WHERE tile_type_pkey = ? and name = ?',
+                (tile_type_pkey, wire))
+
+        result = c.fetchone()
+
+        if result is None:
+            return None
+
+        wire_in_tile_pkey = result[0]
+
+        c.execute('SELECT pkey FROM wire WHERE tile_pkey = ? AND wire_in_tile_pkey = ?',
+                (tile_pkey, wire_in_tile_pkey))
+
+        return c.fetchone()[0]
+
+    return maybe_get_wire
+
+
+def maybe_add_pip(top, maybe_get_wire, feature):
+    if feature.value != 1:
+        return
+
+    parts = feature.feature.split('.')
+    assert len(parts) == 3
+
+    sink_wire = maybe_get_wire(parts[0], parts[2])
+    if sink_wire is None:
+        return
+
+    src_wire = maybe_get_wire(parts[0], parts[1])
+    if src_wire is None:
+        return
+
+    top.active_pips.add((sink_wire, src_wire))
+
+
+def get_node_pkey(conn, wire_pkey):
+    c = conn.cursor()
+
+    c.execute("SELECT node_pkey FROM wire WHERE pkey = ?", (wire_pkey,))
+
+    return c.fetchone()[0]
+
+
+def get_wires_in_node(conn, node_pkey):
+    c = conn.cursor()
+
+    c.execute("SELECT pkey FROM wire WHERE node_pkey = ?", (node_pkey,))
+
+    for row in c.fetchall():
+        yield row[0]
+
+
+def get_wire(conn, tile_pkey, wire_in_tile_pkey):
+    c = conn.cursor()
+    c.execute("SELECT pkey FROM wire WHERE wire_in_tile_pkey = ? AND tile_pkey = ?;",
+            (wire_in_tile_pkey, tile_pkey,))
+    return c.fetchone()[0]
+
+
+def get_tile_type(conn, tile_name):
+    c = conn.cursor()
+
+    c.execute("""
+SELECT name FROM tile_type WHERE pkey = (
+    SELECT tile_type_pkey FROM tile WHERE name = ?);""", (tile_name,))
+
+    return c.fetchone()[0]
+
+
+def get_wire_pkey(conn, tile_name, wire):
+    c = conn.cursor()
+    c.execute("""
+WITH selected_tile(tile_pkey, tile_type_pkey) AS (
+  SELECT
+    pkey,
+    tile_type_pkey
+  FROM
+    tile
+  WHERE
+    name = ?
+)
+SELECT
+  wire.pkey
+FROM
+  wire
+WHERE
+  wire.tile_pkey = (
+    SELECT
+      selected_tile.tile_pkey
+    FROM
+      selected_tile
+  )
+  AND wire.wire_in_tile_pkey = (
+    SELECT
+      wire_in_tile.pkey
+    FROM
+      wire_in_tile
+    WHERE
+      wire_in_tile.name = ?
+      AND wire_in_tile.tile_type_pkey = (
+        SELECT
+          tile_type_pkey
+        FROM
+          selected_tile
+      )
+  );
+""", (tile_name, wire))
+
+    results = c.fetchone()
+    assert results is not None, (tile_name, wire)
+    return results[0]

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -128,6 +128,9 @@ def main():
             help="Path to bitread executable, required if --bit_file is provided.")
     parser.add_argument(
         '--part', help="Name of part being targetted, required if --bit_file is provided.")
+    parser.add_argument(
+        '--top', default="top",
+        help="Root level module name.")
     parser.add_argument('verilog_file',
             help="Filename of output verilog file")
     parser.add_argument('tcl_file',
@@ -149,7 +152,7 @@ def main():
 
     maybe_get_wire = create_maybe_get_wire(conn)
 
-    top = Module(db, grid, conn)
+    top = Module(db, grid, conn, name=args.top)
 
     iostandards = []
 

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -1,0 +1,153 @@
+""" Converts FASM out into BELs and nets.
+
+The BELs will be Xilinx tech primatives.
+The nets will be wires and the route those wires takes.
+
+Output is a Verilog file and a TCL script.  Procedure to use the input in
+Vivado is roughly:
+
+    create_project -force -part <part> design design
+    read_verilog <verilog file name>
+    synth_design -top top
+    source <tcl script file name>
+
+"""
+
+import argparse
+import sqlite3
+
+import fasm
+import prjxray.db
+
+from .bram_models import process_bram
+from .clb_models import process_clb
+from .clk_models import process_hrow, process_bufg
+from .connection_db_utils import create_maybe_get_wire, maybe_add_pip, \
+        get_tile_type
+from .iob_models import process_iobs
+from .verilog_modeling import Module
+
+
+def null_process(conn, top, tile, tiles):
+    pass
+
+
+PROCESS_TILE = {
+        'CLBLL_L': process_clb,
+        'CLBLL_R': process_clb,
+        'CLBLM_L': process_clb,
+        'CLBLM_R': process_clb,
+        'INT_L': null_process,
+        'INT_R': null_process,
+        'LIOB33': process_iobs,
+        'RIOB33': process_iobs,
+        'LIOB33_SING': process_iobs,
+        'RIOB33_SING': process_iobs,
+        'HCLK_L': null_process,
+        'HCLK_R': null_process,
+        'CLK_BUFG_REBUF': null_process,
+        'CLK_BUFG_BOT_R': process_bufg,
+        'CLK_BUFG_TOP_R': process_bufg,
+        'CLK_HROW_BOT_R': process_hrow,
+        'CLK_HROW_TOP_R': process_hrow,
+        'HCLK_CMT': null_process,
+        'HCLK_CMT_L': null_process,
+        'BRAM_L': process_bram,
+        'BRAM_R': process_bram,
+        }
+
+
+def process_tile(top, tile, tile_features):
+    """ Process a tile emits BELs to module top. """
+    tile_type = get_tile_type(top.conn, tile)
+
+    PROCESS_TILE[tile_type](top.conn, top, tile, tile_features)
+
+
+def find_io_standards(feature):
+    """ Scan given feature and return list of possible IOSTANDARDs. """
+
+    if 'IOB' not in feature:
+        return
+
+    for part in feature.split('.'):
+        if 'LVCMOS' in part or 'LVTTL' in part:
+            return part.split('_')
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--connection_database', required=True,
+            help="Path to SQLite3 database for given FASM file part.")
+    parser.add_argument('--db_root', required=True,
+            help="Path to prjxray database for given FASM file part.")
+    parser.add_argument('--allow_orphan_sinks', action='store_true',
+            help="Allow sinks to have no connection.")
+    parser.add_argument('--iostandard',
+            help="Specify IOSTANDARD to use in event of no clear IOSTANDARD from FASM file.")
+    parser.add_argument('fasm_file',
+            help="FASM file to convert BELs and routes.")
+    parser.add_argument('verilog_file',
+            help="Filename of output verilog file")
+    parser.add_argument('tcl_file',
+            help="Filename of output tcl script.")
+
+    args = parser.parse_args()
+
+    conn = sqlite3.connect('file:{}?mode=ro'.format(args.connection_database),
+            uri=True)
+
+    db = prjxray.db.Database(args.db_root)
+    grid = db.grid()
+
+    tiles = {}
+
+    maybe_get_wire = create_maybe_get_wire(conn)
+
+    top = Module(db, grid, conn)
+
+    iostandards = []
+
+    if args.iostandard:
+        iostandards.append([args.iostandard])
+
+    for fasm_line in fasm.parse_fasm_filename(args.fasm_file):
+        if not fasm_line.set_feature:
+            continue
+
+        possible_iostandards = find_io_standards(fasm_line.set_feature.feature)
+        if possible_iostandards is not None:
+            iostandards.append(possible_iostandards)
+
+        parts = fasm_line.set_feature.feature.split('.')
+        tile = parts[0]
+
+        if tile not in tiles:
+            tiles[tile] = []
+
+        tiles[tile].append(fasm_line.set_feature)
+
+        if len(parts) == 3:
+            maybe_add_pip(top, maybe_get_wire, fasm_line.set_feature)
+
+    top.set_iostandard(iostandards)
+
+    for tile, tile_features in tiles.items():
+        process_tile(top, tile, tile_features)
+
+    top.make_routes(allow_orphan_sinks=args.allow_orphan_sinks)
+
+    with open(args.verilog_file, 'w') as f:
+        for l in top.output_verilog():
+            print(l, file=f)
+
+    with open(args.tcl_file, 'w') as f:
+        for l in top.output_bel_locations():
+            print(l, file=f)
+
+        for l in top.output_nets():
+            print(l, file=f)
+
+
+if __name__ == "__main__":
+    main()

--- a/xc7/fasm2bels/iob_models.py
+++ b/xc7/fasm2bels/iob_models.py
@@ -1,0 +1,280 @@
+from .verilog_modeling import Bel, Site
+
+def get_iob_site(db, grid, tile, site):
+    """ Return the prjxray.tile.Site objects and tiles for the given IOB site.
+
+    Returns tuple of (iob_site, iologic_tile, ilogic_site, ologic_site)
+
+    iob_site is the relevant prjxray.tile.Site object for the IOB.
+    ilogic_site is the relevant prjxray.tile.Site object for the ILOGIC
+    connected to the IOB.
+    ologic_site is the relevant prjxray.tile.Site object for the OLOGIC
+    connected to the IOB.
+
+    iologic_tile is the tile containing the ilogic_site and ologic_site.
+
+    """
+    gridinfo = grid.gridinfo_at_tilename(tile)
+    tile_type = db.get_tile_type(gridinfo.tile_type)
+
+    sites = sorted(tile_type.get_instance_sites(gridinfo), key=lambda x: x.y)
+
+    if len(sites) == 1:
+        iob_site = sites[0]
+    else:
+        iob_site = sites[1-int(site[-1])]
+
+    loc = grid.loc_of_tilename(tile)
+
+    if gridinfo.tile_type.startswith('LIOB33'):
+        dx = 1
+    elif gridinfo.tile_type.startswith('RIOB33'):
+        dx = -1
+    else:
+        assert False, gridinfo.tile_type
+
+    iologic_tile = grid.tilename_at_loc((loc.grid_x+dx, loc.grid_y))
+    ioi3_gridinfo = grid.gridinfo_at_loc((loc.grid_x+dx, loc.grid_y))
+
+    ioi3_tile_type = db.get_tile_type(ioi3_gridinfo.tile_type)
+    ioi3_sites = ioi3_tile_type.get_instance_sites(ioi3_gridinfo)
+
+    ilogic_site = None
+    ologic_site = None
+
+    target_ilogic_site = iob_site.name.replace('IOB', 'ILOGIC')
+    target_ologic_site = iob_site.name.replace('IOB', 'OLOGIC')
+
+    for site in ioi3_sites:
+        if site.name == target_ilogic_site:
+            assert ilogic_site is None
+            ilogic_site = site
+
+        if site.name == target_ologic_site:
+            assert ologic_site is None
+            ologic_site = site
+
+    assert ilogic_site is not None
+    assert ologic_site is not None
+
+    return iob_site, iologic_tile, ilogic_site, ologic_site
+
+def get_drive(iostandard, drive):
+    """ Returns the drive strength given the IOSTANDARD and drive feature str.
+    """
+    parts = drive.split('.')
+
+    drive = parts[-1]
+    assert drive[0] == 'I', drive
+
+    if '_' not in drive:
+        return int(drive[1:])
+    else:
+        assert iostandard in ['LVCMOS18', 'LVCMOS33', 'LVTTL']
+        drives = sorted([int(d[1:]) for d in drive.split('_')])
+
+        if iostandard == 'LVCMOS18':
+            return min(drives)
+
+        if drives == [12, 16]:
+            if iostandard == 'LVCMOS33':
+                return 12
+            else:
+                return 16
+        elif drives == [8, 12]:
+            return 8
+
+
+def add_output_parameters(bel, site):
+    """ Adds parameters required for output IOB BELs. """
+    assert 'IOSTANDARD' in bel.parameters
+
+    if site.has_feature('SLEW.FAST'):
+        bel.parameters['SLEW'] = '"FAST"'
+    elif site.has_feature('SLEW.SLOW'):
+        bel.parameters['SLEW'] = '"SLOW"'
+    else:
+        assert False
+
+    drive = None
+    for f in site.set_features:
+        if 'DRIVE' in f:
+            assert drive is None
+            drive  = f
+            break
+
+    iostandard = bel.parameters['IOSTANDARD']
+    assert iostandard[0] == '"'
+    assert iostandard[-1] == '"'
+    assert iostandard[1:-1] in drive
+
+    bel.parameters['DRIVE'] = get_drive(iostandard[1:-1], drive)
+
+
+def process_iob(top, iob):
+    assert top.iostandard is not None
+
+    aparts = iob[0].feature.split('.')
+    iob_site, iologic_tile, ilogic_site, ologic_site = get_iob_site(top.db,
+            top.grid, aparts[0], aparts[1])
+
+    site = Site(iob, iob_site)
+
+    INTERMDISABLE_USED = site.has_feature('INTERMDISABLE.I')
+    IBUFDISABLE_USED = site.has_feature('IBUFDISABLE.I')
+
+    top_wire = None
+    ilogic_active = False
+    ologic_active = False
+
+    if site.has_feature('IN_ONLY'):
+        if not site.has_feature('ZINV_D'):
+            return
+
+        ilogic_active = True
+
+        # Options are:
+        # IBUF, IBUF_IBUFDISABLE, IBUF_INTERMDISABLE
+        if INTERMDISABLE_USED:
+            bel = Bel('IBUF_INTERMDISABLE')
+
+            site.add_sink(bel, 'INTERMDISABLE', 'INTERMDISABLE')
+
+            if IBUFDISABLE_USED:
+                site.add_sink(bel, 'IBUFDISABLE', 'IBUFDISABLE')
+            else:
+                bel.connections['IBUFDISABLE'] = 0
+
+        elif IBUFDISABLE_USED:
+            bel = Bel('IBUF_IBUFDISABLE')
+            site.add_sink(bel, 'IBUFDISABLE', 'IBUFDISABLE')
+        else:
+            bel = Bel('IBUF')
+
+        top_wire = top.add_top_in_port(aparts[0], iob_site.name, 'IPAD')
+        bel.connections['I'] = top_wire
+
+        # Note this looks weird, but the BEL pin is O, and the site wire is
+        # called I, so it is in fact correct.
+        site.add_source(bel, bel_pin='O', source='I')
+
+        bel.parameters['IOSTANDARD'] = '"{}"'.format(top.iostandard)
+
+        site.add_bel(bel)
+    elif site.has_feature('INOUT'):
+        assert site.has_feature('ZINV_D')
+
+        ilogic_active = True
+        ologic_active = True
+
+        # Options are:
+        # IOBUF or IOBUF_INTERMDISABLE
+        if INTERMDISABLE_USED or IBUFDISABLE_USED:
+            bel = Bel('IOBUF_INTERMDISABLE')
+
+            if INTERMDISABLE_USED:
+                site.add_sink(bel, 'INTERMDISABLE', 'INTERMDISABLE')
+            else:
+                bel.connections['INTERMDISABLE'] = 0
+
+            if IBUFDISABLE_USED:
+                site.add_sink(bel, 'IBUFDISABLE', 'IBUFDISABLE')
+            else:
+                bel.connections['IBUFDISABLE'] = 0
+        else:
+            bel = Bel('IOBUF')
+
+        top_wire = top.add_top_inout_port(aparts[0], iob_site.name, 'IOPAD')
+        bel.connections['IO'] = top_wire
+
+        # Note this looks weird, but the BEL pin is O, and the site wire is
+        # called I, so it is in fact correct.
+        site.add_source(bel, bel_pin='O', source='I')
+
+        site.add_sink(bel, 'T', 'T')
+
+        # Note this looks weird, but the BEL pin is I, and the site wire is
+        # called O, so it is in fact correct.
+        site.add_sink(bel, bel_pin='I', sink='O')
+
+        bel.parameters['IOSTANDARD'] = '"{}"'.format(top.iostandard)
+
+        add_output_parameters(bel, site)
+
+        site.add_site(bel)
+    else:
+        has_output = False
+        for f in site.set_features:
+            if 'DRIVE' in f:
+                has_output = True
+                break
+
+        if not has_output:
+            # Naked pull options are not supported
+            assert site.has_feature('PULLTYPE.PULLDOWN')
+        else:
+            # TODO: Could be a OBUFT?
+            bel = Bel('OBUF')
+            top_wire = top.add_top_out_port(aparts[0], iob_site.name, 'OPAD')
+            bel.connections['O'] = top_wire
+
+            # Note this looks weird, but the BEL pin is I, and the site wire
+            # is called O, so it is in fact correct.
+            site.add_sink(bel, bel_pin='I', sink='O')
+
+            bel.parameters['IOSTANDARD'] = '"{}"'.format(top.iostandard)
+
+            add_output_parameters(bel, site)
+            site.add_bel(bel)
+            ologic_active = True
+
+    if top_wire is not None:
+        if site.has_feature('PULLTYPE.PULLDOWN'):
+            bel = Bel('PULLDOWN')
+            bel.connections['O'] = top_wire
+            site.add_bel(bel)
+        elif site.has_feature('PULLTYPE.KEEPER'):
+            bel = Bel('KEEPER')
+            bel.connections['O'] = top_wire
+            site.add_bel(bel)
+        elif site.has_feature('PULLTYPE.PULLUP'):
+            bel = Bel('PULLUP')
+            bel.connections['O'] = top_wire
+            site.add_bel(bel)
+
+    top.add_site(site)
+
+    if ilogic_active:
+        # TODO: Handle IDDR or ISERDES
+        site = Site(iob, tile=iologic_tile, site=ilogic_site)
+        site.sources['O'] = None
+        site.sinks['D'] = []
+        site.outputs['O'] = 'D'
+        top.add_site(site)
+
+    if ologic_active:
+        # TODO: Handle ODDR or OSERDES
+        site = Site(iob, tile=iologic_tile, site=ologic_site)
+        site.sources['OQ'] = None
+        site.sinks['D1'] = []
+        site.outputs['OQ'] = 'D1'
+        top.add_site(site)
+
+
+def process_iobs(conn, top, tile, features):
+    iobs = {
+            '0': [],
+            '1': [],
+            }
+
+    for f in features:
+        parts = f.feature.split('.')
+
+        if not parts[1].startswith('IOB_Y'):
+            continue
+
+        iobs[parts[1][-1]].append(f)
+
+    for iob in iobs:
+        if len(iobs[iob]) > 0:
+            process_iob(top, iobs[iob])

--- a/xc7/fasm2bels/make_routes.py
+++ b/xc7/fasm2bels/make_routes.py
@@ -1,0 +1,544 @@
+import functools
+
+from prjxray.tile_segbits import PsuedoPipType
+
+from .connection_db_utils import get_node_pkey, get_wires_in_node, get_wire
+
+
+ZERO_NET = -1
+ONE_NET = -2
+
+DEBUG = False
+
+def create_check_downstream_default(conn, db):
+    """ Returns check_for_default function. """
+    c = conn.cursor()
+
+    @functools.lru_cache(maxsize=None)
+    def check_for_default(wire_in_tile_pkey):
+        """ Returns downstream wire_in_tile_pkey from given wire_in_tile_pkey.
+
+        This function traverses "always" ppips downstream.
+        Returns None if no ppips are found for the given wire_in_tile_pkey.
+
+        """
+        c.execute("SELECT name, tile_type_pkey FROM wire_in_tile WHERE pkey = ?", (wire_in_tile_pkey,))
+        name, tile_type_pkey = c.fetchone()
+
+        c.execute("SELECT name FROM tile_type WHERE pkey = ?", (tile_type_pkey,))
+        tile_type = c.fetchone()[0]
+
+        tile = db.get_tile_segbits(tile_type)
+
+        for k in tile.ppips:
+            parts = k.split('.')
+            assert len(parts) == 3
+            assert parts[0] == tile_type
+
+            if parts[2] == name and tile.ppips[k] == PsuedoPipType.ALWAYS:
+                downstream_wire = parts[1]
+                c.execute("SELECT pkey FROM wire_in_tile WHERE name = ? AND tile_type_pkey = ?;", (
+                    downstream_wire, tile_type_pkey))
+                downstream_wire_in_tile_pkey = c.fetchone()[0]
+
+                return downstream_wire_in_tile_pkey
+
+        return None
+
+    return check_for_default
+
+
+def find_downstream_node(conn, check_downstream_default, source_node_pkey):
+    """ Finds a downstream node starting from source_node_pkey.
+
+    This function only traverses "always" ppips downstream, not active pips.
+
+    Returns None if no nodes downstream are connected via "always" ppips.
+
+    """
+    c = conn.cursor()
+
+    for wire_pkey in get_wires_in_node(conn, source_node_pkey):
+        c.execute("SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE pkey = ?", (wire_pkey,))
+        tile_pkey, wire_in_tile_pkey = c.fetchone()
+
+        downstream_wire_in_tile_pkey = check_downstream_default(wire_in_tile_pkey)
+        if downstream_wire_in_tile_pkey is not None:
+            c.execute("SELECT node_pkey FROM wire WHERE tile_pkey = ? AND wire_in_tile_pkey = ?",
+                    (tile_pkey, downstream_wire_in_tile_pkey,))
+            downstream_node_pkey = c.fetchone()[0]
+            return downstream_node_pkey
+
+    return None
+
+class Net(object):
+    """ Object to present a net (e.g. a source and it sinks). """
+    def __init__(self, source_wire_pkey):
+        """ Create a net.
+
+        source_wire_pkey (int): A pkey from the wire table that is the source
+            of this net.  This wire must be the wire connected to a site pin.
+
+        """
+
+        self.source_wire_pkey = source_wire_pkey
+        self.route_wire_pkeys = set()
+        self.parent_nodes = {}
+        self.incoming_wire_map = {}
+
+    def add_node(self, conn, net_map, node_pkey, parent_node_pkey, incoming_wire_pkey=None):
+        """ Add a node to a net.
+
+        node_pkey (int): A pkey from the node table that is part of this net.
+        parent_node_pkey (int): A pkey from the node table that is the source
+            for node_pkey.
+        incoming_wire_pkey (int): incoming_wire_pkey is the wire_pkey that is
+            the connecting wire in this node.  For example, if this node is
+            connected to the net via a pip, then incoming_wire_pkey should be
+            the source wire_pkey from the pip.  This is important when dealing
+            with bidirection pips.
+
+        """
+        if DEBUG:
+            print('// sink node {} connected to source {}'.format(node_pkey, self.source_wire_pkey))
+
+        if incoming_wire_pkey is not None:
+            assert node_pkey not in self.incoming_wire_map, node_pkey
+            self.incoming_wire_map[node_pkey] = incoming_wire_pkey
+
+        self.parent_nodes[node_pkey] = parent_node_pkey
+
+        for wire_pkey in get_wires_in_node(conn, node_pkey):
+            net_map[wire_pkey] = self.source_wire_pkey
+            self.route_wire_pkeys.add(wire_pkey)
+
+    def expand_source(self, conn, check_downstream_default, net_map):
+        """ Propigate net downstream through trival PPIP connections. """
+        source_node_pkey = get_node_pkey(conn, self.source_wire_pkey)
+
+        while True:
+            parent_node_pkey = source_node_pkey
+            source_node_pkey = find_downstream_node(conn, check_downstream_default, source_node_pkey)
+
+            if source_node_pkey is not None:
+                self.add_node(conn, net_map, source_node_pkey, parent_node_pkey)
+            else:
+                break
+
+    def prune_antennas(self, sink_node_pkeys):
+        """ Remove entries from parent_nodes that belong to antenna wires.
+
+        The expand_source may add entires in parent_nodes that are
+        disconnected. hese nodes should be removed prior to outputting fixed
+        routes.
+        """
+
+        alive_nodes = set()
+
+        for node in self.parent_nodes.keys():
+            if node in sink_node_pkeys:
+                while node in self.parent_nodes:
+                    alive_nodes.add(node)
+                    node = self.parent_nodes[node]
+
+        dead_nodes = set(self.parent_nodes.keys()) - alive_nodes
+
+        for dead_node in dead_nodes:
+            del self.parent_nodes[dead_node]
+
+    def is_net_alive(self):
+        """ True if this net is connected to sinks.
+
+        Call this method after invoked prune_antennas to avoid false positives.
+
+        """
+        return len(self.parent_nodes) > 0
+
+    def make_fixed_route(self, conn, wire_pkey_to_wire):
+        """ Yields a TCL statement that is the value for the FIXED_ROUTE param.
+
+        Should invoke this method after calling prune_antennas.
+        """
+
+        source_to_sink_node_map = {}
+
+        for sink, src in self.parent_nodes.items():
+            if src not in source_to_sink_node_map:
+                source_to_sink_node_map[src] = []
+
+            source_to_sink_node_map[src].append(sink)
+
+
+        fixed_route = []
+
+        c = conn.cursor()
+
+        def get_a_wire(node_pkey):
+            c.execute("SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE node_pkey = ? LIMIT 1", (node_pkey,))
+            (tile_pkey, wire_in_tile_pkey,) = c.fetchone()
+            c.execute("SELECT name FROM tile WHERE pkey = ?", (tile_pkey,))
+            tile_name = c.fetchone()[0]
+            c.execute("SELECT name FROM wire_in_tile WHERE pkey = ?", (wire_in_tile_pkey,))
+            wire_name = c.fetchone()[0]
+
+            return tile_name + '/' + wire_name
+
+        def descend_fixed_route(source_node_pkey, fixed_route):
+            if source_node_pkey in self.incoming_wire_map:
+                c.execute("SELECT wire_in_tile_pkey, tile_pkey FROM wire WHERE pkey = ?",
+                        (self.incoming_wire_map[source_node_pkey],))
+                wire_in_tile_pkey, tile_pkey = c.fetchone()
+
+                c.execute("SELECT name FROM tile WHERE pkey = ?", (tile_pkey,))
+                (tile_name,) = c.fetchone()
+
+                c.execute("SELECT name FROM wire_in_tile WHERE pkey = ?", (wire_in_tile_pkey,))
+                (wire_name,) = c.fetchone()
+
+                wire_name = tile_name + '/' + wire_name
+            else:
+                # We don't have a specific upstream wire, use any from the node
+                wire_name = get_a_wire(source_node_pkey)
+                wire_name = '[get_nodes -of_object [get_wires {}]]'.format(wire_name)
+
+            fixed_route.append(wire_name)
+
+            if source_node_pkey not in source_to_sink_node_map:
+                return
+
+            descend_routes = []
+
+            for _ in range(len(source_to_sink_node_map[source_node_pkey])-1):
+                fixed_route.append([])
+                descend_routes.append(fixed_route[-1])
+
+            descend_routes.append(fixed_route)
+
+            for idx, next_node_pkey in enumerate(source_to_sink_node_map[source_node_pkey]):
+                descend_fixed_route(next_node_pkey, descend_routes[idx])
+
+        descend_fixed_route(get_node_pkey(conn, self.source_wire_pkey), fixed_route)
+
+        def output_builder(fixed_route):
+            yield '[list'
+
+            for i in fixed_route:
+                if type(i) is list:
+                    for i2 in output_builder(i):
+                        yield i2
+                else:
+                    yield i
+
+            yield ']'
+
+        for i in output_builder(fixed_route):
+            yield i
+
+
+def create_check_for_default(db, conn):
+    """ Returns check_for_default function. """
+    c = conn.cursor()
+
+    @functools.lru_cache(maxsize=None)
+    def check_for_default(wire_in_tile_pkey):
+        """ Returns upstream wire_in_tile_pkey from given wire_in_tile_pkey.
+
+        This function traverses "always" or "default" ppips upstream. Because
+        this function will traverse "default" ppips, it should only be invoked
+        on wire_in_tile_pkey that have no active upstream pips, otherwise an
+        invalid connection could be made.
+
+        Returns None if no ppips are found for the given wire_in_tile_pkey.
+
+        """
+        c.execute("SELECT name, tile_type_pkey FROM wire_in_tile WHERE pkey = ?", (wire_in_tile_pkey,))
+        name, tile_type_pkey = c.fetchone()
+
+        c.execute("SELECT name FROM tile_type WHERE pkey = ?", (tile_type_pkey,))
+        tile_type = c.fetchone()[0]
+
+        tile = db.get_tile_segbits(tile_type)
+
+        # The xMUX wires have multiple "hint" connections.  Deal with them
+        # specially.
+        if name in [
+                'CLBLM_L_AMUX',
+                'CLBLM_L_BMUX',
+                'CLBLM_L_CMUX',
+                'CLBLM_L_DMUX',
+                'CLBLM_M_AMUX',
+                'CLBLM_M_BMUX',
+                'CLBLM_M_CMUX',
+                'CLBLM_M_DMUX',
+                'CLBLL_L_AMUX',
+                'CLBLL_L_BMUX',
+                'CLBLL_L_CMUX',
+                'CLBLL_L_DMUX',
+                'CLBLL_LL_AMUX',
+                'CLBLL_LL_BMUX',
+                'CLBLL_LL_CMUX',
+                'CLBLL_LL_DMUX',
+                ]:
+            upstream_wire = name.replace('MUX', '')
+            c.execute("SELECT pkey FROM wire_in_tile WHERE name = ? AND tile_type_pkey = ?;", (
+                upstream_wire, tile_type_pkey))
+
+            upstream_wire_in_tile_pkey = c.fetchone()[0]
+
+            return upstream_wire_in_tile_pkey
+
+        for k in tile.ppips:
+            parts = k.split('.')
+            assert len(parts) == 3
+            if k.startswith('{}.{}.'.format(tile_type, name)):
+                assert tile.ppips[k] in [PsuedoPipType.ALWAYS, PsuedoPipType.DEFAULT], (k, tile.ppips[k])
+
+                upstream_wire = parts[2]
+
+                c.execute("SELECT pkey FROM wire_in_tile WHERE name = ? AND tile_type_pkey = ?;", (
+                    upstream_wire, tile_type_pkey))
+
+                upstream_wire_in_tile_pkey = c.fetchone()[0]
+
+                return upstream_wire_in_tile_pkey
+
+        return None
+
+    return check_for_default
+
+
+def expand_sink(conn, check_for_default, nets, net_map,
+        source_to_sink_pip_map, sink_wire_pkey,
+        allow_orphan_sinks):
+    """ Attempt to expand a sink to its source. """
+    if sink_wire_pkey in net_map:
+        return
+
+    c = conn.cursor()
+
+    c.execute("SELECT wire_in_tile_pkey, tile_pkey FROM wire WHERE pkey = ?",
+            (sink_wire_pkey,))
+    wire_in_tile_pkey, tile_pkey = c.fetchone()
+
+    c.execute("SELECT name FROM tile WHERE pkey = ?", (tile_pkey,))
+    (tile_name,) = c.fetchone()
+
+    c.execute("SELECT name FROM wire_in_tile WHERE pkey = ?", (wire_in_tile_pkey,))
+    (wire_name,) = c.fetchone()
+
+    if DEBUG:
+        print('//', tile_name, wire_name, sink_wire_pkey)
+
+    sink_node_pkey = get_node_pkey(conn, sink_wire_pkey)
+
+    # Check if there is an upstream active pip on this node.
+    for node_wire_pkey in get_wires_in_node(conn, sink_node_pkey):
+        assert node_wire_pkey not in net_map
+
+        if node_wire_pkey in source_to_sink_pip_map:
+            upstream_sink_wire_pkey = source_to_sink_pip_map[node_wire_pkey]
+
+            if upstream_sink_wire_pkey not in net_map:
+                expand_sink(
+                        conn=conn,
+                        check_for_default=check_for_default,
+                        nets=nets,
+                        net_map=net_map,
+                        source_to_sink_pip_map=source_to_sink_pip_map,
+                        sink_wire_pkey=upstream_sink_wire_pkey,
+                        allow_orphan_sinks=allow_orphan_sinks)
+
+            if upstream_sink_wire_pkey in net_map:
+                if DEBUG:
+                    print('// {}/{} is connected to net via wire_pkey {}'.format(
+                        tile_name, wire_name, upstream_sink_wire_pkey))
+
+                nets[net_map[upstream_sink_wire_pkey]].add_node(
+                    conn=conn,
+                    net_map=net_map,
+                    node_pkey=sink_node_pkey,
+                    parent_node_pkey=get_node_pkey(conn, upstream_sink_wire_pkey),
+                    incoming_wire_pkey=node_wire_pkey)
+                return
+
+    # There are no active pips upstream from this node, check if this is a
+    # site pin connected to a HARD0 or HARD1 pin.  These are connected to the
+    # global ZERO_NET or ONE_NET.
+    c.execute("SELECT site_wire_pkey FROM node WHERE pkey = ?", (sink_node_pkey,))
+    site_wire_pkey = c.fetchone()[0]
+    if site_wire_pkey is not None:
+        upstream_sink_wire_in_tile_pkey = check_for_default(wire_in_tile_pkey)
+        if upstream_sink_wire_in_tile_pkey is not None:
+            upstream_sink_wire_pkey = get_wire(conn, tile_pkey, upstream_sink_wire_in_tile_pkey)
+
+            if upstream_sink_wire_pkey in net_map:
+                nets[net_map[upstream_sink_wire_pkey]].add_node(
+                        conn=conn,
+                        net_map=net_map,
+                        node_pkey=sink_node_pkey,
+                        parent_node_pkey=get_node_pkey(conn, upstream_sink_wire_pkey),
+                        incoming_wire_pkey=sink_wire_pkey,
+                        )
+                return
+
+        c.execute("""
+SELECT site_pin_pkey FROM wire_in_tile WHERE pkey = (
+        SELECT wire_in_tile_pkey FROM wire WHERE pkey = ?);""", (site_wire_pkey,))
+        site_pin_pkey = c.fetchone()[0]
+
+        assert site_pin_pkey is not None
+
+        c.execute("SELECT name, direction FROM site_pin WHERE pkey = ?;""", (site_pin_pkey,))
+        site_pin, direction = c.fetchone()
+
+        if direction == 'OUT':
+            if site_pin == 'HARD1':
+                nets[ONE_NET].add_node(conn, net_map, sink_node_pkey, parent_node_pkey=ONE_NET)
+            elif site_pin == 'HARD0':
+                nets[ZERO_NET].add_node(conn, net_map, sink_node_pkey, parent_node_pkey=ZERO_NET)
+            else:
+                c.execute("SELECT name FROM tile WHERE pkey = (SELECT tile_pkey FROM wire WHERE pkey = ?)", (site_wire_pkey,))
+                tile = c.fetchone()[0]
+                assert site_pin in ['HARD1', 'HARD0'], (sink_node_pkey, tile, site_pin)
+
+            return
+
+    # No active pips to move upstream, find a ppip upstream
+    for node_wire_pkey in get_wires_in_node(conn, sink_node_pkey):
+        c.execute("SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE pkey = ?;", (node_wire_pkey,))
+        tile_pkey, wire_in_tile_pkey = c.fetchone()
+
+        upstream_sink_wire_in_tile_pkey = check_for_default(wire_in_tile_pkey)
+
+        if upstream_sink_wire_in_tile_pkey is not None:
+            c.execute("SELECT pkey FROM wire WHERE wire_in_tile_pkey = ? AND tile_pkey = ?;",
+                    (upstream_sink_wire_in_tile_pkey, tile_pkey,))
+            upstream_sink_wire_pkey = c.fetchone()[0]
+
+            if upstream_sink_wire_pkey not in net_map:
+                expand_sink(
+                        conn=conn,
+                        check_for_default=check_for_default,
+                        nets=nets,
+                        net_map=net_map,
+                        source_to_sink_pip_map=source_to_sink_pip_map,
+                        sink_wire_pkey=upstream_sink_wire_pkey,
+                        allow_orphan_sinks=allow_orphan_sinks)
+
+            if upstream_sink_wire_pkey in net_map:
+                if DEBUG:
+                    print('// {}/{} is connected to net via wire_pkey {}'.format(
+                        tile_name, wire_name, upstream_sink_wire_pkey))
+
+                nets[net_map[upstream_sink_wire_pkey]].add_node(
+                        conn=conn,
+                        net_map=net_map,
+                        node_pkey=sink_node_pkey,
+                        parent_node_pkey=get_node_pkey(conn, upstream_sink_wire_pkey),
+                        incoming_wire_pkey=node_wire_pkey)
+                return
+
+    # There does not appear to be an upstream connection, handle it.
+    if allow_orphan_sinks:
+        print('// ERROR, failed to find source for node = {}'.format(sink_node_pkey))
+    else:
+        assert False, (sink_node_pkey, tile_name, wire_name, sink_wire_pkey)
+
+
+def make_routes(db, conn, wire_pkey_to_wire, unrouted_sinks, unrouted_sources,
+        active_pips, allow_orphan_sinks, shorted_nets, nets, net_map):
+    """ Form nets (and their routes) based:
+
+    unrouted_sinks - Set of wire_pkeys of sinks to BELs in the graph
+    unrouted_sources - Set of wire_pkeys of sources from BELs in the graph
+    active_pips - Known active pips, (sink wire_pkey, source wire_pkey).
+    shorted_nets - Map of source_wire_pkey to sink_wire_pkey that represent
+       shorted_nets
+
+    Once nets are formed, yields wire names to their sources (which may be 0
+    or 1 when connected to a constant net).
+
+    """
+    for wire_pkey in unrouted_sinks:
+        assert wire_pkey in wire_pkey_to_wire
+
+    for wire_pkey in unrouted_sources:
+        assert wire_pkey in wire_pkey_to_wire
+
+    source_to_sink_pip_map = {}
+
+    for sink_wire_pkey, source_wire_pkey in active_pips:
+        assert source_wire_pkey not in source_to_sink_pip_map
+        source_to_sink_pip_map[source_wire_pkey] = sink_wire_pkey
+
+    # Shorted nets can be treated like an active pip.
+    for source_wire_pkey, sink_wire_pkey in shorted_nets.items():
+        assert source_wire_pkey not in source_to_sink_pip_map
+        source_to_sink_pip_map[source_wire_pkey] = sink_wire_pkey
+
+    # Every sink should belong to exactly 1 net
+    # Every net should have exactly 1 source
+    check_downstream_default = create_check_downstream_default(conn, db)
+
+    def report_sources():
+        print('// Source wire pkeys:')
+        c = conn.cursor()
+        for wire_pkey in unrouted_sources:
+            c.execute("SELECT tile_pkey, wire_in_tile_pkey FROM wire WHERE pkey = ?", (wire_pkey,))
+            tile_pkey, wire_in_tile_pkey = c.fetchone()
+
+            c.execute("SELECT name, tile_type_pkey FROM wire_in_tile WHERE pkey = ?", (
+                wire_in_tile_pkey,))
+            name, tile_type_pkey = c.fetchone()
+
+            c.execute("SELECT name FROM tile WHERE pkey = ?", (tile_pkey,))
+            tile = c.fetchone()[0]
+
+            print('//', wire_pkey, tile, name)
+
+    if DEBUG:
+        report_sources()
+
+    for wire_pkey in unrouted_sources:
+        nets[wire_pkey] = Net(wire_pkey)
+        nets[wire_pkey].add_node(conn, net_map, get_node_pkey(conn, wire_pkey), parent_node_pkey=None)
+        nets[wire_pkey].expand_source(conn, check_downstream_default, net_map)
+    del check_downstream_default
+
+    nets[ZERO_NET] = Net(ZERO_NET)
+    nets[ONE_NET] = Net(ONE_NET)
+
+    check_for_default = create_check_for_default(db, conn)
+
+    for wire_pkey in unrouted_sinks:
+        expand_sink(
+                conn=conn,
+                check_for_default=check_for_default,
+                nets=nets,
+                net_map=net_map,
+                source_to_sink_pip_map=source_to_sink_pip_map,
+                sink_wire_pkey=wire_pkey,
+                allow_orphan_sinks=allow_orphan_sinks)
+
+        if wire_pkey in net_map:
+            source_wire_pkey = net_map[wire_pkey]
+
+
+            if source_wire_pkey == ZERO_NET:
+                yield wire_pkey_to_wire[wire_pkey], 0
+            elif source_wire_pkey == ONE_NET:
+                yield wire_pkey_to_wire[wire_pkey], 1
+            else:
+                yield wire_pkey_to_wire[wire_pkey], wire_pkey_to_wire[source_wire_pkey]
+        else:
+            if allow_orphan_sinks:
+                print('// ERROR, source for sink wire {} not found'.format(wire_pkey_to_wire[wire_pkey]))
+
+def prune_antennas(conn, nets, unrouted_sinks):
+    """ Prunes antenna routes from nets based on active sinks. """
+    active_sink_nodes = set()
+    for wire_pkey in unrouted_sinks:
+            active_sink_nodes.add(get_node_pkey(conn, wire_pkey))
+
+    for net in nets.values():
+        net.prune_antennas(active_sink_nodes)

--- a/xc7/fasm2bels/verilog_modeling.py
+++ b/xc7/fasm2bels/verilog_modeling.py
@@ -586,7 +586,8 @@ def merge_exclusive_dicts(dict_a, dict_b):
 
 class Module(object):
     """ Object to model a design. """
-    def __init__(self, db, grid, conn):
+    def __init__(self, db, grid, conn, name="top"):
+        self.name = name
         self.iostandard = None
         self.db = db
         self.grid = grid
@@ -733,7 +734,7 @@ class Module(object):
         for inout_wire in sorted(self.root_inout):
             root_module_args.append('  inout ' + inout_wire)
 
-        yield 'module top('
+        yield 'module {}('.format(self.name)
 
         yield ',\n'.join(root_module_args)
 

--- a/xc7/fasm2bels/verilog_modeling.py
+++ b/xc7/fasm2bels/verilog_modeling.py
@@ -1,0 +1,861 @@
+""" Core classes for modelling a bitstream back into verilog and routes.
+
+There are 3 modelling elements:
+
+ - Bel: A synthesizable element.
+ - Site: A collection of Bel's, routing sinks and routing sources.
+ - Module: The root container for all Sites
+
+The modelling approach works as so:
+
+BELs represent a particular tech library instance (e.g. LUT6 or FDRE).  These
+BELs are connected into the routing fabric or internal site sources via the
+Site methods:
+
+ - Site.add_sink
+ - Site.add_source
+ - Site.add_output_from_internal
+ - Site.connect_internal
+ - Site.add_internal_source
+
+BEL parameters should be on the BEL.
+
+In cases where there is multiple instances of a BEL (e.g. LUT's), the
+Bel.set_bel must be called to ensure that Vivado places the BEL in the exact
+location.
+
+"""
+
+import functools
+from .make_routes import make_routes, ONE_NET, ZERO_NET, prune_antennas
+from .connection_db_utils import get_wire_pkey
+
+
+class Bel(object):
+    """ Object to model a BEL.
+    """
+    def __init__(self, module, name=None, keep=True):
+        """ Construct Bel object.
+
+        module (str): Exact tech library name to instance during synthesis.
+            Example "LUT6_2" or "FDRE".
+        name (str): Optional name of this bel, used to disambiguate multiple
+            instances of the same module in a site.  If there are multiple
+            instances of the same module in a site, name must be specified and
+            unique.
+        keep (bool): Controls if KEEP, DONT_TOUCH constraints are added to this
+            instance.
+
+        """
+        self.module = module
+        if name is None:
+            self.name = module
+        else:
+            self.name = name
+        self.connections = {}
+        self.unused_connections = set()
+        self.parameters = {}
+        self.outputs = set()
+        self.prefix = None
+        self.site = None
+        self.keep = keep
+        self.bel = None
+        self.nets = None
+
+    def set_prefix(self, prefix):
+        """ Set the prefix used for wire and BEL naming.
+
+        This is method is typically called automatically during
+        Site.integrate_site. """
+        self.prefix = prefix
+
+    def set_site(self, site):
+        """ Sets the site string used to set the LOC constraint.
+
+        This is method is typically called automatically during
+        Site.integrate_site. """
+        self.site = site
+
+    def set_bel(self, bel):
+        """ Sets the BEL constraint.
+
+        This method should be called if the parent site has multiple instances
+        of the BEL (e.g. LUT6 in a SLICE).
+        """
+        self.bel = bel
+
+    def _prefix_things(self, s):
+        """ Apply the prefix (if any) to the input string. """
+        if self.prefix is not None:
+            return '{}_{}'.format(self.prefix, s)
+        else:
+            return s
+
+    def get_cell(self):
+        """ Get the cell name of this BEL.
+
+        Should only be called after set_prefix has been invoked (if set_prefix
+        will be called)."""
+        return self._prefix_things(self.name)
+
+    def output_verilog(self, top, indent='  '):
+        """ Output the Verilog to represent this BEL. """
+        connections = {}
+        buses = {}
+
+        for wire, connection in self.connections.items():
+            if top.is_top_level(connection):
+                connection_wire = connection
+            elif connection in [0, 1]:
+                connection_wire = connection
+            else:
+                connection_wire = self._prefix_things(connection)
+
+            if '[' in wire:
+                bus_name, address = wire.split('[')
+                assert address[-1] == ']', address
+
+                if bus_name not in buses:
+                    buses[bus_name] = {}
+
+                buses[bus_name][int(address[:-1])] = connection_wire
+            else:
+                connections[wire] = '{indent}{indent}.{wire}({connection})'.format(indent=indent, wire=wire, connection=connection_wire)
+
+        for bus_name, bus in buses.items():
+            bus_wires = [0 for _ in range(max(bus.keys())+1)]
+
+            for idx, _ in enumerate(bus_wires):
+                assert idx in bus
+                bus_wires[idx] = bus[idx]
+
+            connections[bus_name] = '{indent}{indent}.{bus_name}({connection})'.format(
+                indent=indent,
+                bus_name=bus_name,
+                connection='{{{}}}'.format(', '.join(bus_wires[::-1])))
+
+        for unused_connection in self.unused_connections:
+            connections[unused_connection] = '{indent}{indent}.{connection}()'.format(
+                    indent=indent,
+                    connection=unused_connection)
+
+        yield ''
+
+        if self.site is not None:
+            comment = []
+            if self.keep:
+                comment.append('KEEP')
+                comment.append('DONT_TOUCH')
+
+            comment.append('LOC = "{site}"'.format(site=self.site))
+
+            if self.bel:
+                comment.append('BEL = "{bel}"'.format(bel=self.bel))
+
+            yield '{indent}(* {comment} *)'.format(
+                    indent=indent,
+                    comment=', '.join(comment))
+
+        yield '{indent}{site} #('.format(indent=indent, site=self.module)
+
+        parameters = []
+        for param, value in sorted(self.parameters.items(), key=lambda x: x[0]):
+            parameters.append('{indent}{indent}.{param}({value})'.format(indent=indent, param=param, value=value))
+
+        if parameters:
+            yield ',\n'.join(parameters)
+
+        yield '{indent}) {name} ('.format(indent=indent, name=self.get_cell())
+
+        if connections:
+            yield ',\n'.join(connections[port] for port in sorted(connections))
+
+        yield '{indent});'.format(indent=indent)
+
+
+class Site(object):
+    """ Object to model a Site.
+
+    A site is a collection of BELs, and sources and sinks that connect the
+    site to the routing fabric.  Sources and sinks exported by the Site will
+    be used during routing formation.
+
+    Wires that are not in the sources and sinks lists will be invisible to
+    the routing formation step.  In particular, site connections that should
+    be sources and sinks but are not specified will be ingored during routing
+    formation, and likely end up as disconnected wires.
+
+    On the flip side it is import that specified sinks are always connected
+    to at least one BEL.  If this is not done, antenna nets may be emitted
+    during routing formation, which will result in a DRC violation.
+
+    """
+    def __init__(self, features, site, tile=None):
+        self.bels = []
+        self.sinks = {}
+        self.sources = {}
+        self.outputs = {}
+        self.internal_sources = {}
+
+        self.set_features = set()
+        self.post_route_cleanup = None
+        self.bel_map = {}
+
+        self.site_wire_to_wire_pkey = {}
+
+        aparts = features[0].feature.split('.')
+
+        for f in features:
+            if f.value == 0:
+                continue
+
+            parts = f.feature.split('.')
+            assert parts[0] == aparts[0]
+            assert parts[1] == aparts[1]
+            self.set_features.add('.'.join(parts[2:]))
+
+        if tile is None:
+            self.tile = aparts[0]
+        else:
+            self.tile = tile
+
+        self.site = site
+
+    def has_feature(self, feature):
+        """ Does this set have the specified feature set? """
+        return feature in self.set_features
+
+    def add_sink(self, bel, bel_pin, sink):
+        """ Adds a sink.
+
+        Attaches sink to the specified bel.
+
+        bel (Bel): Bel object
+        bel_pin (str): The exact tech library name for the relevant pin.  Can be
+            a bus (e.g. A[5]).  The name must identically match the library
+            name or an error will occur during synthesis.
+        sink (str): The exact site pin name for this sink.  The name must
+            identically match the site pin name, or an error will be generated
+            when Site.integrate_site is invoked.
+
+        """
+
+        assert bel_pin not in bel.connections
+
+        if sink not in self.sinks:
+            self.sinks[sink] = []
+
+        bel.connections[bel_pin] = sink
+        self.sinks[sink].append((bel, bel_pin))
+
+    def add_source(self, bel, bel_pin, source):
+        """ Adds a source.
+
+        Attaches source to bel.
+
+        bel (Bel): Bel object
+        bel_pin (str): The exact tech library name for the relevant pin.  Can be
+            a bus (e.g. A[5]).  The name must identically match the library
+            name or an error will occur during synthesis.
+        source (str): The exact site pin name for this source.  The name must
+            identically match the site pin name, or an error will be generated
+            when Site.integrate_site is invoked.
+
+        """
+        assert source not in self.sources
+        assert bel_pin not in bel.connections
+
+        bel.connections[bel_pin] = source
+        bel.outputs.add(bel_pin)
+        self.sources[source] = (bel, bel_pin)
+
+    def add_output_from_internal(self, source, internal_source):
+        """ Adds a source from a site internal source.
+
+        This is used to convert an internal_source wire to a site source.
+
+        source (str): The exact site pin name for this source.  The name must
+            identically match the site pin name, or an error will be generated
+            when Site.integrate_site is invoked.
+        internal_source (str): The internal_source must match the internal
+            source name provided to Site.add_internal_source earlier.
+
+        """
+        assert source not in self.sources
+        assert internal_source in self.internal_sources
+
+        self.outputs[source] = internal_source
+        self.sources[source] = self.internal_sources[internal_source]
+
+    def add_output_from_output(self, source, other_source):
+        """ Adds an output wire from an existing source wire.
+
+        The new output wire is not a source, but will participate in routing
+        formation.
+
+        source (str): The exact site pin name for this source.  The name must
+            identically match the site pin name, or an error will be generated
+            when Site.integrate_site is invoked.
+        other_source (str): The name of an existing source generated from add_source.
+
+        """
+        assert source not in self.sources
+        assert other_source in self.sources
+        self.outputs[source] = other_source
+
+    def add_internal_source(self, bel, bel_pin, wire_name):
+        """ Adds a site internal source.
+
+        Adds an internal source to the site.  This wire will not be used during
+        routing formation, but can be connected to other BELs within the site.
+
+        bel (Bel): Bel object
+        bel_pin (str): The exact tech library name for the relevant pin.  Can be
+            a bus (e.g. A[5]).  The name must identically match the library
+            name or an error will occur during synthesis.
+        wire_name (str): The name of the site wire.  This wire_name must be
+            overlap with a source or sink site pin name.
+
+        """
+        bel.connections[bel_pin] = wire_name
+        bel.outputs.add(bel_pin)
+
+        assert wire_name not in self.internal_sources, wire_name
+        self.internal_sources[wire_name] = (bel, bel_pin)
+
+    def connect_internal(self, bel, bel_pin, source):
+        """ Connect a BEL pin to an existing internal source.
+
+        bel (Bel): Bel object
+        bel_pin (str): The exact tech library name for the relevant pin.  Can be
+            a bus (e.g. A[5]).  The name must identically match the library
+            name or an error will occur during synthesis.
+        source (str): Existing internal source wire added via
+            add_internal_source.
+
+        """
+        assert source in self.internal_sources, source
+        assert bel_pin not in bel.connections
+        bel.connections[bel_pin] = source
+
+    def add_bel(self, bel, name=None):
+        """ Adds a BEL to the site.
+
+        All BELs that use the add_sink, add_source, add_internal_source,
+        and connect_internal must call add_bel with the relevant BEL.
+
+        bel (Bel): Bel object
+        name (str): Optional name to assign to the bel to enable retrival with
+            the maybe_get_bel method.  This name is not used for any other
+            reason.
+
+        """
+
+        self.bels.append(bel)
+        if name is not None:
+            assert name not in self.bel_map
+            self.bel_map[name] = bel
+
+
+    def set_post_route_cleanup_function(self, func):
+        """ Set callback to be called on this site during routing formation.
+
+        This callback is intended to enable sites that must perform decisions
+        based on routed connections.
+
+        func (function): Function that takes two arguments, the parent module
+            and the site object to cleanup.
+
+        """
+        self.post_route_cleanup = func
+
+    def integrate_site(self, conn, module):
+        """ Integrates site so that it can be used with routing formation.
+
+        This method is called automatically by Module.add_site.
+
+        """
+        self.check_site()
+
+        prefix = '{}_{}'.format(self.tile, self.site.name)
+
+        site_pin_map = make_site_pin_map(frozenset(self.site.site_pins))
+
+        # Sanity check BEL connections
+        for bel in self.bels:
+            bel.set_prefix(prefix)
+            bel.set_site(self.site.name)
+
+            for wire in bel.connections.values():
+                if wire == 0 or wire == 1:
+                    continue
+
+                assert wire in self.sinks or \
+                       wire in self.sources or \
+                       wire in self.internal_sources or \
+                       module.is_top_level(wire), wire
+
+        wires = set()
+        unrouted_sinks = set()
+        unrouted_sources = set()
+        wire_pkey_to_wire = {}
+        source_bels = {}
+        wire_assigns = {}
+
+        for wire in self.internal_sources:
+            prefix_wire = prefix + '_' + wire
+            wires.add(prefix_wire)
+
+        for wire in self.sinks:
+            if wire is module.is_top_level(wire):
+                continue
+
+            prefix_wire = prefix + '_' + wire
+            wires.add(prefix_wire)
+            wire_pkey = get_wire_pkey(conn, self.tile, site_pin_map[wire])
+            wire_pkey_to_wire[wire_pkey] = prefix_wire
+            self.site_wire_to_wire_pkey[wire] = wire_pkey
+            unrouted_sinks.add(wire_pkey)
+
+        for wire in self.sources:
+            if wire is module.is_top_level(wire):
+                continue
+
+            prefix_wire = prefix + '_' + wire
+            wires.add(prefix_wire)
+            wire_pkey = get_wire_pkey(conn, self.tile, site_pin_map[wire])
+            wire_pkey_to_wire[wire_pkey] = prefix_wire
+            self.site_wire_to_wire_pkey[wire] = wire_pkey
+            unrouted_sources.add(wire_pkey)
+
+            source_bel = self.sources[wire]
+
+            if source_bel is not None:
+                source_bels[wire_pkey] = source_bel
+
+        shorted_nets = {}
+
+        for source_wire, sink_wire in self.outputs.items():
+            wire_source = prefix + '_' + sink_wire
+            wire = prefix + '_' + source_wire
+            wires.add(wire)
+            wire_assigns[wire] = wire_source
+
+            # If this is a passthrough wire, then indicate that allow the net
+            # is be merged.
+            if sink_wire not in site_pin_map:
+                continue
+
+            sink_wire_pkey = get_wire_pkey(conn, self.tile, site_pin_map[sink_wire])
+            source_wire_pkey = get_wire_pkey(conn, self.tile, site_pin_map[source_wire])
+            if sink_wire_pkey in unrouted_sinks:
+                shorted_nets[source_wire_pkey] = sink_wire_pkey
+
+                # Because this is being treated as a short, remove the
+                # source and sink.
+                unrouted_sources.remove(source_wire_pkey)
+                unrouted_sinks.remove(sink_wire_pkey)
+
+        return dict(
+                wires=wires,
+                unrouted_sinks=unrouted_sinks,
+                unrouted_sources=unrouted_sources,
+                wire_pkey_to_wire=wire_pkey_to_wire,
+                source_bels=source_bels,
+                wire_assigns=wire_assigns,
+                shorted_nets=shorted_nets,
+                )
+
+    def check_site(self):
+        """ Sanity checks that the site is internally consistent. """
+        internal_sources = set(self.internal_sources.keys())
+        sinks = set(self.sinks.keys())
+        sources = set(self.sources.keys())
+
+        assert len(internal_sources & sinks) == 0, (internal_sources & sinks)
+        assert len(internal_sources & sources) == 0, (internal_sources & sources)
+
+        bel_ids = set()
+        for bel in self.bels:
+            bel_ids.add(id(bel))
+
+        for bel_pair in self.sources.values():
+            if bel_pair is not None:
+                bel, _ = bel_pair
+                assert id(bel) in bel_ids
+
+        for sinks in self.sinks.values():
+            for bel, _ in sinks:
+                assert id(bel) in bel_ids
+
+        for bel_pair in self.internal_sources.values():
+            if bel_pair is not None:
+                bel, _ = bel_pair
+                assert id(bel) in bel_ids
+
+
+    def maybe_get_bel(self, name):
+        """ Returns named BEL from site.
+
+        name (str): Name given during Site.add_bel.
+
+        Returns None if name is not found, otherwise Bel object.
+        """
+        if name in self.bel_map:
+            return self.bel_map[name]
+        else:
+            return None
+
+    def remove_bel(self, bel_to_remove):
+        """ Attempts to remove BEL from site.
+
+        It is an error to remove a BEL if any of its outputs are currently
+        in use by the Site.  This method does NOT verify that the sources
+        of the BEL are not currently in use.
+
+        """
+        bel_idx = None
+        for idx, bel in enumerate(self.bels):
+            if id(bel) == id(bel_to_remove):
+                bel_idx = idx
+                break
+
+        assert bel_idx is not None
+
+        # Make sure none of the BEL sources are in use
+        for bel in self.bels:
+            if id(bel) == id(bel_to_remove):
+                continue
+
+            for site_wire in bel.connections.values():
+                assert site_wire not in bel_to_remove.outputs, site_wire
+
+        # BEL is not used internal, preceed with removal.
+        del self.bels[bel_idx]
+        removed_sinks = []
+        removed_sources = []
+
+        for sink_wire, bels_using_sink in self.sinks.items():
+            bel_idx = None
+            for idx, (bel, _) in enumerate(bels_using_sink):
+                if id(bel) == id(bel_to_remove):
+                    bel_idx = idx
+                    break
+
+            if bel_idx is not None:
+                del bels_using_sink[bel_idx]
+
+            if len(bels_using_sink) == 0:
+                removed_sinks.append(self.site_wire_to_wire_pkey[sink_wire])
+
+        sources_to_remove = []
+        for source_wire, (bel, _) in self.sources.items():
+            if id(bel) == id(bel_to_remove):
+                removed_sources.append(self.site_wire_to_wire_pkey[source_wire])
+                sources_to_remove.append(source_wire)
+
+        for wire in sources_to_remove:
+            del self.sources[wire]
+
+        return removed_sinks, removed_sources
+
+
+@functools.lru_cache(maxsize=None)
+def make_site_pin_map(site_pins):
+    """ Create map of site pin names to tile wire names. """
+    site_pin_map = {}
+
+    for site_pin in site_pins:
+        site_pin_map[site_pin.name] = site_pin.wire
+
+    return site_pin_map
+
+
+def merge_exclusive_sets(set_a, set_b):
+    """ set_b into set_a after verifying that set_a and set_b are disjoint. """
+    assert len(set_a & set_b) == 0, (set_a & set_b)
+
+    set_a |= set_b
+
+def merge_exclusive_dicts(dict_a, dict_b):
+    """ dict_b into dict_a after verifying that dict_a and dict_b have disjoint keys. """
+    assert len(set(dict_a.keys()) & set(dict_b.keys())) == 0
+
+    dict_a.update(dict_b)
+
+
+class Module(object):
+    """ Object to model a design. """
+    def __init__(self, db, grid, conn):
+        self.iostandard = None
+        self.db = db
+        self.grid = grid
+        self.conn = conn
+        self.sites = []
+        self.source_bels = {}
+
+        # Map of source to sink.
+        self.shorted_nets = {}
+
+        # Map of wire_pkey to Verilog wire.
+        self.wire_pkey_to_wire = {}
+
+        # wire_pkey of sinks that are not connected to their routing.
+        self.unrouted_sinks = set()
+
+        # wire_pkey of sources that are not connected to their routing.
+        self.unrouted_sources = set()
+
+        # Known active pips, tuples of sink and source wire_pkey's.
+        # The sink wire_pkey is a net with the source wire_pkey.
+        self.active_pips = set()
+
+        self.root_in = set()
+        self.root_out = set()
+        self.root_inout = set()
+
+        self.wires = set()
+        self.wire_assigns = {}
+
+    def set_iostandard(self, iostandards):
+        """ Set the IOSTANDARD for the design.
+
+        iostandards (list of list of str): Takes a list of IOSTANDARD
+            possibilities and selects the unique one.  Having no valid or
+            multiple valid IOSTANDARDs is an error.
+        """
+        possible_iostandards = set(iostandards[0])
+
+        for l in iostandards:
+            possible_iostandards &= set(l)
+
+        if len(possible_iostandards) != 1:
+            raise RuntimeError('Ambigous IOSTANDARD, must specify possibilities: {}'.format(possible_iostandards))
+
+        self.iostandard = possible_iostandards.pop()
+
+    def add_top_in_port(self, tile, site, name):
+        """ Add a top level input port.
+
+        tile (str): Tile name that will sink the input port.
+        site (str): Site name that will sink the input port.
+        name (str): Name of port.
+
+        Returns str of root level port name.
+        """
+        port = '{}_{}_{}'.format(tile, site, name)
+        self.root_in.add(port)
+        return port
+
+    def add_top_out_port(self, tile, site, name):
+        """ Add a top level output port.
+
+        tile (str): Tile name that will sink the output port.
+        site (str): Site name that will sink the output port.
+        name (str): Name of port.
+
+        Returns str of root level port name.
+        """
+        port = '{}_{}_{}'.format(tile, site, name)
+        self.root_out.add(port)
+        return port
+
+    def add_top_inout_port(self, tile, site, name):
+        """ Add a top level inout port.
+
+        tile (str): Tile name that will sink the inout port.
+        site (str): Site name that will sink the inout port.
+        name (str): Name of port.
+
+        Returns str of root level port name.
+        """
+        port = '{}_{}_{}'.format(tile, site, name)
+        self.root_inout.add(port)
+        return port
+
+    def is_top_level(self, wire):
+        """ Returns true if specified wire is a top level wire. """
+        return wire in self.root_in or wire in self.root_out or wire in self.root_inout
+
+    def add_site(self, site):
+        """ Adds a site to the module. """
+        integrated_site = site.integrate_site(self.conn, self)
+
+        merge_exclusive_sets(self.wires, integrated_site['wires'])
+        merge_exclusive_sets(self.unrouted_sinks, integrated_site['unrouted_sinks'])
+        merge_exclusive_sets(self.unrouted_sources, integrated_site['unrouted_sources'])
+
+        merge_exclusive_dicts(self.wire_pkey_to_wire, integrated_site['wire_pkey_to_wire'])
+        merge_exclusive_dicts(self.source_bels, integrated_site['source_bels'])
+        merge_exclusive_dicts(self.wire_assigns, integrated_site['wire_assigns'])
+        merge_exclusive_dicts(self.shorted_nets, integrated_site['shorted_nets'])
+
+        self.sites.append(site)
+
+    def make_routes(self, allow_orphan_sinks):
+        """ Create nets from top level wires, activie PIPS, sources and sinks.
+
+        Invoke make_routes after all sites and pips have been added.
+
+        allow_orphan_sinks (bool): Controls whether it is an error if a sink
+            has no source.
+
+        """
+        self.nets = {}
+        self.net_map = {}
+        for sink_wire, src_wire in make_routes(
+                db=self.db,
+                conn=self.conn,
+                wire_pkey_to_wire=self.wire_pkey_to_wire,
+                unrouted_sinks=self.unrouted_sinks,
+                unrouted_sources=self.unrouted_sources,
+                active_pips=self.active_pips,
+                allow_orphan_sinks=allow_orphan_sinks,
+                shorted_nets=self.shorted_nets,
+                nets=self.nets,
+                net_map=self.net_map,):
+            self.wire_assigns[sink_wire] = src_wire
+
+        self.handle_post_route_cleanup()
+
+    def output_verilog(self):
+        """ Yields lines of verilog that represent the design in Verilog.
+
+        Invoke output_verilog after invoking make_routes to ensure that
+        inter-site connections are made.
+
+        """
+        root_module_args = []
+        for in_wire in sorted(self.root_in):
+            root_module_args.append('  input ' + in_wire)
+        for out_wire in sorted(self.root_out):
+            root_module_args.append('  output ' + out_wire)
+        for inout_wire in sorted(self.root_inout):
+            root_module_args.append('  inout ' + inout_wire)
+
+        yield 'module top('
+
+        yield ',\n'.join(root_module_args)
+
+        yield '  );'
+
+        for wire in sorted(self.wires):
+            yield '  wire {};'.format(wire)
+
+        for site in self.sites:
+            for bel in site.bels:
+                yield ''
+                for l in bel.output_verilog(self, indent='  '):
+                    yield l
+
+        for lhs, rhs in self.wire_assigns.items():
+            yield '  assign {} = {};'.format(lhs, rhs)
+
+        yield 'endmodule'
+
+    def output_bel_locations(self):
+        """ Yields lines of tcl that will assign set the location of BELs. """
+        for bel in self.get_bels():
+            yield """
+set cell [get_cells {cell}]
+if {{ $cell == {{}} }} {{
+    error "Failed to find cell!"
+}}
+set_property LOC [get_sites {site}] $cell""".format(
+                cell=bel.get_cell(),
+                site=bel.site)
+
+            if bel.bel is not None:
+                yield """
+set_property BEL "[get_property SITE_TYPE [get_sites {site}]].{bel}" $cell""".format(
+                    site=bel.site,
+                    bel=bel.bel,
+                    )
+
+    def output_nets(self):
+        """ Yields lines of tcl that will assign the exact routing path for nets.
+
+        Invoke output_nets after invoking make_routes.
+
+        """
+        assert len(self.nets) > 0
+
+        for net_wire_pkey, net in self.nets.items():
+            if net_wire_pkey in [ZERO_NET, ONE_NET]:
+                continue
+
+            if net_wire_pkey not in self.source_bels:
+                continue
+
+            if not net.is_net_alive():
+                continue
+
+            bel, pin = self.source_bels[net_wire_pkey]
+
+            yield """
+set pin [get_pins {cell}/{pin}]
+if {{ $pin == {{}} }} {{
+    error "Failed to find pin!"
+}}
+set net [get_nets -of_object $pin]
+if {{ $net == {{}} }} {{
+    error "Failed to find net!"
+}}
+set_property FIXED_ROUTE {fixed_route} $net
+""".format(
+        cell=bel.get_cell(),
+        pin=pin,
+        fixed_route=' '.join(
+            net.make_fixed_route(self.conn, self.wire_pkey_to_wire)))
+
+    def get_bels(self):
+        """ Yield a list of Bel objects in the module. """
+        for site in self.sites:
+            for bel in site.bels:
+                yield bel
+
+    def handle_post_route_cleanup(self):
+        """ Handle post route clean-up. """
+        for site in self.sites:
+            if site.post_route_cleanup is not None:
+                site.post_route_cleanup(self, site)
+
+        prune_antennas(self.conn, self.nets, self.unrouted_sinks)
+
+    def find_sinks_from_source(self, site, site_wire):
+        """ Yields sink wire names from a site wire source. """
+        wire_pkey = site.site_wire_to_wire_pkey[site_wire]
+        assert wire_pkey in self.nets
+
+        source_wire = self.wire_pkey_to_wire[wire_pkey]
+
+        for sink_wire, other_source_wire in self.wire_assigns.items():
+            if source_wire == other_source_wire:
+                yield sink_wire
+
+    def remove_bel(self, site, bel):
+        """ Remove a BEL from the module.
+
+        If this is the last use of a site sink, then that wire and wire
+        connection is removed.
+        """
+
+        removed_sinks, removed_sources = site.remove_bel(bel)
+
+        # Make sure none of the sources are in use.
+        for wire_pkey in removed_sources:
+            source_wire = self.wire_pkey_to_wire[wire_pkey]
+
+            for _, other_source_wire in self.wire_assigns.items():
+                assert source_wire != other_source_wire, source_wire
+
+            self.unrouted_sources.remove(wire_pkey)
+            del self.source_bels[wire_pkey]
+
+        # Remove the sinks from the wires, wire assigns, and net
+        for wire_pkey in removed_sinks:
+            self.wires.remove(self.wire_pkey_to_wire[wire_pkey])
+            if wire_pkey in self.wire_assigns:
+                del self.wire_assigns[wire_pkey]
+
+            self.unrouted_sinks.remove(wire_pkey)

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -55,7 +55,18 @@ function(ADD_XC7_ARCH_DEFINE)
         --frm_file \${OUT_BITSTREAM} \
         --output_file \${OUT_BIN} \
         \${BIT_TO_BIN_EXTRA_ARGS}"
-    NO_BIT_TO_V
+    BIT_TO_V bitread
+    BIT_TO_V_CMD "${CMAKE_COMMAND} -E env \
+    PYTHONPATH=${symbiflow-arch-defs_BINARY_DIR}/env/conda/lib/python3.7/site-packages:${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm:${symbiflow-arch-defs_SOURCE_DIR}/xc7 \
+        \${PYTHON3} -mfasm2bels \
+        \${BIT_TO_V_EXTRA_ARGS} \
+        --db_root ${PRJXRAY_DB_DIR}/${ARCH} \
+        --iostandard LVCMOS33 \
+        --bitread $<TARGET_FILE:bitread> \
+        --bit_file \${OUT_BIN} \
+        --fasm_file \${OUT_BIN}.fasm \
+        --top \${TOP} \
+        \${OUT_BIT_VERILOG} \${OUT_BIT_VERILOG}.tcl"
     NO_BIT_TIME
     USE_FASM
     RR_GRAPH_EXT ".xml"

--- a/xc7/make/device_define.cmake
+++ b/xc7/make/device_define.cmake
@@ -33,6 +33,11 @@ function(ADD_XC7_DEVICE_DEFINE_TYPE)
     --part_name ${ROI_PART} \
     --part_file ${PRJXRAY_DB_DIR}/${ARCH}/${ROI_PART}.yaml \
   ")
+  set_target_properties(${ARCH}_${DEVICE}_${NAME}
+      PROPERTIES BIT_TO_V_EXTRA_ARGS " \
+    --part ${ROI_PART}
+    --connection_database ${CMAKE_CURRENT_BINARY_DIR}/channels.db
+  ")
 
   project_xray_arch(
     PART ${ARCH}


### PR DESCRIPTION
This correctly works on designs with the following restrictions:
 - IO's must not use IDDR, ODDR, ISERDES, or OSERDES
 - IO's must be single ended
 - Only sites from IOB33, IOI33, CLBxx_x, BRAM_x, BUFGCTRL and BUFHCE tiles are supported.
 - RAMB36 is not supported
 - RAMB18 designs will have different routing for constants connected to the WEBWE and WEA ports.  This results in a significant different in routing pips, but should result in functionally identical output.
 - Constant routes are not explicitly specified, resulting in a small feature variations, but no functional differences.
 - VPR designs should use all top-level ports, or significant differences will result.