### PR TITLE
Move output writing into Yosys tcl script.

### DIFF
--- a/ice40/yosys/synth.tcl
+++ b/ice40/yosys/synth.tcl
@@ -15,3 +15,5 @@ opt_expr -undriven
 opt_clean
 
 setundef -zero -params
+write_blif -attr -cname -param $::env(OUT_EBLIF)
+write_verilog $::env(OUT_SYNTH_V)

--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -819,7 +819,7 @@ function(ADD_FPGA_TARGET)
   if(NOT ${ADD_FPGA_TARGET_NO_SYNTHESIS})
     set(
       COMPLETE_YOSYS_SCRIPT
-      "tcl ${YOSYS_SCRIPT} $<SEMICOLON> write_blif -attr -cname -param ${OUT_EBLIF} $<SEMICOLON> write_verilog ${OUT_SYNTH_V}"
+      "tcl ${YOSYS_SCRIPT}"
     )
 
     add_custom_command(
@@ -830,7 +830,11 @@ function(ADD_FPGA_TARGET)
       COMMAND
         ${CMAKE_COMMAND} -E make_directory ${OUT_LOCAL}
       COMMAND
-        ${CMAKE_COMMAND} -E env symbiflow-arch-defs_SOURCE_DIR=${symbiflow-arch-defs_SOURCE_DIR} ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SCRIPT}" -l ${OUT_EBLIF}.log ${SOURCE_FILES}
+        ${CMAKE_COMMAND} -E env
+          symbiflow-arch-defs_SOURCE_DIR=${symbiflow-arch-defs_SOURCE_DIR}
+          OUT_EBLIF=${OUT_EBLIF}
+          OUT_SYNTH_V=${OUT_SYNTH_V}
+          ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SCRIPT}" -l ${OUT_EBLIF}.log ${SOURCE_FILES}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       VERBATIM
     )

--- a/testarch/yosys/synth.tcl
+++ b/testarch/yosys/synth.tcl
@@ -3,3 +3,6 @@ yosys -import
 synth -top top -flatten
 abc -lut 4
 opt_clean
+
+write_blif -attr -cname -param $::env(OUT_EBLIF)
+write_verilog $::env(OUT_SYNTH_V)

--- a/xc7/yosys/synth.tcl
+++ b/xc7/yosys/synth.tcl
@@ -15,3 +15,5 @@ opt_clean
 
 setundef -zero -params
 stat
+write_blif -attr -cname -param $::env(OUT_EBLIF)
+write_verilog $::env(OUT_SYNTH_V)


### PR DESCRIPTION
This is required to enable 7-series constant generator support using the
write_blif -true/-false arguments.