### PR TITLE
Fix database cache for in progress transactions.

### DIFF
--- a/xc7/utils/prjxray_db_cache.py
+++ b/xc7/utils/prjxray_db_cache.py
@@ -50,6 +50,10 @@ class DatabaseCache(object):
 
         # Write back only if not read-only
         if not self.read_only:
+            if self.memory_connection.in_transaction:
+                assert exc_type is not None, "Outstanding transaction, but no exception?"
+                self.memory_connection.rollback()
+
             print("Dumping database to '{}'".format(self.file_name))
             self.memory_connection.backup(self.file_connection, pages=100, progress=self._progress)
 


### PR DESCRIPTION
If the database cache __exit__ method is called when a transaction
is in progress, it will never proceed.  Handle the exception case by
rolling back, and generate an assertion error in the nominal path.

Fixes #482.