### PR TITLE
Convert testarch to graph2 library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,21 @@ add_conda_package(
   PROVIDES iverilog vvp
   )
 
+add_conda_pip(
+  NAME progressbar2
+  NO_EXE
+)
+
+add_conda_pip(
+  NAME simplejson
+  NO_EXE
+)
+
+add_conda_pip(
+  NAME intervaltree
+  NO_EXE
+)
+
 include(make/image_gen.cmake)
 include(make/gen.cmake)
 

--- a/testarch/devices/CMakeLists.txt
+++ b/testarch/devices/CMakeLists.txt
@@ -7,6 +7,7 @@ define_device(
   ARCH testarch
   DEVICE_TYPE clutff-unidir-s4
   PACKAGES dummy
+  RR_PATCH_DEPS intervaltree progressbar2
   )
 
 define_device(
@@ -14,4 +15,5 @@ define_device(
   ARCH testarch
   DEVICE_TYPE clutff-unidir-s4
   PACKAGES dummy
+  RR_PATCH_DEPS intervaltree progressbar2
   )

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -243,7 +243,7 @@ def graph_from_xml(input_xml, progressbar=None):
 class Graph(object):
     def __init__(self, input_xml, output_file_name=None, progressbar=None):
         if progressbar is None:
-            self.progressbar = lambda x: x
+            progressbar = lambda x: x
 
         self.input_xml = input_xml
         self.progressbar = progressbar

--- a/xc7/CMakeLists.txt
+++ b/xc7/CMakeLists.txt
@@ -4,19 +4,4 @@ set(PRJXRAY_DB_DIR
   ${symbiflow-arch-defs_SOURCE_DIR}/third_party/prjxray-db
   CACHE PATH "Path to prjxray database files")
 
-add_conda_pip(
-  NAME progressbar2
-  NO_EXE
-)
-
-add_conda_pip(
-  NAME simplejson
-  NO_EXE
-)
-
-add_conda_pip(
-  NAME intervaltree
-  NO_EXE
-)
-
 include(arch.cmake)


### PR DESCRIPTION
Removes use of graph (per #339) and lays groundwork for constant routing experiment.

This also exposed some bugs in some paths of the graph2 library, which are fixed.

Also fixes #486