### PR TITLE
Lock miniconda version.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,11 @@ include(make/devices.cmake)
 
 find_package(PythonInterp 3 REQUIRED)
 
-setup_env()
+# Using miniconda3 4.5.4 instead of later (e.g. 4.5.12) because of Python 3.7
+# deprecation warnings in progressbar2 (and possible others).
+setup_env(
+    MINICONDA3_VERSION 4.5.4
+    )
 add_conda_package(
   NAME yosys
   PROVIDES yosys

--- a/make/env.cmake
+++ b/make/env.cmake
@@ -26,6 +26,18 @@ function(SETUP_ENV)
   # will cause get_target_property(var env VPR) to return $ENV{VPR}.
   #
   # FIXME: Consider using CMake CACHE variables instead of target properties.
+
+  set(options)
+  set(oneValueArgs MINICONDA3_VERSION)
+  set(multiValueArgs)
+  cmake_parse_arguments(
+      SETUP_ENV
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
+
   add_custom_target(env)
   set(ENV_DIR ${symbiflow-arch-defs_BINARY_DIR}/env)
   add_custom_target(clean_env
@@ -43,7 +55,7 @@ function(SETUP_ENV)
   if(${USE_CONDA})
     set_target_properties(env PROPERTIES USE_CONDA TRUE)
 
-    set(MINICONDA_FILE Miniconda3-latest-Linux-x86_64.sh)
+    set(MINICONDA_FILE Miniconda3-${SETUP_ENV_MINICONDA3_VERSION}-Linux-x86_64.sh)
     set(MINICONDA_URL https://repo.continuum.io/miniconda/${MINICONDA_FILE})
     find_program(WGET wget)
     add_custom_command(


### PR DESCRIPTION
Following the same philosophy for conda packages, this PR locks the miniconda version to a particular version, rather than grabbing the latest version.