### PR TITLE
Tile grid location mapping

### DIFF
--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -262,3 +262,11 @@ CREATE TABLE constant_sources(
     FOREIGN KEY(vcc_track_pkey) REFERENCES track(pkey),
     FOREIGN KEY(gnd_track_pkey) REFERENCES track(pkey)
 );
+
+-- Grid location map.
+CREATE TABLE grid_loc_map(
+    phy_tile_pkey INT,
+    vpr_tile_pkey INT,
+    FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
+    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
+);

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -51,7 +51,17 @@ CREATE TABLE site_type(
   name TEXT
 );
 
--- Tile table, contains type and name of tile and location in grid.
+-- Tile table, contains type and name of tile and location in the physical grid.
+CREATE TABLE phy_tile(
+  pkey INTEGER PRIMARY KEY,
+  name TEXT,
+  tile_type_pkey INT,
+  grid_x INT,
+  grid_y INT,
+  FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+);
+
+-- Tile table, contains type and name of tile and location in the VPR grid.
 CREATE TABLE tile(
   pkey INTEGER PRIMARY KEY,
   name TEXT,

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+import sqlite3
+import argparse
+import os
+import itertools
+
+# =============================================================================
+
+class GridLocMap(object):
+    """
+    This class preforms forward (physical -> VPR) and backward (VPR -> physical)
+    grid location mapping.
+    """
+
+    def __init__(self, db_conn):
+
+        # Create a database cursor
+        self.db_cursor = db_conn.cursor()
+
+        # Get the whole table
+        grid_loc_map = self.db_cursor.execute(
+            "SELECT grid_phy_x, grid_phy_y, grid_vpr_x, grid_vpr_y FROM grid_loc_map"
+        ).fetchall()
+
+        # Build maps
+        self.fwd_loc_map = {}
+        self.bwd_loc_map = {}
+
+        for loc_pair in grid_loc_map:
+            phy_loc = loc_pair[0:2]
+            vpr_loc = loc_pair[2:4]
+
+            if phy_loc not in self.fwd_loc_map.keys():
+                self.fwd_loc_map[phy_loc] = []
+            self.fwd_loc_map[phy_loc].append(vpr_loc)
+
+            if vpr_loc not in self.bwd_loc_map.keys():
+                self.bwd_loc_map[vpr_loc] = []
+            self.bwd_loc_map[vpr_loc].append(phy_loc)
+
+    def get_vpr_loc(self, grid_loc):
+        return tuple(self.fwd_loc_map[grid_loc])
+
+    def get_phy_loc(self, grid_loc):
+        return tuple(self.bwd_loc_map[grid_loc])
+
+# =============================================================================
+
+def create_tables(conn):
+    """
+    Creates database tables related to grid location mappings
+    """
+
+    sql_file = os.path.join(os.path.dirname(__file__), "grid_mapping.sql")
+
+    with open(sql_file, "r") as fp:
+        cursor = conn.cursor()
+        cursor.executescript(fp.read())
+        conn.commit()
+
+def get_phy_grid_extent(conn):
+    """
+    Returns a tuple with (xmin, ymin, xmax, ymax) which defines
+    the grid extent.
+    """
+
+    # Get coordinates of all tiles
+    cursor = conn.cursor()
+    coords = list(cursor.execute("SELECT grid_x, grid_y FROM phy_tile"))
+
+    # Determine extent
+    xmin = min([loc[0] for loc in coords])
+    xmax = max([loc[0] for loc in coords])
+    ymin = min([loc[1] for loc in coords])
+    ymax = max([loc[1] for loc in coords])
+
+    return (xmin, ymin, xmax, ymax)
+
+def get_vpr_grid_extent(conn):
+    """
+    Returns a tuple with (xmin, ymin, xmax, ymax) which defines
+    the grid extent.
+    """
+
+    # Get coordinates of all tiles
+    cursor = conn.cursor()
+    coords = list(cursor.execute("SELECT grid_x, grid_y FROM tile"))
+
+    # Determine extent
+    xmin = min([loc[0] for loc in coords])
+    xmax = max([loc[0] for loc in coords])
+    ymin = min([loc[1] for loc in coords])
+    ymax = max([loc[1] for loc in coords])
+
+    return (xmin, ymin, xmax, ymax)
+
+def initialize_one_to_one_map(conn):
+    """
+    Initializes a one to one mapping of grid coordinates. The grid must be
+    imported to the database before calling this function.
+    """
+
+    cursor = conn.cursor()
+
+    # Clear the table (just in case)
+    cursor.executescript("DELETE FROM grid_loc_map; VACUUM;")
+
+    # Get the physical grid extent
+    extent = get_phy_grid_extent(conn)
+
+    # Make a one-to-one map
+    for x, y in itertools.product(range(extent[0], extent[2]+1), range(extent[1], extent[3]+1)):
+        cursor.execute("INSERT INTO grid_loc_map VALUES (?, ?, ?, ?);", (x, y, x, y))
+
+    cursor.execute("COMMIT TRANSACTION;")
+    cursor.connection.commit()
+
+# =============================================================================
+
+def main():
+    """
+    When executed adds grid location map table(s) to the database and initializes
+    a "dummy" one-to-one map.
+    """
+
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", type=str, required=True, help="Database file")
+
+    args = parser.parse_args()
+
+    # Open the DB
+    conn = sqlite3.Connection(args.db)
+
+    # Create table
+    create_tables(conn)
+
+    # Initialize one-to-one mapping
+    initialize_one_to_one_map(conn)
+
+    conn.close()
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()
+

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -31,8 +31,8 @@ class GridLocMap(object):
         bwd_loc_map = {}
 
         # Make a one-to-one map
-        for x, y in itertools.product(range(xmin, xmax + 1),
-                                      range(ymin, ymax + 1)):
+        for x, y in itertools.product(range(xmin, xmax + 1), range(ymin,
+                                                                   ymax + 1)):
 
             fwd_loc_map[(x, y)] = [(x, y)]
             bwd_loc_map[(x, y)] = [(x, y)]
@@ -58,8 +58,8 @@ class GridLocMap(object):
         bwd_loc_map = {}
 
         # Make a one-to-one map
-        for x, y in itertools.product(range(xmin, xmax + 1),
-                                      range(ymin, ymax + 1)):
+        for x, y in itertools.product(range(xmin, xmax + 1), range(ymin,
+                                                                   ymax + 1)):
 
             phy_loc = (x, y)
             vpr_loc = (x + shift_x, y + shift_y)
@@ -82,14 +82,16 @@ class GridLocMap(object):
         c = conn.cursor()
 
         # Query the grid map from the database
-        grid_loc_map = c.execute("""
+        grid_loc_map = c.execute(
+            """
 SELECT phy.grid_x, phy.grid_y, vpr.grid_x, vpr.grid_y
 FROM phy_tile phy
 INNER JOIN grid_loc_map map
 ON phy.pkey = map.phy_tile_pkey
 INNER JOIN tile vpr
 ON vpr.pkey = map.vpr_tile_pkey
-""").fetchall()
+"""
+        ).fetchall()
 
         # Build maps
         fwd_loc_map = {}
@@ -115,6 +117,7 @@ ON vpr.pkey = map.vpr_tile_pkey
 
     def get_phy_loc(self, grid_loc):
         return tuple(self.bwd_loc_map[grid_loc])
+
 
 # =============================================================================
 
@@ -169,9 +172,8 @@ def get_vpr_grid_extent(conn):
 
     return (xmin, ymin, xmax, ymax)
 
-# =============================================================================
 
+# =============================================================================
 
 if __name__ == "__main__":
     main()
-

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -21,8 +21,13 @@ class GridLocMap(object):
     def generate_one_to_one_map(extent):
         """
         Generates a one-to-one map for specified location range.
-        :param extent:
-        :return:
+
+        Args:
+            extent: A 4-element tuple with the grid extent:
+                xmin, ymin, xmax, ymax
+
+        Returns:
+            A GridLocMap object with the grid mapping.
         """
 
         xmin, ymin, xmax, ymax = extent
@@ -45,11 +50,15 @@ class GridLocMap(object):
         """
         Generates a one-to-one map for specified location range. For debugging
         purposes.
-        :param extent:
-        :param shift_x:
-        :param shift_y:
 
-        :return:
+        Args:
+            extent: A 4-element tuple with the grid extent:
+                xmin, ymin, xmax, ymax
+            shift_x: Grid shift in X axis
+            shift_y: Grid shift in Y axis
+
+        Returns:
+            A GridLocMap object with the grid mapping.
         """
 
         xmin, ymin, xmax, ymax = extent
@@ -75,8 +84,12 @@ class GridLocMap(object):
         """
         Loads grid location mapping from a SQL database. Returns a GridLocMap
         object.
-        :param conn:
-        :return:
+
+        Args:
+            conn: A database connection object
+
+        Returns:
+            A GridLocMap object with the grid mapping.
         """
 
         c = conn.cursor()
@@ -91,7 +104,7 @@ ON phy.pkey = map.phy_tile_pkey
 INNER JOIN tile vpr
 ON vpr.pkey = map.vpr_tile_pkey
 """
-        ).fetchall()
+        )
 
         # Build maps
         fwd_loc_map = {}
@@ -113,26 +126,13 @@ ON vpr.pkey = map.vpr_tile_pkey
         return GridLocMap(fwd_loc_map, bwd_loc_map)
 
     def get_vpr_loc(self, grid_loc):
-        return tuple(self.fwd_loc_map[grid_loc])
+        return self.fwd_loc_map[grid_loc]
 
     def get_phy_loc(self, grid_loc):
-        return tuple(self.bwd_loc_map[grid_loc])
+        return self.bwd_loc_map[grid_loc]
 
 
 # =============================================================================
-
-
-def create_tables(conn):
-    """
-    Creates database tables related to grid location mappings
-    """
-
-    sql_file = os.path.join(os.path.dirname(__file__), "grid_mapping.sql")
-
-    with open(sql_file, "r") as fp:
-        cursor = conn.cursor()
-        cursor.executescript(fp.read())
-        conn.commit()
 
 
 def get_phy_grid_extent(conn):
@@ -151,7 +151,7 @@ def get_phy_grid_extent(conn):
     ymin = min([loc[1] for loc in coords])
     ymax = max([loc[1] for loc in coords])
 
-    return (xmin, ymin, xmax, ymax)
+    return xmin, ymin, xmax, ymax
 
 
 def get_vpr_grid_extent(conn):
@@ -170,7 +170,7 @@ def get_vpr_grid_extent(conn):
     ymin = min([loc[1] for loc in coords])
     ymax = max([loc[1] for loc in coords])
 
-    return (xmin, ymin, xmax, ymax)
+    return xmin, ymin, xmax, ymax
 
 
 # =============================================================================

--- a/utils/lib/grid_mapping.sql
+++ b/utils/lib/grid_mapping.sql
@@ -1,0 +1,12 @@
+-- Grid location map
+-- This table maps locations from the input (physical) grid to the VPR grid
+-- locations and vice versa. If there are multiple entries for the same physical
+-- location (grid_phy_x, grid_phy_y) then it means that a single physical tile 
+-- should end up being splitted.
+CREATE TABLE IF NOT EXISTS grid_loc_map(
+    grid_phy_x INT,
+    grid_phy_y INT,
+    grid_vpr_x INT,
+    grid_vpr_y INT
+);
+

--- a/utils/lib/grid_mapping.sql
+++ b/utils/lib/grid_mapping.sql
@@ -1,8 +1,0 @@
--- Grid location map
-CREATE TABLE IF NOT EXISTS grid_loc_map(
-    phy_tile_pkey INT,
-    vpr_tile_pkey INT,
-    FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
-    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
-);
-

--- a/utils/lib/grid_mapping.sql
+++ b/utils/lib/grid_mapping.sql
@@ -1,12 +1,8 @@
 -- Grid location map
--- This table maps locations from the input (physical) grid to the VPR grid
--- locations and vice versa. If there are multiple entries for the same physical
--- location (grid_phy_x, grid_phy_y) then it means that a single physical tile 
--- should end up being splitted.
 CREATE TABLE IF NOT EXISTS grid_loc_map(
-    grid_phy_x INT,
-    grid_phy_y INT,
-    grid_vpr_x INT,
-    grid_vpr_y INT
+    phy_tile_pkey INT,
+    vpr_tile_pkey INT,
+    FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
+    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
 );
 

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -31,7 +31,6 @@ function(ADD_XC7_ARCH_DEFINE)
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \
     PYTHONPATH=${PRJXRAY_DIR}:${symbiflow-arch-defs_SOURCE_DIR}/utils:${symbiflow-arch-defs_BINARY_DIR}/utils \
         \${PYTHON3} \${RR_PATCH_TOOL} \
-        --db_root ${PRJXRAY_DB_DIR}/${ARCH} \
         --read_rr_graph \${OUT_RRXML_VIRT} \
         --write_rr_graph \${OUT_RRXML_REAL}"
     PLACE_TOOL

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -166,6 +166,9 @@ function(PROJECT_XRAY_ARCH)
   set(ROI_ARG "")
   set(ROI_ARG_FOR_CREATE_EDGES "")
 
+  set(SYNTH_TILES_DEPS "")
+  append_file_dependency(SYNTH_TILES_DEPS ${GENERIC_CHANNELS})
+
   if(NOT "${PROJECT_XRAY_ARCH_USE_ROI}" STREQUAL "")
     add_custom_command(
       OUTPUT synth_tiles.json
@@ -177,7 +180,7 @@ function(PROJECT_XRAY_ARCH)
         --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json
       DEPENDS
         ${CREATE_SYNTH_TILES}
-        ${PROJECT_XRAY_ARCH_USE_ROI} ${CMAKE_CURRENT_BINARY_DIR}/channels.db
+        ${PROJECT_XRAY_ARCH_USE_ROI} ${SYNTH_TILES_DEPS}
         ${PYTHON3} ${PYTHON3_TARGET} simplejson intervaltree
         )
 

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -200,6 +200,8 @@ function(PROJECT_XRAY_ARCH)
   append_file_dependency(DEPS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/pin_assignments.json)
   get_file_location(PIN_ASSIGNMENTS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/pin_assignments.json)
 
+  append_file_dependency(DEPS ${GENERIC_CHANNELS})
+
   string(REPLACE ";" "," TILE_TYPES_COMMA "${PROJECT_XRAY_ARCH_TILE_TYPES}")
 
   add_custom_command(
@@ -215,7 +217,7 @@ function(PROJECT_XRAY_ARCH)
       ${ROI_ARG}
     DEPENDS
     ${ARCH_IMPORT}
-    ${DEPS} ${CMAKE_CURRENT_BINARY_DIR}/channels.db
+    ${DEPS}
     ${PYTHON3} ${PYTHON3_TARGET} simplejson
     )
 

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -5,8 +5,8 @@ By default this will generate a complete arch XML for all tile types specified.
 If the --use_roi flag is passed, only the tiles within the ROI will be included,
 and synthetic IO pads will be created and connected to the routing fabric.
 The mapping of the pad name to synthetic tile location will be outputted to the
-file specified in the --synth_tiles output argument.  This can be used to generate
-IO placement spefications to target the synthetic IO pads.
+file specified in the --synth_tiles output argument.  This can be used to
+generate IO placement spefications to target the synthetic IO pads.
 
 """
 from __future__ import print_function
@@ -24,8 +24,11 @@ from prjxray.grid_types import GridLoc
 from prjxray_db_cache import DatabaseCache
 from lib.grid_mapping import GridLocMap, get_vpr_grid_extent
 
+
 def create_synth_io_tiles(complexblocklist_xml, pb_name, is_input):
-    """ Creates synthetic IO pad tiles used to connect ROI inputs and outputs to the routing network.
+    """
+    Creates synthetic IO pad tiles used to connect ROI inputs and outputs
+    to the routing network.
     """
     pb_xml = ET.SubElement(
         complexblocklist_xml, 'pb_type', {
@@ -182,8 +185,7 @@ def create_synth_constant_tiles(
 
 
 def add_synthetic_tiles(model_xml, complexblocklist_xml):
-    create_synth_io_tiles(
-        complexblocklist_xml, 'BLK_SY-INPAD', is_input=True)
+    create_synth_io_tiles(complexblocklist_xml, 'BLK_SY-INPAD', is_input=True)
     create_synth_io_tiles(
         complexblocklist_xml, 'BLK_SY-OUTPAD', is_input=False
     )
@@ -219,7 +221,8 @@ def main():
     parser.add_argument(
         '--connection_database',
         help='Database of fabric connectivity',
-        required=True)
+        required=True
+    )
     parser.add_argument(
         '--output-arch',
         nargs='?',
@@ -350,8 +353,8 @@ def main():
         # VBRK tiles are known to have no bitstream data.
         if not is_vbrk and not gridinfo.bits:
             print(
-                '*** WARNING *** Skipping tile {} because it lacks bitstream data.'
-                .format(tile),
+                '*** WARNING *** Skipping tile {} because it lacks bitstream '
+                'data.'.format(tile),
                 file=sys.stderr
             )
 
@@ -361,7 +364,8 @@ def main():
                 'type': vpr_tile_type,
                 'x': str(vpr_loc[0]),
                 'y': str(vpr_loc[1]),
-            })
+            }
+        )
         meta = ET.SubElement(single_xml, 'metadata')
         ET.SubElement(meta, 'meta', {
             'name': 'fasm_prefix',
@@ -470,7 +474,8 @@ def main():
     pin_assignments = json.load(args.pin_assignments)
 
     # Choose smallest distance for block to block connections with multiple
-    # direct_connections.  VPR cannot handle multiple block to block connections.
+    # direct_connections.  VPR cannot handle multiple block to block
+    # connections.
     directs = {}
     for direct in pin_assignments['direct_connections']:
         key = (direct['from_pin'], direct['to_pin'])

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -217,6 +217,10 @@ def main():
         help="""Project X-Ray database to use."""
     )
     parser.add_argument(
+        '--connection_database',
+        help='Database of fabric connectivity',
+        required=True)
+    parser.add_argument(
         '--output-arch',
         nargs='?',
         type=argparse.FileType('w'),

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -243,7 +243,7 @@ def main():
 
         # The object will read data from the DB so it can live
         # outside the scope of the "with" statement
-        grid_loc_mapper = GridLocMap(conn)
+        grid_loc_mapper = GridLocMap.load_from_database(conn)
 
         # Get the VPR grid extent
         vpr_grid_extent = get_vpr_grid_extent(conn)

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -338,6 +338,10 @@ def main():
 
             assert len(synth_tile['pins']) == 1
 
+            # Check location
+            assert vpr_loc.grid_x == synth_tile["loc"]["grid_x"]
+            assert vpr_loc.grid_y == synth_tile["loc"]["grid_y"]
+
             vpr_tile_type = synth_tile_map[synth_tile['pins'][0]['port_type']]
         elif only_emit_roi and not roi.tile_in_roi(vpr_loc):
             # This tile is outside the ROI, skip it.

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -305,20 +305,12 @@ def main():
         with open(args.synth_tiles) as f:
             synth_tiles = json.load(f)
 
-        # Map ROI coordinates to the target VPR grid
-        roi_loc_lo = grid_loc_mapper.get_vpr_loc(
-            (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN']))
-        roi_loc_hi = grid_loc_mapper.get_vpr_loc(
-            (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX']))
-
         roi = Roi(
             db=db,
-            x1=min([p[0] for p in roi_loc_lo
-                    ]),  # One physical grid location may map to more than one
-            y1=min([p[1] for p in roi_loc_lo
-                    ]),  # VPR locations. So here we take min and max.
-            x2=max([p[0] for p in roi_loc_hi]),
-            y2=max([p[1] for p in roi_loc_hi]),
+            x1=j['info']['GRID_X_MIN'],
+            y1=j['info']['GRID_Y_MIN'],
+            x2=j['info']['GRID_X_MAX'],
+            y2=j['info']['GRID_Y_MAX']
         )
 
         synth_tile_map = add_synthetic_tiles(model_xml, complexblocklist_xml)
@@ -343,7 +335,7 @@ def main():
             assert vpr_loc.grid_y == synth_tile["loc"]["grid_y"]
 
             vpr_tile_type = synth_tile_map[synth_tile['pins'][0]['port_type']]
-        elif only_emit_roi and not roi.tile_in_roi(vpr_loc):
+        elif only_emit_roi and not roi.tile_in_roi(loc):
             # This tile is outside the ROI, skip it.
             continue
         elif gridinfo.tile_type in tile_types:

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -307,13 +307,15 @@ def main():
     with DatabaseCache(args.connection_database, read_only=True) as conn:
 
         c = conn.cursor()
+        c2 = conn.cursor()
 
         # List tile wires and site wires
-        tiles = c.execute("SELECT pkey, name FROM tile_type").fetchall()
-        for tile_type_pkey, tile_type in tiles:
+        for tile_type_pkey, tile_type in c2.execute(
+                "SELECT pkey, name FROM tile_type"
+        ):
 
             for wire_name, site_pkey in c.execute(
-                    "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
+        "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
                 (tile_type_pkey, )):
 
                 # Tile wire

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -40,8 +40,8 @@ def handle_direction_connections(conn, direct_connections, edge_assignments):
     # It is expected that all edges_with_mux will lies in a line (e.g. X only or
     # Y only).
     c = conn.cursor()
-    for src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey in progressbar.progressbar(
-            c.execute("""
+    for src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey in \
+            progressbar.progressbar(c.execute("""
 SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")
     ):
 
@@ -89,16 +89,16 @@ SELECT node_pkey FROM wire WHERE pkey = ?""", (dest_wire_pkey, )
         # Find the wire connected to the sink.
         dest_wire = list(node_to_site_pins(conn, dest_node_pkey))
         assert len(dest_wire) == 1
-        destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = dest_wire[
-            0]
+        destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = \
+            dest_wire[0]
 
         c2.execute(
             """
 SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
             (dest_tile_pkey, )
         )
-        dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = c2.fetchone(
-        )
+        dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = \
+            c2.fetchone()
 
         c2.execute(
             """
@@ -213,8 +213,8 @@ SELECT pkey, name, site_pin_pkey FROM wire_in_tile WHERE pkey = ?;""",
             if site_pin_pkey is None:
                 continue
 
-            for pip_pkey, pip, src_wire_in_tile_pkey, dest_wire_in_tile_pkey in c3.execute(
-                    """
+            for pip_pkey, pip, src_wire_in_tile_pkey, dest_wire_in_tile_pkey \
+                    in c3.execute("""
 SELECT
   pkey,
   name,
@@ -237,8 +237,8 @@ WHERE
                     other_wire_in_tile_pkey = src_wire_in_tile_pkey
 
                 # Need to walk from the wire_in_tile table, to the wire table,
-                # to the node table and get track_pkey.
-                # other_wire_in_tile_pkey -> wire pkey -> node_pkey -> track_pkey
+                # to the node table and get track_pkey. other_wire_in_tile_pkey
+                # -> wire pkey -> node_pkey -> track_pkey
                 c4 = conn.cursor()
                 c4.execute(
                     """
@@ -291,7 +291,8 @@ def main():
     parser.add_argument(
         '--connection_database',
         help='Database of fabric connectivity',
-        required=True)
+        required=True
+    )
     parser.add_argument(
         '--pin_assignments',
         help=
@@ -311,11 +312,10 @@ def main():
 
         # List tile wires and site wires
         for tile_type_pkey, tile_type in c2.execute(
-                "SELECT pkey, name FROM tile_type"
-        ):
+                "SELECT pkey, name FROM tile_type"):
 
             for wire_name, site_pkey in c.execute(
-        "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
+                    "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
                 (tile_type_pkey, )):
 
                 # Tile wire
@@ -361,8 +361,8 @@ def main():
         # List of nodes that are channels.
         channel_nodes = []
 
-        # Map of (tile, wire) to track.  This will be used to find channels for pips
-        # that come from EDGES_TO_CHANNEL.
+        # Map of (tile, wire) to track.  This will be used to find channels for
+        # pips that come from EDGES_TO_CHANNEL.
         channel_wires_to_tracks = {}
 
         # Generate track models and verify that wires are either in a channel
@@ -402,7 +402,8 @@ def main():
         # been marked as NULL during channel formation.
         print('{} Handling edges to channels.'.format(now()))
         handle_edges_to_channels(
-            conn, null_tile_wires, edge_assignments, channel_wires_to_tracks)
+            conn, null_tile_wires, edge_assignments, channel_wires_to_tracks
+        )
 
         print('{} Processing edge assignments.'.format(now()))
         final_edge_assignments = {}
@@ -411,8 +412,8 @@ def main():
             (tile_type, wire) = key
             if len(available_pins) == 0:
                 if (tile_type, wire) not in null_tile_wires:
-                    # TODO: Figure out what is going on with these wires.  Appear to
-                    # tile internal connections sometimes?
+                    # TODO: Figure out what is going on with these wires.
+                    #  Appear to tile internal connections sometimes?
                     print((tile_type, wire))
 
                 final_edge_assignments[key] = [tracks.Direction.RIGHT]
@@ -425,7 +426,8 @@ def main():
             if len(pins) > 0:
                 final_edge_assignments[key] = [list(pins)[0]]
             else:
-                # More than 2 pins are required, final the minimal number of pins
+                # More than 2 pins are required, final the minimal number
+                # of pins
                 pins = set()
                 for p in available_pins:
                     pins |= set(p)

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -332,7 +332,8 @@ class Connector(object):
                 if pin_dir in self.pins.edge_map:
                     return self.pins.edge_map[pin_dir], graph_nodes[idx]
         elif self.tracks and other_connector.pins:
-            assert other_connector.pins.site_pin_direction == SitePinDirection.IN
+            assert other_connector.pins.site_pin_direction == \
+                   SitePinDirection.IN
             assert other_connector.pins.x == loc[0]
             assert other_connector.pins.y == loc[1]
 
@@ -343,7 +344,8 @@ class Connector(object):
                         pin_dir]
         elif self.pins and other_connector.pins:
             assert self.pins.site_pin_direction == SitePinDirection.OUT
-            assert other_connector.pins.site_pin_direction == SitePinDirection.IN
+            assert other_connector.pins.site_pin_direction == \
+                   SitePinDirection.IN
 
             if len(self.pins.edge_map) == 1 and len(
                     other_connector.pins.edge_map) == 1:
@@ -394,8 +396,8 @@ def create_find_connector(conn):
         # Find all graph_nodes for this node.
         c.execute(
             """
-        SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high FROM graph_node
-        WHERE node_pkey = ?;""", (node_pkey, )
+        SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high
+        FROM graph_node WHERE node_pkey = ?;""", (node_pkey, )
         )
 
         graph_nodes = c.fetchall()
@@ -535,8 +537,9 @@ SELECT vcc_track_pkey, gnd_track_pkey FROM constant_sources;
 
 def make_connection(
         conn, input_only_nodes, output_only_nodes, loc, tile_pkey,
-        src_wire_pkey, dst_wire_pkey, pip_pkey, switch_pkey, delayless_switch_pkey,
-        find_connector, const_connectors):
+        src_wire_pkey, dst_wire_pkey, pip_pkey, switch_pkey,
+        delayless_switch_pkey, find_connector, const_connectors
+):
     """ Attempt to connect graph nodes on either side of a pip.
 
     Args:
@@ -574,11 +577,13 @@ def make_connection(
 
     # Get node pkeys
     src_node_pkey = c.execute(
-        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND wire_in_tile_pkey = (?)",
-        (tile_pkey, src_wire_pkey)).fetchone()[0]
+        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND "
+        "wire_in_tile_pkey = (?)", (tile_pkey, src_wire_pkey)
+    ).fetchone()[0]
     dst_node_pkey = c.execute(
-        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND wire_in_tile_pkey = (?)",
-        (tile_pkey, dst_wire_pkey)).fetchone()[0]
+        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND "
+        "wire_in_tile_pkey = (?)", (tile_pkey, dst_wire_pkey)
+    ).fetchone()[0]
 
     # Skip nodes that are reserved because of ROI
     if src_node_pkey in input_only_nodes:
@@ -619,8 +624,6 @@ def make_connection(
         src_graph_node_pkey, dst_graph_node_pkey = const_connectors[
             constant_src].connect_at(loc, dst_connector)
 
-        #print("SYNTH EDGE: ", src_graph_node_pkey, dst_graph_node_pkey, delayless_switch_pkey, tile_pkey)
-
         edges.append(
             (
                 src_graph_node_pkey,
@@ -633,7 +636,10 @@ def make_connection(
 
     return edges
 
-def mark_track_liveness(conn, pool, input_only_nodes, output_only_nodes, alive_tracks):
+
+def mark_track_liveness(
+        conn, pool, input_only_nodes, output_only_nodes, alive_tracks
+):
     """ Checks tracks for liveness.
 
     Iterates over all graph nodes that are routing tracks and determines if
@@ -717,8 +723,8 @@ def build_channels(conn, pool, active_tracks):
 
     x_tracks = {}
     y_tracks = {}
-    for pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high in c.execute(
-            """
+    for pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high in \
+            c.execute("""
 SELECT
   pkey,
   track_pkey,
@@ -896,8 +902,9 @@ def verify_channels(conn, alive_tracks):
     for (graph_node_pkey, track_pkey, graph_node_type, x_low, x_high, y_low,
          y_high, ptc, capacity) in c.execute(
              """
-    SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high, ptc, capacity FROM
-        graph_node WHERE (graph_node_type = ? or graph_node_type = ?);""",
+    SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high,
+    ptc, capacity FROM graph_node WHERE 
+    (graph_node_type = ? or graph_node_type = ?);""",
              (graph2.NodeType.CHANX.value, graph2.NodeType.CHANY.value)):
 
         if track_pkey not in alive_tracks and capacity != 0:
@@ -931,15 +938,15 @@ def main():
     parser.add_argument(
         '--connection_database',
         help='Database of fabric connectivity',
-        required=True)
+        required=True
+    )
     parser.add_argument(
-        '--pin_assignments',
-        help='Pin assignments JSON',
-        required=True)
+        '--pin_assignments', help='Pin assignments JSON', required=True
+    )
     parser.add_argument(
         '--synth_tiles',
-        help=
-        'If using an ROI, synthetic tile defintion from prjxray-arch-import')
+        help='If using an ROI, synthetic tile defintion from prjxray-arch-import'
+    )
 
     args = parser.parse_args()
 
@@ -972,7 +979,8 @@ def main():
                 synth_tiles["info"]["GRID_X_MIN"],
                 synth_tiles["info"]["GRID_Y_MIN"],
                 synth_tiles["info"]["GRID_X_MAX"],
-                synth_tiles["info"]["GRID_Y_MAX"])
+                synth_tiles["info"]["GRID_Y_MAX"]
+            )
 
             print('{} generating routing graph for ROI.'.format(now()))
         else:
@@ -994,13 +1002,14 @@ def main():
             c = conn.cursor()
             c2 = conn.cursor()
 
-            for tile_name, tile_type_pkey, grid_x, grid_y in progressbar.progressbar(
-                    c.execute(
+            for tile_name, tile_type_pkey, grid_x, grid_y in\
+                    progressbar.progressbar(c.execute(
                         "SELECT name, tile_type_pkey, grid_x, grid_y FROM tile"
                     )):
                 tile_type = c2.execute(
                     "SELECT name FROM tile_type WHERE pkey = (?)",
-                    (tile_type_pkey, )).fetchone()[0]
+                    (tile_type_pkey, )
+                ).fetchone()[0]
 
                 if tile_name in synth_tiles['tiles']:
                     assert len(synth_tiles['tiles'][tile_name]['pins']) == 1
@@ -1010,7 +1019,8 @@ def main():
                             continue
 
                         _, _, node_pkey = find_wire(
-                            tile_name, tile_type, pin['wire'])
+                            tile_name, tile_type, pin['wire']
+                        )
 
                         if pin['port_type'] == 'input':
                             # This track can output be used as a sink.
@@ -1036,7 +1046,8 @@ def main():
         edge_set = set()
 
         c2 = conn.cursor()
-        for tile_pkey, tile_type_pkey, grid_x, grid_y in progressbar.progressbar(
+        for tile_pkey, tile_type_pkey, grid_x, grid_y in \
+                progressbar.progressbar(
                 c.execute(
                     "SELECT pkey, tile_type_pkey, grid_x, grid_y FROM tile")):
             loc = (grid_x, grid_y)
@@ -1048,8 +1059,10 @@ def main():
                 continue
 
             # Process PIPs
-            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey in c2.execute(
-                    "SELECT pkey, name, src_wire_in_tile_pkey, dest_wire_in_tile_pkey FROM pip_in_tile WHERE tile_type_pkey = (?)",
+            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey in\
+                    c2.execute("""SELECT pkey, name, src_wire_in_tile_pkey,
+                               dest_wire_in_tile_pkey FROM pip_in_tile WHERE
+                               tile_type_pkey = (?)""",
                 (tile_type_pkey, )):
 
                 # No pseudo pips and bidirectional pips should be present here
@@ -1061,7 +1074,9 @@ def main():
                 connections = make_connection(
                     conn, input_only_nodes, output_only_nodes, loc, tile_pkey,
                     pip_src_wire_pkey, pip_dst_wire_pkey, pip_pkey,
-                    switch_pkey, delayless_switch_pkey, find_connector, const_connectors)
+                    switch_pkey, delayless_switch_pkey, find_connector,
+                    const_connectors
+                )
 
                 if connections:
                     # TODO: Skip duplicate connections, until they have unique
@@ -1092,10 +1107,12 @@ def main():
         print('{} Inserted edges'.format(now()))
 
         c.execute(
-            """CREATE INDEX src_node_index ON graph_edge(src_graph_node_pkey);"""
+            """CREATE INDEX src_node_index ON 
+            graph_edge(src_graph_node_pkey);"""
         )
         c.execute(
-            """CREATE INDEX dest_node_index ON graph_edge(dest_graph_node_pkey);"""
+            """CREATE INDEX dest_node_index ON 
+            graph_edge(dest_graph_node_pkey);"""
         )
         c.connection.commit()
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -1072,10 +1072,18 @@ def main():
                 # FIXME: Will require a change here once merged with #537 (!)
 
                 connections = make_connection(
-                    conn, input_only_nodes, output_only_nodes, loc, tile_pkey,
-                    pip_src_wire_pkey, pip_dst_wire_pkey, pip_pkey,
-                    switch_pkey, delayless_switch_pkey, find_connector,
-                    const_connectors
+                    conn=conn,
+                    input_only_nodes=input_only_nodes,
+                    output_only_nodes=output_only_nodes,
+                    loc=loc,
+                    tile_pkey=tile_pkey,
+                    src_wire_pkey=pip_src_wire_pkey,
+                    dst_wire_pkey=pip_dst_wire_pkey,
+                    pip_pkey=pip_pkey,
+                    switch_pkey=switch_pkey,
+                    delayless_switch_pkey=delayless_switch_pkey,
+                    find_connector=find_connector,
+                    const_connectors=const_connectors
                 )
 
                 if connections:

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -616,13 +616,15 @@ def make_connection(
 
     # Make additional connections to constant network if the sink needs it.
     for constant_src in yield_ties_to_wire(src_wire_name):
-        src_graph_node_pkey, dest_graph_node_pkey = const_connectors[
+        src_graph_node_pkey, dst_graph_node_pkey = const_connectors[
             constant_src].connect_at(loc, dst_connector)
+
+        #print("SYNTH EDGE: ", src_graph_node_pkey, dst_graph_node_pkey, delayless_switch_pkey, tile_pkey)
 
         edges.append(
             (
                 src_graph_node_pkey,
-                dest_graph_node_pkey,
+                dst_graph_node_pkey,
                 delayless_switch_pkey,
                 tile_pkey,
                 None,
@@ -1082,7 +1084,8 @@ def main():
                     INSERT INTO graph_edge(
                         src_graph_node_pkey, dest_graph_node_pkey, switch_pkey,
                         tile_pkey, pip_in_tile_pkey)  VALUES (?, ?, ?, ?, ?)""",
-                edge)
+                edge
+            )
 
         c.execute("""COMMIT TRANSACTION;""")
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -549,7 +549,7 @@ def make_connection(
         tile_pkey (int): pkey of the tile in the tile table
         src_wire_pkey (int): pkey of the source wire in the wire table
         dst_wire_pkey (int): pkey of the destination wire in the wire table
-        loc (tuple): Location of tile.
+        loc (tuple): Location of tile in the VPR grid space.
         pip_pkey (int): Pip being connected.
         switch_pkey (int): Primary key to switch table of switch to be used
             in this connection.

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -1059,17 +1059,21 @@ def main():
                 continue
 
             # Process PIPs
-            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey in\
+            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey,\
+                is_pseudo, is_directional in \
                     c2.execute("""SELECT pkey, name, src_wire_in_tile_pkey,
-                               dest_wire_in_tile_pkey FROM pip_in_tile WHERE
+                               dest_wire_in_tile_pkey, is_pseudo,
+                               is_directional FROM pip_in_tile WHERE
                                tile_type_pkey = (?)""",
-                (tile_type_pkey, )):
+                               (tile_type_pkey, )):
 
-                # No pseudo pips and bidirectional pips should be present here
-                # as they were skipped during import to the SQLite database
-                # in prjxray_form_channels.py
+                # Skip pseudo pips. They are not part of the routing
+                if is_pseudo:
+                    continue
 
-                # FIXME: Will require a change here once merged with #537 (!)
+                # FIXME: TODO: Handle bi-directional pips
+                if not is_directional:
+                    continue
 
                 connections = make_connection(
                     conn=conn,

--- a/xc7/utils/prjxray_create_ioplace.py
+++ b/xc7/utils/prjxray_create_ioplace.py
@@ -61,8 +61,8 @@ def main():
     for pcf_constraint in parse_simple_pcf(args.pcf):
         if not io_place.is_net(pcf_constraint.net):
             print(
-                'PCF constraint "{}" from line {} constraints net {} which is not in available netlist:\n{}'
-                .format(
+                'PCF constraint "{}" from line {} constraints net {} which is'
+                ' not in available netlist:\n{}'.format(
                     pcf_constraint.line_str, pcf_constraint.line_num,
                     pcf_constraint.net, '\n'.join(io_place.get_nets())
                 ),
@@ -72,8 +72,8 @@ def main():
 
         if pcf_constraint.pad not in pad_map:
             print(
-                'PCF constraint "{}" from line {} constraints pad {} which is not in available pad map:\n{}'
-                .format(
+                'PCF constraint "{}" from line {} constraints pad {} which is'
+                ' not in available pad map:\n{}'.format(
                     pcf_constraint.line_str, pcf_constraint.line_num,
                     pcf_constraint.pad, '\n'.join(sorted(pad_map.keys()))
                 ),

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -54,12 +54,14 @@ def find_vbrk_closest_to(grid, roi, loc, loc_in_use):
 
     return loc_best
 
+
 def main():
     parser = argparse.ArgumentParser(description="Generate synth_tiles.json")
     parser.add_argument('--db_root', required=True)
     parser.add_argument('--roi', required=True)
     parser.add_argument(
-        '--connection_database', help='Connection database', required=True)
+        '--connection_database', help='Connection database', required=True
+    )
     parser.add_argument('--synth_tiles', required=False)
 
     args = parser.parse_args()
@@ -90,9 +92,11 @@ def main():
 
     # Map ROI coordinates to the target VPR grid
     roi_loc_lo = grid_loc_mapper.get_vpr_loc(
-        (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN']))
+        (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN'])
+    )
     roi_loc_hi = grid_loc_mapper.get_vpr_loc(
-        (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX']))
+        (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX'])
+    )
 
     synth_tiles['info'] = {
         "GRID_X_MIN": min([p[0] for p in roi_loc_lo]),
@@ -133,7 +137,8 @@ def main():
             # Or if in the ROI, make sure it has no sites.
             gridinfo = g.gridinfo_at_tilename(tile)
             assert len(
-                db.get_tile_type(gridinfo.tile_type).get_sites()) == 0, tile
+                db.get_tile_type(gridinfo.tile_type).get_sites()
+            ) == 0, tile
 
         if tile not in synth_tiles['tiles']:
             synth_tiles['tiles'][tile] = {

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -3,12 +3,19 @@ import prjxray.db
 from prjxray.roi import Roi
 import simplejson as json
 
+from prjxray.grid_types import GridLoc
+
+from prjxray_db_cache import DatabaseCache
+from lib.grid_mapping import GridLocMap
+
 
 def main():
     parser = argparse.ArgumentParser(description="Generate synth_tiles.json")
     parser.add_argument('--db_root', required=True)
     parser.add_argument('--roi', required=True)
-    parser.add_argument('--synth_tiles', required=True)
+    parser.add_argument(
+        '--connection_database', help='Connection database', required=True)
+    parser.add_argument('--synth_tiles', required=False)
 
     args = parser.parse_args()
 
@@ -18,19 +25,41 @@ def main():
     synth_tiles = {}
     synth_tiles['tiles'] = {}
 
+    # Initialize grid mapper
+    with DatabaseCache(args.connection_database, read_only=True) as conn:
+
+        # The object will read data from the DB so it can live
+        # outside the scope of the "with" statement
+        grid_loc_mapper = GridLocMap(conn)
+
     with open(args.roi) as f:
         j = json.load(f)
 
+    # Map ROI coordinates to the target VPR grid
+    roi_loc_lo = grid_loc_mapper.get_vpr_loc(
+        (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN']))
+    roi_loc_hi = grid_loc_mapper.get_vpr_loc(
+        (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX']))
+
+    vbrk_in_use = set()
+
     roi = Roi(
         db=db,
-        x1=j['info']['GRID_X_MIN'],
-        y1=j['info']['GRID_Y_MIN'],
-        x2=j['info']['GRID_X_MAX'],
-        y2=j['info']['GRID_Y_MAX'],
+        x1=min([p[0] for p in roi_loc_lo
+                ]),  # One physical grid location may map to more than one
+        y1=min([p[1] for p in roi_loc_lo
+                ]),  # VPR locations. So here we take min and max.
+        x2=max([p[0] for p in roi_loc_hi]),
+        y2=max([p[1] for p in roi_loc_hi]),
     )
 
-    synth_tiles['info'] = j['info']
-    vbrk_in_use = set()
+    synth_tiles['info'] = {
+        "GRID_X_MIN": roi.x1,
+        "GRID_Y_MIN": roi.y1,
+        "GRID_X_MAX": roi.x2,
+        "GRID_Y_MAX": roi.y2
+    }
+
     for port in j['ports']:
         if port['name'].startswith('dout['):
             port_type = 'input'
@@ -48,19 +77,23 @@ def main():
 
         vbrk_in_use.add(tile)
 
-        # Make sure connecting wire is not in ROI!
+        # Map tile location to the VPR grid
         loc = g.loc_of_tilename(tile)
-        if roi.tile_in_roi(loc):
+        vpr_loc = grid_loc_mapper.get_vpr_loc((loc.grid_x, loc.grid_y))
+        vpr_loc = vpr_loc[0]  # FIXME: Assuming no split of that tile!
+        vpr_loc = GridLoc(vpr_loc[0], vpr_loc[1])
+
+        # Make sure connecting wire is not in ROI!
+        if roi.tile_in_roi(vpr_loc):
             # Or if in the ROI, make sure it has no sites.
             gridinfo = g.gridinfo_at_tilename(tile)
             assert len(
-                db.get_tile_type(gridinfo.tile_type).get_sites()
-            ) == 0, tile
+                db.get_tile_type(gridinfo.tile_type).get_sites()) == 0, tile
 
         if tile not in synth_tiles['tiles']:
             synth_tiles['tiles'][tile] = {
                 'pins': [],
-                'loc': g.loc_of_tilename(tile),
+                'loc': vpr_loc,
             }
 
         synth_tiles['tiles'][tile]['pins'].append(

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -75,7 +75,7 @@ def main():
 
         # The object will read data from the DB so it can live
         # outside the scope of the "with" statement
-        grid_loc_mapper = GridLocMap(conn)
+        grid_loc_mapper = GridLocMap.load_from_database(conn)
 
     with open(args.roi) as f:
         j = json.load(f)

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -153,7 +153,7 @@ def main():
 
     # Find two VBRK's in the corner of the fabric to use as the synthetic VCC
     loc_min = GridLoc(g.dims()[0], g.dims()[2])
-    loc_max = GridLoc(g.dims()[1], g.dims()[3])
+    loc_max = GridLoc(g.dims()[0], g.dims()[3])
 
     #print("loc_min:", loc_min, "phy")
     #print("loc_max:", loc_max, "phy")

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -14,11 +14,16 @@ def find_vbrk_closest_to(grid, roi, loc, loc_in_use):
     Finds a VBRK tile (optionally within the ROI) which is located closest
     to a given location. Checks if such a tile is not already used by
     another synth tile.
-    :param grid:
-    :param roi:
-    :param loc:
-    :param loc_in_use:
-    :return:
+
+    Args:
+        grid: A Grid object from the prjxray database
+        roi: A Roi object from the prjxray database or None when ROI not used.
+        loc: A GridLoc with location to find the closest VBRK to.
+        loc_in_use: A set with GridLoc objects which indicate occupied VBRKs
+
+    Returns:
+        A GridLoc with the "best" (closest) VBRK tile location to the given
+        input loc.
     """
 
     loc_best = None

--- a/xc7/utils/prjxray_db_cache.py
+++ b/xc7/utils/prjxray_db_cache.py
@@ -47,13 +47,15 @@ class DatabaseCache(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         """
-        Writes back the database to file if the database was open as not read-only
+        Writes back the database to file if the database was open as not
+        read-only
         """
 
         # Write back only if not read-only
         if not self.read_only:
             if self.memory_connection.in_transaction:
-                assert exc_type is not None, "Outstanding transaction, but no exception?"
+                assert exc_type is not None, "Outstanding transaction, " \
+                                             "but no exception?"
                 self.memory_connection.rollback()
 
             print("Dumping database to '{}'".format(self.file_name))

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -1048,5 +1048,6 @@ def main():
             )
         )
 
+
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -247,9 +247,7 @@ def import_dummy_tracks(conn, graph, segment_id):
     return num_dummy
 
 
-def create_track_rr_graph(
-        conn, graph, node_mapping, segment_id
-):
+def create_track_rr_graph(conn, graph, node_mapping, segment_id):
     c = conn.cursor()
     c.execute("""SELECT count(*) FROM track;""")
     (num_channels, ) = c.fetchone()
@@ -537,7 +535,8 @@ def main():
     )
     parser.add_argument(
         '--synth_tiles',
-        help='If using an ROI, synthetic tile defintion from prjxray-arch-import'
+        help='If using an ROI, synthetic tile defintion from'
+        ' prjxray-arch-import'
     )
 
     args = parser.parse_args()
@@ -600,9 +599,7 @@ def main():
         # Walk all track graph nodes and add them.
         print('{} Creating tracks'.format(now()))
         segment_id = graph.get_segment_id_from_name('dummy')
-        create_track_rr_graph(
-            conn, graph, node_mapping, segment_id
-        )
+        create_track_rr_graph(conn, graph, node_mapping, segment_id)
 
         # Set of (src, sink, switch_id) tuples that pip edges have been sent to
         # VPR.  VPR cannot handle duplicate paths with the same switch id.

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -314,7 +314,6 @@ WHERE
                     (track_pkey, ) = c.fetchone()
                 else:
                     assert False, pin['port_type']
-
                 tracks_model, track_nodes = get_track_model(conn, track_pkey)
 
                 option = list(tracks_model.get_tracks_for_wire_at_coord(loc))

--- a/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
+++ b/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
@@ -57,6 +57,5 @@ def main():
                 )
             )
 
-
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
+++ b/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
@@ -57,5 +57,6 @@ def main():
                 )
             )
 
+
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
+++ b/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
-""" Tool generate convert a synth_tiles.json (describing an ROI) to a pin map CSV usable for pin placement. """
+""" Tool generate convert a synth_tiles.json (describing an ROI) to a pin map
+ CSV usable for pin placement. """
 from __future__ import print_function
 import argparse
 import json

--- a/xc7/utils/prjxray_tile_import.py
+++ b/xc7/utils/prjxray_tile_import.py
@@ -110,7 +110,10 @@ def main():
         '--fused_sites',
         action='store_true',
         help=
-        "Typically a tile can treat the sites within the tile as independent.  For tiles where this is not true, fused sites only imports 1 primatative for the entire tile, which should be named the same as the tile type."
+        "Typically a tile can treat the sites within the tile as independent."
+        "For tiles where this is not true, fused sites only imports 1"
+        "primatative for the entire tile, which should be named the same as"
+        "the tile type."
     )
 
     args = parser.parse_args()
@@ -150,10 +153,12 @@ def main():
             for site_pin in site.site_pins:
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     if site_pin.wire is not None:
                         input_wires.add(site_pin.wire)
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     if site_pin.wire is not None:
                         output_wires.add(site_pin.wire)
                 else:
@@ -177,10 +182,12 @@ def main():
             for site_pin in site.site_pins:
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     if site_pin.wire is not None:
                         input_wires.add(site_pin.wire)
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     if site_pin.wire is not None:
                         output_wires.add(site_pin.wire)
                 else:
@@ -389,21 +396,25 @@ def main():
                 port = find_port(site_pin.name, site_type_ports[site_instance])
                 if port is None:
                     print(
-                        "*** WARNING *** Didn't find port for name {} for site type {}"
-                        .format(site_pin.name, site.type),
+                        "*** WARNING *** Didn't find port for"
+                        " name {} for site type {}".format(
+                            site_pin.name, site.type
+                        ),
                         file=sys.stderr
                     )
                     continue
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(tile_name, site_pin.wire),
                         output=object_ref(site_name, **port)
                     )
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     pass
                 else:
                     assert False, site_type_pin.direction
@@ -420,9 +431,11 @@ def main():
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     pass
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(site_name, **port),
@@ -474,21 +487,25 @@ def main():
                 port = find_port(port_name, ports)
                 if port is None:
                     print(
-                        "*** WARNING *** Didn't find port for name {} for site type {}"
-                        .format(port_name, site.type),
+                        "*** WARNING *** Didn't find port for"
+                        " name {} for site type {}".format(
+                            port_name, site.type
+                        ),
                         file=sys.stderr
                     )
                     continue
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(tile_name, site_pin.wire),
                         output=object_ref(site_name, **port)
                     )
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     pass
                 else:
                     assert False, site_type_pin.direction
@@ -506,9 +523,11 @@ def main():
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     pass
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(site_name, **port),

--- a/xc7/utils/splitter/grid_splitter.py
+++ b/xc7/utils/splitter/grid_splitter.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import logging
+import itertools
+import argparse
+import sqlite3
+
+import sys
+sys.path.append("../")  # Hackish way...
+
+from prjxray_db_cache import DatabaseCache
+from lib.grid_mapping import get_phy_grid_extent
+
+# =============================================================================
+
+
+class GridSplitter(object):
+    def __init__(self, db_conn):
+        self.db_cursor = db_conn.cursor()
+
+        self.tile_types_to_split = None
+
+        # Get the grid from database:
+        self.grid = self.db_cursor.execute(
+            "SELECT grid_x, grid_y, ( SELECT name FROM tile_type WHERE tile_type.pkey = phy_tile.tile_type_pkey ) FROM phy_tile"
+        )
+        # Get the physical grid extent
+        self.grid_extent = get_phy_grid_extent(db_conn)
+
+    def set_tile_types_to_split(self, tile_types):
+        """
+        Set tile types to split
+        """
+        self.tile_types_to_split = tile_types
+
+    def split(self):
+        """
+        Do the split
+        """
+
+        # Identify grid colums to split
+        columns_to_split = set()
+
+        for tile in self.grid:
+            if tile[2] in self.tile_types_to_split:
+                columns_to_split.add(tile[0])
+
+        logging.info("Splitting columns: %s" % str(columns_to_split))
+
+        # Clear the grid_loc_map
+        self.db_cursor.executescript("DELETE FROM grid_loc_map; VACUUM;")
+
+        # Build an new coordinate mapping
+        for phy_x, phy_y in itertools.product(range(self.grid_extent[0],
+                                                    self.grid_extent[2] + 1),
+                                              range(self.grid_extent[1],
+                                                    self.grid_extent[3] + 1)):
+            vpr_x = phy_x + sum([phy_x > x for x in columns_to_split])
+            vpr_y = phy_y
+
+            self.db_cursor.execute(
+                "INSERT INTO grid_loc_map VALUES (?, ?, ?, ?);",
+                (phy_x, phy_y, vpr_x, vpr_y))
+
+        # Commit
+        self.db_cursor.execute("COMMIT TRANSACTION;")
+        self.db_cursor.connection.commit()
+
+
+# =============================================================================
+
+
+def main():
+    """
+    The main
+    """
+
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--connection_database",
+        required=True,
+        type=str,
+        help="Database of fabric connectivity")
+    parser.add_argument(
+        "--split-tiles",
+        required=True,
+        type=str,
+        nargs="*",
+        action="append",
+        help="Tile types to split")
+
+    args = parser.parse_args()
+
+    # Logging
+    logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+
+    # .................................
+
+    # Build a list of tiles to split
+    tile_types = []
+    for tile_type_list in args.split_tiles:
+        for tile_type in tile_type_list:
+            tile_types.append(tile_type)
+
+    # .................................
+
+    with DatabaseCache(args.connection_database) as conn:
+
+        # Initialize the grid splitter
+        splitter = GridSplitter(conn)
+
+        # Add list of tiles to split
+        splitter.set_tile_types_to_split(tile_types)
+
+        # Do the split
+        splitter.split()
+
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I've implemented a generic mechanism which allows to map tile locations in an arbitrary way. In this implementation new tables are added to the `channels.db` database:

 - `phy_tile`: This is the same table as `tile` but now it stores the tile grid as imported from the prjxray database. The `tile` table now stores the tile grid to be used with VPR. Primary keys of corresponding entries in those tables are equal.
- `grid_loc_map`: The table stores pairs of (x,y) coordinates thus provides a map between the physical grid (`phy_tile` table) and the VPR grid (the `tile`) table.

It is worth noting that in general the grid mapping can be one-to-many as it is meant to be used for splitting a CLB at one location into two SLICEs which will have two separate locations.

There is also the `grid_splitter.py` script which, for testing purposes, inserts an empty column east of each CLB  column. Therefore it simulates splitting CLBs into SLICEs but without doing the actual split.

Wile working on the problem of location mapping I managed to remove prjxray database dependency from `prjxray_assign_tile_pin_direction.py`, `prjxray_create_edges.py` and `prjxray_routing_import.py`. All information necessary for these scripts are already in `channels.db`