### PR TITLE
Fix multi-process bugs in CMake build system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,13 @@ include(make/devices.cmake)
 
 find_package(PythonInterp 3 REQUIRED)
 
-# Using miniconda3 4.5.4 instead of later (e.g. 4.5.12) because of Python 3.7
-# deprecation warnings in progressbar2 (and possible others).
+# Some commands use file locks to prevent incorrect parallel access.
+# All file locks are required to register a clean command with the clean_locks
+# targets to prevent stale locks.
+add_custom_target(clean_locks)
+
 setup_env(
-    MINICONDA3_VERSION 4.5.4
+    MINICONDA3_VERSION 4.5.12
     )
 add_conda_package(
   NAME yosys

--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -851,7 +851,7 @@ function(ADD_FPGA_TARGET)
       )
   endif()
 
-  add_custom_target(${NAME}_eblif ALL DEPENDS ${OUT_EBLIF})
+  add_custom_target(${NAME}_eblif DEPENDS ${OUT_EBLIF})
 
   # Generate routing and generate HLC.
   set(OUT_ROUTE ${OUT_LOCAL}/${TOP}.route)
@@ -1145,7 +1145,7 @@ function(ADD_FPGA_TARGET)
       )
     endif()
 
-    add_custom_target(${NAME}_bit ALL DEPENDS ${OUT_BITSTREAM})
+    add_custom_target(${NAME}_bit DEPENDS ${OUT_BITSTREAM})
 
     get_target_property_required(BIN_EXTENSION ${ARCH} BIN_EXTENSION)
     set(OUT_BIN ${OUT_LOCAL}/${TOP}.${BIN_EXTENSION})

--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -280,15 +280,10 @@ function(DEFINE_DEVICE_TYPE)
   set(DEVICE_MERGED_LINT_FILE arch.merged.lint.html)
 
   set(MERGE_XML_XSL ${symbiflow-arch-defs_SOURCE_DIR}/common/xml/xmlsort.xsl)
-  set(
-    MERGE_XML_INPUT ${CMAKE_CURRENT_BINARY_DIR}/${DEFINE_DEVICE_TYPE_ARCH_XML}
-  )
-  get_file_target(MERGE_XML_INPUT_TARGET ${DEFINE_DEVICE_TYPE_ARCH_XML})
-  get_target_property(INCLUDE_FILES ${MERGE_XML_INPUT_TARGET} INCLUDE_FILES)
-  set(DEPS "")
-  foreach(SRC ${INCLUDE_FILES})
-    append_file_dependency(DEPS ${SRC})
-  endforeach()
+
+  get_file_location(MERGE_XML_INPUT ${DEFINE_DEVICE_TYPE_ARCH_XML})
+  append_file_dependency(DEPS ${DEFINE_DEVICE_TYPE_ARCH_XML})
+
   set(MERGE_XML_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${DEVICE_MERGED_FILE})
   set(UNIQUE_PACK_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${DEVICE_UNIQUE_PACK_FILE})
   set(MERGE_XMLLINT_OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${DEVICE_MERGED_LINT_FILE})
@@ -301,8 +296,6 @@ function(DEFINE_DEVICE_TYPE)
     OUTPUT ${MERGE_XML_OUTPUT}
     DEPENDS
       ${MERGE_XML_XSL}
-      ${MERGE_XML_INPUT}
-      ${MERGE_XML_INPUT_TARGET}
       ${DEPS}
       ${XSLTPROC} ${XSLTPROC_TARGET}
     COMMAND
@@ -316,6 +309,9 @@ function(DEFINE_DEVICE_TYPE)
       --output ${MERGE_XML_OUTPUT} ${MERGE_XML_XSL} ${MERGE_XML_INPUT}
   )
 
+  add_file_target(FILE ${DEVICE_MERGED_FILE} GENERATED)
+  append_file_dependency(SPECIALIZE_CARRYCHAINS_DEPS ${DEVICE_MERGED_FILE})
+
   get_target_property_required(PYTHON3 env PYTHON3)
   get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
   set(SPECIALIZE_CARRYCHAINS ${symbiflow-arch-defs_SOURCE_DIR}/utils/specialize_carrychains.py)
@@ -324,10 +320,11 @@ function(DEFINE_DEVICE_TYPE)
       COMMAND ${PYTHON3} ${SPECIALIZE_CARRYCHAINS}
       --input_arch_xml ${MERGE_XML_OUTPUT} > ${UNIQUE_PACK_OUTPUT}
       DEPENDS
-        ${MERGE_XML_OUTPUT}
         ${PYTHON3} ${PYTHON3_TARGET}
         ${SPECIALIZE_CARRYCHAINS}
+        ${SPECIALIZE_CARRYCHAINS_DEPS}
         )
+
   add_custom_target(
     ${DEFINE_DEVICE_TYPE_ARCH}_${DEFINE_DEVICE_TYPE_DEVICE_TYPE}_arch
     DEPENDS ${UNIQUE_PACK_OUTPUT}
@@ -468,8 +465,8 @@ function(DEFINE_DEVICE)
     )
 
     set(RR_PATCH_DEPS ${DEFINE_DEVICE_RR_PATCH_DEPS})
-    list(APPEND RR_PATCH_DEPS ${DEVICE_MERGED_FILE})
-    list(APPEND RR_PATCH_DEPS ${DEVICE_MERGED_FILE_TARGET})
+    append_file_dependency(RR_PATCH_DEPS ${VIRT_DEVICE_MERGED_FILE})
+    append_file_dependency(RR_PATCH_DEPS ${OUT_RRXML_VIRT_FILENAME})
 
     # Generate the "real" rr_graph.xml from the default rr_graph.xml file
     get_target_property_required(PYTHON3 env PYTHON3)
@@ -479,7 +476,7 @@ function(DEFINE_DEVICE)
     )
     add_custom_command(
       OUTPUT ${OUT_RRXML_REAL}
-      DEPENDS ${RR_PATCH_DEPS} ${RR_PATCH_TOOL} ${OUT_RRXML_VIRT}
+      DEPENDS ${RR_PATCH_DEPS} ${RR_PATCH_TOOL}
       COMMAND ${RR_PATCH_CMD_FOR_TARGET_LIST} ${DEFINE_DEVICE_RR_PATCH_EXTRA_ARGS}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       VERBATIM
@@ -556,6 +553,9 @@ function(DEFINE_BOARD)
       PROPERTIES ${ARG} "${DEFINE_BOARD_${ARG}}"
     )
   endforeach()
+
+  # Target for gathering all targets for a particular board.
+  add_custom_target(all_${DEFINE_BOARD_BOARD}_bin)
 endfunction()
 
 function(ADD_OUTPUT_TO_FPGA_TARGET name property file)
@@ -1169,6 +1169,7 @@ function(ADD_FPGA_TARGET)
 
     add_custom_target(${NAME}_bin DEPENDS ${OUT_BIN})
     add_output_to_fpga_target(${NAME} BIN ${OUT_LOCAL_REL}/${TOP}.bin)
+    add_dependencies(all_${BOARD}_bin ${NAME}_bin)
 
     get_target_property(PROG_TOOL ${BOARD} PROG_TOOL)
     get_target_property(PROG_CMD ${BOARD} PROG_CMD)

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -176,10 +176,11 @@ function(PROJECT_XRAY_ARCH)
         SYNTH_TILES ${CMAKE_CURRENT_SOURCE_DIR}/synth_tiles.json)
 
     set(ROI_ARG --use_roi ${PROJECT_XRAY_ARCH_USE_ROI} --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json)
-    list(APPEND DEPS ${PROJECT_XRAY_ARCH_USE_ROI} synth_tiles.json)
+    append_file_dependency(DEPS synth_tiles.json)
+    list(APPEND DEPS ${PROJECT_XRAY_ARCH_USE_ROI})
 
     set(ROI_ARG_FOR_CREATE_EDGES --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json)
-    list(APPEND CHANNELS_DEPS synth_tiles.json)
+    append_file_dependency(CHANNELS_DEPS synth_tiles.json)
   endif()
 
   append_file_dependency(DEPS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/pin_assignments.json)
@@ -268,6 +269,7 @@ function(PROJECT_XRAY_PREPARE_DATABASE)
 
   add_file_target(FILE ${CHANNELS} GENERATED)
 
+  append_file_dependency(DEPS ${CHANNELS})
   set(PIN_ASSIGNMENTS pin_assignments.json)
   add_custom_command(
     OUTPUT ${PIN_ASSIGNMENTS}
@@ -278,7 +280,7 @@ function(PROJECT_XRAY_PREPARE_DATABASE)
     --pin_assignments ${CMAKE_CURRENT_BINARY_DIR}/${PIN_ASSIGNMENTS}
     DEPENDS
     ${ASSIGN_PINS}
-    ${DEPS} ${DEPS2} ${CHANNELS}
+    ${DEPS} ${DEPS2}
     ${PYTHON3} ${PYTHON3_TARGET} simplejson progressbar2
     )
 

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -108,9 +108,15 @@ function(PROJECT_XRAY_TILE)
   get_file_target(PB_TYPE_TARGET ${TILE}.pb_type.xml)
   set_target_properties(${PB_TYPE_TARGET} PROPERTIES INCLUDE_FILES "${PB_TYPE_INCLUDE_FILES}")
 
-  add_file_target(FILE ${TILE}.model.xml GENERATED)
   get_file_target(MODEL_TARGET ${TILE}.model.xml)
-  set_target_properties(${MODEL_TARGET} PROPERTIES INCLUDE_FILES "${MODEL_INCLUDE_FILES}")
+  add_custom_target(${MODEL_TARGET})
+
+  # Linearize the dependency to prevent double builds.
+  add_dependencies(${MODEL_TARGET} ${PB_TYPE_TARGET})
+  set_target_properties(${MODEL_TARGET} PROPERTIES
+      INCLUDE_FILES "${MODEL_INCLUDE_FILES}"
+      LOCATION ${CMAKE_CURRENT_BINARY_DIR}/${TILE}.model.xml
+      )
 endfunction()
 
 function(PROJECT_XRAY_ARCH)


### PR DESCRIPTION
 - Add lock files for conda and pip installations to prevent those tools
   from being invoked in parallel.
 - Change some file dependencies to target dependencies, which is
   important when multiple process builds occur.
 - Remove eblif and bit files from ALL, instead only having the conda environment on all.

Fixes #448, fixes #337