### PR TITLE
[XC7] Make use of global constant network optional.

### DIFF
--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -687,6 +687,7 @@ function(ADD_FPGA_TARGET)
   #   [EMIT_CHECK_TESTS EQUIV_CHECK_SCRIPT <yosys to script verify two bitstreams gold and gate>]
   #   [NO_SYNTHESIS]
   #   [ASSERT_USAGE <usage_spec>]
+  #   [DEFINES <definitions>]
   #   )
   # ~~~
   #
@@ -703,6 +704,9 @@ function(ADD_FPGA_TARGET)
   # used to run test benches.
   #
   # If NO_SYNTHESIS is supplied, <source list> must be 1 eblif file.
+  #
+  # DEFINES is a list of environment variables to be defined during Yosys
+  # invocation.
   #
   # Targets generated:
   #
@@ -724,7 +728,7 @@ function(ADD_FPGA_TARGET)
   #
   set(options EXPLICIT_ADD_FILE_TARGET EMIT_CHECK_TESTS NO_SYNTHESIS ROUTE_ONLY)
   set(oneValueArgs NAME TOP BOARD INPUT_IO_FILE EQUIV_CHECK_SCRIPT AUTOSIM_CYCLES ASSERT_USAGE)
-  set(multiValueArgs SOURCES TESTBENCH_SOURCES)
+  set(multiValueArgs SOURCES TESTBENCH_SOURCES DEFINES)
   cmake_parse_arguments(
     ADD_FPGA_TARGET
     "${options}"
@@ -834,6 +838,7 @@ function(ADD_FPGA_TARGET)
           symbiflow-arch-defs_SOURCE_DIR=${symbiflow-arch-defs_SOURCE_DIR}
           OUT_EBLIF=${OUT_EBLIF}
           OUT_SYNTH_V=${OUT_SYNTH_V}
+          ${ADD_FPGA_TARGET_DEFINES}
           ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SCRIPT}" -l ${OUT_EBLIF}.log ${SOURCE_FILES}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
       VERBATIM

--- a/tests/0-const/CMakeLists.txt
+++ b/tests/0-const/CMakeLists.txt
@@ -2,4 +2,6 @@ add_simple_test(
   NAME 0-const
   SOURCES const.v
   BOARDS ${BOARDS}
+  DEFINES USE_LUT_CONSTANTS=1
+
   )

--- a/tests/6-led/CMakeLists.txt
+++ b/tests/6-led/CMakeLists.txt
@@ -3,4 +3,5 @@ add_simple_test(
   SOURCES led.v
   BOARDS ${FULL_BOARDS}
   ROUTE_ONLY
+  DEFINES USE_LUT_CONSTANTS=1
   )

--- a/tests/6-rot/CMakeLists.txt
+++ b/tests/6-rot/CMakeLists.txt
@@ -4,5 +4,6 @@ add_simple_test(
   BOARDS ${BOARDS}
   EQUIV_CHECK_SCRIPT
       ${symbiflow-arch-defs_SOURCE_DIR}/yosys/miter_and_tempinduct_skip_1.ys
+  DEFINES USE_LUT_CONSTANTS=1
   )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ function(add_simple_test)
   #     [ROUTE_ONLY]
   #     [EQUIV_CHECK_SCRIPT <filename of yosys script to prove gold and gate>]
   #     [EXPLICIT_ADD_FILE_TARGET]
+  #     [DEFINES <list of defines>]
   #   )
   # ~~~
   #
@@ -26,7 +27,7 @@ function(add_simple_test)
   # between original source, post-synthesis and post-place and route modules.
   set(options ROUTE_ONLY EXPLICIT_ADD_FILE_TARGET NO_SYNTHESIS)
   set(oneValueArgs NAME EQUIV_CHECK_SCRIPT)
-  set(multiValueArgs SOURCES BOARDS)
+  set(multiValueArgs SOURCES BOARDS DEFINES)
   cmake_parse_arguments(
     ADD_SIMPLE_TEST
     "${options}"
@@ -88,6 +89,7 @@ function(add_simple_test)
       EXPLICIT_ADD_FILE_TARGET
       ${CHECK_TEST_ARGS}
       ${NO_SYNTHESIS_ARG}
+      DEFINES ${ADD_SIMPLE_TEST_DEFINES}
       )
 
     add_dependencies(all_route_tests ${ADD_SIMPLE_TEST_NAME}_${BOARD}_route)

--- a/xc7/yosys/synth.tcl
+++ b/xc7/yosys/synth.tcl
@@ -15,9 +15,19 @@ opt_clean
 
 setundef -zero -params
 stat
-write_blif -attr -cname -param \
- -true VCC VCC \
- -false GND GND \
- -undef VCC VCC \
- $::env(OUT_EBLIF)
+
+# Designs that directly tie OPAD's to constants cannot use the dedicate
+# constant network as an artifact of the way the ROI is configured.
+# Until the ROI is removed, enable designs to selectively disable the dedicated
+# constant network.
+if { [info exists ::env(USE_LUT_CONSTANTS)] } {
+    write_blif -attr -cname -param \
+      $::env(OUT_EBLIF)
+} else {
+    write_blif -attr -cname -param \
+      -true VCC VCC \
+      -false GND GND \
+      -undef VCC VCC \
+    $::env(OUT_EBLIF)
+}
 write_verilog $::env(OUT_SYNTH_V)


### PR DESCRIPTION
Because of how the ROI is defined, the global constant network cannot be
connected directly to the OPADs of the ROI.  Selectively disable the global
constant network on designs that tie OPADs directly to VCC or GND.

Fixes #544