### PR TITLE
Adds route grouping targets and all targets for major variants.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,3 +123,72 @@ add_custom_command(
   TARGET format_python
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/yapf_helper.sh -f -y ${YAPF}
   )
+
+
+add_custom_target(all_ice40_demos)
+add_dependencies(all_ice40_demos
+    all_icevision_bin
+    all_icestick_bin
+    all_hx8k-b-evn_bin
+    all_iceblink40-lp1k_bin
+    all_tinyfpga-bx_bin
+    all_tinyfpga-b2_bin
+    )
+
+add_custom_target(all_ice40_route_tests)
+add_dependencies(all_ice40_route_tests
+    all_dummy_ice40_hx1k_tq144_route
+    all_dummy_ice40_lp1k_qn84_route
+    all_dummy_ice40_hx1k_tq144_route
+    )
+
+if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
+add_dependencies(all_ice40_route_tests
+    all_dummy_ice40_up5k_sg48_route
+    all_dummy_ice40_lp8k_cm81_route
+    all_dummy_ice40_hx8k_ct256_route
+    )
+endif()
+
+add_custom_target(all_ice40)
+add_dependencies(all_ice40
+    all_ice40_demos
+    all_ice40_route_tests
+    )
+
+add_custom_target(all_7series_route_tests)
+
+
+if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
+add_dependencies(all_7series_route_tests
+    all_dummy_artix7_xc7a50t-arty_test_route
+    all_dummy_artix7_xc7a50t-basys3_test_route
+    )
+endif()
+
+add_custom_target(all_7series_demos)
+if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
+add_dependencies(all_7series_demos
+    all_arty_bin
+    all_basys3_bin
+    all_zybo_bin
+    )
+endif()
+
+add_custom_target(all_7series)
+add_dependencies(all_7series
+    all_7series_route_tests
+    all_7series_demos
+    )
+
+add_custom_target(all_testarch)
+add_dependencies(all_testarch
+    all_dummy_testarch_10x10_dummy_route
+    all_dummy_testarch_4x4_dummy_route
+    )
+
+add_custom_target(all_demos)
+add_dependencies(all_demos
+    all_ice40_demos
+    all_7series_demos
+    )

--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -555,6 +555,7 @@ function(DEFINE_BOARD)
   endforeach()
 
   # Target for gathering all targets for a particular board.
+  add_custom_target(all_${DEFINE_BOARD_BOARD}_route)
   add_custom_target(all_${DEFINE_BOARD_BOARD}_bin)
 endfunction()
 
@@ -1015,6 +1016,7 @@ function(ADD_FPGA_TARGET)
     WORKING_DIRECTORY ${OUT_LOCAL}
   )
   add_custom_target(${NAME}_route DEPENDS ${OUT_ROUTE})
+  add_dependencies(all_${BOARD}_route ${NAME}_route)
 
   set(ECHO_ATOM_NETLIST_ORIG ${OUT_LOCAL}/echo/atom_netlist.orig.echo.blif)
   set(ECHO_ATOM_NETLIST_CLEANED ${OUT_LOCAL}/echo/atom_netlist.cleaned.echo.blif)


### PR DESCRIPTION
@mithro and @elmsfu Does this address https://github.com/SymbiFlow/symbiflow-arch-defs/issues/539 ?

This doesn't tie them into the true all target, but I don't think we want to.