### PR TITLE
Add support for naming top-level port names based on pcf file.

### DIFF
--- a/utils/lib/parse_pcf.py
+++ b/utils/lib/parse_pcf.py
@@ -1,0 +1,28 @@
+from collections import namedtuple
+import re
+
+PcfIoConstraint = namedtuple('PcfIoConstraint', 'net pad line_str line_num')
+
+
+def parse_simple_pcf(f):
+    """ Parse a simple PCF file object and yield PcfIoConstraint objects. """
+    for line_number, line in enumerate(f):
+        line_number += 1
+
+        # Remove comments.
+        args = re.sub(r"#.*", "", line.strip()).split()
+
+        if not args or args[0] != 'set_io':
+            continue
+
+        # Ignore arguments to set_io.
+        args = [arg for arg in args if arg[0] != '-']
+
+        assert len(args) == 3, args
+
+        yield PcfIoConstraint(
+            net=args[1],
+            pad=args[2],
+            line_str=line.strip(),
+            line_num=line_number,
+        )

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -56,7 +56,7 @@ function(ADD_XC7_ARCH_DEFINE)
         \${BIT_TO_BIN_EXTRA_ARGS}"
     BIT_TO_V bitread
     BIT_TO_V_CMD "${CMAKE_COMMAND} -E env \
-    PYTHONPATH=${symbiflow-arch-defs_BINARY_DIR}/env/conda/lib/python3.7/site-packages:${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm:${symbiflow-arch-defs_SOURCE_DIR}/xc7 \
+    PYTHONPATH=${symbiflow-arch-defs_BINARY_DIR}/env/conda/lib/python3.7/site-packages:${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm:${symbiflow-arch-defs_SOURCE_DIR}/xc7:${symbiflow-arch-defs_SOURCE_DIR}/utils \
         \${PYTHON3} -mfasm2bels \
         \${BIT_TO_V_EXTRA_ARGS} \
         --db_root ${PRJXRAY_DB_DIR}/${ARCH} \
@@ -64,6 +64,7 @@ function(ADD_XC7_ARCH_DEFINE)
         --bitread $<TARGET_FILE:bitread> \
         --bit_file \${OUT_BIN} \
         --fasm_file \${OUT_BIN}.fasm \
+        --pcf \${INPUT_IO_FILE} \
         --top \${TOP} \
         \${OUT_BIT_VERILOG} \${OUT_BIT_VERILOG}.tcl"
     NO_BIT_TIME

--- a/xc7/utils/prjxray_create_ioplace.py
+++ b/xc7/utils/prjxray_create_ioplace.py
@@ -1,36 +1,10 @@
 """ Convert a PCF file into a VPR io.place file. """
 from __future__ import print_function
 import argparse
-from collections import namedtuple
 import csv
 import sys
-import re
 import vpr_io_place
-
-PcfIoConstraint = namedtuple('PcfIoConstraint', 'net pad line_str line_num')
-
-
-def parse_simple_pcf(f):
-    for line_number, line in enumerate(f):
-        line_number += 1
-
-        # Remove comments.
-        args = re.sub(r"#.*", "", line.strip()).split()
-
-        if not args or args[0] != 'set_io':
-            continue
-
-        # Ignore arguments to set_io.
-        args = [arg for arg in args if arg[0] != '-']
-
-        assert len(args) == 3, args
-
-        yield PcfIoConstraint(
-            net=args[1],
-            pad=args[2],
-            line_str=line.strip(),
-            line_num=line_number,
-        )
+from lib.parse_pcf import parse_simple_pcf
 
 
 def main():


### PR DESCRIPTION
This is useful for binding to test benches and equivilence miter
circuits.