### PR TITLE
Modify the "buttons" project to change switch/led behavior.

### DIFF
--- a/xc7/tests/buttons/buttons_basys3.v
+++ b/xc7/tests/buttons/buttons_basys3.v
@@ -2,5 +2,5 @@ module top(
 	input [15:0] in,
 	output [15:0] out
 );
-  assign out = in;
+  assign out = in + 16'h5A69;
 endmodule


### PR DESCRIPTION
The previous behavior (out = in) was confusing, because the switches
behaved exactly as they did before the BASYS3 was programmed.

Signed-off-by: Dusty DeWeese <dustin.deweese@gmail.com>