### PR TITLE
Use SymbiYosys to prove FF CE/SR tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "third_party/fasm"]
 	path = third_party/fasm
 	url = https://github.com/SymbiFlow/fasm.git
+[submodule "third_party/symbiyosys"]
+	path = third_party/symbiyosys
+	url = https://github.com/YosysHQ/SymbiYosys.git

--- a/make/devices.cmake
+++ b/make/devices.cmake
@@ -1220,8 +1220,10 @@ function(ADD_FPGA_TARGET)
         DEPENDS ${BIT_TO_V} ${OUT_BITSTREAM} ${OUT_BIN}
         )
 
-        add_custom_target(${NAME}_bit_v DEPENDS ${OUT_BIT_VERILOG})
+
         add_output_to_fpga_target(${NAME} BIT_V ${OUT_LOCAL_REL}/${TOP}_bit.v)
+        get_file_target(BIT_V_TARGET ${OUT_LOCAL_REL}/${TOP}_bit.v)
+        add_custom_target(${NAME}_bit_v DEPENDS ${BIT_V_TARGET})
 
         set(AUTOSIM_CYCLES ${ADD_FPGA_TARGET_AUTOSIM_CYCLES})
         if("${AUTOSIM_CYCLES}" STREQUAL "")
@@ -1296,7 +1298,7 @@ function(ADD_FPGA_TARGET)
         READ_GOLD "${READ_GOLD} rename ${TOP} gold"
         READ_GATE "read_verilog ${OUT_BIT_VERILOG} $<SEMICOLON> rename ${TOP} gate"
         EQUIV_CHECK_SCRIPT ${ADD_FPGA_TARGET_EQUIV_CHECK_SCRIPT}
-        DEPENDS ${SOURCE_FILES} ${SOURCE_FILES_DEPS} ${OUT_BIT_VERILOG}
+        DEPENDS ${SOURCE_FILES} ${SOURCE_FILES_DEPS} ${BIT_V_TARGET} ${OUT_BIT_VERILOG}
         )
       # Add bit-to-v check tests to all_check_tests.
       add_dependencies(all_check_tests ${NAME}_check_eblif)

--- a/xc7/tests/ff_sr_ce/CMakeLists.txt
+++ b/xc7/tests/ff_sr_ce/CMakeLists.txt
@@ -49,6 +49,36 @@ function(ff_ce_sr_test num_ff)
         testbench_ff_ce_sr_${num_ff}_tb
         testbinch_ff_ce_sr_${num_ff}_tb
         )
+
+    get_target_property_required(YOSYS env YOSYS)
+    get_target_property(YOSYS_TARGET env YOSYS_TARGET)
+
+    # Note that the name of sby will become a directory, so do NOT name it the
+    # same as the add_fpga_target name, otherwise sby will remove that 
+    # directory.
+    add_custom_command(
+        OUTPUT ff_ce_sr_${num_ff}_proof.sby
+        COMMAND ${PYTHON3}
+            ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py --num_ff ${num_ff} > ff_ce_sr_${num_ff}_proof.sby
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS
+            ${PYTHON3} ${PYTHON3_TARGET}
+            ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py
+        )
+
+    set(SBY
+        ${symbiflow-arch-defs_SOURCE_DIR}/third_party/symbiyosys/sbysrc/sby.py)
+    add_custom_target(
+        ff_ce_sr_${num_ff}_prove
+        COMMAND ${PYTHON3} ${SBY}
+            --yosys ${YOSYS} --abc ${YOSYS}-abc -f ff_ce_sr_${num_ff}_proof.sby
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+        DEPENDS
+            ff_ce_sr_${num_ff}_proof.sby
+            ${PYTHON3} ${PYTHON3_TARGET}
+            ${YOSYS} ${YOSYS_TARGET}
+            ff_ce_sr_${num_ff}_bit_v
+        )
 endfunction()
 
 ff_ce_sr_test(3)

--- a/xc7/tests/ff_sr_ce/CMakeLists.txt
+++ b/xc7/tests/ff_sr_ce/CMakeLists.txt
@@ -79,6 +79,10 @@ function(ff_ce_sr_test num_ff)
             ${YOSYS} ${YOSYS_TARGET}
             ff_ce_sr_${num_ff}_bit_v
         )
+
+    add_dependencies(all_ff_ce_sr_test
+        ff_ce_sr_${num_ff}_prove
+        )
 endfunction()
 
 ff_ce_sr_test(3)

--- a/xc7/tests/ff_sr_ce/CMakeLists.txt
+++ b/xc7/tests/ff_sr_ce/CMakeLists.txt
@@ -54,7 +54,7 @@ function(ff_ce_sr_test num_ff)
     get_target_property(YOSYS_TARGET env YOSYS_TARGET)
 
     # Note that the name of sby will become a directory, so do NOT name it the
-    # same as the add_fpga_target name, otherwise sby will remove that 
+    # same as the add_fpga_target name, otherwise sby will remove that
     # directory.
     add_custom_command(
         OUTPUT ff_ce_sr_${num_ff}_proof.sby
@@ -71,7 +71,10 @@ function(ff_ce_sr_test num_ff)
     add_custom_target(
         ff_ce_sr_${num_ff}_prove
         COMMAND ${PYTHON3} ${SBY}
-            --yosys ${YOSYS} --abc ${YOSYS}-abc -f ff_ce_sr_${num_ff}_proof.sby
+            --yosys ${YOSYS}
+            --abc ${YOSYS}-abc
+            --smtbmc ${YOSYS}-smtbmc
+            -f ff_ce_sr_${num_ff}_proof.sby
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS
             ff_ce_sr_${num_ff}_proof.sby

--- a/xc7/tests/ff_sr_ce/CMakeLists.txt
+++ b/xc7/tests/ff_sr_ce/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_file_target(FILE ff_type.v SCANNER_TYPE verilog)
 add_file_target(FILE ff_ce_sr.v SCANNER_TYPE verilog)
 add_file_target(FILE ff_ce_sr_testbench.v SCANNER_TYPE verilog)
 
@@ -8,84 +9,101 @@ function(ff_ce_sr_test num_ff)
     get_target_property_required(PYTHON3 env PYTHON3)
     get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
-    add_custom_command(
-        OUTPUT ff_ce_sr_${num_ff}.v
-        COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
-            --template ${CMAKE_CURRENT_SOURCE_DIR}/ff_ce_sr.v
-            --params "NUM_FF=${num_ff}"
-            --output ${CMAKE_CURRENT_BINARY_DIR}/ff_ce_sr_${num_ff}.v
-        DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ff_ce_sr.v generate.py
-        )
-    add_file_target(FILE ff_ce_sr_${num_ff}.v GENERATED)
-
-    add_custom_command(
-        OUTPUT ff_ce_sr_${num_ff}_tb.v
-        COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
-            --template ${CMAKE_CURRENT_SOURCE_DIR}/ff_ce_sr_testbench.v
-            --params "NUM_FF=${num_ff}"
-            --output ${CMAKE_CURRENT_BINARY_DIR}/ff_ce_sr_${num_ff}_tb.v
-        DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ff_ce_sr_testbench.v generate.py
-        )
-    add_file_target(FILE ff_ce_sr_${num_ff}_tb.v GENERATED)
-    get_file_target(TB_SOURCE_TARGET ff_ce_sr_testbench.v)
-    get_file_target(TB_TARGET ff_ce_sr_${num_ff}_tb.v)
-    get_target_property(INCLUDE_FILES ${TB_SOURCE_TARGET} INCLUDE_FILES)
-    set_target_properties(${TB_TARGET} PROPERTIES INCLUDE_FILES
-        ${INCLUDE_FILES})
-
-    add_fpga_target(
-        NAME ff_ce_sr_${num_ff}
-        BOARD basys3
-        INPUT_IO_FILE ../common/basys3.pcf
-        SOURCES ${symbiflow-arch-defs_SOURCE_DIR}/library/lfsr.v ff_ce_sr_${num_ff}.v
-        TESTBENCH_SOURCES ff_ce_sr_${num_ff}_tb.v
-        EXPLICIT_ADD_FILE_TARGET
-        EMIT_CHECK_TESTS
-        EQUIV_CHECK_SCRIPT
-            ${symbiflow-arch-defs_SOURCE_DIR}/yosys/equiv_simple_opt_full.ys
-    )
-
-    add_dependencies(all_ff_ce_sr_test
-        testbench_ff_ce_sr_${num_ff}_tb
-        testbinch_ff_ce_sr_${num_ff}_tb
-        )
-
     get_target_property_required(YOSYS env YOSYS)
     get_target_property(YOSYS_TARGET env YOSYS_TARGET)
 
-    # Note that the name of sby will become a directory, so do NOT name it the
-    # same as the add_fpga_target name, otherwise sby will remove that
-    # directory.
-    add_custom_command(
-        OUTPUT ff_ce_sr_${num_ff}_proof.sby
-        COMMAND ${PYTHON3}
-            ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py --num_ff ${num_ff} > ff_ce_sr_${num_ff}_proof.sby
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS
-            ${PYTHON3} ${PYTHON3_TARGET}
-            ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py
-        )
-
     set(SBY
         ${symbiflow-arch-defs_SOURCE_DIR}/third_party/symbiyosys/sbysrc/sby.py)
-    add_custom_target(
-        ff_ce_sr_${num_ff}_prove
-        COMMAND ${PYTHON3} ${SBY}
-            --yosys ${YOSYS}
-            --abc ${YOSYS}-abc
-            --smtbmc ${YOSYS}-smtbmc
-            -f ff_ce_sr_${num_ff}_proof.sby
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        DEPENDS
-            ff_ce_sr_${num_ff}_proof.sby
-            ${PYTHON3} ${PYTHON3_TARGET}
-            ${YOSYS} ${YOSYS_TARGET}
-            ff_ce_sr_${num_ff}_bit_v
+
+    foreach(ff_type FDRE FDSE FDCE FDPE)
+        string(TOLOWER ${ff_type} ff_type_lower)
+
+        add_custom_command(
+            OUTPUT ff_ce_sr_${num_ff}_${ff_type_lower}.v
+            COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+                --template ${CMAKE_CURRENT_SOURCE_DIR}/ff_ce_sr.v
+                --params "'NUM_FF=${num_ff},FF_TYPE=\"${ff_type}\"'"
+                --output
+                  ${CMAKE_CURRENT_BINARY_DIR}/ff_ce_sr_${num_ff}_${ff_type_lower}.v
+            DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ff_ce_sr.v generate.py
+            )
+        add_file_target(FILE ff_ce_sr_${num_ff}_${ff_type_lower}.v GENERATED)
+
+        set(TESTBENCH "")
+        if("${ff_type}" STREQUAL "FDRE")
+            # The testbench is written for FDRE only.
+            add_custom_command(
+                OUTPUT ff_ce_sr_${num_ff}_tb.v
+                COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate.py
+                    --template ${CMAKE_CURRENT_SOURCE_DIR}/ff_ce_sr_testbench.v
+                    --params "NUM_FF=${num_ff}"
+                    --output ${CMAKE_CURRENT_BINARY_DIR}/ff_ce_sr_${num_ff}_tb.v
+                DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ff_ce_sr_testbench.v generate.py
+                )
+            add_file_target(FILE ff_ce_sr_${num_ff}_tb.v GENERATED)
+            get_file_target(TB_SOURCE_TARGET ff_ce_sr_testbench.v)
+            get_file_target(TB_TARGET ff_ce_sr_${num_ff}_tb.v)
+            get_target_property(INCLUDE_FILES ${TB_SOURCE_TARGET} INCLUDE_FILES)
+            set_target_properties(${TB_TARGET} PROPERTIES INCLUDE_FILES
+                ${INCLUDE_FILES})
+
+            set(TESTBENCH TESTBENCH_SOURCES ff_ce_sr_${num_ff}_tb.v)
+        endif()
+
+        add_fpga_target(
+            NAME ff_ce_sr_${num_ff}_${ff_type_lower}
+            BOARD basys3
+            INPUT_IO_FILE ../common/basys3.pcf
+            SOURCES
+                ${symbiflow-arch-defs_SOURCE_DIR}/library/lfsr.v
+                ff_type.v
+                ff_ce_sr_${num_ff}_${ff_type_lower}.v
+            ${TESTBENCH}
+            EXPLICIT_ADD_FILE_TARGET
         )
 
-    add_dependencies(all_ff_ce_sr_test
-        ff_ce_sr_${num_ff}_prove
-        )
+        if(${ff_type} EQUAL FDRE)
+            add_dependencies(all_ff_ce_sr_test
+                testbench_ff_ce_sr_${num_ff}_tb
+                testbinch_ff_ce_sr_${num_ff}_tb
+                )
+        endif()
+
+        # Note that the name of sby will become a directory, so do NOT name it
+        # the same as the add_fpga_target name, otherwise sby will remove that
+        # directory.
+        add_custom_command(
+            OUTPUT ff_ce_sr_${num_ff}_${ff_type_lower}_proof.sby
+            COMMAND ${PYTHON3}
+                ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py
+                    --num_ff ${num_ff}
+                    --ff_type ${ff_type_lower} >
+                    ff_ce_sr_${num_ff}_${ff_type_lower}_proof.sby
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            DEPENDS
+                ${PYTHON3} ${PYTHON3_TARGET}
+                ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py
+            )
+
+        add_custom_target(
+            ff_ce_sr_${num_ff}_${ff_type_lower}_prove
+            COMMAND ${PYTHON3} ${SBY}
+                --yosys ${YOSYS}
+                --abc ${YOSYS}-abc
+                --smtbmc ${YOSYS}-smtbmc
+                -f ff_ce_sr_${num_ff}_${ff_type_lower}_proof.sby
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            DEPENDS
+                ff_ce_sr_${num_ff}_${ff_type_lower}_proof.sby
+                ${PYTHON3} ${PYTHON3_TARGET}
+                ${YOSYS} ${YOSYS_TARGET}
+                ff_ce_sr_${num_ff}_${ff_type_lower}_bit_v
+            )
+
+        add_dependencies(all_ff_ce_sr_test
+            ff_ce_sr_${num_ff}_${ff_type_lower}_prove
+            )
+    endforeach()
 endfunction()
 
 ff_ce_sr_test(3)

--- a/xc7/tests/ff_sr_ce/create_sby.py
+++ b/xc7/tests/ff_sr_ce/create_sby.py
@@ -1,0 +1,39 @@
+import argparse
+import sys
+
+def write_template(f, num_ff):
+    template = """
+[options]
+mode prove
+depth 50
+timeout 600
+aigsmt z3
+
+[engines]
+abc pdr
+
+[script]
+read_verilog +/xilinx/cells_sim.v
+read_verilog -sv ff_ce_sr_{num_ff}.v
+rename top gold
+read_verilog -sv top_bit.v
+rename top gate
+miter -equiv -make_assert gold gate miter
+prep -top miter
+
+[files]
+ff_ce_sr_{num_ff}/artix7-xc7a50t-basys3-roi-virt-xc7a50t-basys3-test/top_bit.v
+ff_ce_sr_{num_ff}.v
+"""
+    print(template.format(num_ff=num_ff, file=f))
+
+def main():
+    parser = argparse.ArgumentParser(description="Creates SymbiYosys project file for proving FF CE/SR.")
+    parser.add_argument('--num_ff', required=True, type=int)
+
+    args = parser.parse_args()
+
+    write_template(f=sys.stdout, num_ff=args.num_ff)
+
+if __name__ == "__main__":
+    main()

--- a/xc7/tests/ff_sr_ce/create_sby.py
+++ b/xc7/tests/ff_sr_ce/create_sby.py
@@ -1,6 +1,7 @@
 import argparse
 import sys
 
+
 def write_template(f, num_ff, ff_type):
     template = """
 [options]
@@ -29,14 +30,18 @@ ff_type.v
 """
     print(template.format(num_ff=num_ff, ff_type=ff_type, file=f))
 
+
 def main():
-    parser = argparse.ArgumentParser(description="Creates SymbiYosys project file for proving FF CE/SR.")
+    parser = argparse.ArgumentParser(
+        description="Creates SymbiYosys project file for proving FF CE/SR."
+    )
     parser.add_argument('--num_ff', required=True, type=int)
     parser.add_argument('--ff_type', required=True)
 
     args = parser.parse_args()
 
     write_template(f=sys.stdout, num_ff=args.num_ff, ff_type=args.ff_type)
+
 
 if __name__ == "__main__":
     main()

--- a/xc7/tests/ff_sr_ce/create_sby.py
+++ b/xc7/tests/ff_sr_ce/create_sby.py
@@ -1,7 +1,7 @@
 import argparse
 import sys
 
-def write_template(f, num_ff):
+def write_template(f, num_ff, ff_type):
     template = """
 [options]
 mode prove
@@ -14,7 +14,8 @@ abc pdr
 
 [script]
 read_verilog +/xilinx/cells_sim.v
-read_verilog -sv ff_ce_sr_{num_ff}.v
+read_verilog -sv ff_type.v
+read_verilog -sv ff_ce_sr_{num_ff}_{ff_type}.v
 rename top gold
 read_verilog -sv top_bit.v
 rename top gate
@@ -22,18 +23,20 @@ miter -equiv -make_assert gold gate miter
 prep -top miter
 
 [files]
-ff_ce_sr_{num_ff}/artix7-xc7a50t-basys3-roi-virt-xc7a50t-basys3-test/top_bit.v
-ff_ce_sr_{num_ff}.v
+ff_ce_sr_{num_ff}_{ff_type}/artix7-xc7a50t-basys3-roi-virt-xc7a50t-basys3-test/top_bit.v
+ff_ce_sr_{num_ff}_{ff_type}.v
+ff_type.v
 """
-    print(template.format(num_ff=num_ff, file=f))
+    print(template.format(num_ff=num_ff, ff_type=ff_type, file=f))
 
 def main():
     parser = argparse.ArgumentParser(description="Creates SymbiYosys project file for proving FF CE/SR.")
     parser.add_argument('--num_ff', required=True, type=int)
+    parser.add_argument('--ff_type', required=True)
 
     args = parser.parse_args()
 
-    write_template(f=sys.stdout, num_ff=args.num_ff)
+    write_template(f=sys.stdout, num_ff=args.num_ff, ff_type=args.ff_type)
 
 if __name__ == "__main__":
     main()

--- a/xc7/tests/ff_sr_ce/ff_ce_sr.v
+++ b/xc7/tests/ff_sr_ce/ff_ce_sr.v
@@ -7,6 +7,7 @@ module top(
 );
 
 localparam NUM_FF = 4;
+localparam FF_TYPE = "FDRE";
 
 assign tx = rx;
 
@@ -51,47 +52,51 @@ generate for(i = 0; i < NUM_FF; i=i+1) begin:ff
     assign D[4*i+3] = sw[(4*i+3) % 14];
 
     // Tie SR to GND and CE to VCC
-    (* keep *) FDRE #(
-        .INIT(1'b0)
+    (* keep *) FF #(
+        .INIT(1'b0),
+        .FF_TYPE(FF_TYPE)
     ) vcc_gnd (
         .Q(Q[4*i+0]),
         .C(clk),
         .D(D[4*i+0]),
         .CE(1'b1),
-        .R(1'b0)
+        .SR(1'b0)
     );
 
     // Tie SR to GND and CE to signal
-    (* keep *) FDRE #(
-        .INIT(1'b0)
+    (* keep *) FF #(
+        .INIT(1'b0),
+        .FF_TYPE(FF_TYPE)
     ) s_gnd (
         .Q(Q[4*i+1]),
         .C(clk),
         .D(D[4*i+1]),
         .CE(ce),
-        .R(1'b0)
+        .SR(1'b0)
     );
 
     // Tie SR to signal and CE to signal
-    (* keep *) FDRE #(
-        .INIT(1'b0)
+    (* keep *) FF #(
+        .INIT(1'b0),
+        .FF_TYPE(FF_TYPE)
     ) s_s (
         .Q(Q[4*i+2]),
         .C(clk),
         .D(D[4*i+2]),
         .CE(ce),
-        .R(reset)
+        .SR(reset)
     );
 
     // Tie SR to signal and CE to VCC
-    (* keep *) FDRE #(
-        .INIT(0)
+    (* keep *) FF #(
+        .INIT(0),
+        .FF_TYPE(FF_TYPE)
     ) vcc_s (
         .Q(Q[4*i+3]),
         .C(clk),
         .D(D[4*i+3]),
         .CE(1'b1),
-        .R(reset)
+        .SR(reset)
     );
 end endgenerate
 

--- a/xc7/tests/ff_sr_ce/ff_type.v
+++ b/xc7/tests/ff_sr_ce/ff_type.v
@@ -1,0 +1,48 @@
+module FF(input D, C, CE, SR, output Q);
+
+parameter INIT = 1'b0;
+parameter FF_TYPE = "FDRE";
+
+if(FF_TYPE == "FDRE") begin
+    (* keep *) FDRE #(
+        .INIT(INIT)
+    ) fdre (
+        .Q(Q),
+        .C(C),
+        .D(D),
+        .CE(CE),
+        .R(SR)
+    );
+end else if(FF_TYPE == "FDSE") begin
+    (* keep *) FDSE #(
+        .INIT(INIT)
+    ) fdse (
+        .Q(Q),
+        .C(C),
+        .D(D),
+        .CE(CE),
+        .S(SR)
+    );
+end else if(FF_TYPE == "FDCE") begin
+    (* keep *) FDCE #(
+        .INIT(INIT)
+    ) fdce (
+        .Q(Q),
+        .C(C),
+        .D(D),
+        .CE(CE),
+        .CLR(SR)
+    );
+end else if(FF_TYPE == "FDPE") begin
+    (* keep *) FDPE #(
+        .INIT(INIT)
+    ) fdpe (
+        .Q(Q),
+        .C(C),
+        .D(D),
+        .CE(CE),
+        .PRE(SR)
+    );
+end
+
+endmodule

--- a/xc7/tests/ff_sr_ce/generate.py
+++ b/xc7/tests/ff_sr_ce/generate.py
@@ -2,7 +2,7 @@ import argparse
 import os.path
 import re
 
-LOCALPARAM_RE = re.compile(r'^(\s*)localparam\s+([^\s]+)\s*=\s*\d+\s*;\s*$')
+LOCALPARAM_RE = re.compile(r'^(\s*)localparam\s+([^\s]+)\s*=.*$')
 DUMPVARS_RE = re.compile(r'^(\s*)\$dumpfile\([^\)]+\)\s*;\s*$')
 
 


### PR DESCRIPTION
This PR adds SymbiYosys to third_party and uses it to prove equivalence on the FF CE/SR tests.  This PR also expands the FF CE/SR test to the other 3 FD types (FDSE, FDPE, FDCE).

This PR is dependent on https://github.com/SymbiFlow/symbiflow-arch-defs/pull/570 (which is blocked by https://github.com/SymbiFlow/prjxray-db/pull/7).

This takes a first attempt at #572 by using submodules.  This is fine for the "PASS" case, but in the failure case, another SMT2 solver needs to be installed.  However for the purposes of getting an equivalence testing working on the FF CE/SR test, this does work.