### PR TITLE
Make scalable tests debuggable with fasm2v

### DIFF
--- a/tests/9-scalable_proc/CMakeLists.txt
+++ b/tests/9-scalable_proc/CMakeLists.txt
@@ -89,7 +89,7 @@ scalable_proc(
   BOARD basys3
   INPUT_IO_FILE basys3.pcf
   ROM_STYLE bram
-  MAX_PROC 5
+  MAX_PROC 8
 )
 
 scalable_proc(

--- a/tests/9-scalable_proc/basys3.pcf
+++ b/tests/9-scalable_proc/basys3.pcf
@@ -1,15 +1,43 @@
 
 # Pinout for the basys3 Breakout Board
-# FIXME: These pindefs are random for placement.
 
 set_io clk W5
-set_io rst V17
 
 set_io ser_tx A18
 set_io ser_rx B18
 
-set_io leds[0] U16
-set_io leds[1] E19
-set_io leds[2] U19
-set_io leds[3] V19
+# in[0:15] correspond with SW0-SW15 on the basys3
+set_io sw[0] V17
+set_io sw[1] V16
+set_io sw[2] W16
+set_io sw[3] W17
+set_io sw[4] W15
+set_io sw[5] V15
+set_io sw[6] W14
+set_io sw[7] W13
+set_io sw[8] V2
+set_io sw[9] T3
+set_io sw[10] T2
+set_io sw[11] R3
+set_io sw[12] W2
+set_io sw[13] U1
+set_io sw[14] T1
+set_io sw[15] R2
 
+# out[0:15] correspond with LD0-LD15 on the basys3
+set_io led[0] U16
+set_io led[1] E19
+set_io led[2] U19
+set_io led[3] V19
+set_io led[4] W18
+set_io led[5] U15
+set_io led[6] U14
+set_io led[7] V14
+set_io led[8] V13
+set_io led[9] V3
+set_io led[10] W3
+set_io led[11] U3
+set_io led[12] P3
+set_io led[13] N3
+set_io led[14] P1
+set_io led[15] L1

--- a/tests/9-scalable_proc/basys3_top.v
+++ b/tests/9-scalable_proc/basys3_top.v
@@ -1,60 +1,46 @@
 module top
 (
 input  wire         clk,
-input  wire         rst,
 
 output wire         ser_tx,
 input  wire         ser_rx,
 
-output wire [3:0]   leds
+input wire [15:0]   sw,
+output wire [15:0]  led
 );
 
 // ============================================================================
 
-// Clock divider k = 1/(1<<N_CLK_DIV)
-localparam integer N_CLK_DIV = 7;
+reg rst = 1;
+reg rst1 = 1;
+reg rst2 = 1;
+reg rst3 = 1;
+assign led[0] = rst;
+assign led[13:1] = sw[13:1];
+assign led[14] = ^sw;
+assign led[15] = ser_rx;
 
-reg [N_CLK_DIV-1:0] clk_out;
-wire clk_div = clk_out[N_CLK_DIV-1];
-
-clk_div clk_div_0 (.clk_in(clk), .clk_out(clk_out[0]));
-genvar i;
-generate for(i=0; i<(N_CLK_DIV-1); i=i+1) begin
-    clk_div clk_div_n (.clk_in(clk_out[i]), .clk_out(clk_out[i+1]));
-end endgenerate
+always @(posedge clk) begin
+    rst3 <= 0;
+    rst2 <= rst3;
+    rst1 <= rst2;
+    rst <= rst1;
+end
 
 // ============================================================================
 //
 scalable_proc #
 (
 .NUM_PROCESSING_UNITS   (2),
-.UART_PRESCALER         ((100000000 >> N_CLK_DIV) / 9600),
+.UART_PRESCALER         ((100000000) / (500000))
 )
 scalable_proc
 (
-.CLK        (clk_div),
+.CLK        (clk),
 .RST        (rst),
 
 .UART_TX    (ser_tx),
 .UART_RX    (ser_rx)
 );
-
-assign leds = {rst, !ser_rx, !ser_tx, !rst};
-
-endmodule
-
-// ============================================================================
-
-module clk_div (
-    input  clk_in,
-    output clk_out
-);
-
-initial begin
-    clk_out <= 0;
-end
-
-always @(posedge clk_in)
-    clk_out <= ~clk_out;
 
 endmodule

--- a/tests/9-scalable_proc/utils/receiver.py
+++ b/tests/9-scalable_proc/utils/receiver.py
@@ -133,6 +133,9 @@ def main():
                     # Got a match
                     if word == pattern[pat_index][1]:
                         pat_index = (pat_index + 1) % len(pattern)
+                        sync_cnt += 1
+                        if sync_cnt % 1000 == 0:
+                            print('In sync, sync_cnt = {}'.format(sync_cnt))
                     # Got a mismatch
                     else:
                         print(

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -23,6 +23,8 @@ function(ADD_XC7_ARCH_DEFINE)
       --place_algorithm bounding_box
       --enable_timing_computations off
       --allow_unrelated_clustering on
+      # TODO: Consider removing round robin packing once tile split and
+      # equivilant tiles are in.
       --round_robin_prepacking on
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -23,6 +23,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --place_algorithm bounding_box
       --enable_timing_computations off
       --allow_unrelated_clustering on
+      --round_robin_prepacking on
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \


### PR DESCRIPTION
- Remove clock divider from scalable tests.
- Use all IO pins in ROI.
- Re-enable round robin packing.