### PR TITLE
gen.cmake: handle generated verilog and xml deps

### DIFF
--- a/make/gen.cmake
+++ b/make/gen.cmake
@@ -300,6 +300,7 @@ function(N_TEMPLATE)
 
   foreach(PREFIX ${N_TEMPLATE_PREFIXES})
     foreach(SRC ${N_TEMPLATE_SRCS})
+      set(REAL_INCLUDE_FILES "")
       string(
         REPLACE
           "ntemplate."
@@ -314,6 +315,28 @@ function(N_TEMPLATE)
           SRC_WITH_PREFIX
           ${SRC_NO_NTEMPLATE}
       )
+      get_file_target(SRC_TARGET_NAME ${SRC})
+      get_target_property(SRC_INCLUDE_FILES ${SRC_TARGET_NAME} INCLUDE_FILES)
+      foreach(INC ${SRC_INCLUDE_FILES})
+        get_filename_component(INC_FILE ${INC} NAME)
+        get_filename_component(INC_DIR ${INC} DIRECTORY)
+        # template all the include files
+        string(
+          REPLACE
+            "ntemplate."
+            ""
+            INC_NO_NTEMPLATE
+            ${INC_FILE}
+        )
+        string(
+          REPLACE
+            "N"
+            ${PREFIX}
+            INC_WITH_PREFIX
+            ${INC_NO_NTEMPLATE}
+        )
+        list(APPEND REAL_INCLUDE_FILES ${INC_DIR}/${INC_WITH_PREFIX})
+      endforeach()
       get_file_location(SRC_LOCATION ${SRC})
       set(DEPS "")
       append_file_dependency(DEPS ${SRC})
@@ -329,7 +352,9 @@ function(N_TEMPLATE)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       )
 
-      add_file_target(FILE ${SRC_WITH_PREFIX} GENERATED DEPENDS ${SRC})
+      add_file_target(FILE ${SRC_WITH_PREFIX} GENERATED)
+      get_file_target(SRC_TARGET_NAME ${SRC_WITH_PREFIX})
+      set_target_properties(${SRC_TARGET_NAME} PROPERTIES INCLUDE_FILES "${REAL_INCLUDE_FILES}")
 
       list(APPEND OUTPUTS ${SRC_WITH_PREFIX})
 

--- a/make/gen.cmake
+++ b/make/gen.cmake
@@ -31,6 +31,8 @@ function(V2X)
   set(INCLUDES "")
 
   set(DEPENDS_LIST "")
+  set(MODEL_INCLUDE_FILES "")
+  set(PB_TYPE_INCLUDE_FILES "")
   get_target_property_required(PYTHON3 env PYTHON3)
   get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
   list(APPEND DEPENDS_LIST ${PYTHON3} ${PYTHON3_TARGET})
@@ -60,6 +62,8 @@ function(V2X)
 
       append_file_dependency(DEPENDS_LIST ${INCLUDE_SRC_DIR}/${INCLUDE_ROOT}.model.xml)
       append_file_dependency(DEPENDS_LIST ${INCLUDE_SRC_DIR}/${INCLUDE_ROOT}.pb_type.xml)
+      list(APPEND MODEL_INCLUDE_FILES ${INCLUDE_SRC_DIR}/${INCLUDE_ROOT}.model.xml)
+      list(APPEND PB_TYPE_INCLUDE_FILES ${INCLUDE_SRC_DIR}/${INCLUDE_ROOT}.pb_type.xml)
     endforeach()
   endforeach()
 
@@ -97,6 +101,8 @@ function(V2X)
   )
 
   add_file_target(FILE "${V2X_NAME}.pb_type.xml" GENERATED)
+  get_file_target(SRC_TARGET_NAME "${V2X_NAME}.pb_type.xml")
+  set_target_properties(${SRC_TARGET_NAME} PROPERTIES INCLUDE_FILES "${PB_TYPE_INCLUDE_FILES}")
 
   add_custom_command(
     OUTPUT "${V2X_NAME}.model.xml"
@@ -111,6 +117,8 @@ function(V2X)
   )
 
   add_file_target(FILE "${V2X_NAME}.model.xml" GENERATED)
+  get_file_target(SRC_TARGET_NAME "${V2X_NAME}.model.xml")
+  set_target_properties(${SRC_TARGET_NAME} PROPERTIES INCLUDE_FILES "${MODEL_INCLUDE_FILES}")
 
   add_custom_target(
     ${V2X_NAME}

--- a/make/gen.cmake
+++ b/make/gen.cmake
@@ -264,6 +264,38 @@ function(MUX_GEN)
   endif()
 endfunction(MUX_GEN)
 
+function(GET_TEMPLATED_FILENAME var SRC PREFIX)
+  # ~~~
+  # GET_TEMPLATED_FILENAME(
+  #   NAME <name>
+  #   var <calculated templated filename>
+  #   SRC <template file>
+  #   PREFIX <template prefixes>
+  #   )
+  # ~~~
+  #
+  # GET_TEMPLATED_FILENAME calculates file name that from given template and prefix.
+  # The template file should have a form of ntemplate.<rest>.
+  # The function removes the "ntemplate" prefix and converting all N's in file name
+  # to <prefix>.
+  #
+  string(
+    REPLACE
+      "ntemplate."
+      ""
+      SRC_NO_NTEMPLATE
+      ${SRC}
+  )
+  string(
+    REPLACE
+      "N"
+      ${PREFIX}
+      SRC_WITH_PREFIX
+      ${SRC_NO_NTEMPLATE}
+  )
+set(${var} ${SRC_WITH_PREFIX} PARENT_SCOPE)
+endfunction()
+
 function(N_TEMPLATE)
   # ~~~
   # N_TEMPLATE(
@@ -301,40 +333,14 @@ function(N_TEMPLATE)
   foreach(PREFIX ${N_TEMPLATE_PREFIXES})
     foreach(SRC ${N_TEMPLATE_SRCS})
       set(REAL_INCLUDE_FILES "")
-      string(
-        REPLACE
-          "ntemplate."
-          ""
-          SRC_NO_NTEMPLATE
-          ${SRC}
-      )
-      string(
-        REPLACE
-          "N"
-          ${PREFIX}
-          SRC_WITH_PREFIX
-          ${SRC_NO_NTEMPLATE}
-      )
+      get_templated_filename(SRC_WITH_PREFIX ${SRC} ${PREFIX})
       get_file_target(SRC_TARGET_NAME ${SRC})
       get_target_property(SRC_INCLUDE_FILES ${SRC_TARGET_NAME} INCLUDE_FILES)
       foreach(INC ${SRC_INCLUDE_FILES})
         get_filename_component(INC_FILE ${INC} NAME)
         get_filename_component(INC_DIR ${INC} DIRECTORY)
         # template all the include files
-        string(
-          REPLACE
-            "ntemplate."
-            ""
-            INC_NO_NTEMPLATE
-            ${INC_FILE}
-        )
-        string(
-          REPLACE
-            "N"
-            ${PREFIX}
-            INC_WITH_PREFIX
-            ${INC_NO_NTEMPLATE}
-        )
+        get_templated_filename(INC_WITH_PREFIX ${INC_FILE} ${PREFIX})
         list(APPEND REAL_INCLUDE_FILES ${INC_DIR}/${INC_WITH_PREFIX})
       endforeach()
       get_file_location(SRC_LOCATION ${SRC})

--- a/utils/n.py
+++ b/utils/n.py
@@ -26,7 +26,8 @@ def main(args):
 
     template = open(templatepath, "r").read()
     template = re.sub(r'(["\s])ntemplate\.N', r'\1{FN}', template)
-    open(outpath, "w").write(template.format(N=replacement.upper(), FN=replacement))
+    open(outpath,
+         "w").write(template.format(N=replacement.upper(), FN=replacement))
     print(
         "Generated {} from {}".format(os.path.relpath(outpath), templatefile)
     )

--- a/utils/n.py
+++ b/utils/n.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import re
 
 from lib.asserts import assert_eq
 
@@ -24,7 +25,8 @@ def main(args):
     assert_eq(outname_value, outfile)
 
     template = open(templatepath, "r").read()
-    open(outpath, "w").write(template.format(N=replacement.upper()))
+    template = re.sub(r'(["\s])ntemplate\.N', r'\1{FN}', template)
+    open(outpath, "w").write(template.format(N=replacement.upper(), FN=replacement))
     print(
         "Generated {} from {}".format(os.path.relpath(outpath), templatefile)
     )


### PR DESCRIPTION
V2X and N_TEMPLATE now can handle dependency on a generated XML or Verilog file. The list of the dependencies can be passed via GENERATEDXMLDEPS and GENERATEDVERILOGDEPS for both n_template and v2x functions.

This may fix #262 