### PR TITLE
Import of all pips (bidirectional and pseudo) to channels.db

### DIFF
--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -108,6 +108,9 @@ CREATE TABLE pip_in_tile(
   tile_type_pkey INT,
   src_wire_in_tile_pkey INT,
   dest_wire_in_tile_pkey INT,
+  can_invert BOOLEAN,
+  is_directional BOOLEAN,
+  is_pseudo BOOLEAN,
   FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey),
   FOREIGN KEY(src_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey),
   FOREIGN KEY(dest_wire_in_tile_pkey) REFERENCES wire_in_tile(pkey)

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -225,8 +225,9 @@ SELECT
 FROM
   pip_in_tile
 WHERE
+  is_directional = 1 AND is_pseudo = 0 AND (
   src_wire_in_tile_pkey = ?
-  OR dest_wire_in_tile_pkey = ?;""", (wire_in_tile_pkey, wire_in_tile_pkey)):
+  OR dest_wire_in_tile_pkey = ?);""", (wire_in_tile_pkey, wire_in_tile_pkey)):
                 assert (
                     src_wire_in_tile_pkey == wire_in_tile_pkey
                     or dest_wire_in_tile_pkey == wire_in_tile_pkey

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -87,23 +87,18 @@ VALUES
         wires[wire] = c.lastrowid
 
     for pip in tile_type.get_pips():
-        # Psuedo pips are not part of the routing fabric, so don't add them.
-        if pip.is_pseudo:
-            continue
-
-        if not pip.is_directional:
-            continue
 
         c.execute(
             """
 INSERT INTO pip_in_tile(
   name, tile_type_pkey, src_wire_in_tile_pkey,
-  dest_wire_in_tile_pkey
+  dest_wire_in_tile_pkey, can_invert, is_directional, is_pseudo
 )
 VALUES
-  (?, ?, ?, ?)""", (
+  (?, ?, ?, ?, ?, ?, ?)""", (
                 pip.name, tile_types[tile_type_name], wires[pip.net_from],
-                wires[pip.net_to]
+                wires[pip.net_to
+                      ], pip.can_invert, pip.is_directional, pip.is_pseudo
             )
         )
 
@@ -395,8 +390,9 @@ FROM
   pip_in_tile
   INNER JOIN wire
 WHERE
+  pip_in_tile.is_directional = 1 AND pip_in_tile.is_pseudo = 0 AND (
   pip_in_tile.src_wire_in_tile_pkey = wire.wire_in_tile_pkey
-  OR pip_in_tile.dest_wire_in_tile_pkey = wire.wire_in_tile_pkey
+  OR pip_in_tile.dest_wire_in_tile_pkey = wire.wire_in_tile_pkey)
 GROUP BY
   wire.node_pkey;"""
     )
@@ -509,8 +505,9 @@ FROM
   wire_in_node
   INNER JOIN pip_in_tile
 WHERE
+  pip_in_tile.is_directional = 1 AND pip_in_tile.is_pseudo = 0 AND (
   pip_in_tile.src_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey
-  OR pip_in_tile.dest_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey
+  OR pip_in_tile.dest_wire_in_tile_pkey = wire_in_node.wire_in_tile_pkey)
 LIMIT
   1;
 """, (node, )

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -411,7 +411,8 @@ def create_get_pip_wire_names(conn):
     def get_pip_wire_names(pip_pkey):
         c.execute(
             """SELECT src_wire_in_tile_pkey, dest_wire_in_tile_pkey
-            FROM pip_in_tile WHERE pkey = ?;""", (pip_pkey, )
+            FROM pip_in_tile WHERE pkey = ? AND is_directional = 1 AND is_pseudo = 0;""",
+            (pip_pkey, )
         )
         src_wire_in_tile_pkey, dest_wire_in_tile_pkey = c.fetchone()
 


### PR DESCRIPTION
This PR adds additional columns to the `pip_in_tile` table namely: `can_invert`, `is_directional` and `is_pseudo`. All pseudo pips are now imported from the prjxray database instead of being rejected. All SQL queries regarding the `pip_in_tile` table table were modified to reject pseudo and bidirectional pips.