### PR TITLE
WIP: CLB to SLICE split

### DIFF
--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -262,3 +262,11 @@ CREATE TABLE constant_sources(
     FOREIGN KEY(vcc_track_pkey) REFERENCES track(pkey),
     FOREIGN KEY(gnd_track_pkey) REFERENCES track(pkey)
 );
+
+-- Grid location map.
+CREATE TABLE grid_loc_map(
+    phy_tile_pkey INT,
+    vpr_tile_pkey INT,
+    FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
+    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
+);

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -270,3 +270,12 @@ CREATE TABLE grid_loc_map(
     FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
     FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
 );
+
+-- Tile type map.
+-- Maps physical tiles to VPR tiles. Used for CLB splitting
+CREATE TABLE tile_type_map(
+    phy_tile_type_pkey INT,
+    vpr_tile_type_pkey INT,
+    FOREIGN KEY(phy_tile_type_pkey) REFERENCES tile_type(pkey),
+    FOREIGN KEY(vpr_tile_type_pkey) REFERENCES tile_type(pkey)
+);

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -286,7 +286,7 @@ CREATE TABLE tile_type_map(
 -- Relates a pip_in_tile with a concrete tile instance in the VPR grid.
 -- This is necessary as in the VPR we have generic SLICE tiles but pips
 -- inside them are not generic.
-CREATE TABLE pip_in_tile_instance(
+CREATE TABLE pip(
     vpr_tile_pkey INT,
     pip_in_tile_pkey INT,
     FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey),

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -44,6 +44,16 @@ CREATE TABLE tile_type(
   name TEXT
 );
 
+-- VPR tile type table.
+-- Relates tile types from the tile_type table with their names as they
+-- appear in the VPR
+CREATE TABLE vpr_tile_type(
+  pkey INTEGER PRIMARY KEY,
+  tile_type_pkey INT,
+  name TEXT,
+  FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+);
+
 -- Site type table, used to track site_type using a pkey, and provide
 -- the site_type_pkey <-> name mapping.
 CREATE TABLE site_type(
@@ -66,11 +76,11 @@ CREATE TABLE tile(
   pkey INTEGER PRIMARY KEY,
   name TEXT,
   tile_type_pkey INT,
-  site_remap_pkey INT,
+  vpr_tile_type_pkey INT,
   grid_x INT,
   grid_y INT,
   FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
-  FOREIGN KEY(site_remap_pkey) REFERENCES site(pkey)
+  FOREIGN KEY(vpr_tile_type_pkey) REFERENCES vpr_tile_type(pkey)
 );
 
 -- Site pin table, contains names of pins and their direction, along
@@ -280,15 +290,4 @@ CREATE TABLE tile_type_map(
     vpr_tile_type_pkey INT,
     FOREIGN KEY(phy_tile_type_pkey) REFERENCES tile_type(pkey),
     FOREIGN KEY(vpr_tile_type_pkey) REFERENCES tile_type(pkey)
-);
-
--- Pip in tile instance
--- Relates a pip_in_tile with a concrete tile instance in the VPR grid.
--- This is necessary as in the VPR we have generic SLICE tiles but pips
--- inside them are not generic.
-CREATE TABLE pip(
-    vpr_tile_pkey INT,
-    pip_in_tile_pkey INT,
-    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey),
-    FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip_in_tile(pkey)
 );

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -51,7 +51,17 @@ CREATE TABLE site_type(
   name TEXT
 );
 
--- Tile table, contains type and name of tile and location in grid.
+-- Tile table, contains type and name of tile and location in the physical grid.
+CREATE TABLE phy_tile(
+  pkey INTEGER PRIMARY KEY,
+  name TEXT,
+  tile_type_pkey INT,
+  grid_x INT,
+  grid_y INT,
+  FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+);
+
+-- Tile table, contains type and name of tile and location in the VPR grid.
 CREATE TABLE tile(
   pkey INTEGER PRIMARY KEY,
   name TEXT,

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -44,10 +44,10 @@ CREATE TABLE tile_type(
   name TEXT
 );
 
--- VPR tile type table.
--- Relates tile types from the tile_type table with their names as they
--- appear in the VPR
-CREATE TABLE vpr_tile_type(
+-- Tile type alias.
+-- Used to make generic tile types from specific ones when generating
+-- architecture definition for the VPR
+CREATE TABLE tile_type_alias(
   pkey INTEGER PRIMARY KEY,
   tile_type_pkey INT,
   name TEXT,
@@ -76,11 +76,11 @@ CREATE TABLE tile(
   pkey INTEGER PRIMARY KEY,
   name TEXT,
   tile_type_pkey INT,
-  vpr_tile_type_pkey INT,
+  tile_type_alias_pkey INT,
   grid_x INT,
   grid_y INT,
   FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
-  FOREIGN KEY(vpr_tile_type_pkey) REFERENCES vpr_tile_type(pkey)
+  FOREIGN KEY(tile_type_alias_pkey) REFERENCES tile_type_alias(pkey)
 );
 
 -- Site pin table, contains names of pins and their direction, along

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -66,9 +66,11 @@ CREATE TABLE tile(
   pkey INTEGER PRIMARY KEY,
   name TEXT,
   tile_type_pkey INT,
+  site_remap_pkey INT,
   grid_x INT,
   grid_y INT,
   FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+  FOREIGN KEY(site_remap_pkey) REFERENCES site(pkey)
 );
 
 -- Site pin table, contains names of pins and their direction, along
@@ -278,17 +280,6 @@ CREATE TABLE tile_type_map(
     vpr_tile_type_pkey INT,
     FOREIGN KEY(phy_tile_type_pkey) REFERENCES tile_type(pkey),
     FOREIGN KEY(vpr_tile_type_pkey) REFERENCES tile_type(pkey)
-);
-
--- Former site table
--- Contains entries only for CLB split products. Holds information
--- which site instance correspond to the new tile. It is necessary to know
--- that when remapping routing resources.
-CREATE TABLE tile_former_site(
-    vpr_tile_pkey INT,
-    site_pkey INT,
-    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey),
-    FOREIGN KEY(site_pkey) REFERENCES site(pkey)
 );
 
 -- Pip in tile instance

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -290,3 +290,14 @@ CREATE TABLE tile_former_site(
     FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey),
     FOREIGN KEY(site_pkey) REFERENCES site(pkey)
 );
+
+-- Pip in tile instance
+-- Relates a pip_in_tile with a concrete tile instance in the VPR grid.
+-- This is necessary as in the VPR we have generic SLICE tiles but pips
+-- inside them are not generic.
+CREATE TABLE pip_in_tile_instance(
+    vpr_tile_pkey INT,
+    pip_in_tile_pkey INT,
+    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey),
+    FOREIGN KEY(pip_in_tile_pkey) REFERENCES pip_in_tile(pkey)
+);

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -283,6 +283,12 @@ CREATE TABLE grid_loc_map(
     FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
 );
 
+-- Tile types to split
+CREATE TABLE tile_types_to_split(
+    tile_type_pkey INT,
+    FOREIGN KEY(tile_type_pkey) REFERENCES tile_type(pkey)
+);
+
 -- Tile type map.
 -- Maps physical tiles to VPR tiles. Used for CLB splitting
 CREATE TABLE tile_type_map(

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -279,3 +279,14 @@ CREATE TABLE tile_type_map(
     FOREIGN KEY(phy_tile_type_pkey) REFERENCES tile_type(pkey),
     FOREIGN KEY(vpr_tile_type_pkey) REFERENCES tile_type(pkey)
 );
+
+-- Former site table
+-- Contains entries only for CLB split products. Holds information
+-- which site instance correspond to the new tile. It is necessary to know
+-- that when remapping routing resources.
+CREATE TABLE tile_former_site(
+    vpr_tile_pkey INT,
+    site_pkey INT,
+    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey),
+    FOREIGN KEY(site_pkey) REFERENCES site(pkey)
+);

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -4,6 +4,8 @@ import argparse
 import os
 import itertools
 
+from collections import namedtuple
+
 # =============================================================================
 
 
@@ -131,6 +133,11 @@ ON vpr.pkey = map.vpr_tile_pkey
     def get_phy_loc(self, grid_loc):
         return self.bwd_loc_map[grid_loc]
 
+# =============================================================================
+
+
+# A generic structure for representing forward and backward mapping.
+GenericMap = namedtuple("GenericMap", "fwd_map bwd_map")
 
 # =============================================================================
 
@@ -173,7 +180,4 @@ def get_vpr_grid_extent(conn):
     return xmin, ymin, xmax, ymax
 
 
-# =============================================================================
 
-if __name__ == "__main__":
-    main()

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+import sqlite3
+import argparse
+import os
+import itertools
+
+# =============================================================================
+
+class GridLocMap(object):
+    """
+    This class preforms forward (physical -> VPR) and backward (VPR -> physical)
+    grid location mapping.
+    """
+
+    def __init__(self, db_conn):
+
+        # Create a database cursor
+        self.db_cursor = db_conn.cursor()
+
+        # Get the whole table
+        grid_loc_map = self.db_cursor.execute(
+            "SELECT grid_phy_x, grid_phy_y, grid_vpr_x, grid_vpr_y FROM grid_loc_map"
+        ).fetchall()
+
+        # Build maps
+        self.fwd_loc_map = {}
+        self.bwd_loc_map = {}
+
+        for loc_pair in grid_loc_map:
+            phy_loc = loc_pair[0:2]
+            vpr_loc = loc_pair[2:4]
+
+            if phy_loc not in self.fwd_loc_map.keys():
+                self.fwd_loc_map[phy_loc] = []
+            self.fwd_loc_map[phy_loc].append(vpr_loc)
+
+            if vpr_loc not in self.bwd_loc_map.keys():
+                self.bwd_loc_map[vpr_loc] = []
+            self.bwd_loc_map[vpr_loc].append(phy_loc)
+
+    def get_vpr_loc(self, grid_loc):
+        return tuple(self.fwd_loc_map[grid_loc])
+
+    def get_phy_loc(self, grid_loc):
+        return tuple(self.bwd_loc_map[grid_loc])
+
+# =============================================================================
+
+def create_tables(conn):
+    """
+    Creates database tables related to grid location mappings
+    """
+
+    sql_file = os.path.join(os.path.dirname(__file__), "grid_mapping.sql")
+
+    with open(sql_file, "r") as fp:
+        cursor = conn.cursor()
+        cursor.executescript(fp.read())
+        conn.commit()
+
+def get_phy_grid_extent(conn):
+    """
+    Returns a tuple with (xmin, ymin, xmax, ymax) which defines
+    the grid extent.
+    """
+
+    # Get coordinates of all tiles
+    cursor = conn.cursor()
+    coords = list(cursor.execute("SELECT grid_x, grid_y FROM phy_tile"))
+
+    # Determine extent
+    xmin = min([loc[0] for loc in coords])
+    xmax = max([loc[0] for loc in coords])
+    ymin = min([loc[1] for loc in coords])
+    ymax = max([loc[1] for loc in coords])
+
+    return (xmin, ymin, xmax, ymax)
+
+def get_vpr_grid_extent(conn):
+    """
+    Returns a tuple with (xmin, ymin, xmax, ymax) which defines
+    the grid extent.
+    """
+
+    # Get coordinates of all tiles
+    cursor = conn.cursor()
+    coords = list(cursor.execute("SELECT grid_x, grid_y FROM tile"))
+
+    # Determine extent
+    xmin = min([loc[0] for loc in coords])
+    xmax = max([loc[0] for loc in coords])
+    ymin = min([loc[1] for loc in coords])
+    ymax = max([loc[1] for loc in coords])
+
+    return (xmin, ymin, xmax, ymax)
+
+def initialize_one_to_one_map(conn):
+    """
+    Initializes a one to one mapping of grid coordinates. The grid must be
+    imported to the database before calling this function.
+    """
+
+    cursor = conn.cursor()
+
+    # Clear the table (just in case)
+    cursor.executescript("DELETE FROM grid_loc_map; VACUUM;")
+
+    # Get the physical grid extent
+    extent = get_phy_grid_extent(conn)
+
+    # Make a one-to-one map
+    for x, y in itertools.product(range(extent[0], extent[2]+1), range(extent[1], extent[3]+1)):
+        cursor.execute("INSERT INTO grid_loc_map VALUES (?, ?, ?, ?);", (x, y, x, y))
+
+    cursor.execute("COMMIT TRANSACTION;")
+    cursor.connection.commit()
+
+# =============================================================================
+
+def main():
+    """
+    When executed adds grid location map table(s) to the database and initializes
+    a "dummy" one-to-one map.
+    """
+
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--db", type=str, required=True, help="Database file")
+
+    args = parser.parse_args()
+
+    # Open the DB
+    conn = sqlite3.Connection(args.db)
+
+    # Create table
+    create_tables(conn)
+
+    # Initialize one-to-one mapping
+    initialize_one_to_one_map(conn)
+
+    conn.close()
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()
+

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -31,8 +31,8 @@ class GridLocMap(object):
         bwd_loc_map = {}
 
         # Make a one-to-one map
-        for x, y in itertools.product(range(xmin, xmax + 1),
-                                      range(ymin, ymax + 1)):
+        for x, y in itertools.product(range(xmin, xmax + 1), range(ymin,
+                                                                   ymax + 1)):
 
             fwd_loc_map[(x, y)] = [(x, y)]
             bwd_loc_map[(x, y)] = [(x, y)]
@@ -58,8 +58,8 @@ class GridLocMap(object):
         bwd_loc_map = {}
 
         # Make a one-to-one map
-        for x, y in itertools.product(range(xmin, xmax + 1),
-                                      range(ymin, ymax + 1)):
+        for x, y in itertools.product(range(xmin, xmax + 1), range(ymin,
+                                                                   ymax + 1)):
 
             phy_loc = (x, y)
             vpr_loc = (x + shift_x, y + shift_y)
@@ -82,14 +82,16 @@ class GridLocMap(object):
         c = conn.cursor()
 
         # Query the grid map from the database
-        grid_loc_map = c.execute("""
+        grid_loc_map = c.execute(
+            """
 SELECT phy.grid_x, phy.grid_y, vpr.grid_x, vpr.grid_y
 FROM phy_tile phy
 INNER JOIN grid_loc_map map
 ON phy.pkey = map.phy_tile_pkey
 INNER JOIN tile vpr
 ON vpr.pkey = map.vpr_tile_pkey
-""").fetchall()
+"""
+        ).fetchall()
 
         # Build maps
         fwd_loc_map = {}
@@ -115,6 +117,7 @@ ON vpr.pkey = map.vpr_tile_pkey
 
     def get_phy_loc(self, grid_loc):
         return tuple(self.bwd_loc_map[grid_loc])
+
 
 # =============================================================================
 
@@ -169,9 +172,8 @@ def get_vpr_grid_extent(conn):
 
     return (xmin, ymin, xmax, ymax)
 
-# =============================================================================
 
+# =============================================================================
 
 if __name__ == "__main__":
     main()
-

--- a/utils/lib/grid_mapping.py
+++ b/utils/lib/grid_mapping.py
@@ -21,8 +21,13 @@ class GridLocMap(object):
     def generate_one_to_one_map(extent):
         """
         Generates a one-to-one map for specified location range.
-        :param extent:
-        :return:
+
+        Args:
+            extent: A 4-element tuple with the grid extent:
+                xmin, ymin, xmax, ymax
+
+        Returns:
+            A GridLocMap object with the grid mapping.
         """
 
         xmin, ymin, xmax, ymax = extent
@@ -45,11 +50,15 @@ class GridLocMap(object):
         """
         Generates a one-to-one map for specified location range. For debugging
         purposes.
-        :param extent:
-        :param shift_x:
-        :param shift_y:
 
-        :return:
+        Args:
+            extent: A 4-element tuple with the grid extent:
+                xmin, ymin, xmax, ymax
+            shift_x: Grid shift in X axis
+            shift_y: Grid shift in Y axis
+
+        Returns:
+            A GridLocMap object with the grid mapping.
         """
 
         xmin, ymin, xmax, ymax = extent
@@ -75,8 +84,12 @@ class GridLocMap(object):
         """
         Loads grid location mapping from a SQL database. Returns a GridLocMap
         object.
-        :param conn:
-        :return:
+
+        Args:
+            conn: A database connection object
+
+        Returns:
+            A GridLocMap object with the grid mapping.
         """
 
         c = conn.cursor()
@@ -91,7 +104,7 @@ ON phy.pkey = map.phy_tile_pkey
 INNER JOIN tile vpr
 ON vpr.pkey = map.vpr_tile_pkey
 """
-        ).fetchall()
+        )
 
         # Build maps
         fwd_loc_map = {}
@@ -113,26 +126,13 @@ ON vpr.pkey = map.vpr_tile_pkey
         return GridLocMap(fwd_loc_map, bwd_loc_map)
 
     def get_vpr_loc(self, grid_loc):
-        return tuple(self.fwd_loc_map[grid_loc])
+        return self.fwd_loc_map[grid_loc]
 
     def get_phy_loc(self, grid_loc):
-        return tuple(self.bwd_loc_map[grid_loc])
+        return self.bwd_loc_map[grid_loc]
 
 
 # =============================================================================
-
-
-def create_tables(conn):
-    """
-    Creates database tables related to grid location mappings
-    """
-
-    sql_file = os.path.join(os.path.dirname(__file__), "grid_mapping.sql")
-
-    with open(sql_file, "r") as fp:
-        cursor = conn.cursor()
-        cursor.executescript(fp.read())
-        conn.commit()
 
 
 def get_phy_grid_extent(conn):
@@ -151,7 +151,7 @@ def get_phy_grid_extent(conn):
     ymin = min([loc[1] for loc in coords])
     ymax = max([loc[1] for loc in coords])
 
-    return (xmin, ymin, xmax, ymax)
+    return xmin, ymin, xmax, ymax
 
 
 def get_vpr_grid_extent(conn):
@@ -170,7 +170,7 @@ def get_vpr_grid_extent(conn):
     ymin = min([loc[1] for loc in coords])
     ymax = max([loc[1] for loc in coords])
 
-    return (xmin, ymin, xmax, ymax)
+    return xmin, ymin, xmax, ymax
 
 
 # =============================================================================

--- a/utils/lib/grid_mapping.sql
+++ b/utils/lib/grid_mapping.sql
@@ -1,0 +1,12 @@
+-- Grid location map
+-- This table maps locations from the input (physical) grid to the VPR grid
+-- locations and vice versa. If there are multiple entries for the same physical
+-- location (grid_phy_x, grid_phy_y) then it means that a single physical tile 
+-- should end up being splitted.
+CREATE TABLE IF NOT EXISTS grid_loc_map(
+    grid_phy_x INT,
+    grid_phy_y INT,
+    grid_vpr_x INT,
+    grid_vpr_y INT
+);
+

--- a/utils/lib/grid_mapping.sql
+++ b/utils/lib/grid_mapping.sql
@@ -1,8 +1,0 @@
--- Grid location map
-CREATE TABLE IF NOT EXISTS grid_loc_map(
-    phy_tile_pkey INT,
-    vpr_tile_pkey INT,
-    FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
-    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
-);
-

--- a/utils/lib/grid_mapping.sql
+++ b/utils/lib/grid_mapping.sql
@@ -1,12 +1,8 @@
 -- Grid location map
--- This table maps locations from the input (physical) grid to the VPR grid
--- locations and vice versa. If there are multiple entries for the same physical
--- location (grid_phy_x, grid_phy_y) then it means that a single physical tile 
--- should end up being splitted.
 CREATE TABLE IF NOT EXISTS grid_loc_map(
-    grid_phy_x INT,
-    grid_phy_y INT,
-    grid_vpr_x INT,
-    grid_vpr_y INT
+    phy_tile_pkey INT,
+    vpr_tile_pkey INT,
+    FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
+    FOREIGN KEY(vpr_tile_pkey) REFERENCES tile(pkey)
 );
 

--- a/xc7/archs/artix7/devices/xc7a50t-arty-roi-virt/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/xc7a50t-arty-roi-virt/CMakeLists.txt
@@ -3,7 +3,7 @@ add_xc7_device_define_type(
   DEVICE xc7a50t-arty
   ROI_PART xc7a35tcsg324-1
   ROI_DIR ${PRJXRAY_DB_DIR}/artix7/harness/arty-a7/uart
-  TILE_TYPES CLBLL_R CLBLL_L CLBLM_R CLBLM_L BRAM_L
+  TILE_TYPES BRAM_L
   NAME arty
 )
 

--- a/xc7/archs/artix7/devices/xc7a50t-basys3-roi-virt/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/xc7a50t-basys3-roi-virt/CMakeLists.txt
@@ -3,7 +3,7 @@ add_xc7_device_define_type(
   DEVICE xc7a50t-basys3
   ROI_PART xc7a35tcpg236-1
   ROI_DIR ${PRJXRAY_DB_DIR}/artix7/harness/basys3/swbut
-  TILE_TYPES CLBLL_R CLBLL_L CLBLM_R CLBLM_L BRAM_L
+  TILE_TYPES BRAM_L
   NAME basys3
 )
 

--- a/xc7/archs/artix7/tiles/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(bram_l)
 add_subdirectory(bram_r)
+add_subdirectory(clbll_l)
+add_subdirectory(clbll_r)
 add_subdirectory(slicel)
 add_subdirectory(slicem)

--- a/xc7/archs/artix7/tiles/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_subdirectory(bram_l)
 add_subdirectory(bram_r)
-#add_subdirectory(slicel)
-#add_subdirectory(slicem)
+add_subdirectory(slicel)
+add_subdirectory(slicem)

--- a/xc7/archs/artix7/tiles/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/CMakeLists.txt
@@ -1,6 +1,4 @@
 add_subdirectory(bram_l)
 add_subdirectory(bram_r)
-add_subdirectory(clbll_l)
-add_subdirectory(clbll_r)
-add_subdirectory(clblm_l)
-add_subdirectory(clblm_r)
+#add_subdirectory(slicel)
+#add_subdirectory(slicem)

--- a/xc7/archs/artix7/tiles/clbll_l/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/clbll_l/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART artix7
-  TILE CLBLL_L
-  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
-  )

--- a/xc7/archs/artix7/tiles/clbll_l/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/clbll_l/CMakeLists.txt
@@ -1,0 +1,5 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLL_L
+  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
+  )

--- a/xc7/archs/artix7/tiles/clbll_r/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/clbll_r/CMakeLists.txt
@@ -1,0 +1,5 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLL_R
+  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
+  )

--- a/xc7/archs/artix7/tiles/clbll_r/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/clbll_r/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART artix7
-  TILE CLBLL_R
-  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
-  )

--- a/xc7/archs/artix7/tiles/clblm_l/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/clblm_l/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART artix7
-  TILE CLBLM_L
-  SITE_TYPES SLICEM/SLICEM SLICEL/SLICEL2
-  )

--- a/xc7/archs/artix7/tiles/clblm_r/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/clblm_r/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART artix7
-  TILE CLBLM_R
-  SITE_TYPES SLICEM/SLICEM SLICEL/SLICEL2
-  )

--- a/xc7/archs/artix7/tiles/slicel/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/slicel/CMakeLists.txt
@@ -1,6 +1,6 @@
 project_xray_tile(
   PART artix7
-  TILE CLBLL_L
+  TILE CLBLM_L
   SITE_TYPES SLICEL/SLICEL
   ALIAS SLICEL
 )

--- a/xc7/archs/artix7/tiles/slicel/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/slicel/CMakeLists.txt
@@ -1,0 +1,7 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLL_L
+  SITE_TYPES SLICEL/SLICEL
+  ALIAS SLICEL
+)
+

--- a/xc7/archs/artix7/tiles/slicem/CMakeLists.txt
+++ b/xc7/archs/artix7/tiles/slicem/CMakeLists.txt
@@ -1,0 +1,7 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLM_L
+  SITE_TYPES SLICEM/SLICEM
+  ALIAS SLICEM
+)
+

--- a/xc7/archs/zynq7/devices/xc7z010-zybo-roi-virt/CMakeLists.txt
+++ b/xc7/archs/zynq7/devices/xc7z010-zybo-roi-virt/CMakeLists.txt
@@ -3,6 +3,6 @@ add_xc7_device_define_type(
   DEVICE xc7z010-zybo
   ROI_PART xc7z010clg400-1
   ROI_DIR ${PRJXRAY_DB_DIR}/zynq7/harness/zybo/swbut
-  TILE_TYPES CLBLL_R CLBLL_L CLBLM_R CLBLM_L BRAM_L
+  TILE_TYPES BRAM_L
   NAME zybo
 )

--- a/xc7/archs/zynq7/tiles/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/CMakeLists.txt
@@ -1,6 +1,5 @@
 add_subdirectory(bram_l)
 add_subdirectory(bram_r)
-add_subdirectory(clbll_l)
-add_subdirectory(clbll_r)
-add_subdirectory(clblm_l)
-add_subdirectory(clblm_r)
+add_subdirectory(slicel)
+add_subdirectory(slicem)
+

--- a/xc7/archs/zynq7/tiles/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(bram_l)
 add_subdirectory(bram_r)
+add_subdirectory(clbll_l)
+add_subdirectory(clbll_r)
 add_subdirectory(slicel)
 add_subdirectory(slicem)
 

--- a/xc7/archs/zynq7/tiles/clbll_l/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/clbll_l/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART zynq7
-  TILE CLBLL_L
-  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
-  )

--- a/xc7/archs/zynq7/tiles/clbll_l/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/clbll_l/CMakeLists.txt
@@ -1,0 +1,5 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLL_L
+  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
+  )

--- a/xc7/archs/zynq7/tiles/clbll_r/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/clbll_r/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART zynq7
-  TILE CLBLL_R
-  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
-  )

--- a/xc7/archs/zynq7/tiles/clbll_r/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/clbll_r/CMakeLists.txt
@@ -1,0 +1,5 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLL_R
+  SITE_TYPES SLICEL/SLICEL0 SLICEL/SLICEL1
+  )

--- a/xc7/archs/zynq7/tiles/clblm_l/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/clblm_l/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART zynq7
-  TILE CLBLM_L
-  SITE_TYPES SLICEM/SLICEM SLICEL/SLICEL2
-  )

--- a/xc7/archs/zynq7/tiles/clblm_r/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/clblm_r/CMakeLists.txt
@@ -1,5 +1,0 @@
-project_xray_tile(
-  PART zynq7
-  TILE CLBLM_R
-  SITE_TYPES SLICEM/SLICEM SLICEL/SLICEL2
-  )

--- a/xc7/archs/zynq7/tiles/slicel/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/slicel/CMakeLists.txt
@@ -1,0 +1,7 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLL_L
+  SITE_TYPES SLICEL/SLICEL
+  ALIAS SLICEL
+)
+

--- a/xc7/archs/zynq7/tiles/slicem/CMakeLists.txt
+++ b/xc7/archs/zynq7/tiles/slicem/CMakeLists.txt
@@ -1,0 +1,7 @@
+project_xray_tile(
+  PART artix7
+  TILE CLBLM_L
+  SITE_TYPES SLICEM/SLICEM
+  ALIAS SLICEM
+)
+

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -31,7 +31,6 @@ function(ADD_XC7_ARCH_DEFINE)
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \
     PYTHONPATH=${PRJXRAY_DIR}:${symbiflow-arch-defs_SOURCE_DIR}/utils:${symbiflow-arch-defs_BINARY_DIR}/utils \
         \${PYTHON3} \${RR_PATCH_TOOL} \
-        --db_root ${PRJXRAY_DB_DIR}/${ARCH} \
         --read_rr_graph \${OUT_RRXML_VIRT} \
         --write_rr_graph \${OUT_RRXML_REAL}"
     PLACE_TOOL

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -166,6 +166,9 @@ function(PROJECT_XRAY_ARCH)
   set(ROI_ARG "")
   set(ROI_ARG_FOR_CREATE_EDGES "")
 
+  set(SYNTH_TILES_DEPS "")
+  append_file_dependency(SYNTH_TILES_DEPS ${GENERIC_CHANNELS})
+
   if(NOT "${PROJECT_XRAY_ARCH_USE_ROI}" STREQUAL "")
     add_custom_command(
       OUTPUT synth_tiles.json
@@ -177,7 +180,7 @@ function(PROJECT_XRAY_ARCH)
         --synth_tiles ${CMAKE_CURRENT_BINARY_DIR}/synth_tiles.json
       DEPENDS
         ${CREATE_SYNTH_TILES}
-        ${PROJECT_XRAY_ARCH_USE_ROI} ${CMAKE_CURRENT_BINARY_DIR}/channels.db
+        ${PROJECT_XRAY_ARCH_USE_ROI} ${SYNTH_TILES_DEPS}
         ${PYTHON3} ${PYTHON3_TARGET} simplejson intervaltree
         )
 

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -148,8 +148,11 @@ function(PROJECT_XRAY_ARCH)
   set(CREATE_EDGES ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_create_edges.py)
   set(DEPS ${PRJXRAY_DB_DIR}/${PART}/tilegrid.json)
 
+  # FIXME: This will add dependency on SLICE
+  set(DEP_TILE_TYPES ${PROJECT_XRAY_ARCH_TILE_TYPES} "SLICEL" "SLICEM")
+
   set(ARCH_INCLUDE_FILES "")
-  foreach(TILE_TYPE ${PROJECT_XRAY_ARCH_TILE_TYPES})
+  foreach(TILE_TYPE ${DEP_TILE_TYPES})
     string(TOLOWER ${TILE_TYPE} TILE_TYPE_LOWER)
     set(PB_TYPE_XML ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/tiles/${TILE_TYPE_LOWER}/${TILE_TYPE_LOWER}.pb_type.xml)
     set(MODEL_XML ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/tiles/${TILE_TYPE_LOWER}/${TILE_TYPE_LOWER}.model.xml)

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -63,6 +63,7 @@ function(PROJECT_XRAY_TILE)
     string(TOLOWER ${PROJECT_XRAY_TILE_ALIAS} ALIAS)
   else()
     string(TOLOWER ${PROJECT_XRAY_TILE_TILE}  TILE)
+    set(PROJECT_XRAY_TILE_ALIAS ${PROJECT_XRAY_TILE_TILE})
     set(ALIAS ${TILE})
   endif()
 
@@ -98,6 +99,7 @@ function(PROJECT_XRAY_TILE)
     ${PYTHON3} ${TILE_IMPORT}
     --part ${PROJECT_XRAY_TILE_PART}
     --tile ${PROJECT_XRAY_TILE_TILE}
+    --tile-alias ${PROJECT_XRAY_TILE_ALIAS}
     --site_directory ${symbiflow-arch-defs_BINARY_DIR}/xc7/primitives
     --site_types ${SITE_TYPES_COMMA}
     --pin_assignments ${PIN_ASSIGNMENTS}
@@ -148,8 +150,8 @@ function(PROJECT_XRAY_ARCH)
   set(CREATE_EDGES ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_create_edges.py)
   set(DEPS ${PRJXRAY_DB_DIR}/${PART}/tilegrid.json)
 
-  # FIXME: This will add dependency on SLICE
-  set(DEP_TILE_TYPES ${PROJECT_XRAY_ARCH_TILE_TYPES} "SLICEL" "SLICEM")
+  # FIXME: This will add dependency on SLICE and CLBLL
+  set(DEP_TILE_TYPES ${PROJECT_XRAY_ARCH_TILE_TYPES} "SLICEL" "SLICEM" "CLBLL_L" "CLBLL_R")
 
   set(ARCH_INCLUDE_FILES "")
   foreach(TILE_TYPE ${DEP_TILE_TYPES})

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -200,6 +200,8 @@ function(PROJECT_XRAY_ARCH)
   append_file_dependency(DEPS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/pin_assignments.json)
   get_file_location(PIN_ASSIGNMENTS ${symbiflow-arch-defs_SOURCE_DIR}/xc7/archs/${PART}/pin_assignments.json)
 
+  append_file_dependency(DEPS ${GENERIC_CHANNELS})
+
   string(REPLACE ";" "," TILE_TYPES_COMMA "${PROJECT_XRAY_ARCH_TILE_TYPES}")
 
   add_custom_command(
@@ -215,7 +217,7 @@ function(PROJECT_XRAY_ARCH)
       ${ROI_ARG}
     DEPENDS
     ${ARCH_IMPORT}
-    ${DEPS} ${CMAKE_CURRENT_BINARY_DIR}/channels.db
+    ${DEPS}
     ${PYTHON3} ${PYTHON3_TARGET} simplejson
     )
 

--- a/xc7/primitives/slicel/CMakeLists.txt
+++ b/xc7/primitives/slicel/CMakeLists.txt
@@ -1,15 +1,2 @@
-add_file_target(FILE ntemplate.slicelN.model.xml SCANNER_TYPE xml)
-add_file_target(FILE ntemplate.slicelN.pb_type.xml SCANNER_TYPE xml)
-add_file_target(FILE slicel.sim.v SCANNER_TYPE verilog)
-add_verilog_image_gen(FILE slicel.sim.v)
-
-n_template(
-    NAME sliceN.pb_type.xml
-    PREFIXES 0;1;2
-    SRCS ntemplate.slicelN.pb_type.xml
-    )
-n_template(
-    NAME sliceN.model.xml
-    PREFIXES 0;1;2
-    SRCS ntemplate.slicelN.model.xml
-    )
+add_file_target(FILE slicel.model.xml SCANNER_TYPE xml)
+add_file_target(FILE slicel.pb_type.xml SCANNER_TYPE xml)

--- a/xc7/primitives/slicel/CMakeLists.txt
+++ b/xc7/primitives/slicel/CMakeLists.txt
@@ -1,2 +1,19 @@
+add_file_target(FILE ntemplate.slicelN.model.xml SCANNER_TYPE xml)
+add_file_target(FILE ntemplate.slicelN.pb_type.xml SCANNER_TYPE xml)
+add_file_target(FILE slicel.sim.v SCANNER_TYPE verilog)
+add_verilog_image_gen(FILE slicel.sim.v)
+
+n_template(
+    NAME sliceN.pb_type.xml
+    PREFIXES 0;1;2
+    SRCS ntemplate.slicelN.pb_type.xml
+    )
+n_template(
+    NAME sliceN.model.xml
+    PREFIXES 0;1;2
+    SRCS ntemplate.slicelN.model.xml
+    )
+
+# Generic SLICEL
 add_file_target(FILE slicel.model.xml SCANNER_TYPE xml)
 add_file_target(FILE slicel.pb_type.xml SCANNER_TYPE xml)

--- a/xc7/primitives/slicel/slicel.model.xml
+++ b/xc7/primitives/slicel/slicel.model.xml
@@ -1,0 +1,4 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+ <xi:include href="../common_slice/common_slice.model.xml" xpointer="xpointer(models/child::node())" />
+ <xi:include href="../common_slice/common_lut_and_f78mux.model.xml" xpointer="xpointer(models/child::node())" />
+</models>

--- a/xc7/primitives/slicel/slicel.pb_type.xml
+++ b/xc7/primitives/slicel/slicel.pb_type.xml
@@ -1,0 +1,157 @@
+<!-- A diagram for the SLICEL is shown in;
+    7 Series FPGAs CLB User Guide UG474 (v1.8) September 27, 2016
+    Figure 2-4: Diagram of SLICEL
+  -->
+<pb_type name="BLK_IG-SLICEL" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+  <input name="DX" num_pins="1"/>
+  <input name="D1" num_pins="1"/>
+  <input name="D2" num_pins="1"/>
+  <input name="D3" num_pins="1"/>
+  <input name="D4" num_pins="1"/>
+  <input name="D5" num_pins="1"/>
+  <input name="D6" num_pins="1"/>
+
+  <input name="CX" num_pins="1"/>
+  <input name="C1" num_pins="1"/>
+  <input name="C2" num_pins="1"/>
+  <input name="C3" num_pins="1"/>
+  <input name="C4" num_pins="1"/>
+  <input name="C5" num_pins="1"/>
+  <input name="C6" num_pins="1"/>
+
+  <input name="BX" num_pins="1"/>
+  <input name="B1" num_pins="1"/>
+  <input name="B2" num_pins="1"/>
+  <input name="B3" num_pins="1"/>
+  <input name="B4" num_pins="1"/>
+  <input name="B5" num_pins="1"/>
+  <input name="B6" num_pins="1"/>
+
+  <input name="AX" num_pins="1"/>
+  <input name="A1" num_pins="1"/>
+  <input name="A2" num_pins="1"/>
+  <input name="A3" num_pins="1"/>
+  <input name="A4" num_pins="1"/>
+  <input name="A5" num_pins="1"/>
+  <input name="A6" num_pins="1"/>
+
+  <input name="SR" num_pins="1"/>
+  <input name="CE" num_pins="1"/>
+
+  <clock name="CLK" num_pins="1"/>
+
+  <input  name="CIN"  num_pins="1"/>
+  <output name="COUT" num_pins="1"/>
+
+  <output name="DMUX" num_pins="1"/>
+  <output name="D"    num_pins="1"/>
+  <output name="DQ"   num_pins="1"/>
+
+  <output name="CMUX" num_pins="1"/>
+  <output name="C"    num_pins="1"/>
+  <output name="CQ"   num_pins="1"/>
+
+  <output name="BMUX" num_pins="1"/>
+  <output name="B"    num_pins="1"/>
+  <output name="BQ"   num_pins="1"/>
+
+  <output name="AMUX" num_pins="1"/>
+  <output name="A"    num_pins="1"/>
+  <output name="AQ"   num_pins="1"/>
+
+  <!-- d6lut, c6lut, b6lut, a6lut == N6lut
+       A fracturable 6 input LUT. Can either be;
+        - 2 * 5 input, 1 output LUT
+        - 1 * 6 input, 1 output LUT
+    -->
+  <xi:include href="../common_slice/common_lut_and_f78mux.pb_type.xml"/>
+  <xi:include href="../common_slice/common_slice.pb_type.xml"/>
+
+  <interconnect>
+    <!-- LUT input pins -->
+    <direct name="D1" input="BLK_IG-SLICEL.D1" output="BLK_IG-COMMON_LUT_AND_F78MUX.D1" />
+    <direct name="D2" input="BLK_IG-SLICEL.D2" output="BLK_IG-COMMON_LUT_AND_F78MUX.D2" />
+    <direct name="D3" input="BLK_IG-SLICEL.D3" output="BLK_IG-COMMON_LUT_AND_F78MUX.D3" />
+    <direct name="D4" input="BLK_IG-SLICEL.D4" output="BLK_IG-COMMON_LUT_AND_F78MUX.D4" />
+    <direct name="D5" input="BLK_IG-SLICEL.D5" output="BLK_IG-COMMON_LUT_AND_F78MUX.D5" />
+    <direct name="D6" input="BLK_IG-SLICEL.D6" output="BLK_IG-COMMON_LUT_AND_F78MUX.D6" />
+
+    <direct name="C1" input="BLK_IG-SLICEL.C1" output="BLK_IG-COMMON_LUT_AND_F78MUX.C1" />
+    <direct name="C2" input="BLK_IG-SLICEL.C2" output="BLK_IG-COMMON_LUT_AND_F78MUX.C2" />
+    <direct name="C3" input="BLK_IG-SLICEL.C3" output="BLK_IG-COMMON_LUT_AND_F78MUX.C3" />
+    <direct name="C4" input="BLK_IG-SLICEL.C4" output="BLK_IG-COMMON_LUT_AND_F78MUX.C4" />
+    <direct name="C5" input="BLK_IG-SLICEL.C5" output="BLK_IG-COMMON_LUT_AND_F78MUX.C5" />
+    <direct name="C6" input="BLK_IG-SLICEL.C6" output="BLK_IG-COMMON_LUT_AND_F78MUX.C6" />
+
+    <direct name="B1" input="BLK_IG-SLICEL.B1" output="BLK_IG-COMMON_LUT_AND_F78MUX.B1" />
+    <direct name="B2" input="BLK_IG-SLICEL.B2" output="BLK_IG-COMMON_LUT_AND_F78MUX.B2" />
+    <direct name="B3" input="BLK_IG-SLICEL.B3" output="BLK_IG-COMMON_LUT_AND_F78MUX.B3" />
+    <direct name="B4" input="BLK_IG-SLICEL.B4" output="BLK_IG-COMMON_LUT_AND_F78MUX.B4" />
+    <direct name="B5" input="BLK_IG-SLICEL.B5" output="BLK_IG-COMMON_LUT_AND_F78MUX.B5" />
+    <direct name="B6" input="BLK_IG-SLICEL.B6" output="BLK_IG-COMMON_LUT_AND_F78MUX.B6" />
+
+    <direct name="A1" input="BLK_IG-SLICEL.A1" output="BLK_IG-COMMON_LUT_AND_F78MUX.A1" />
+    <direct name="A2" input="BLK_IG-SLICEL.A2" output="BLK_IG-COMMON_LUT_AND_F78MUX.A2" />
+    <direct name="A3" input="BLK_IG-SLICEL.A3" output="BLK_IG-COMMON_LUT_AND_F78MUX.A3" />
+    <direct name="A4" input="BLK_IG-SLICEL.A4" output="BLK_IG-COMMON_LUT_AND_F78MUX.A4" />
+    <direct name="A5" input="BLK_IG-SLICEL.A5" output="BLK_IG-COMMON_LUT_AND_F78MUX.A5" />
+    <direct name="A6" input="BLK_IG-SLICEL.A6" output="BLK_IG-COMMON_LUT_AND_F78MUX.A6" />
+
+    <direct name="CX"  input="BLK_IG-SLICEL.CX" output="BLK_IG-COMMON_LUT_AND_F78MUX.CX" />
+    <direct name="BX"  input="BLK_IG-SLICEL.BX" output="BLK_IG-COMMON_LUT_AND_F78MUX.BX" />
+    <direct name="AX"  input="BLK_IG-SLICEL.AX" output="BLK_IG-COMMON_LUT_AND_F78MUX.AX" />
+
+    <!-- COMMON_SLICE inputs -->
+    <direct name="DX2" input="BLK_IG-SLICEL.DX" output="BLK_IG-COMMON_SLICE.DX" />
+    <direct name="DO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.DO6"   output="BLK_IG-COMMON_SLICE.DO6" />
+    <direct name="DO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.DO5"   output="BLK_IG-COMMON_SLICE.DO5" />
+
+    <direct name="CX2" input="BLK_IG-SLICEL.CX" output="BLK_IG-COMMON_SLICE.CX" />
+    <direct name="CO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.CO6"   output="BLK_IG-COMMON_SLICE.CO6" />
+    <direct name="CO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.CO5"   output="BLK_IG-COMMON_SLICE.CO5" />
+
+    <direct name="BX2" input="BLK_IG-SLICEL.BX" output="BLK_IG-COMMON_SLICE.BX" />
+    <direct name="BO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.BO6"   output="BLK_IG-COMMON_SLICE.BO6" />
+    <direct name="BO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.BO5"   output="BLK_IG-COMMON_SLICE.BO5" />
+
+    <direct name="AX2" input="BLK_IG-SLICEL.AX" output="BLK_IG-COMMON_SLICE.AX" />
+    <direct name="AO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.AO6"   output="BLK_IG-COMMON_SLICE.AO6" />
+    <direct name="AO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.AO5"   output="BLK_IG-COMMON_SLICE.AO5" />
+
+    <direct name="F7AMUX_O" input="BLK_IG-COMMON_LUT_AND_F78MUX.F7AMUX_O"   output="BLK_IG-COMMON_SLICE.F7AMUX_O" />
+    <direct name="F7BMUX_O" input="BLK_IG-COMMON_LUT_AND_F78MUX.F7BMUX_O"   output="BLK_IG-COMMON_SLICE.F7BMUX_O" />
+    <direct name="F8MUX_O"  input="BLK_IG-COMMON_LUT_AND_F78MUX.F8MUX_O"    output="BLK_IG-COMMON_SLICE.F8MUX_O" />
+
+    <!-- [A-F]Q outputs -->
+    <direct name="AQ" input="BLK_IG-COMMON_SLICE.AQ" output="BLK_IG-SLICEL.AQ" />
+    <direct name="BQ" input="BLK_IG-COMMON_SLICE.BQ" output="BLK_IG-SLICEL.BQ" />
+    <direct name="CQ" input="BLK_IG-COMMON_SLICE.CQ" output="BLK_IG-SLICEL.CQ" />
+    <direct name="DQ" input="BLK_IG-COMMON_SLICE.DQ" output="BLK_IG-SLICEL.DQ" />
+
+    <!-- A-D output -->
+    <direct name="BLK_IG-SLICEL_DOUT" input="BLK_IG-COMMON_SLICE.D" output="BLK_IG-SLICEL.D" />
+    <direct name="BLK_IG-SLICEL_COUT" input="BLK_IG-COMMON_SLICE.C" output="BLK_IG-SLICEL.C" />
+    <direct name="BLK_IG-SLICEL_BOUT" input="BLK_IG-COMMON_SLICE.B" output="BLK_IG-SLICEL.B" />
+    <direct name="BLK_IG-SLICEL_AOUT" input="BLK_IG-COMMON_SLICE.A" output="BLK_IG-SLICEL.A" />
+
+    <!-- AMUX-DMUX output -->
+    <direct name="BLK_IG-SLICEL_DMUX" input="BLK_IG-COMMON_SLICE.DMUX" output="BLK_IG-SLICEL.DMUX" />
+    <direct name="BLK_IG-SLICEL_CMUX" input="BLK_IG-COMMON_SLICE.CMUX" output="BLK_IG-SLICEL.CMUX" />
+    <direct name="BLK_IG-SLICEL_BMUX" input="BLK_IG-COMMON_SLICE.BMUX" output="BLK_IG-SLICEL.BMUX" />
+    <direct name="BLK_IG-SLICEL_AMUX" input="BLK_IG-COMMON_SLICE.AMUX" output="BLK_IG-SLICEL.AMUX" />
+
+    <!-- Carry -->
+
+    <direct name="CIN" input="BLK_IG-SLICEL.CIN" output="BLK_IG-COMMON_SLICE.CIN" >
+    </direct>
+    <direct name="COUT" input="BLK_IG-COMMON_SLICE.COUT" output="BLK_IG-SLICEL.COUT" >
+    </direct>
+
+    <!-- Clock, Clock Enable and Reset -->
+    <direct name="CK" input="BLK_IG-SLICEL.CLK" output="BLK_IG-COMMON_SLICE.CLK"/>
+    <direct name="CE" input="BLK_IG-SLICEL.CE"  output="BLK_IG-COMMON_SLICE.CE"/>
+    <direct name="SR" input="BLK_IG-SLICEL.SR"  output="BLK_IG-COMMON_SLICE.SR"/>
+
+  </interconnect>
+</pb_type>

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -294,16 +294,16 @@ def main():
 
     tile_types = args.tile_types.split(',')
 
-    # FIXME: HACK - always import CLBs
-    tile_types = set(tile_types)
-    tile_types |= set(["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"])
-    tile_types = tuple(tile_types)
-
     tile_model = "../../tiles/{0}/{0}.model.xml"
     tile_pbtype = "../../tiles/{0}/{0}.pb_type.xml"
 
     # Initialize grid mapper
     with DatabaseCache(args.connection_database, read_only=True) as conn:
+
+        # FIXME: Always import tile types
+        tile_types = set(tile_types)
+        tile_types |= set(["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"])
+        tile_types = tuple(tile_types)
 
         # The object will read data from the DB so it can live
         # outside the scope of the "with" statement

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -5,8 +5,8 @@ By default this will generate a complete arch XML for all tile types specified.
 If the --use_roi flag is passed, only the tiles within the ROI will be included,
 and synthetic IO pads will be created and connected to the routing fabric.
 The mapping of the pad name to synthetic tile location will be outputted to the
-file specified in the --synth_tiles output argument.  This can be used to generate
-IO placement spefications to target the synthetic IO pads.
+file specified in the --synth_tiles output argument.  This can be used to
+generate IO placement spefications to target the synthetic IO pads.
 
 """
 from __future__ import print_function
@@ -24,8 +24,11 @@ from prjxray.grid_types import GridLoc
 from prjxray_db_cache import DatabaseCache
 from lib.grid_mapping import GridLocMap, get_vpr_grid_extent
 
+
 def create_synth_io_tiles(complexblocklist_xml, pb_name, is_input):
-    """ Creates synthetic IO pad tiles used to connect ROI inputs and outputs to the routing network.
+    """
+    Creates synthetic IO pad tiles used to connect ROI inputs and outputs
+    to the routing network.
     """
     pb_xml = ET.SubElement(
         complexblocklist_xml, 'pb_type', {
@@ -182,8 +185,7 @@ def create_synth_constant_tiles(
 
 
 def add_synthetic_tiles(model_xml, complexblocklist_xml):
-    create_synth_io_tiles(
-        complexblocklist_xml, 'BLK_SY-INPAD', is_input=True)
+    create_synth_io_tiles(complexblocklist_xml, 'BLK_SY-INPAD', is_input=True)
     create_synth_io_tiles(
         complexblocklist_xml, 'BLK_SY-OUTPAD', is_input=False
     )
@@ -219,7 +221,8 @@ def main():
     parser.add_argument(
         '--connection_database',
         help='Database of fabric connectivity',
-        required=True)
+        required=True
+    )
     parser.add_argument(
         '--output-arch',
         nargs='?',
@@ -350,8 +353,8 @@ def main():
         # VBRK tiles are known to have no bitstream data.
         if not is_vbrk and not gridinfo.bits:
             print(
-                '*** WARNING *** Skipping tile {} because it lacks bitstream data.'
-                .format(tile),
+                '*** WARNING *** Skipping tile {} because it lacks bitstream '
+                'data.'.format(tile),
                 file=sys.stderr
             )
 
@@ -361,7 +364,8 @@ def main():
                 'type': vpr_tile_type,
                 'x': str(vpr_loc[0]),
                 'y': str(vpr_loc[1]),
-            })
+            }
+        )
         meta = ET.SubElement(single_xml, 'metadata')
         ET.SubElement(meta, 'meta', {
             'name': 'fasm_prefix',
@@ -470,7 +474,8 @@ def main():
     pin_assignments = json.load(args.pin_assignments)
 
     # Choose smallest distance for block to block connections with multiple
-    # direct_connections.  VPR cannot handle multiple block to block connections.
+    # direct_connections.  VPR cannot handle multiple block to block
+    # connections.
     directs = {}
     for direct in pin_assignments['direct_connections']:
         key = (direct['from_pin'], direct['to_pin'])

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -217,6 +217,10 @@ def main():
         help="""Project X-Ray database to use."""
     )
     parser.add_argument(
+        '--connection_database',
+        help='Database of fabric connectivity',
+        required=True)
+    parser.add_argument(
         '--output-arch',
         nargs='?',
         type=argparse.FileType('w'),

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -243,7 +243,7 @@ def main():
 
         # The object will read data from the DB so it can live
         # outside the scope of the "with" statement
-        grid_loc_mapper = GridLocMap(conn)
+        grid_loc_mapper = GridLocMap.load_from_database(conn)
 
         # Get the VPR grid extent
         vpr_grid_extent = get_vpr_grid_extent(conn)

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -338,6 +338,10 @@ def main():
 
             assert len(synth_tile['pins']) == 1
 
+            # Check location
+            assert vpr_loc.grid_x == synth_tile["loc"]["grid_x"]
+            assert vpr_loc.grid_y == synth_tile["loc"]["grid_y"]
+
             vpr_tile_type = synth_tile_map[synth_tile['pins'][0]['port_type']]
         elif only_emit_roi and not roi.tile_in_roi(vpr_loc):
             # This tile is outside the ROI, skip it.

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -305,20 +305,12 @@ def main():
         with open(args.synth_tiles) as f:
             synth_tiles = json.load(f)
 
-        # Map ROI coordinates to the target VPR grid
-        roi_loc_lo = grid_loc_mapper.get_vpr_loc(
-            (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN']))
-        roi_loc_hi = grid_loc_mapper.get_vpr_loc(
-            (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX']))
-
         roi = Roi(
             db=db,
-            x1=min([p[0] for p in roi_loc_lo
-                    ]),  # One physical grid location may map to more than one
-            y1=min([p[1] for p in roi_loc_lo
-                    ]),  # VPR locations. So here we take min and max.
-            x2=max([p[0] for p in roi_loc_hi]),
-            y2=max([p[1] for p in roi_loc_hi]),
+            x1=j['info']['GRID_X_MIN'],
+            y1=j['info']['GRID_Y_MIN'],
+            x2=j['info']['GRID_X_MAX'],
+            y2=j['info']['GRID_Y_MAX']
         )
 
         synth_tile_map = add_synthetic_tiles(model_xml, complexblocklist_xml)
@@ -343,7 +335,7 @@ def main():
             assert vpr_loc.grid_y == synth_tile["loc"]["grid_y"]
 
             vpr_tile_type = synth_tile_map[synth_tile['pins'][0]['port_type']]
-        elif only_emit_roi and not roi.tile_in_roi(vpr_loc):
+        elif only_emit_roi and not roi.tile_in_roi(loc):
             # This tile is outside the ROI, skip it.
             continue
         elif gridinfo.tile_type in tile_types:

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -307,13 +307,15 @@ def main():
     with DatabaseCache(args.connection_database, read_only=True) as conn:
 
         c = conn.cursor()
+        c2 = conn.cursor()
 
         # List tile wires and site wires
-        tiles = c.execute("SELECT pkey, name FROM tile_type").fetchall()
-        for tile_type_pkey, tile_type in tiles:
+        for tile_type_pkey, tile_type in c2.execute(
+                "SELECT pkey, name FROM tile_type"
+        ):
 
             for wire_name, site_pkey in c.execute(
-                    "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
+        "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
                 (tile_type_pkey, )):
 
                 # Tile wire

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -40,8 +40,8 @@ def handle_direction_connections(conn, direct_connections, edge_assignments):
     # It is expected that all edges_with_mux will lies in a line (e.g. X only or
     # Y only).
     c = conn.cursor()
-    for src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey in progressbar.progressbar(
-            c.execute("""
+    for src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey in \
+            progressbar.progressbar(c.execute("""
 SELECT src_wire_pkey, dest_wire_pkey, pip_in_tile_pkey FROM edge_with_mux;""")
     ):
 
@@ -89,16 +89,16 @@ SELECT node_pkey FROM wire WHERE pkey = ?""", (dest_wire_pkey, )
         # Find the wire connected to the sink.
         dest_wire = list(node_to_site_pins(conn, dest_node_pkey))
         assert len(dest_wire) == 1
-        destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = dest_wire[
-            0]
+        destination_wire_pkey, dest_tile_pkey, dest_wire_in_tile_pkey = \
+            dest_wire[0]
 
         c2.execute(
             """
 SELECT tile_type_pkey, grid_x, grid_y FROM tile WHERE pkey = ?;""",
             (dest_tile_pkey, )
         )
-        dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = c2.fetchone(
-        )
+        dest_tile_type_pkey, destination_loc_grid_x, destination_loc_grid_y = \
+            c2.fetchone()
 
         c2.execute(
             """
@@ -213,8 +213,8 @@ SELECT pkey, name, site_pin_pkey FROM wire_in_tile WHERE pkey = ?;""",
             if site_pin_pkey is None:
                 continue
 
-            for pip_pkey, pip, src_wire_in_tile_pkey, dest_wire_in_tile_pkey in c3.execute(
-                    """
+            for pip_pkey, pip, src_wire_in_tile_pkey, dest_wire_in_tile_pkey \
+                    in c3.execute("""
 SELECT
   pkey,
   name,
@@ -237,8 +237,8 @@ WHERE
                     other_wire_in_tile_pkey = src_wire_in_tile_pkey
 
                 # Need to walk from the wire_in_tile table, to the wire table,
-                # to the node table and get track_pkey.
-                # other_wire_in_tile_pkey -> wire pkey -> node_pkey -> track_pkey
+                # to the node table and get track_pkey. other_wire_in_tile_pkey
+                # -> wire pkey -> node_pkey -> track_pkey
                 c4 = conn.cursor()
                 c4.execute(
                     """
@@ -291,7 +291,8 @@ def main():
     parser.add_argument(
         '--connection_database',
         help='Database of fabric connectivity',
-        required=True)
+        required=True
+    )
     parser.add_argument(
         '--pin_assignments',
         help=
@@ -311,11 +312,10 @@ def main():
 
         # List tile wires and site wires
         for tile_type_pkey, tile_type in c2.execute(
-                "SELECT pkey, name FROM tile_type"
-        ):
+                "SELECT pkey, name FROM tile_type"):
 
             for wire_name, site_pkey in c.execute(
-        "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
+                    "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
                 (tile_type_pkey, )):
 
                 # Tile wire
@@ -361,8 +361,8 @@ def main():
         # List of nodes that are channels.
         channel_nodes = []
 
-        # Map of (tile, wire) to track.  This will be used to find channels for pips
-        # that come from EDGES_TO_CHANNEL.
+        # Map of (tile, wire) to track.  This will be used to find channels for
+        # pips that come from EDGES_TO_CHANNEL.
         channel_wires_to_tracks = {}
 
         # Generate track models and verify that wires are either in a channel
@@ -402,7 +402,8 @@ def main():
         # been marked as NULL during channel formation.
         print('{} Handling edges to channels.'.format(now()))
         handle_edges_to_channels(
-            conn, null_tile_wires, edge_assignments, channel_wires_to_tracks)
+            conn, null_tile_wires, edge_assignments, channel_wires_to_tracks
+        )
 
         print('{} Processing edge assignments.'.format(now()))
         final_edge_assignments = {}
@@ -411,8 +412,8 @@ def main():
             (tile_type, wire) = key
             if len(available_pins) == 0:
                 if (tile_type, wire) not in null_tile_wires:
-                    # TODO: Figure out what is going on with these wires.  Appear to
-                    # tile internal connections sometimes?
+                    # TODO: Figure out what is going on with these wires.
+                    #  Appear to tile internal connections sometimes?
                     print((tile_type, wire))
 
                 final_edge_assignments[key] = [tracks.Direction.RIGHT]
@@ -425,7 +426,8 @@ def main():
             if len(pins) > 0:
                 final_edge_assignments[key] = [list(pins)[0]]
             else:
-                # More than 2 pins are required, final the minimal number of pins
+                # More than 2 pins are required, final the minimal number
+                # of pins
                 pins = set()
                 for p in available_pins:
                     pins |= set(p)

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -316,7 +316,9 @@ def main():
 
             # FIXME: This is a HACK for now. Porobably need to store the info
             # in the db.
-            if tile_type in ["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"]:
+            #if tile_type in ["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"]:
+            #    continue
+            if tile_type in ["CLBLM_L", "CLBLM_R"]:
                 continue
 
             for wire_name, site_pkey in c.execute(

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -310,15 +310,20 @@ def main():
         c = conn.cursor()
         c2 = conn.cursor()
 
+        # Get a list of tile types to split
+        tile_types_to_split = [row[0] for row in c.execute("""
+            SELECT name FROM tile_type
+            INNER JOIN tile_types_to_split ON
+            tile_types_to_split.tile_type_pkey = tile_type.pkey""")
+            ]
+
         # List tile wires and site wires
         for tile_type_pkey, tile_type in c2.execute(
                 "SELECT pkey, name FROM tile_type"):
 
-            # FIXME: This is a HACK for now. Porobably need to store the info
-            # in the db.
-            #if tile_type in ["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"]:
-            #    continue
-            if tile_type in ["CLBLM_L", "CLBLM_R"]:
+            # This tile type has been split and is no longer present in the
+            # VPR grid. Skip it
+            if tile_type in tile_types_to_split:
                 continue
 
             for wire_name, site_pkey in c.execute(

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -314,6 +314,11 @@ def main():
         for tile_type_pkey, tile_type in c2.execute(
                 "SELECT pkey, name FROM tile_type"):
 
+            # FIXME: This is a HACK for now. Porobably need to store the info
+            # in the db.
+            if tile_type in ["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"]:
+                continue
+
             for wire_name, site_pkey in c.execute(
                     "SELECT name, site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?)",
                 (tile_type_pkey, )):

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -332,7 +332,8 @@ class Connector(object):
                 if pin_dir in self.pins.edge_map:
                     return self.pins.edge_map[pin_dir], graph_nodes[idx]
         elif self.tracks and other_connector.pins:
-            assert other_connector.pins.site_pin_direction == SitePinDirection.IN
+            assert other_connector.pins.site_pin_direction == \
+                   SitePinDirection.IN
             assert other_connector.pins.x == loc[0]
             assert other_connector.pins.y == loc[1]
 
@@ -343,7 +344,8 @@ class Connector(object):
                         pin_dir]
         elif self.pins and other_connector.pins:
             assert self.pins.site_pin_direction == SitePinDirection.OUT
-            assert other_connector.pins.site_pin_direction == SitePinDirection.IN
+            assert other_connector.pins.site_pin_direction == \
+                   SitePinDirection.IN
 
             if len(self.pins.edge_map) == 1 and len(
                     other_connector.pins.edge_map) == 1:
@@ -394,8 +396,8 @@ def create_find_connector(conn):
         # Find all graph_nodes for this node.
         c.execute(
             """
-        SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high FROM graph_node
-        WHERE node_pkey = ?;""", (node_pkey, )
+        SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high
+        FROM graph_node WHERE node_pkey = ?;""", (node_pkey, )
         )
 
         graph_nodes = c.fetchall()
@@ -535,8 +537,9 @@ SELECT vcc_track_pkey, gnd_track_pkey FROM constant_sources;
 
 def make_connection(
         conn, input_only_nodes, output_only_nodes, loc, tile_pkey,
-        src_wire_pkey, dst_wire_pkey, pip_pkey, switch_pkey, delayless_switch_pkey,
-        find_connector, const_connectors):
+        src_wire_pkey, dst_wire_pkey, pip_pkey, switch_pkey,
+        delayless_switch_pkey, find_connector, const_connectors
+):
     """ Attempt to connect graph nodes on either side of a pip.
 
     Args:
@@ -574,11 +577,13 @@ def make_connection(
 
     # Get node pkeys
     src_node_pkey = c.execute(
-        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND wire_in_tile_pkey = (?)",
-        (tile_pkey, src_wire_pkey)).fetchone()[0]
+        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND "
+        "wire_in_tile_pkey = (?)", (tile_pkey, src_wire_pkey)
+    ).fetchone()[0]
     dst_node_pkey = c.execute(
-        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND wire_in_tile_pkey = (?)",
-        (tile_pkey, dst_wire_pkey)).fetchone()[0]
+        "SELECT node_pkey FROM wire WHERE tile_pkey = (?) AND "
+        "wire_in_tile_pkey = (?)", (tile_pkey, dst_wire_pkey)
+    ).fetchone()[0]
 
     # Skip nodes that are reserved because of ROI
     if src_node_pkey in input_only_nodes:
@@ -619,8 +624,6 @@ def make_connection(
         src_graph_node_pkey, dst_graph_node_pkey = const_connectors[
             constant_src].connect_at(loc, dst_connector)
 
-        #print("SYNTH EDGE: ", src_graph_node_pkey, dst_graph_node_pkey, delayless_switch_pkey, tile_pkey)
-
         edges.append(
             (
                 src_graph_node_pkey,
@@ -633,7 +636,10 @@ def make_connection(
 
     return edges
 
-def mark_track_liveness(conn, pool, input_only_nodes, output_only_nodes, alive_tracks):
+
+def mark_track_liveness(
+        conn, pool, input_only_nodes, output_only_nodes, alive_tracks
+):
     """ Checks tracks for liveness.
 
     Iterates over all graph nodes that are routing tracks and determines if
@@ -717,8 +723,8 @@ def build_channels(conn, pool, active_tracks):
 
     x_tracks = {}
     y_tracks = {}
-    for pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high in c.execute(
-            """
+    for pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high in \
+            c.execute("""
 SELECT
   pkey,
   track_pkey,
@@ -896,8 +902,9 @@ def verify_channels(conn, alive_tracks):
     for (graph_node_pkey, track_pkey, graph_node_type, x_low, x_high, y_low,
          y_high, ptc, capacity) in c.execute(
              """
-    SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high, ptc, capacity FROM
-        graph_node WHERE (graph_node_type = ? or graph_node_type = ?);""",
+    SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high,
+    ptc, capacity FROM graph_node WHERE 
+    (graph_node_type = ? or graph_node_type = ?);""",
              (graph2.NodeType.CHANX.value, graph2.NodeType.CHANY.value)):
 
         if track_pkey not in alive_tracks and capacity != 0:
@@ -931,15 +938,15 @@ def main():
     parser.add_argument(
         '--connection_database',
         help='Database of fabric connectivity',
-        required=True)
+        required=True
+    )
     parser.add_argument(
-        '--pin_assignments',
-        help='Pin assignments JSON',
-        required=True)
+        '--pin_assignments', help='Pin assignments JSON', required=True
+    )
     parser.add_argument(
         '--synth_tiles',
-        help=
-        'If using an ROI, synthetic tile defintion from prjxray-arch-import')
+        help='If using an ROI, synthetic tile defintion from prjxray-arch-import'
+    )
 
     args = parser.parse_args()
 
@@ -972,7 +979,8 @@ def main():
                 synth_tiles["info"]["GRID_X_MIN"],
                 synth_tiles["info"]["GRID_Y_MIN"],
                 synth_tiles["info"]["GRID_X_MAX"],
-                synth_tiles["info"]["GRID_Y_MAX"])
+                synth_tiles["info"]["GRID_Y_MAX"]
+            )
 
             print('{} generating routing graph for ROI.'.format(now()))
         else:
@@ -994,13 +1002,14 @@ def main():
             c = conn.cursor()
             c2 = conn.cursor()
 
-            for tile_name, tile_type_pkey, grid_x, grid_y in progressbar.progressbar(
-                    c.execute(
+            for tile_name, tile_type_pkey, grid_x, grid_y in\
+                    progressbar.progressbar(c.execute(
                         "SELECT name, tile_type_pkey, grid_x, grid_y FROM tile"
                     )):
                 tile_type = c2.execute(
                     "SELECT name FROM tile_type WHERE pkey = (?)",
-                    (tile_type_pkey, )).fetchone()[0]
+                    (tile_type_pkey, )
+                ).fetchone()[0]
 
                 if tile_name in synth_tiles['tiles']:
                     assert len(synth_tiles['tiles'][tile_name]['pins']) == 1
@@ -1010,7 +1019,8 @@ def main():
                             continue
 
                         _, _, node_pkey = find_wire(
-                            tile_name, tile_type, pin['wire'])
+                            tile_name, tile_type, pin['wire']
+                        )
 
                         if pin['port_type'] == 'input':
                             # This track can output be used as a sink.
@@ -1036,7 +1046,8 @@ def main():
         edge_set = set()
 
         c2 = conn.cursor()
-        for tile_pkey, tile_type_pkey, grid_x, grid_y in progressbar.progressbar(
+        for tile_pkey, tile_type_pkey, grid_x, grid_y in \
+                progressbar.progressbar(
                 c.execute(
                     "SELECT pkey, tile_type_pkey, grid_x, grid_y FROM tile")):
             loc = (grid_x, grid_y)
@@ -1048,8 +1059,10 @@ def main():
                 continue
 
             # Process PIPs
-            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey in c2.execute(
-                    "SELECT pkey, name, src_wire_in_tile_pkey, dest_wire_in_tile_pkey FROM pip_in_tile WHERE tile_type_pkey = (?)",
+            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey in\
+                    c2.execute("""SELECT pkey, name, src_wire_in_tile_pkey,
+                               dest_wire_in_tile_pkey FROM pip_in_tile WHERE
+                               tile_type_pkey = (?)""",
                 (tile_type_pkey, )):
 
                 # No pseudo pips and bidirectional pips should be present here
@@ -1061,7 +1074,9 @@ def main():
                 connections = make_connection(
                     conn, input_only_nodes, output_only_nodes, loc, tile_pkey,
                     pip_src_wire_pkey, pip_dst_wire_pkey, pip_pkey,
-                    switch_pkey, delayless_switch_pkey, find_connector, const_connectors)
+                    switch_pkey, delayless_switch_pkey, find_connector,
+                    const_connectors
+                )
 
                 if connections:
                     # TODO: Skip duplicate connections, until they have unique
@@ -1092,10 +1107,12 @@ def main():
         print('{} Inserted edges'.format(now()))
 
         c.execute(
-            """CREATE INDEX src_node_index ON graph_edge(src_graph_node_pkey);"""
+            """CREATE INDEX src_node_index ON 
+            graph_edge(src_graph_node_pkey);"""
         )
         c.execute(
-            """CREATE INDEX dest_node_index ON graph_edge(dest_graph_node_pkey);"""
+            """CREATE INDEX dest_node_index ON 
+            graph_edge(dest_graph_node_pkey);"""
         )
         c.connection.commit()
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -1072,10 +1072,18 @@ def main():
                 # FIXME: Will require a change here once merged with #537 (!)
 
                 connections = make_connection(
-                    conn, input_only_nodes, output_only_nodes, loc, tile_pkey,
-                    pip_src_wire_pkey, pip_dst_wire_pkey, pip_pkey,
-                    switch_pkey, delayless_switch_pkey, find_connector,
-                    const_connectors
+                    conn=conn,
+                    input_only_nodes=input_only_nodes,
+                    output_only_nodes=output_only_nodes,
+                    loc=loc,
+                    tile_pkey=tile_pkey,
+                    src_wire_pkey=pip_src_wire_pkey,
+                    dst_wire_pkey=pip_dst_wire_pkey,
+                    pip_pkey=pip_pkey,
+                    switch_pkey=switch_pkey,
+                    delayless_switch_pkey=delayless_switch_pkey,
+                    find_connector=find_connector,
+                    const_connectors=const_connectors
                 )
 
                 if connections:

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -616,13 +616,15 @@ def make_connection(
 
     # Make additional connections to constant network if the sink needs it.
     for constant_src in yield_ties_to_wire(src_wire_name):
-        src_graph_node_pkey, dest_graph_node_pkey = const_connectors[
+        src_graph_node_pkey, dst_graph_node_pkey = const_connectors[
             constant_src].connect_at(loc, dst_connector)
+
+        #print("SYNTH EDGE: ", src_graph_node_pkey, dst_graph_node_pkey, delayless_switch_pkey, tile_pkey)
 
         edges.append(
             (
                 src_graph_node_pkey,
-                dest_graph_node_pkey,
+                dst_graph_node_pkey,
                 delayless_switch_pkey,
                 tile_pkey,
                 None,
@@ -1082,7 +1084,8 @@ def main():
                     INSERT INTO graph_edge(
                         src_graph_node_pkey, dest_graph_node_pkey, switch_pkey,
                         tile_pkey, pip_in_tile_pkey)  VALUES (?, ?, ?, ?, ?)""",
-                edge)
+                edge
+            )
 
         c.execute("""COMMIT TRANSACTION;""")
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -549,7 +549,7 @@ def make_connection(
         tile_pkey (int): pkey of the tile in the tile table
         src_wire_pkey (int): pkey of the source wire in the wire table
         dst_wire_pkey (int): pkey of the destination wire in the wire table
-        loc (tuple): Location of tile.
+        loc (tuple): Location of tile in the VPR grid space.
         pip_pkey (int): Pip being connected.
         switch_pkey (int): Primary key to switch table of switch to be used
             in this connection.

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -1059,17 +1059,21 @@ def main():
                 continue
 
             # Process PIPs
-            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey in\
+            for pip_pkey, pip_name, pip_src_wire_pkey, pip_dst_wire_pkey,\
+                is_pseudo, is_directional in \
                     c2.execute("""SELECT pkey, name, src_wire_in_tile_pkey,
-                               dest_wire_in_tile_pkey FROM pip_in_tile WHERE
+                               dest_wire_in_tile_pkey, is_pseudo,
+                               is_directional FROM pip_in_tile WHERE
                                tile_type_pkey = (?)""",
-                (tile_type_pkey, )):
+                               (tile_type_pkey, )):
 
-                # No pseudo pips and bidirectional pips should be present here
-                # as they were skipped during import to the SQLite database
-                # in prjxray_form_channels.py
+                # Skip pseudo pips. They are not part of the routing
+                if is_pseudo:
+                    continue
 
-                # FIXME: Will require a change here once merged with #537 (!)
+                # FIXME: TODO: Handle bi-directional pips
+                if not is_directional:
+                    continue
 
                 connections = make_connection(
                     conn=conn,

--- a/xc7/utils/prjxray_create_ioplace.py
+++ b/xc7/utils/prjxray_create_ioplace.py
@@ -61,8 +61,8 @@ def main():
     for pcf_constraint in parse_simple_pcf(args.pcf):
         if not io_place.is_net(pcf_constraint.net):
             print(
-                'PCF constraint "{}" from line {} constraints net {} which is not in available netlist:\n{}'
-                .format(
+                'PCF constraint "{}" from line {} constraints net {} which is'
+                ' not in available netlist:\n{}'.format(
                     pcf_constraint.line_str, pcf_constraint.line_num,
                     pcf_constraint.net, '\n'.join(io_place.get_nets())
                 ),
@@ -72,8 +72,8 @@ def main():
 
         if pcf_constraint.pad not in pad_map:
             print(
-                'PCF constraint "{}" from line {} constraints pad {} which is not in available pad map:\n{}'
-                .format(
+                'PCF constraint "{}" from line {} constraints pad {} which is'
+                ' not in available pad map:\n{}'.format(
                     pcf_constraint.line_str, pcf_constraint.line_num,
                     pcf_constraint.pad, '\n'.join(sorted(pad_map.keys()))
                 ),

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -54,12 +54,14 @@ def find_vbrk_closest_to(grid, roi, loc, loc_in_use):
 
     return loc_best
 
+
 def main():
     parser = argparse.ArgumentParser(description="Generate synth_tiles.json")
     parser.add_argument('--db_root', required=True)
     parser.add_argument('--roi', required=True)
     parser.add_argument(
-        '--connection_database', help='Connection database', required=True)
+        '--connection_database', help='Connection database', required=True
+    )
     parser.add_argument('--synth_tiles', required=False)
 
     args = parser.parse_args()
@@ -90,9 +92,11 @@ def main():
 
     # Map ROI coordinates to the target VPR grid
     roi_loc_lo = grid_loc_mapper.get_vpr_loc(
-        (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN']))
+        (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN'])
+    )
     roi_loc_hi = grid_loc_mapper.get_vpr_loc(
-        (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX']))
+        (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX'])
+    )
 
     synth_tiles['info'] = {
         "GRID_X_MIN": min([p[0] for p in roi_loc_lo]),
@@ -133,7 +137,8 @@ def main():
             # Or if in the ROI, make sure it has no sites.
             gridinfo = g.gridinfo_at_tilename(tile)
             assert len(
-                db.get_tile_type(gridinfo.tile_type).get_sites()) == 0, tile
+                db.get_tile_type(gridinfo.tile_type).get_sites()
+            ) == 0, tile
 
         if tile not in synth_tiles['tiles']:
             synth_tiles['tiles'][tile] = {

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -3,12 +3,19 @@ import prjxray.db
 from prjxray.roi import Roi
 import simplejson as json
 
+from prjxray.grid_types import GridLoc
+
+from prjxray_db_cache import DatabaseCache
+from lib.grid_mapping import GridLocMap
+
 
 def main():
     parser = argparse.ArgumentParser(description="Generate synth_tiles.json")
     parser.add_argument('--db_root', required=True)
     parser.add_argument('--roi', required=True)
-    parser.add_argument('--synth_tiles', required=True)
+    parser.add_argument(
+        '--connection_database', help='Connection database', required=True)
+    parser.add_argument('--synth_tiles', required=False)
 
     args = parser.parse_args()
 
@@ -18,19 +25,41 @@ def main():
     synth_tiles = {}
     synth_tiles['tiles'] = {}
 
+    # Initialize grid mapper
+    with DatabaseCache(args.connection_database, read_only=True) as conn:
+
+        # The object will read data from the DB so it can live
+        # outside the scope of the "with" statement
+        grid_loc_mapper = GridLocMap(conn)
+
     with open(args.roi) as f:
         j = json.load(f)
 
+    # Map ROI coordinates to the target VPR grid
+    roi_loc_lo = grid_loc_mapper.get_vpr_loc(
+        (j['info']['GRID_X_MIN'], j['info']['GRID_Y_MIN']))
+    roi_loc_hi = grid_loc_mapper.get_vpr_loc(
+        (j['info']['GRID_X_MAX'], j['info']['GRID_Y_MAX']))
+
+    vbrk_in_use = set()
+
     roi = Roi(
         db=db,
-        x1=j['info']['GRID_X_MIN'],
-        y1=j['info']['GRID_Y_MIN'],
-        x2=j['info']['GRID_X_MAX'],
-        y2=j['info']['GRID_Y_MAX'],
+        x1=min([p[0] for p in roi_loc_lo
+                ]),  # One physical grid location may map to more than one
+        y1=min([p[1] for p in roi_loc_lo
+                ]),  # VPR locations. So here we take min and max.
+        x2=max([p[0] for p in roi_loc_hi]),
+        y2=max([p[1] for p in roi_loc_hi]),
     )
 
-    synth_tiles['info'] = j['info']
-    vbrk_in_use = set()
+    synth_tiles['info'] = {
+        "GRID_X_MIN": roi.x1,
+        "GRID_Y_MIN": roi.y1,
+        "GRID_X_MAX": roi.x2,
+        "GRID_Y_MAX": roi.y2
+    }
+
     for port in j['ports']:
         if port['name'].startswith('dout['):
             port_type = 'input'
@@ -48,19 +77,23 @@ def main():
 
         vbrk_in_use.add(tile)
 
-        # Make sure connecting wire is not in ROI!
+        # Map tile location to the VPR grid
         loc = g.loc_of_tilename(tile)
-        if roi.tile_in_roi(loc):
+        vpr_loc = grid_loc_mapper.get_vpr_loc((loc.grid_x, loc.grid_y))
+        vpr_loc = vpr_loc[0]  # FIXME: Assuming no split of that tile!
+        vpr_loc = GridLoc(vpr_loc[0], vpr_loc[1])
+
+        # Make sure connecting wire is not in ROI!
+        if roi.tile_in_roi(vpr_loc):
             # Or if in the ROI, make sure it has no sites.
             gridinfo = g.gridinfo_at_tilename(tile)
             assert len(
-                db.get_tile_type(gridinfo.tile_type).get_sites()
-            ) == 0, tile
+                db.get_tile_type(gridinfo.tile_type).get_sites()) == 0, tile
 
         if tile not in synth_tiles['tiles']:
             synth_tiles['tiles'][tile] = {
                 'pins': [],
-                'loc': g.loc_of_tilename(tile),
+                'loc': vpr_loc,
             }
 
         synth_tiles['tiles'][tile]['pins'].append(

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -75,7 +75,7 @@ def main():
 
         # The object will read data from the DB so it can live
         # outside the scope of the "with" statement
-        grid_loc_mapper = GridLocMap(conn)
+        grid_loc_mapper = GridLocMap.load_from_database(conn)
 
     with open(args.roi) as f:
         j = json.load(f)

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -153,7 +153,7 @@ def main():
 
     # Find two VBRK's in the corner of the fabric to use as the synthetic VCC
     loc_min = GridLoc(g.dims()[0], g.dims()[2])
-    loc_max = GridLoc(g.dims()[1], g.dims()[3])
+    loc_max = GridLoc(g.dims()[0], g.dims()[3])
 
     #print("loc_min:", loc_min, "phy")
     #print("loc_max:", loc_max, "phy")

--- a/xc7/utils/prjxray_create_synth_tiles.py
+++ b/xc7/utils/prjxray_create_synth_tiles.py
@@ -14,11 +14,16 @@ def find_vbrk_closest_to(grid, roi, loc, loc_in_use):
     Finds a VBRK tile (optionally within the ROI) which is located closest
     to a given location. Checks if such a tile is not already used by
     another synth tile.
-    :param grid:
-    :param roi:
-    :param loc:
-    :param loc_in_use:
-    :return:
+
+    Args:
+        grid: A Grid object from the prjxray database
+        roi: A Roi object from the prjxray database or None when ROI not used.
+        loc: A GridLoc with location to find the closest VBRK to.
+        loc_in_use: A set with GridLoc objects which indicate occupied VBRKs
+
+    Returns:
+        A GridLoc with the "best" (closest) VBRK tile location to the given
+        input loc.
     """
 
     loc_best = None

--- a/xc7/utils/prjxray_db_cache.py
+++ b/xc7/utils/prjxray_db_cache.py
@@ -47,13 +47,15 @@ class DatabaseCache(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         """
-        Writes back the database to file if the database was open as not read-only
+        Writes back the database to file if the database was open as not
+        read-only
         """
 
         # Write back only if not read-only
         if not self.read_only:
             if self.memory_connection.in_transaction:
-                assert exc_type is not None, "Outstanding transaction, but no exception?"
+                assert exc_type is not None, "Outstanding transaction, " \
+                                             "but no exception?"
                 self.memory_connection.rollback()
 
             print("Dumping database to '{}'".format(self.file_name))

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -1103,7 +1103,8 @@ def main():
         print("{}: Initial database formed".format(datetime.datetime.now()))
 
         # List of tile types to split FIXME: Hard coded !
-        tile_types_to_split = ["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"]
+        #tile_types_to_split = ["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"]
+        tile_types_to_split = ["CLBLM_L", "CLBLM_R"]
 
         gs = GridSplitter(conn)
         gs.set_tile_types_to_split(tile_types_to_split)

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -1048,5 +1048,6 @@ def main():
             )
         )
 
+
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -247,9 +247,7 @@ def import_dummy_tracks(conn, graph, segment_id):
     return num_dummy
 
 
-def create_track_rr_graph(
-        conn, graph, node_mapping, segment_id
-):
+def create_track_rr_graph(conn, graph, node_mapping, segment_id):
     c = conn.cursor()
     c.execute("""SELECT count(*) FROM track;""")
     (num_channels, ) = c.fetchone()
@@ -537,7 +535,8 @@ def main():
     )
     parser.add_argument(
         '--synth_tiles',
-        help='If using an ROI, synthetic tile defintion from prjxray-arch-import'
+        help='If using an ROI, synthetic tile defintion from'
+        ' prjxray-arch-import'
     )
 
     args = parser.parse_args()
@@ -600,9 +599,7 @@ def main():
         # Walk all track graph nodes and add them.
         print('{} Creating tracks'.format(now()))
         segment_id = graph.get_segment_id_from_name('dummy')
-        create_track_rr_graph(
-            conn, graph, node_mapping, segment_id
-        )
+        create_track_rr_graph(conn, graph, node_mapping, segment_id)
 
         # Set of (src, sink, switch_id) tuples that pip edges have been sent to
         # VPR.  VPR cannot handle duplicate paths with the same switch id.

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -314,7 +314,6 @@ WHERE
                     (track_pkey, ) = c.fetchone()
                 else:
                     assert False, pin['port_type']
-
                 tracks_model, track_nodes = get_track_model(conn, track_pkey)
 
                 option = list(tracks_model.get_tracks_for_wire_at_coord(loc))

--- a/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
+++ b/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
@@ -57,6 +57,5 @@ def main():
                 )
             )
 
-
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
+++ b/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
@@ -57,5 +57,6 @@ def main():
                 )
             )
 
+
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
+++ b/xc7/utils/prjxray_synth_tiles_to_pinmap_csv.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python3
-""" Tool generate convert a synth_tiles.json (describing an ROI) to a pin map CSV usable for pin placement. """
+""" Tool generate convert a synth_tiles.json (describing an ROI) to a pin map
+ CSV usable for pin placement. """
 from __future__ import print_function
 import argparse
 import json

--- a/xc7/utils/prjxray_tile_import.py
+++ b/xc7/utils/prjxray_tile_import.py
@@ -110,7 +110,10 @@ def main():
         '--fused_sites',
         action='store_true',
         help=
-        "Typically a tile can treat the sites within the tile as independent.  For tiles where this is not true, fused sites only imports 1 primatative for the entire tile, which should be named the same as the tile type."
+        "Typically a tile can treat the sites within the tile as independent."
+        "For tiles where this is not true, fused sites only imports 1"
+        "primatative for the entire tile, which should be named the same as"
+        "the tile type."
     )
 
     args = parser.parse_args()
@@ -150,10 +153,12 @@ def main():
             for site_pin in site.site_pins:
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     if site_pin.wire is not None:
                         input_wires.add(site_pin.wire)
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     if site_pin.wire is not None:
                         output_wires.add(site_pin.wire)
                 else:
@@ -177,10 +182,12 @@ def main():
             for site_pin in site.site_pins:
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     if site_pin.wire is not None:
                         input_wires.add(site_pin.wire)
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     if site_pin.wire is not None:
                         output_wires.add(site_pin.wire)
                 else:
@@ -389,21 +396,25 @@ def main():
                 port = find_port(site_pin.name, site_type_ports[site_instance])
                 if port is None:
                     print(
-                        "*** WARNING *** Didn't find port for name {} for site type {}"
-                        .format(site_pin.name, site.type),
+                        "*** WARNING *** Didn't find port for"
+                        " name {} for site type {}".format(
+                            site_pin.name, site.type
+                        ),
                         file=sys.stderr
                     )
                     continue
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(tile_name, site_pin.wire),
                         output=object_ref(site_name, **port)
                     )
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     pass
                 else:
                     assert False, site_type_pin.direction
@@ -420,9 +431,11 @@ def main():
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     pass
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(site_name, **port),
@@ -474,21 +487,25 @@ def main():
                 port = find_port(port_name, ports)
                 if port is None:
                     print(
-                        "*** WARNING *** Didn't find port for name {} for site type {}"
-                        .format(port_name, site.type),
+                        "*** WARNING *** Didn't find port for"
+                        " name {} for site type {}".format(
+                            port_name, site.type
+                        ),
                         file=sys.stderr
                     )
                     continue
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(tile_name, site_pin.wire),
                         output=object_ref(site_name, **port)
                     )
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     pass
                 else:
                     assert False, site_type_pin.direction
@@ -506,9 +523,11 @@ def main():
 
                 site_type_pin = site_type.get_site_pin(site_pin.name)
 
-                if site_type_pin.direction == prjxray.site_type.SitePinDirection.IN:
+                if site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.IN:
                     pass
-                elif site_type_pin.direction == prjxray.site_type.SitePinDirection.OUT:
+                elif site_type_pin.direction == \
+                        prjxray.site_type.SitePinDirection.OUT:
                     add_direct(
                         interconnect_xml,
                         input=object_ref(site_name, **port),

--- a/xc7/utils/splitter/grid_splitter.py
+++ b/xc7/utils/splitter/grid_splitter.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+import logging
+import itertools
+import argparse
+import sqlite3
+
+import sys
+sys.path.append("../")  # Hackish way...
+
+from prjxray_db_cache import DatabaseCache
+from lib.grid_mapping import get_phy_grid_extent
+
+# =============================================================================
+
+
+class GridSplitter(object):
+    def __init__(self, db_conn):
+        self.db_cursor = db_conn.cursor()
+
+        self.tile_types_to_split = None
+
+        # Get the grid from database:
+        self.grid = self.db_cursor.execute(
+            "SELECT grid_x, grid_y, ( SELECT name FROM tile_type WHERE tile_type.pkey = phy_tile.tile_type_pkey ) FROM phy_tile"
+        )
+        # Get the physical grid extent
+        self.grid_extent = get_phy_grid_extent(db_conn)
+
+    def set_tile_types_to_split(self, tile_types):
+        """
+        Set tile types to split
+        """
+        self.tile_types_to_split = tile_types
+
+    def split(self):
+        """
+        Do the split
+        """
+
+        # Identify grid colums to split
+        columns_to_split = set()
+
+        for tile in self.grid:
+            if tile[2] in self.tile_types_to_split:
+                columns_to_split.add(tile[0])
+
+        logging.info("Splitting columns: %s" % str(columns_to_split))
+
+        # Clear the grid_loc_map
+        self.db_cursor.executescript("DELETE FROM grid_loc_map; VACUUM;")
+
+        # Build an new coordinate mapping
+        for phy_x, phy_y in itertools.product(range(self.grid_extent[0],
+                                                    self.grid_extent[2] + 1),
+                                              range(self.grid_extent[1],
+                                                    self.grid_extent[3] + 1)):
+            vpr_x = phy_x + sum([phy_x > x for x in columns_to_split])
+            vpr_y = phy_y
+
+            self.db_cursor.execute(
+                "INSERT INTO grid_loc_map VALUES (?, ?, ?, ?);",
+                (phy_x, phy_y, vpr_x, vpr_y))
+
+        # Commit
+        self.db_cursor.execute("COMMIT TRANSACTION;")
+        self.db_cursor.connection.commit()
+
+
+# =============================================================================
+
+
+def main():
+    """
+    The main
+    """
+
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--connection_database",
+        required=True,
+        type=str,
+        help="Database of fabric connectivity")
+    parser.add_argument(
+        "--split-tiles",
+        required=True,
+        type=str,
+        nargs="*",
+        action="append",
+        help="Tile types to split")
+
+    args = parser.parse_args()
+
+    # Logging
+    logging.basicConfig(level=logging.DEBUG, format="%(message)s")
+
+    # .................................
+
+    # Build a list of tiles to split
+    tile_types = []
+    for tile_type_list in args.split_tiles:
+        for tile_type in tile_type_list:
+            tile_types.append(tile_type)
+
+    # .................................
+
+    with DatabaseCache(args.connection_database) as conn:
+
+        # Initialize the grid splitter
+        splitter = GridSplitter(conn)
+
+        # Add list of tiles to split
+        splitter.set_tile_types_to_split(tile_types)
+
+        # Do the split
+        splitter.split()
+
+
+# =============================================================================
+
+if __name__ == "__main__":
+    main()

--- a/xc7/utils/splitter/grid_splitter.py
+++ b/xc7/utils/splitter/grid_splitter.py
@@ -41,10 +41,6 @@ FROM phy_tile
     def append_loc_map(loc_map, src_loc, dst_loc):
         """
         Appends a coordinate correspondence to the given location map.
-        :param loc_map:
-        :param src_loc:
-        :param dst_loc:
-        :return:
         """
 
         if src_loc not in loc_map.keys():

--- a/xc7/utils/splitter/tile_splitter.py
+++ b/xc7/utils/splitter/tile_splitter.py
@@ -1,0 +1,218 @@
+import sqlite3
+
+from lib.grid_mapping import GenericMap
+
+# =============================================================================
+
+
+class TileSplitter(object):
+
+    def __init__(self, prjxray_db, sql_db):
+        self.prjxray_db = prjxray_db
+        self.sql_db = sql_db
+
+        self.tile_types_to_split = []
+
+    def set_tile_types_to_split(self, tile_types):
+        """
+        Set tile types to split
+        """
+        self.tile_types_to_split = tile_types
+
+    def get_tile_type_sites(self, tile_type):
+        """
+        Returns all site types for a given tile type
+        """
+
+        c = self.sql_db.cursor()
+
+        # Get the tile type pkey
+        tile_type_pkey = c.execute("SELECT pkey FROM tile_type WHERE name = (?)", (tile_type,)).fetchone()[0]
+
+        # Get sites
+        sites = c.execute("SELECT site_type.name, site.x_coord FROM site INNER JOIN site_type ON site.site_type_pkey = site_type.pkey WHERE site.pkey IN (SELECT site_pkey FROM wire_in_tile WHERE tile_type_pkey = (?) AND site_pkey IS NOT NULL)", (tile_type_pkey, )).fetchall()
+
+        # Sort them according to x_coord
+        sites = sorted(sites, key=lambda s: s[1])
+        return [s[0] for s in sites]
+
+    def get_unique_site_types(self):
+        """
+        Returns unique site types among all considered tile types
+        """
+
+        unique_site_types = set()
+
+        for tile_type in self.tile_types_to_split:
+            sites = self.get_tile_type_sites(tile_type)
+            for site_type in sites:
+                unique_site_types.add(site_type)
+
+        return unique_site_types
+
+    def create_new_tile_types(self):
+        """
+        Creates new tile types and insets them to the database
+        """
+
+        c = self.sql_db.cursor()
+
+        # Identify all unique site types for tiles being split and insert them
+        # as new tile types.
+        unique_site_types = self.get_unique_site_types()
+        for site_type in unique_site_types:
+            c.execute("INSERT INTO tile_type(name) VALUES(?)", (site_type, ))
+            print(c.lastrowid, site_type)
+
+    @staticmethod
+    def append_to_map(map_dict, map_key, map_item):
+        """
+        Appends something to a dict of lists. If the key is not present in
+        the dict then a single element is added to it.
+
+        Args:
+            map_dict:
+            map_key:
+            map_item:
+
+        Returns:
+
+        """
+
+        if map_key not in map_dict:
+            map_dict[map_key] = [map_item]
+        else:
+            map_dict[map_key].append(map_item)
+
+    def build_tile_type_pkey_map(self):
+        """
+        Builds a forward and backward correspondence map of tile types
+        as pkeys.
+        """
+
+        c = self.sql_db.cursor()
+
+        # Built tile type map
+        fwd_tile_type_map = {}
+        bwd_tile_type_map = {}
+
+        for tile_type in self.tile_types_to_split:
+
+            # Get the physical tile type pkey
+            tile_type_pkey = c.execute("SELECT pkey FROM tile_type WHERE name = (?)", (tile_type,)).fetchone()[0]
+
+            # Insert corresponding VPR tile type pkeys
+            fwd_tile_type_map[tile_type_pkey] = []
+            for site_type in self.get_tile_type_sites(tile_type):
+
+                # Get new tile type pkey from site name
+                new_tile_type_pkey = c.execute("SELECT pkey FROM tile_type WHERE name = (?)", (site_type,)).fetchone()[0]
+
+                fwd_tile_type_map[tile_type_pkey].append(new_tile_type_pkey)
+                bwd_tile_type_map[new_tile_type_pkey] = [tile_type_pkey]
+
+        # Return forward and backward mapping.
+        return fwd_tile_type_map, bwd_tile_type_map
+
+    def build_tile_wire_names_map(self, tile_type):
+        """
+        Builds a map which holds information about which wires are relevant
+        for particular site (new tile type). Wires which do not have any
+        sites/pips are included for all sites.
+
+        Args:
+            tile_type: Tile type string
+
+        Returns:
+
+        """
+
+        #print(tile_type)
+
+        fwd_map = {}
+
+        # Get the tile type object and its site objects
+        tile_type_obj = self.prjxray_db.get_tile_type(tile_type)
+        site_objs = tile_type_obj.get_sites()
+
+        # Get list of all site wires
+        site_wires = {}
+        for site_obj in site_objs:
+            site_wires[site_obj.name] = [pin.wire for pin in site_obj.site_pins]
+
+        # Loop through all tile wires
+        for wire in tile_type_obj.get_wires():
+            wire_info = tile_type_obj.get_wire_info(wire, allow_pseudo=False)
+            #print(wire, wire_info.pips, wire_info.sites)
+
+            # The wire has no pips and sites. It is a passthrough one which
+            # should appear in all new tile types after CLB split.
+            if len(wire_info.pips) == 0 and len(wire_info.sites) == 0:
+                for site_obj in site_objs:
+                    self.append_to_map(fwd_map, wire, site_obj.name)
+
+            # The wire is relevant to a particular site(s) and pip(s).
+            else:
+
+                # The wire goes directly to site(s)
+                for site_name, site_pin in wire_info.sites:
+                    self.append_to_map(fwd_map, wire, site_name)
+
+                # The wire goes to a pip(s)
+                for pip_name in wire_info.pips:
+                    pip_obj = tile_type_obj.get_pip_by_name(pip_name)
+
+                    # If the pip is connected to a site then the wire
+                    # is also relevant for that site
+                    for site_name, wires in site_wires.items():
+
+                        # FIXME: It is assumed here that there can be only one
+                        # pip between a tile wire and a site. This is true
+                        # for 7-series CLBs.
+
+                        if pip_obj.net_to in wires or \
+                           pip_obj.net_from in wires:
+                            self.append_to_map(fwd_map, wire, site_name)
+
+        # Return maps
+        return fwd_map, None
+
+    def split(self):
+        """
+        Performs the tile split
+        """
+
+        # TODO: I plan to use this class here for generating pb_type XMLs for
+        # the arch.xml
+
+        # Create new tile types
+        self.create_new_tile_types()
+
+        # Build tile type map
+        fwd_map, bwd_map = self.build_tile_type_pkey_map()
+        tile_type_pkey_map = GenericMap(fwd_map, bwd_map)
+
+        # Build tile wire map
+        tile_wire_name_map = {}
+        for tile_type in self.tile_types_to_split:
+            fwd_map, _ = self.build_tile_wire_names_map(tile_type)
+            tile_wire_name_map[tile_type] = GenericMap(fwd_map, None)
+
+        # Return the map
+        return tile_type_pkey_map, tile_wire_name_map
+
+# =============================================================================
+
+
+if __name__ == "__main__":
+
+    db = "/home/mkurc/Repos/google-symbiflow-arch-defs/build/xc7/archs/artix7/devices/xc7a50t-basys3-roi-virt/channels.db"
+    db_conn = sqlite3.Connection(db)
+
+    ts = TileSplitter(db_conn)
+    ts.set_tile_types_to_split(["CLBLL_L", "CLBLL_R", "CLBLM_L", "CLBLM_R"])
+
+    ts.split()
+
+    #for x in ts.get_unique_site_types():
+    #    print(x)

--- a/xc7/utils/splitter/tile_splitter.py
+++ b/xc7/utils/splitter/tile_splitter.py
@@ -292,8 +292,8 @@ class TileSplitter(object):
                 c.execute("INSERT INTO tile_type(name) VALUES (?)", (new_tile_type, ))
                 new_tile_type_pkey = c.lastrowid
 
-                # Insert new tile type as it should appear in the VPR
-                c.execute("INSERT INTO vpr_tile_type(name, tile_type_pkey) VALUES (?, ?)", (site_type, new_tile_type_pkey))
+                # Insert new tile type alias
+                c.execute("INSERT INTO tile_type_alias(name, tile_type_pkey) VALUES (?, ?)", (site_type, new_tile_type_pkey))
                 vpr_tile_pkey = c.lastrowid
 
                 print("{} -> {} -> {}".format(tile_type, new_tile_type, site_type))

--- a/xc7/utils/splitter/tile_splitter.py
+++ b/xc7/utils/splitter/tile_splitter.py
@@ -35,26 +35,6 @@ class TileSplitter(object):
         # Return a list of tuples (site_type, site_ofs)
         return [(s[0], (s[1], s[2])) for s in sites]
 
-    # def insert_new_tile_types(self):
-    #
-    #     c = self.sql_db.cursor()
-    #
-    #     unique_site_types = set()
-    #
-    #     # For a tile type to split list its sites
-    #     for tile_type in self.tile_types_to_split:
-    #         sites = self.get_tile_type_sites(tile_type)
-    #
-    #         # Process sites
-    #         for site_type, site_ofs in sites:
-    #             unique_site_types.add(site_type)
-    #
-    #             # # Find the site in tile instance in the SQL db
-    #             # site_pkey = c.execute("SELECT pkey FROM site WHERE x_coord = (?) AND y_coord = (?) AND site_type_pkey = (SELECT pkey FROM site_type WHERE name = (?))", (site_ofs[0], site_ofs[1], site_type, )).fetchone()[0]
-    #             # #print(tile_type, site_type, site_ofs, site_pkey)
-    #
-    #             # Reference the site in the new tile type
-
     def get_unique_site_types(self):
         """
         Returns unique site types among all considered tile types
@@ -105,6 +85,32 @@ class TileSplitter(object):
     #
     #             c.execute("""INSERT INTO wire_in_tile(name, tile_type_pkey) VALUES (?, ?)""", (wire, tile_types[tile_type_name]))
     #             wires[wire] = c.lastrowid
+
+    def insert_new_tile_wires(self):
+        """
+        Insert wires relevant to split tiles to the wire_in_tile table.
+        """
+
+        c = self.sql_db.cursor()
+
+        for phy_tile_type_pkey, vpr_tile_data in self.tile_type_pkey_map.fwd_map.items():
+            vpr_tile_type_pkey = vpr_tile_data[0]
+            site_ofs = vpr_tile_data[1]
+
+
+
+        # # For every wire in tile being split
+        # for phy_tile_type, fwd_map in self.tile_wire_name_map.items():
+        #
+        #     # Get the physical tile type pkey
+        #     phy_tile_type_pkey = c.execute("SELECT pkey FROM tile_type WHERE name = (?)", (phy_tile_type,)).fetchone()[0]
+        #
+        #     for wire, wire_site_name in fwd_map.items():
+        #
+        #         # Match wire_site_name with tile_site_name
+        #         for xxx in self.tile_type_pkey_map
+
+
 
 
     @staticmethod
@@ -220,6 +226,9 @@ class TileSplitter(object):
                            pip_obj.net_from in wires:
                             self.append_to_map(fwd_map, wire, site_name)
 
+            # Remove duplicates
+            fwd_map[wire] = list(set(fwd_map[wire]))
+
         # Return maps
         return fwd_map, None
 
@@ -244,8 +253,11 @@ class TileSplitter(object):
             fwd_map, _ = self.build_tile_wire_names_map(tile_type)
             self.tile_wire_name_map[tile_type] = GenericMap(fwd_map, None)
 
+            #for k, v in fwd_map.items():
+            #    print(tile_type, k, v)
+
         # Insert wires and pips for new tile types
-        #self.insert_wires_and_pips()
+        self.insert_new_tile_wires()
 
         # Return the map
         return self.tile_type_pkey_map, self.tile_wire_name_map

--- a/xc7/utils/splitter/tile_splitter.py
+++ b/xc7/utils/splitter/tile_splitter.py
@@ -305,6 +305,9 @@ class TileSplitter(object):
                 # Internal map with tile to site type and site loc.
                 self.append_to_map(self.tile_site_pkeys, tile_type, (new_tile_type_pkey, vpr_tile_pkey, site_pkey))
 
+            # Insert the tile type to the tile_types_to_split table
+            c.execute("INSERT INTO tile_types_to_split(tile_type_pkey) VALUES (?)", (tile_type_pkey, ))
+
         return GenericMap(fwd_map, bwd_map)
 
     def import_tile_type_map(self, tile_type_map):

--- a/xc7/utils/splitter/tile_splitter.py
+++ b/xc7/utils/splitter/tile_splitter.py
@@ -307,6 +307,23 @@ class TileSplitter(object):
 
         return GenericMap(fwd_map, bwd_map)
 
+    def import_tile_type_map(self, tile_type_map):
+        """
+        Imports tile type map to the database
+        """
+        c = self.sql_db.cursor()
+
+        for phy_tile_type, vpr_tile_types in tile_type_map.fwd_map.items():
+            for vpr_tile_type in vpr_tile_types:
+
+                # Get pkeys from names
+                (phy_tile_type_pkey, ) = c.execute("SELECT pkey FROM tile_type WHERE name = (?)", (phy_tile_type, )).fetchone()
+                (vpr_tile_type_pkey, ) = c.execute("SELECT pkey FROM tile_type WHERE name = (?)", (vpr_tile_type, )).fetchone()
+
+                # Insert binding
+                c.execute("INSERT INTO tile_type_map(phy_tile_type_pkey, vpr_tile_type_pkey) VALUES (?, ?)",
+                          (phy_tile_type_pkey, vpr_tile_type_pkey))
+
     # .........................................................................
 
     def split(self):
@@ -316,6 +333,9 @@ class TileSplitter(object):
 
         # Split the tiles
         tile_type_map = self.split_tiles()
+
+        # Import the tile type map
+        self.import_tile_type_map(tile_type_map)
 
         # Remap tile wires and pips
         wire_pkey_map, pip_pkey_map = self.remap_tile_wires_and_pips()


### PR DESCRIPTION
This PR is a continuation of work started in #537. It should be merged afterwards.

There are two new tables in the SQL database:
- "tile_former_site" Relates new SLICE tiles (instances) to concrete site instances of a CLB which were used to create them.
- "pip_in_tile_instance" Relates new SLICE tiles (instances) to pips from the pip_in_tile table.

The whole import flow works until the `handle_direction_connections` in `prjxray_assign_tile_pin_direction.py`. Right now it fails there as it cannot find SLICEL tile in the `edge_assignments` map.