### PR TITLE
infra: Fixing the Makefile forwarding.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,10 @@ env:
 	git submodule update --init --recursive
 	mkdir -p build && cd build && cmake ..
 
+build/Makefile:
+	make env
+
 .PHONY: Makefile
 
-%: env
+%: build/Makefile
 	cd build && $(MAKE) $@


### PR DESCRIPTION
Small fix to forwarding from the top level makefile to the targets in `build/Makefile`.

 * Don't always call `make env` unless `build/Makefile` doesn't exist.
 * Actually seems to work with tab complete!?

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>