### PR TITLE
Move the type information from the names into metadata.

### DIFF
--- a/ice40/cells/io_local/io_local.pb_type.xml
+++ b/ice40/cells/io_local/io_local.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_IG-IO_LOCAL" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="IO_LOCAL" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- SB_IO inputs -->
  <output name="io_0_D_IN"       num_pins="2"/>
  <output name="io_1_D_IN"       num_pins="2"/>
@@ -17,28 +17,32 @@
  <clock name="io_global_outclk" num_pins="1"/>
  <input name="io_global_latch"  num_pins="1"/>
 
- <pb_type name="BLK_IG-IO" num_pb="2">
+ <pb_type name="IO" num_pb="2">
   <xi:include href="../../primitives/sb_io/sb_io.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  </pb_type>
 
  <interconnect>
-  <direct name="io_0_D_IN"         input="BLK_IG-IO[0].D_IN"                output="BLK_IG-IO_LOCAL.io_0_D_IN" />
-  <direct name="io_1_D_IN"         input="BLK_IG-IO[1].D_IN"                output="BLK_IG-IO_LOCAL.io_1_D_IN" />
+  <direct name="io_0_D_IN"         input="IO[0].D_IN"                output="IO_LOCAL.io_0_D_IN" />
+  <direct name="io_1_D_IN"         input="IO[1].D_IN"                output="IO_LOCAL.io_1_D_IN" />
 
-  <direct name="io_0_D_OUT"        input="BLK_IG-IO_LOCAL.io_0_D_OUT"       output="BLK_IG-IO[0].D_OUT"        />
-  <direct name="io_1_D_OUT"        input="BLK_IG-IO_LOCAL.io_1_D_OUT"       output="BLK_IG-IO[1].D_OUT"        />
+  <direct name="io_0_D_OUT"        input="IO_LOCAL.io_0_D_OUT"       output="IO[0].D_OUT"        />
+  <direct name="io_1_D_OUT"        input="IO_LOCAL.io_1_D_OUT"       output="IO[1].D_OUT"        />
 
-  <direct name="io_0_OUT_ENB"      input="BLK_IG-IO_LOCAL.io_0_OUT_ENB"     output="BLK_IG-IO[0].OUT_ENB"      />
-  <direct name="io_1_OUT_ENB"      input="BLK_IG-IO_LOCAL.io_1_OUT_ENB"     output="BLK_IG-IO[1].OUT_ENB"      />
+  <direct name="io_0_OUT_ENB"      input="IO_LOCAL.io_0_OUT_ENB"     output="IO[0].OUT_ENB"      />
+  <direct name="io_1_OUT_ENB"      input="IO_LOCAL.io_1_OUT_ENB"     output="IO[1].OUT_ENB"      />
 
-  <direct name="io_global_cen0"    input="BLK_IG-IO_LOCAL.io_global_cen"    output="BLK_IG-IO[0].CEN"          />
-  <direct name="io_global_cen1"    input="BLK_IG-IO_LOCAL.io_global_cen"    output="BLK_IG-IO[1].CEN"          />
-  <direct name="io_global_inclk0"  input="BLK_IG-IO_LOCAL.io_global_inclk"  output="BLK_IG-IO[0].INCLK"        />
-  <direct name="io_global_inclk1"  input="BLK_IG-IO_LOCAL.io_global_inclk"  output="BLK_IG-IO[1].INCLK"        />
-  <direct name="io_global_outclk0" input="BLK_IG-IO_LOCAL.io_global_outclk" output="BLK_IG-IO[0].OUTCLK"       />
-  <direct name="io_global_outclk1" input="BLK_IG-IO_LOCAL.io_global_outclk" output="BLK_IG-IO[1].OUTCLK"       />
-  <direct name="io_global_latch0"  input="BLK_IG-IO_LOCAL.io_global_latch"  output="BLK_IG-IO[0].LATCH"        />
-  <direct name="io_global_latch1"  input="BLK_IG-IO_LOCAL.io_global_latch"  output="BLK_IG-IO[1].LATCH"        />
+  <direct name="io_global_cen0"    input="IO_LOCAL.io_global_cen"    output="IO[0].CEN"          />
+  <direct name="io_global_cen1"    input="IO_LOCAL.io_global_cen"    output="IO[1].CEN"          />
+  <direct name="io_global_inclk0"  input="IO_LOCAL.io_global_inclk"  output="IO[0].INCLK"        />
+  <direct name="io_global_inclk1"  input="IO_LOCAL.io_global_inclk"  output="IO[1].INCLK"        />
+  <direct name="io_global_outclk0" input="IO_LOCAL.io_global_outclk" output="IO[0].OUTCLK"       />
+  <direct name="io_global_outclk1" input="IO_LOCAL.io_global_outclk" output="IO[1].OUTCLK"       />
+  <direct name="io_global_latch0"  input="IO_LOCAL.io_global_latch"  output="IO[0].LATCH"        />
+  <direct name="io_global_latch1"  input="IO_LOCAL.io_global_latch"  output="IO[1].LATCH"        />
  </interconnect>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/cells/lutff/lutff.pb_type.xml
+++ b/ice40/cells/lutff/lutff.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_IG-LUTFF" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="LUTFF" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- LUT -->
  <input  name="I"     num_pins="4"/>
 
@@ -28,21 +28,21 @@
  <xi:include href="../../primitives/sb_carry/sb_carry.pb_type.xml"/>
  <xi:include href="../../primitives/sb_ff/sb_ff.pb_type.xml"/>
 
- <pb_type name="BLK_IG-ENABLE_FF" num_pb="1">
+ <pb_type name="ENABLE_FF" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-ENABLE_FF.I" output="BLK_IG-ENABLE_FF.O" />
+   <direct name="I" input="ENABLE_FF.I" output="ENABLE_FF.O" />
   </interconnect>
   <metadata>
    <meta name="hlc_property">enable_dff</meta>
   </metadata>
  </pb_type>
- <pb_type name="BLK_IG-DISABLE_FF" num_pb="1">
+ <pb_type name="DISABLE_FF" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-DISABLE_FF.I" output="BLK_IG-DISABLE_FF.O" />
+   <direct name="I" input="DISABLE_FF.I" output="DISABLE_FF.O" />
   </interconnect>
   <metadata>
    <meta name="hlc_property"># disable_dff</meta>
@@ -51,81 +51,81 @@
 
  <interconnect>
   <!-- LUT -->
-  <direct name="LUT.I[0]" input="BLK_IG-LUTFF.I[0]"                      output="BEL_LT-LUT.in[0]" />
-  <direct name="LUT.I[1]" input="BLK_IG-LUTFF.I[1]"                      output="BEL_LT-LUT.in[1]" />
-  <mux    name="LUT.I[2]" input="BLK_IG-LUTFF.LCIN[0] BLK_IG-LUTFF.I[2]" output="BEL_LT-LUT.in[2]" />
+  <direct name="LUT.I[0]" input="LUTFF.I[0]"               output="LUT.in[0]" />
+  <direct name="LUT.I[1]" input="LUTFF.I[1]"               output="LUT.in[1]" />
+  <mux    name="LUT.I[2]" input="LUTFF.LCIN[0] LUTFF.I[2]" output="LUT.in[2]" />
   <!-- Disable FCIN->I3 mux until https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/325 is fixed.
-  <mux    name="LUT.I[3]" input="BLK_IG-LUTFF.I[3] BLK_IG-LUTFF.FCIN" output="BEL_LT-LUT.in[3]" /> -->
-  <direct name="LUT.I[3]" input="BLK_IG-LUTFF.I[3]"                      output="BEL_LT-LUT.in[3]" />
-  <direct name="LCOUT"    input="BEL_LT-LUT.out"                         output="BLK_IG-LUTFF.LCOUT" />
+  <mux    name="LUT.I[3]" input="LUTFF.I[3] LUTFF.FCIN" output="LUT.in[3]" /> -->
+  <direct name="LUT.I[3]" input="LUTFF.I[3]"               output="LUT.in[3]" />
+  <direct name="LCOUT"    input="LUT.out"                  output="LUTFF.LCOUT" />
 
   <!-- LUT -->
-  <direct name="FF.PCLK"        input="BLK_IG-LUTFF.PCLK"        output="BEL_FF-SB_FF.PCLK"        />
-  <direct name="FF.NCLK"        input="BLK_IG-LUTFF.NCLK"        output="BEL_FF-SB_FF.NCLK"        />
-  <direct name="FF.PCLK+CEN"    input="BLK_IG-LUTFF.PCLK+CEN"    output="BEL_FF-SB_FF.PCLK+CEN"    />
-  <direct name="FF.NCLK+CEN"    input="BLK_IG-LUTFF.NCLK+CEN"    output="BEL_FF-SB_FF.NCLK+CEN"    />
-  <direct name="FF.PCLK+SR"     input="BLK_IG-LUTFF.PCLK+SR"     output="BEL_FF-SB_FF.PCLK+SR"     />
-  <direct name="FF.NCLK+SR"     input="BLK_IG-LUTFF.NCLK+SR"     output="BEL_FF-SB_FF.NCLK+SR"     />
-  <direct name="FF.PCLK+CEN+SR" input="BLK_IG-LUTFF.PCLK+CEN+SR" output="BEL_FF-SB_FF.PCLK+CEN+SR" />
-  <direct name="FF.NCLK+CEN+SR" input="BLK_IG-LUTFF.NCLK+CEN+SR" output="BEL_FF-SB_FF.NCLK+CEN+SR" />
+  <direct name="FF.PCLK"        input="LUTFF.PCLK"        output="SB_FF.PCLK"        />
+  <direct name="FF.NCLK"        input="LUTFF.NCLK"        output="SB_FF.NCLK"        />
+  <direct name="FF.PCLK+CEN"    input="LUTFF.PCLK+CEN"    output="SB_FF.PCLK+CEN"    />
+  <direct name="FF.NCLK+CEN"    input="LUTFF.NCLK+CEN"    output="SB_FF.NCLK+CEN"    />
+  <direct name="FF.PCLK+SR"     input="LUTFF.PCLK+SR"     output="SB_FF.PCLK+SR"     />
+  <direct name="FF.NCLK+SR"     input="LUTFF.NCLK+SR"     output="SB_FF.NCLK+SR"     />
+  <direct name="FF.PCLK+CEN+SR" input="LUTFF.PCLK+CEN+SR" output="SB_FF.PCLK+CEN+SR" />
+  <direct name="FF.NCLK+CEN+SR" input="LUTFF.NCLK+CEN+SR" output="SB_FF.NCLK+CEN+SR" />
 
-  <direct name="FF.E"           input="BLK_IG-LUTFF.EN"          output="BEL_FF-SB_FF.E"           />
-  <direct name="FF.R"           input="BLK_IG-LUTFF.SR"          output="BEL_FF-SB_FF.R"           />
-  <direct name="FF.S"           input="BLK_IG-LUTFF.SR"          output="BEL_FF-SB_FF.S"           />
-  <direct name="FF.D"           input="BEL_LT-LUT.out"           output="BEL_FF-SB_FF.D"            >
-   <pack_pattern name="LUT+FFA" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFB" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFC" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFD" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFE" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFF" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFG" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFH" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFI" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFJ" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFK" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFL" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFM" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFN" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFO" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFP" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFQ" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFR" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFS" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFT" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
-   <pack_pattern name="LUT+FFU" in_port="BEL_LT-LUT.out" out_port="BEL_FF-SB_FF.D"/>
+  <direct name="FF.E"           input="LUTFF.EN"          output="SB_FF.E"           />
+  <direct name="FF.R"           input="LUTFF.SR"          output="SB_FF.R"           />
+  <direct name="FF.S"           input="LUTFF.SR"          output="SB_FF.S"           />
+  <direct name="FF.D"           input="LUT.out"           output="SB_FF.D"            >
+   <pack_pattern name="LUT+FFA" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFB" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFC" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFD" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFE" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFF" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFG" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFH" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFI" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFJ" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFK" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFL" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFM" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFN" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFO" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFP" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFQ" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFR" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFS" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFT" in_port="LUT.out" out_port="SB_FF.D"/>
+   <pack_pattern name="LUT+FFU" in_port="LUT.out" out_port="SB_FF.D"/>
   </direct>
 
-  <direct name="DISABLE_FF" input="BEL_LT-LUT.out" output="BLK_IG-DISABLE_FF.I" />
-  <direct name="ENABLE_FF"  input="BEL_FF-SB_FF.Q" output="BLK_IG-ENABLE_FF.I"  />
+  <direct name="DISABLE_FF" input="LUT.out" output="DISABLE_FF.I" />
+  <direct name="ENABLE_FF"  input="SB_FF.Q" output="ENABLE_FF.I"  />
   <!-- Output -->
-  <mux name="O" input="BLK_IG-DISABLE_FF.O BLK_IG-ENABLE_FF.O" output="BLK_IG-LUTFF.O">
+  <mux name="O" input="DISABLE_FF.O ENABLE_FF.O" output="LUTFF.O">
     <metadata>
       <meta name="fasm_mux">
-	BLK_IG-ENABLE_FF.O  = DffEnable
-	BLK_IG-DISABLE_FF.O = NULL
+	ENABLE_FF.O  = DffEnable
+	DISABLE_FF.O = NULL
       </meta>
     </metadata>
   </mux>
   <!--
-  <direct name="OMUX.LT" input="BLK_IG-ENABLE_FF.O"  output="BEL_RX-RMUX2.LT" />
-  <direct name="OMUX.FF" input="BLK_IG-DISABLE_FF.O" output="BEL_RX-RMUX2.FF" />
-  <direct name="OMUX.O"  input="BEL_RX-RMUX2.O"      output="BLK_IG-LUTFF.O" />
+  <direct name="OMUX.LT" input="ENABLE_FF.O"  output="RMUX2.LT" />
+  <direct name="OMUX.FF" input="DISABLE_FF.O" output="RMUX2.FF" />
+  <direct name="OMUX.O"  input="RMUX2.O"      output="LUTFF.O" />
        -->
 
   <!-- CARRY -->
-  <direct name="SB_CARRY.I0" input="BLK_IG-LUTFF.I[1]" output="SB_CARRY.I0" />
-  <direct name="SB_CARRY.I1" input="BLK_IG-LUTFF.I[2]" output="SB_CARRY.I1" />
+  <direct name="SB_CARRY.I0" input="LUTFF.I[1]" output="SB_CARRY.I0" />
+  <direct name="SB_CARRY.I1" input="LUTFF.I[2]" output="SB_CARRY.I1" />
 
-  <direct name="BLK_IG-LUTFF.FCIN" input="BLK_IG-LUTFF.FCIN" output="SB_CARRY.CI">
-   <pack_pattern name="CARRYCHAIN" in_port="BLK_IG-LUTFF.FCIN" out_port="SB_CARRY.CI" />
+  <direct name="LUTFF.FCIN" input="LUTFF.FCIN" output="SB_CARRY.CI">
+   <pack_pattern name="CARRYCHAIN" in_port="LUTFF.FCIN" out_port="SB_CARRY.CI" />
   </direct>
-  <direct name="BLK_IG-LUTFF.FCOUT" input="SB_CARRY.CO" output="BLK_IG-LUTFF.FCOUT">
-   <pack_pattern name="CARRYCHAIN" in_port="SB_CARRY.CO" out_port="BLK_IG-LUTFF.FCOUT" />
+  <direct name="LUTFF.FCOUT" input="SB_CARRY.CO" output="LUTFF.FCOUT">
+   <pack_pattern name="CARRYCHAIN" in_port="SB_CARRY.CO" out_port="LUTFF.FCOUT" />
   </direct>
   <!--
-  <direct name="BLK_IG-LUTFF.FCIN" input="BLK_IG-LUTFF.FCIN" output="SB_CARRY.CI" />
-  <direct name="BLK_IG-LUTFF.FCOUT" input="SB_CARRY.CO" output="BLK_IG-LUTFF.FCOUT" />
+  <direct name="LUTFF.FCIN" input="LUTFF.FCIN" output="SB_CARRY.CI" />
+  <direct name="LUTFF.FCOUT" input="SB_CARRY.CO" output="LUTFF.FCOUT" />
   -->
 
  </interconnect>

--- a/ice40/cells/plb/plb.pb_type.xml
+++ b/ice40/cells/plb/plb.pb_type.xml
@@ -6,7 +6,7 @@
 
      It is 8 x (SB_CARRY + SB_LUT4 + FF)
   -->
-<pb_type name="BLK_IG-PLB" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PLB_CELLS" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- SB_LUT4 inputs -->
  <input  name="I0"     num_pins="4"/>
  <input  name="I1"     num_pins="4"/>
@@ -36,7 +36,7 @@
  <input  name="FCIN"   num_pins="1"/>
  <output name="FCOUT"  num_pins="1"/>
 
- <pb_type name="BLK_IG-MODE_CLK" num_pb="1">
+ <pb_type name="MODE_CLK" num_pb="1">
   <input  name="I" num_pins="1"/>
 
   <output name="PCLK"        num_pins="1"/>
@@ -49,432 +49,399 @@
   <output name="NCLK+SR"     num_pins="1"/>
   <output name="NCLK+CEN+SR" num_pins="1"/>
 
-  <mode name="BLK_IG-PCLK">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="PCLK">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
-    <metadata>
-     <meta name="hlc_property"># PosClk, CEN constant 1, SR constant 0</meta>
-    </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="PCLK"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-PCLK+CEN">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="PCLK+CEN">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
-    <metadata>
-     <meta name="hlc_property"># PosClk, CEN in use, SR constant 0</meta>
-    </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK+CEN"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="PCLK+CEN"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-PCLK+SR">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="PCLK+SR">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
-    <metadata>
-     <meta name="hlc_property"># PosClk, CEN constant 0, SR in use</meta>
-    </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK+SR"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="PCLK+SR"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-PCLK+CEN+SR">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="PCLK+CEN+SR">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
-    <metadata>
-     <meta name="hlc_property"># PosClk, CEN in use, SR in use</meta>
-    </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="PCLK+CEN+SR"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="PCLK+CEN+SR"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-NCLK">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="NCLK">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-      <meta name="hlc_property">NegClk # CEN constant 1, SR constant 0</meta>
       <meta name="fasm_features">NegClk</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="NCLK"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-NCLK+CEN">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="NCLK+CEN">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property">NegClk # CEN in use, SR constant 0</meta>
      <meta name="fasm_features">NegClk</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK+CEN"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="NCLK+CEN"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-NCLK+SR">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="NCLK+SR">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property">NegClk # CEN constant 0, SR in use</meta>
      <meta name="fasm_features">NegClk</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK+SR"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="NCLK+SR"/></direct>
    </interconnect>
   </mode>
-  <mode name="BLK_IG-NCLK+CEN+SR">
-   <pb_type name="BLK_IG-BUF" num_pb="1">
+  <mode name="NCLK+CEN+SR">
+   <pb_type name="BUF" num_pb="1">
     <input  name="I" num_pins="1"/>
     <output name="O" num_pins="1"/>
     <metadata>
-     <meta name="hlc_property">NegClk # CEN in use, SR in use</meta>
      <meta name="fasm_features">NegClk</meta>
     </metadata>
     <interconnect><direct><port type="input" name="I" /><port type="output" name="O"/></direct></interconnect>
    </pb_type>
    <interconnect>
-    <direct><port type="input" name="I" /><port type="output" name="I" from="BLK_IG-BUF"/></direct>
-    <direct><port type="input" name="O" from="BLK_IG-BUF"/><port type="output" name="NCLK+CEN+SR"/></direct>
+    <direct><port type="input" name="I" /><port type="output" name="I" from="BUF"/></direct>
+    <direct><port type="input" name="O" from="BUF"/><port type="output" name="NCLK+CEN+SR"/></direct>
    </interconnect>
   </mode>
  </pb_type>
 
- <pb_type name="BLK_IG-LUTFF" num_pb="8">
+ <pb_type name="LUTFF" num_pb="8">
    <xi:include href="../lutff/lutff.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
    <metadata>
-     <meta name="hlc_cell">lutff</meta>
      <meta name="fasm_prefix">LC_0 LC_1 LC_2 LC_3 LC_4 LC_5 LC_6 LC_7</meta>
      <meta name="fasm_type">LUT</meta>
      <meta name="fasm_lut">
-       INIT[15:0] = BLK_LT-LUT
+       INIT[15:0] = LUT
      </meta>
+     <meta name="type">block</meta>
+     <meta name="subtype">ignore</meta>
    </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC0" num_pb="1">
+ <pb_type name="LC0" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC0.I" output="BLK_IG-LC0.O">
+   <direct name="I" input="LC0.I" output="LC0.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC0.I = buffer.lutff_0_lout.lutff_1_in_2</meta>
+     <meta name="fasm_mux">LC0.I = buffer.lutff_0_lout.lutff_1_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_0/lout -> lutff_1/in_2</meta>
-  </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC1" num_pb="1">
+ <pb_type name="LC1" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC1.I" output="BLK_IG-LC1.O">
+   <direct name="I" input="LC1.I" output="LC1.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC1.I = buffer.lutff_1_lout.lutff_2_in_2</meta>
+     <meta name="fasm_mux">LC1.I = buffer.lutff_1_lout.lutff_2_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_1/lout -> lutff_2/in_2</meta>
-  </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC2" num_pb="1">
+ <pb_type name="LC2" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC2.I" output="BLK_IG-LC2.O">
+   <direct name="I" input="LC2.I" output="LC2.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC2.I = buffer.lutff_2_lout.lutff_3_in_2</meta>
+     <meta name="fasm_mux">LC2.I = buffer.lutff_2_lout.lutff_3_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_2/lout -> lutff_3/in_2</meta>
-  </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC3" num_pb="1">
+ <pb_type name="LC3" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC3.I" output="BLK_IG-LC3.O">
+   <direct name="I" input="LC3.I" output="LC3.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC3.I = buffer.lutff_3_lout.lutff_4_in_2</meta>
+     <meta name="fasm_mux">LC3.I = buffer.lutff_3_lout.lutff_4_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_3/lout -> lutff_4/in_2</meta>
-  </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC4" num_pb="1">
+ <pb_type name="LC4" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC4.I" output="BLK_IG-LC4.O">
+   <direct name="I" input="LC4.I" output="LC4.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC4.I = buffer.lutff_4_lout.lutff_5_in_2</meta>
+     <meta name="fasm_mux">LC4.I = buffer.lutff_4_lout.lutff_5_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_4/lout -> lutff_5/in_2</meta>
-  </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC5" num_pb="1">
+ <pb_type name="LC5" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC5.I" output="BLK_IG-LC5.O">
+   <direct name="I" input="LC5.I" output="LC5.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC5.I = buffer.lutff_5_lout.lutff_6_in_2</meta>
+     <meta name="fasm_mux">LC5.I = buffer.lutff_5_lout.lutff_6_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_5/lout -> lutff_6/in_2</meta>
-  </metadata>
  </pb_type>
 
- <pb_type name="BLK_IG-LC6" num_pb="1">
+ <pb_type name="LC6" num_pb="1">
   <input  name="I" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <direct name="I" input="BLK_IG-LC6.I" output="BLK_IG-LC6.O">
+   <direct name="I" input="LC6.I" output="LC6.O">
     <metadata>
-     <meta name="fasm_mux">BLK_IG-LC6.I = buffer.lutff_6_lout.lutff_7_in_2</meta>
+     <meta name="fasm_mux">LC6.I = buffer.lutff_6_lout.lutff_7_in_2</meta>
     </metadata>
    </direct>
   </interconnect>
-  <metadata>
-   <meta name="hlc_property">lutff_6/lout -> lutff_7/in_2</meta>
-  </metadata>
  </pb_type>
 
  <interconnect>
-  <direct name="CLK"   input="BLK_IG-PLB.CLK"       output="BLK_IG-MODE_CLK.I"    />
+  <direct name="CLK"   input="PLB_CELLS.CLK"        output="MODE_CLK.I"    />
 
   <!-- Cell 0 -->
-  <direct name="I0[0]" input="BLK_IG-PLB.I0[0]"     output="BLK_IG-LUTFF[0].I[0]" />
-  <direct name="I0[1]" input="BLK_IG-PLB.I0[1]"     output="BLK_IG-LUTFF[0].I[1]" />
-  <direct name="I0[2]" input="BLK_IG-PLB.I0[2]"     output="BLK_IG-LUTFF[0].I[2]" />
-  <direct name="I0[3]" input="BLK_IG-PLB.I0[3]"     output="BLK_IG-LUTFF[0].I[3]" />
-  <direct name="PC0"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[0].PCLK"        />
-  <direct name="NC0"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[0].NCLK"        />
-  <direct name="PCE0"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[0].PCLK+CEN"    />
-  <direct name="NCE0"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[0].NCLK+CEN"    />
-  <direct name="PCS0"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[0].PCLK+SR"     />
-  <direct name="NCS0"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[0].NCLK+SR"     />
-  <direct name="PCES0" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[0].PCLK+CEN+SR" />
-  <direct name="NCES0" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[0].NCLK+CEN+SR" />
-  <direct name="E0"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[0].EN"   />
-  <direct name="S0"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[0].SR"   />
-  <direct name="O0"    input="BLK_IG-LUTFF[0].O"    output="BLK_IG-PLB.O0"        />
+  <direct name="I0[0]" input="PLB_CELLS.I0[0]"      output="LUTFF[0].I[0]" />
+  <direct name="I0[1]" input="PLB_CELLS.I0[1]"      output="LUTFF[0].I[1]" />
+  <direct name="I0[2]" input="PLB_CELLS.I0[2]"      output="LUTFF[0].I[2]" />
+  <direct name="I0[3]" input="PLB_CELLS.I0[3]"      output="LUTFF[0].I[3]" />
+  <direct name="PC0"   input="MODE_CLK.PCLK"        output="LUTFF[0].PCLK"        />
+  <direct name="NC0"   input="MODE_CLK.NCLK"        output="LUTFF[0].NCLK"        />
+  <direct name="PCE0"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[0].PCLK+CEN"    />
+  <direct name="NCE0"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[0].NCLK+CEN"    />
+  <direct name="PCS0"  input="MODE_CLK.PCLK+SR"     output="LUTFF[0].PCLK+SR"     />
+  <direct name="NCS0"  input="MODE_CLK.NCLK+SR"     output="LUTFF[0].NCLK+SR"     />
+  <direct name="PCES0" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[0].PCLK+CEN+SR" />
+  <direct name="NCES0" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[0].NCLK+CEN+SR" />
+  <direct name="E0"    input="PLB_CELLS.EN"         output="LUTFF[0].EN"   />
+  <direct name="S0"    input="PLB_CELLS.SR"         output="LUTFF[0].SR"   />
+  <direct name="O0"    input="LUTFF[0].O"           output="PLB_CELLS.O0"  />
 
   <!-- Cell 1 -->
-  <direct name="I1[0]" input="BLK_IG-PLB.I1[0]"     output="BLK_IG-LUTFF[1].I[0]" />
-  <direct name="I1[1]" input="BLK_IG-PLB.I1[1]"     output="BLK_IG-LUTFF[1].I[1]" />
-  <direct name="I1[2]" input="BLK_IG-PLB.I1[2]"     output="BLK_IG-LUTFF[1].I[2]" />
-  <direct name="I1[3]" input="BLK_IG-PLB.I1[3]"     output="BLK_IG-LUTFF[1].I[3]" />
-  <direct name="PC1"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[1].PCLK"        />
-  <direct name="NC1"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[1].NCLK"        />
-  <direct name="PCE1"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[1].PCLK+CEN"    />
-  <direct name="NCE1"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[1].NCLK+CEN"    />
-  <direct name="PCS1"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[1].PCLK+SR"     />
-  <direct name="NCS1"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[1].NCLK+SR"     />
-  <direct name="PCES1" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[1].PCLK+CEN+SR" />
-  <direct name="NCES1" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[1].NCLK+CEN+SR" />
-  <direct name="E1"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[1].EN"   />
-  <direct name="S1"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[1].SR"   />
-  <direct name="O1"    input="BLK_IG-LUTFF[1].O"    output="BLK_IG-PLB.O1"        />
+  <direct name="I1[0]" input="PLB_CELLS.I1[0]"      output="LUTFF[1].I[0]" />
+  <direct name="I1[1]" input="PLB_CELLS.I1[1]"      output="LUTFF[1].I[1]" />
+  <direct name="I1[2]" input="PLB_CELLS.I1[2]"      output="LUTFF[1].I[2]" />
+  <direct name="I1[3]" input="PLB_CELLS.I1[3]"      output="LUTFF[1].I[3]" />
+  <direct name="PC1"   input="MODE_CLK.PCLK"        output="LUTFF[1].PCLK"        />
+  <direct name="NC1"   input="MODE_CLK.NCLK"        output="LUTFF[1].NCLK"        />
+  <direct name="PCE1"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[1].PCLK+CEN"    />
+  <direct name="NCE1"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[1].NCLK+CEN"    />
+  <direct name="PCS1"  input="MODE_CLK.PCLK+SR"     output="LUTFF[1].PCLK+SR"     />
+  <direct name="NCS1"  input="MODE_CLK.NCLK+SR"     output="LUTFF[1].NCLK+SR"     />
+  <direct name="PCES1" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[1].PCLK+CEN+SR" />
+  <direct name="NCES1" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[1].NCLK+CEN+SR" />
+  <direct name="E1"    input="PLB_CELLS.EN"         output="LUTFF[1].EN"   />
+  <direct name="S1"    input="PLB_CELLS.SR"         output="LUTFF[1].SR"   />
+  <direct name="O1"    input="LUTFF[1].O"           output="PLB_CELLS.O1"  />
 
   <!-- Cell 2 -->
-  <direct name="I2[0]" input="BLK_IG-PLB.I2[0]"     output="BLK_IG-LUTFF[2].I[0]" />
-  <direct name="I2[1]" input="BLK_IG-PLB.I2[1]"     output="BLK_IG-LUTFF[2].I[1]" />
-  <direct name="I2[2]" input="BLK_IG-PLB.I2[2]"     output="BLK_IG-LUTFF[2].I[2]" />
-  <direct name="I2[3]" input="BLK_IG-PLB.I2[3]"     output="BLK_IG-LUTFF[2].I[3]" />
-  <direct name="PC2"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[2].PCLK"        />
-  <direct name="NC2"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[2].NCLK"        />
-  <direct name="PCE2"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[2].PCLK+CEN"    />
-  <direct name="NCE2"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[2].NCLK+CEN"    />
-  <direct name="PCS2"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[2].PCLK+SR"     />
-  <direct name="NCS2"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[2].NCLK+SR"     />
-  <direct name="PCES2" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[2].PCLK+CEN+SR" />
-  <direct name="NCES2" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[2].NCLK+CEN+SR" />
-  <direct name="E2"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[2].EN"   />
-  <direct name="S2"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[2].SR"   />
-  <direct name="O2"    input="BLK_IG-LUTFF[2].O"    output="BLK_IG-PLB.O2"        />
+  <direct name="I2[0]" input="PLB_CELLS.I2[0]"      output="LUTFF[2].I[0]" />
+  <direct name="I2[1]" input="PLB_CELLS.I2[1]"      output="LUTFF[2].I[1]" />
+  <direct name="I2[2]" input="PLB_CELLS.I2[2]"      output="LUTFF[2].I[2]" />
+  <direct name="I2[3]" input="PLB_CELLS.I2[3]"      output="LUTFF[2].I[3]" />
+  <direct name="PC2"   input="MODE_CLK.PCLK"        output="LUTFF[2].PCLK"        />
+  <direct name="NC2"   input="MODE_CLK.NCLK"        output="LUTFF[2].NCLK"        />
+  <direct name="PCE2"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[2].PCLK+CEN"    />
+  <direct name="NCE2"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[2].NCLK+CEN"    />
+  <direct name="PCS2"  input="MODE_CLK.PCLK+SR"     output="LUTFF[2].PCLK+SR"     />
+  <direct name="NCS2"  input="MODE_CLK.NCLK+SR"     output="LUTFF[2].NCLK+SR"     />
+  <direct name="PCES2" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[2].PCLK+CEN+SR" />
+  <direct name="NCES2" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[2].NCLK+CEN+SR" />
+  <direct name="E2"    input="PLB_CELLS.EN"         output="LUTFF[2].EN"   />
+  <direct name="S2"    input="PLB_CELLS.SR"         output="LUTFF[2].SR"   />
+  <direct name="O2"    input="LUTFF[2].O"           output="PLB_CELLS.O2"  />
 
   <!-- Cell 3 -->
-  <direct name="I3[0]" input="BLK_IG-PLB.I3[0]"     output="BLK_IG-LUTFF[3].I[0]" />
-  <direct name="I3[1]" input="BLK_IG-PLB.I3[1]"     output="BLK_IG-LUTFF[3].I[1]" />
-  <direct name="I3[2]" input="BLK_IG-PLB.I3[2]"     output="BLK_IG-LUTFF[3].I[2]" />
-  <direct name="I3[3]" input="BLK_IG-PLB.I3[3]"     output="BLK_IG-LUTFF[3].I[3]" />
-  <direct name="PC3"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[3].PCLK"        />
-  <direct name="NC3"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[3].NCLK"        />
-  <direct name="PCE3"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[3].PCLK+CEN"    />
-  <direct name="NCE3"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[3].NCLK+CEN"    />
-  <direct name="PCS3"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[3].PCLK+SR"     />
-  <direct name="NCS3"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[3].NCLK+SR"     />
-  <direct name="PCES3" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[3].PCLK+CEN+SR" />
-  <direct name="NCES3" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[3].NCLK+CEN+SR" />
-  <direct name="E3"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[3].EN"   />
-  <direct name="S3"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[3].SR"   />
-  <direct name="O3"    input="BLK_IG-LUTFF[3].O"    output="BLK_IG-PLB.O3"        />
+  <direct name="I3[0]" input="PLB_CELLS.I3[0]"      output="LUTFF[3].I[0]" />
+  <direct name="I3[1]" input="PLB_CELLS.I3[1]"      output="LUTFF[3].I[1]" />
+  <direct name="I3[2]" input="PLB_CELLS.I3[2]"      output="LUTFF[3].I[2]" />
+  <direct name="I3[3]" input="PLB_CELLS.I3[3]"      output="LUTFF[3].I[3]" />
+  <direct name="PC3"   input="MODE_CLK.PCLK"        output="LUTFF[3].PCLK"        />
+  <direct name="NC3"   input="MODE_CLK.NCLK"        output="LUTFF[3].NCLK"        />
+  <direct name="PCE3"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[3].PCLK+CEN"    />
+  <direct name="NCE3"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[3].NCLK+CEN"    />
+  <direct name="PCS3"  input="MODE_CLK.PCLK+SR"     output="LUTFF[3].PCLK+SR"     />
+  <direct name="NCS3"  input="MODE_CLK.NCLK+SR"     output="LUTFF[3].NCLK+SR"     />
+  <direct name="PCES3" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[3].PCLK+CEN+SR" />
+  <direct name="NCES3" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[3].NCLK+CEN+SR" />
+  <direct name="E3"    input="PLB_CELLS.EN"         output="LUTFF[3].EN"   />
+  <direct name="S3"    input="PLB_CELLS.SR"         output="LUTFF[3].SR"   />
+  <direct name="O3"    input="LUTFF[3].O"           output="PLB_CELLS.O3"  />
 
   <!-- Cell 4 -->
-  <direct name="I4[0]" input="BLK_IG-PLB.I4[0]"     output="BLK_IG-LUTFF[4].I[0]" />
-  <direct name="I4[1]" input="BLK_IG-PLB.I4[1]"     output="BLK_IG-LUTFF[4].I[1]" />
-  <direct name="I4[2]" input="BLK_IG-PLB.I4[2]"     output="BLK_IG-LUTFF[4].I[2]" />
-  <direct name="I4[3]" input="BLK_IG-PLB.I4[3]"     output="BLK_IG-LUTFF[4].I[3]" />
-  <direct name="PC4"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[4].PCLK"        />
-  <direct name="NC4"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[4].NCLK"        />
-  <direct name="PCE4"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[4].PCLK+CEN"    />
-  <direct name="NCE4"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[4].NCLK+CEN"    />
-  <direct name="PCS4"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[4].PCLK+SR"     />
-  <direct name="NCS4"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[4].NCLK+SR"     />
-  <direct name="PCES4" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[4].PCLK+CEN+SR" />
-  <direct name="NCES4" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[4].NCLK+CEN+SR" />
-  <direct name="E4"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[4].EN"   />
-  <direct name="S4"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[4].SR"   />
-  <direct name="O4"    input="BLK_IG-LUTFF[4].O"    output="BLK_IG-PLB.O4"        />
+  <direct name="I4[0]" input="PLB_CELLS.I4[0]"      output="LUTFF[4].I[0]" />
+  <direct name="I4[1]" input="PLB_CELLS.I4[1]"      output="LUTFF[4].I[1]" />
+  <direct name="I4[2]" input="PLB_CELLS.I4[2]"      output="LUTFF[4].I[2]" />
+  <direct name="I4[3]" input="PLB_CELLS.I4[3]"      output="LUTFF[4].I[3]" />
+  <direct name="PC4"   input="MODE_CLK.PCLK"        output="LUTFF[4].PCLK"        />
+  <direct name="NC4"   input="MODE_CLK.NCLK"        output="LUTFF[4].NCLK"        />
+  <direct name="PCE4"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[4].PCLK+CEN"    />
+  <direct name="NCE4"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[4].NCLK+CEN"    />
+  <direct name="PCS4"  input="MODE_CLK.PCLK+SR"     output="LUTFF[4].PCLK+SR"     />
+  <direct name="NCS4"  input="MODE_CLK.NCLK+SR"     output="LUTFF[4].NCLK+SR"     />
+  <direct name="PCES4" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[4].PCLK+CEN+SR" />
+  <direct name="NCES4" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[4].NCLK+CEN+SR" />
+  <direct name="E4"    input="PLB_CELLS.EN"         output="LUTFF[4].EN"   />
+  <direct name="S4"    input="PLB_CELLS.SR"         output="LUTFF[4].SR"   />
+  <direct name="O4"    input="LUTFF[4].O"           output="PLB_CELLS.O4"  />
 
   <!-- Cell 5 -->
-  <direct name="I5[0]" input="BLK_IG-PLB.I5[0]"     output="BLK_IG-LUTFF[5].I[0]" />
-  <direct name="I5[1]" input="BLK_IG-PLB.I5[1]"     output="BLK_IG-LUTFF[5].I[1]" />
-  <direct name="I5[2]" input="BLK_IG-PLB.I5[2]"     output="BLK_IG-LUTFF[5].I[2]" />
-  <direct name="I5[3]" input="BLK_IG-PLB.I5[3]"     output="BLK_IG-LUTFF[5].I[3]" />
-  <direct name="PC5"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[5].PCLK"        />
-  <direct name="NC5"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[5].NCLK"        />
-  <direct name="PCE5"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[5].PCLK+CEN"    />
-  <direct name="NCE5"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[5].NCLK+CEN"    />
-  <direct name="PCS5"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[5].PCLK+SR"     />
-  <direct name="NCS5"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[5].NCLK+SR"     />
-  <direct name="PCES5" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[5].PCLK+CEN+SR" />
-  <direct name="NCES5" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[5].NCLK+CEN+SR" />
-  <direct name="E5"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[5].EN"   />
-  <direct name="S5"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[5].SR"   />
-  <direct name="O5"    input="BLK_IG-LUTFF[5].O"    output="BLK_IG-PLB.O5"        />
+  <direct name="I5[0]" input="PLB_CELLS.I5[0]"      output="LUTFF[5].I[0]" />
+  <direct name="I5[1]" input="PLB_CELLS.I5[1]"      output="LUTFF[5].I[1]" />
+  <direct name="I5[2]" input="PLB_CELLS.I5[2]"      output="LUTFF[5].I[2]" />
+  <direct name="I5[3]" input="PLB_CELLS.I5[3]"      output="LUTFF[5].I[3]" />
+  <direct name="PC5"   input="MODE_CLK.PCLK"        output="LUTFF[5].PCLK"        />
+  <direct name="NC5"   input="MODE_CLK.NCLK"        output="LUTFF[5].NCLK"        />
+  <direct name="PCE5"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[5].PCLK+CEN"    />
+  <direct name="NCE5"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[5].NCLK+CEN"    />
+  <direct name="PCS5"  input="MODE_CLK.PCLK+SR"     output="LUTFF[5].PCLK+SR"     />
+  <direct name="NCS5"  input="MODE_CLK.NCLK+SR"     output="LUTFF[5].NCLK+SR"     />
+  <direct name="PCES5" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[5].PCLK+CEN+SR" />
+  <direct name="NCES5" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[5].NCLK+CEN+SR" />
+  <direct name="E5"    input="PLB_CELLS.EN"         output="LUTFF[5].EN"   />
+  <direct name="S5"    input="PLB_CELLS.SR"         output="LUTFF[5].SR"   />
+  <direct name="O5"    input="LUTFF[5].O"           output="PLB_CELLS.O5"  />
 
   <!-- Cell 6 -->
-  <direct name="I6[0]" input="BLK_IG-PLB.I6[0]"     output="BLK_IG-LUTFF[6].I[0]" />
-  <direct name="I6[1]" input="BLK_IG-PLB.I6[1]"     output="BLK_IG-LUTFF[6].I[1]" />
-  <direct name="I6[2]" input="BLK_IG-PLB.I6[2]"     output="BLK_IG-LUTFF[6].I[2]" />
-  <direct name="I6[3]" input="BLK_IG-PLB.I6[3]"     output="BLK_IG-LUTFF[6].I[3]" />
-  <direct name="PC6"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[6].PCLK"        />
-  <direct name="NC6"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[6].NCLK"        />
-  <direct name="PCE6"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[6].PCLK+CEN"    />
-  <direct name="NCE6"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[6].NCLK+CEN"    />
-  <direct name="PCS6"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[6].PCLK+SR"     />
-  <direct name="NCS6"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[6].NCLK+SR"     />
-  <direct name="PCES6" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[6].PCLK+CEN+SR" />
-  <direct name="NCES6" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[6].NCLK+CEN+SR" />
-  <direct name="E6"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[6].EN"   />
-  <direct name="S6"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[6].SR"   />
-  <direct name="O6"    input="BLK_IG-LUTFF[6].O"    output="BLK_IG-PLB.O6"        />
+  <direct name="I6[0]" input="PLB_CELLS.I6[0]"      output="LUTFF[6].I[0]" />
+  <direct name="I6[1]" input="PLB_CELLS.I6[1]"      output="LUTFF[6].I[1]" />
+  <direct name="I6[2]" input="PLB_CELLS.I6[2]"      output="LUTFF[6].I[2]" />
+  <direct name="I6[3]" input="PLB_CELLS.I6[3]"      output="LUTFF[6].I[3]" />
+  <direct name="PC6"   input="MODE_CLK.PCLK"        output="LUTFF[6].PCLK"        />
+  <direct name="NC6"   input="MODE_CLK.NCLK"        output="LUTFF[6].NCLK"        />
+  <direct name="PCE6"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[6].PCLK+CEN"    />
+  <direct name="NCE6"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[6].NCLK+CEN"    />
+  <direct name="PCS6"  input="MODE_CLK.PCLK+SR"     output="LUTFF[6].PCLK+SR"     />
+  <direct name="NCS6"  input="MODE_CLK.NCLK+SR"     output="LUTFF[6].NCLK+SR"     />
+  <direct name="PCES6" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[6].PCLK+CEN+SR" />
+  <direct name="NCES6" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[6].NCLK+CEN+SR" />
+  <direct name="E6"    input="PLB_CELLS.EN"         output="LUTFF[6].EN"   />
+  <direct name="S6"    input="PLB_CELLS.SR"         output="LUTFF[6].SR"   />
+  <direct name="O6"    input="LUTFF[6].O"           output="PLB_CELLS.O6"  />
 
   <!-- Cell 7 -->
-  <direct name="I7[0]" input="BLK_IG-PLB.I7[0]"     output="BLK_IG-LUTFF[7].I[0]" />
-  <direct name="I7[1]" input="BLK_IG-PLB.I7[1]"     output="BLK_IG-LUTFF[7].I[1]" />
-  <direct name="I7[2]" input="BLK_IG-PLB.I7[2]"     output="BLK_IG-LUTFF[7].I[2]" />
-  <direct name="I7[3]" input="BLK_IG-PLB.I7[3]"     output="BLK_IG-LUTFF[7].I[3]" />
-  <direct name="PC7"   input="BLK_IG-MODE_CLK.PCLK"        output="BLK_IG-LUTFF[7].PCLK"        />
-  <direct name="NC7"   input="BLK_IG-MODE_CLK.NCLK"        output="BLK_IG-LUTFF[7].NCLK"        />
-  <direct name="PCE7"  input="BLK_IG-MODE_CLK.PCLK+CEN"    output="BLK_IG-LUTFF[7].PCLK+CEN"    />
-  <direct name="NCE7"  input="BLK_IG-MODE_CLK.NCLK+CEN"    output="BLK_IG-LUTFF[7].NCLK+CEN"    />
-  <direct name="PCS7"  input="BLK_IG-MODE_CLK.PCLK+SR"     output="BLK_IG-LUTFF[7].PCLK+SR"     />
-  <direct name="NCS7"  input="BLK_IG-MODE_CLK.NCLK+SR"     output="BLK_IG-LUTFF[7].NCLK+SR"     />
-  <direct name="PCES7" input="BLK_IG-MODE_CLK.PCLK+CEN+SR" output="BLK_IG-LUTFF[7].PCLK+CEN+SR" />
-  <direct name="NCES7" input="BLK_IG-MODE_CLK.NCLK+CEN+SR" output="BLK_IG-LUTFF[7].NCLK+CEN+SR" />
-  <direct name="E7"    input="BLK_IG-PLB.EN"        output="BLK_IG-LUTFF[7].EN"   />
-  <direct name="S7"    input="BLK_IG-PLB.SR"        output="BLK_IG-LUTFF[7].SR"   />
-  <direct name="O7"    input="BLK_IG-LUTFF[7].O"    output="BLK_IG-PLB.O7"        />
+  <direct name="I7[0]" input="PLB_CELLS.I7[0]"      output="LUTFF[7].I[0]" />
+  <direct name="I7[1]" input="PLB_CELLS.I7[1]"      output="LUTFF[7].I[1]" />
+  <direct name="I7[2]" input="PLB_CELLS.I7[2]"      output="LUTFF[7].I[2]" />
+  <direct name="I7[3]" input="PLB_CELLS.I7[3]"      output="LUTFF[7].I[3]" />
+  <direct name="PC7"   input="MODE_CLK.PCLK"        output="LUTFF[7].PCLK"        />
+  <direct name="NC7"   input="MODE_CLK.NCLK"        output="LUTFF[7].NCLK"        />
+  <direct name="PCE7"  input="MODE_CLK.PCLK+CEN"    output="LUTFF[7].PCLK+CEN"    />
+  <direct name="NCE7"  input="MODE_CLK.NCLK+CEN"    output="LUTFF[7].NCLK+CEN"    />
+  <direct name="PCS7"  input="MODE_CLK.PCLK+SR"     output="LUTFF[7].PCLK+SR"     />
+  <direct name="NCS7"  input="MODE_CLK.NCLK+SR"     output="LUTFF[7].NCLK+SR"     />
+  <direct name="PCES7" input="MODE_CLK.PCLK+CEN+SR" output="LUTFF[7].PCLK+CEN+SR" />
+  <direct name="NCES7" input="MODE_CLK.NCLK+CEN+SR" output="LUTFF[7].NCLK+CEN+SR" />
+  <direct name="E7"    input="PLB_CELLS.EN"         output="LUTFF[7].EN"   />
+  <direct name="S7"    input="PLB_CELLS.SR"         output="LUTFF[7].SR"   />
+  <direct name="O7"    input="LUTFF[7].O"           output="PLB_CELLS.O7"  />
 
   <!-- LUT carry chain -->
   <!--
-  <direct name="LCIN"  input="BLK_IG-PLB.LCIN"    output="BLK_IG-LUTFF[0].LCIN" />
+  <direct name="LCIN"  input="PLB_CELLS.LCIN"    output="LUTFF[0].LCIN" />
     -->
-  <direct name="LCCI0" input="BLK_IG-LUTFF[0].LCOUT" output="BLK_IG-LC0.I" />
-  <direct name="LCCI1" input="BLK_IG-LUTFF[1].LCOUT" output="BLK_IG-LC1.I" />
-  <direct name="LCCI2" input="BLK_IG-LUTFF[2].LCOUT" output="BLK_IG-LC2.I" />
-  <direct name="LCCI3" input="BLK_IG-LUTFF[3].LCOUT" output="BLK_IG-LC3.I" />
-  <direct name="LCCI4" input="BLK_IG-LUTFF[4].LCOUT" output="BLK_IG-LC4.I" />
-  <direct name="LCCI5" input="BLK_IG-LUTFF[5].LCOUT" output="BLK_IG-LC5.I" />
-  <direct name="LCCI6" input="BLK_IG-LUTFF[6].LCOUT" output="BLK_IG-LC6.I" />
-  <direct name="LCCO0" input="BLK_IG-LC0.O"          output="BLK_IG-LUTFF[1].LCIN" />
-  <direct name="LCCO1" input="BLK_IG-LC1.O"          output="BLK_IG-LUTFF[2].LCIN" />
-  <direct name="LCCO2" input="BLK_IG-LC2.O"          output="BLK_IG-LUTFF[3].LCIN" />
-  <direct name="LCCO3" input="BLK_IG-LC3.O"          output="BLK_IG-LUTFF[4].LCIN" />
-  <direct name="LCCO4" input="BLK_IG-LC4.O"          output="BLK_IG-LUTFF[5].LCIN" />
-  <direct name="LCCO5" input="BLK_IG-LC5.O"          output="BLK_IG-LUTFF[6].LCIN" />
-  <direct name="LCCO6" input="BLK_IG-LC6.O"          output="BLK_IG-LUTFF[7].LCIN" />
+  <direct name="LCCI0" input="LUTFF[0].LCOUT" output="LC0.I" />
+  <direct name="LCCI1" input="LUTFF[1].LCOUT" output="LC1.I" />
+  <direct name="LCCI2" input="LUTFF[2].LCOUT" output="LC2.I" />
+  <direct name="LCCI3" input="LUTFF[3].LCOUT" output="LC3.I" />
+  <direct name="LCCI4" input="LUTFF[4].LCOUT" output="LC4.I" />
+  <direct name="LCCI5" input="LUTFF[5].LCOUT" output="LC5.I" />
+  <direct name="LCCI6" input="LUTFF[6].LCOUT" output="LC6.I" />
+  <direct name="LCCO0" input="LC0.O"          output="LUTFF[1].LCIN" />
+  <direct name="LCCO1" input="LC1.O"          output="LUTFF[2].LCIN" />
+  <direct name="LCCO2" input="LC2.O"          output="LUTFF[3].LCIN" />
+  <direct name="LCCO3" input="LC3.O"          output="LUTFF[4].LCIN" />
+  <direct name="LCCO4" input="LC4.O"          output="LUTFF[5].LCIN" />
+  <direct name="LCCO5" input="LC5.O"          output="LUTFF[6].LCIN" />
+  <direct name="LCCO6" input="LC6.O"          output="LUTFF[7].LCIN" />
   <!--
-  <direct name="LCOUT" input="BLK_IG-LUTFF[7].LCOUT" output="BLK_IG-PLB.LCOUT"  />
+  <direct name="LCOUT" input="LUTFF[7].LCOUT" output="PLB_CELLS.LCOUT"  />
     -->
 
-  <direct name="FCIN" input="BLK_IG-PLB.FCIN" output="BLK_IG-LUTFF[0].FCIN">
+  <direct name="FCIN"  input="PLB_CELLS.FCIN" output="LUTFF[0].FCIN">
   </direct>
-  <direct name="FCC0" input="BLK_IG-LUTFF[0].FCOUT" output="BLK_IG-LUTFF[1].FCIN">
+  <direct name="FCC0"  input="LUTFF[0].FCOUT" output="LUTFF[1].FCIN">
   </direct>
-  <direct name="FCC1" input="BLK_IG-LUTFF[1].FCOUT" output="BLK_IG-LUTFF[2].FCIN">
+  <direct name="FCC1"  input="LUTFF[1].FCOUT" output="LUTFF[2].FCIN">
   </direct>
-  <direct name="FCC2" input="BLK_IG-LUTFF[2].FCOUT" output="BLK_IG-LUTFF[3].FCIN">
+  <direct name="FCC2"  input="LUTFF[2].FCOUT" output="LUTFF[3].FCIN">
   </direct>
-  <direct name="FCC3" input="BLK_IG-LUTFF[3].FCOUT" output="BLK_IG-LUTFF[4].FCIN">
+  <direct name="FCC3"  input="LUTFF[3].FCOUT" output="LUTFF[4].FCIN">
   </direct>
-  <direct name="FCC4" input="BLK_IG-LUTFF[4].FCOUT" output="BLK_IG-LUTFF[5].FCIN">
+  <direct name="FCC4"  input="LUTFF[4].FCOUT" output="LUTFF[5].FCIN">
   </direct>
-  <direct name="FCC5" input="BLK_IG-LUTFF[5].FCOUT" output="BLK_IG-LUTFF[6].FCIN">
+  <direct name="FCC5"  input="LUTFF[5].FCOUT" output="LUTFF[6].FCIN">
   </direct>
-  <direct name="FCC6" input="BLK_IG-LUTFF[6].FCOUT" output="BLK_IG-LUTFF[7].FCIN">
+  <direct name="FCC6"  input="LUTFF[6].FCOUT" output="LUTFF[7].FCIN">
   </direct>
-  <direct name="FCOUT" input="BLK_IG-LUTFF[7].FCOUT" output="BLK_IG-PLB.FCOUT">
+  <direct name="FCOUT" input="LUTFF[7].FCOUT" output="PLB_CELLS.FCOUT">
   </direct>
   <!-- Fast carry chain
-  <direct name="FCIN" input="BLK_IG-PLB.FCIN" output="BLK_IG-LUTFF[0].FCIN" />
-  <direct name="FCC0" input="BLK_IG-LUTFF[0].FCOUT" output="BLK_IG-LUTFF[1].FCIN" />
-  <direct name="FCC1" input="BLK_IG-LUTFF[1].FCOUT" output="BLK_IG-LUTFF[2].FCIN" />
-  <direct name="FCC2" input="BLK_IG-LUTFF[2].FCOUT" output="BLK_IG-LUTFF[3].FCIN" />
-  <direct name="FCC3" input="BLK_IG-LUTFF[3].FCOUT" output="BLK_IG-LUTFF[4].FCIN" />
-  <direct name="FCC4" input="BLK_IG-LUTFF[4].FCOUT" output="BLK_IG-LUTFF[5].FCIN" />
-  <direct name="FCC5" input="BLK_IG-LUTFF[5].FCOUT" output="BLK_IG-LUTFF[6].FCIN" />
-  <direct name="FCC6" input="BLK_IG-LUTFF[6].FCOUT" output="BLK_IG-LUTFF[7].FCIN" />
-  <direct name="FCOUT" input="BLK_IG-LUTFF[7].FCOUT" output="BLK_IG-PLB.FCOUT" />
+  <direct name="FCIN" input="PLB_CELLS.FCIN" output="LUTFF[0].FCIN" />
+  <direct name="FCC0" input="LUTFF[0].FCOUT" output="LUTFF[1].FCIN" />
+  <direct name="FCC1" input="LUTFF[1].FCOUT" output="LUTFF[2].FCIN" />
+  <direct name="FCC2" input="LUTFF[2].FCOUT" output="LUTFF[3].FCIN" />
+  <direct name="FCC3" input="LUTFF[3].FCOUT" output="LUTFF[4].FCIN" />
+  <direct name="FCC4" input="LUTFF[4].FCOUT" output="LUTFF[5].FCIN" />
+  <direct name="FCC5" input="LUTFF[5].FCOUT" output="LUTFF[6].FCIN" />
+  <direct name="FCC6" input="LUTFF[6].FCOUT" output="LUTFF[7].FCIN" />
+  <direct name="FCOUT" input="LUTFF[7].FCOUT" output="PLB_CELLS.FCOUT" />
        -->
 
  </interconnect>
-
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/ice40/devices/layouts/N1k/ntemplate.N1k.fixed_layout.xml
+++ b/ice40/devices/layouts/N1k/ntemplate.N1k.fixed_layout.xml
@@ -4,23 +4,23 @@
   Due to the way channels work in VPR, we need to pad the top+right edge with
   extra empty tiles.
  -->
- <col     type="EMPTY"          startx="0"  priority="30"/>
- <col     type="BLK_TL-PIO_A"   startx="1"  priority="10"/>
- <region  type="BLK_TL-PLB"     startx="2" endx="13" starty="2" endy="17" priority="4"/> <!-- Logic blocks 11x15 -->
- <col     type="BLK_TL-PIO_A"   startx="14" priority="10"/>
- <col     type="EMPTY"          startx="15" priority="30"/>
+ <col     type="EMPTY"   startx="0"  priority="30"/>
+ <col     type="PIO_A"   startx="1"  priority="10"/>
+ <region  type="PLB"     startx="2" endx="13" starty="2" endy="17" priority="4"/> <!-- Logic blocks 11x15 -->
+ <col     type="PIO_A"   startx="14" priority="10"/>
+ <col     type="EMPTY"   startx="15" priority="30"/>
 
- <row     type="EMPTY"          starty="0"  priority="31"/>
- <row     type="BLK_TL-PIO_A"   starty="1"  priority="11"/>
- <!--                           starty="2" endy="17" -->
- <row     type="BLK_TL-PIO_A"   starty="18" priority="11"/>
- <row     type="EMPTY"          starty="19" priority="31"/>
+ <row     type="EMPTY"   starty="0"  priority="31"/>
+ <row     type="PIO_A"   starty="1"  priority="11"/>
+ <!--                    starty="2" endy="17" -->
+ <row     type="PIO_A"   starty="18" priority="11"/>
+ <row     type="EMPTY"   starty="19" priority="31"/>
 
  <!-- Block RAM -->
- <col     type="BLK_TL-RAMB"    startx="4"            starty="2"                      priority="5"/>
- <region  type="BLK_TL-RAMT"    startx="4"  endx="4"  starty="3" endy="3" repeaty="2" priority="6"/>
- <col     type="BLK_TL-RAMB"    startx="11"           starty="2"                      priority="5"/>
- <region  type="BLK_TL-RAMT"    startx="11" endx="11" starty="3" endy="3" repeaty="2" priority="6"/>
+ <col     type="RAMB"    startx="4"            starty="2"                      priority="5"/>
+ <region  type="RAMT"    startx="4"  endx="4"  starty="3" endy="3" repeaty="2" priority="6"/>
+ <col     type="RAMB"    startx="11"           starty="2"                      priority="5"/>
+ <region  type="RAMT"    startx="11" endx="11" starty="3" endy="3" repeaty="2" priority="6"/>
 
  <!-- Create empty blocks at all corners -->
  <single  type="EMPTY" x="1"  y="1"  priority="40"/>

--- a/ice40/devices/layouts/N384/ntemplate.N384.fixed_layout.xml
+++ b/ice40/devices/layouts/N384/ntemplate.N384.fixed_layout.xml
@@ -1,18 +1,18 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <fixed_layout name="{N}384" width="12" height="12">
- <col    type="EMPTY"            startx="0"  priority="30"/>
- <col    type="BLK_TL-PIO_L"     startx="1"  priority="10"/>
- <region type="BLK_TL-PLB"       startx="2" endx="7" starty="2" endy="9" priority="4"/> <!-- Logic blocks 8x10 -->
- <col    type="BLK_TL-PIO_R"     startx="8"  priority="10"/>
- <col    type="EMPTY"            startx="9"  priority="30"/>
- <col    type="EMPTY"            startx="10" priority="30"/>
- <col    type="EMPTY"            startx="11" priority="30"/>
+ <col    type="EMPTY"     startx="0"  priority="30"/>
+ <col    type="PIO_L"     startx="1"  priority="10"/>
+ <region type="PLB"       startx="2" endx="7" starty="2" endy="9" priority="4"/> <!-- Logic blocks 8x10 -->
+ <col    type="PIO_R"     startx="8"  priority="10"/>
+ <col    type="EMPTY"     startx="9"  priority="30"/>
+ <col    type="EMPTY"     startx="10" priority="30"/>
+ <col    type="EMPTY"     startx="11" priority="30"/>
 
- <row    type="EMPTY"            starty="0"  priority="31"/>
- <row    type="BLK_TL-PIO_B"     starty="1"  priority="11"/>
- <!--                            starty="2" endy="17" -->
- <row    type="BLK_TL-PIO_T"     starty="10" priority="11"/>
- <row    type="EMPTY"            starty="11" priority="31"/>
+ <row    type="EMPTY"     starty="0"  priority="31"/>
+ <row    type="PIO_B"     starty="1"  priority="11"/>
+ <!--                     starty="2" endy="17" -->
+ <row    type="PIO_T"     starty="10" priority="11"/>
+ <row    type="EMPTY"     starty="11" priority="31"/>
 
  <!-- Create empty blocks at all corners -->
  <single type="EMPTY" x="1" y="1"  priority="40"/>

--- a/ice40/devices/layouts/N8k/ntemplate.N8k.fixed_layout.xml
+++ b/ice40/devices/layouts/N8k/ntemplate.N8k.fixed_layout.xml
@@ -4,23 +4,23 @@
   Due to the way channels work in VPR, we need to pad the top+right edge with
   extra empty tiles.
  -->
- <col     type="EMPTY"          startx="0"  priority="30"/>
- <col     type="BLK_TL-PIO_L"   startx="1"  priority="10"/>
- <region  type="BLK_TL-PLB"     startx="2" endx="33" starty="2" endy="33" priority="4"/> <!-- Logic blocks 31x31 -->
- <col     type="BLK_TL-PIO_R"   startx="34" priority="10"/>
- <col     type="EMPTY"          startx="35" priority="30"/>
+ <col     type="EMPTY"   startx="0"  priority="30"/>
+ <col     type="PIO_L"   startx="1"  priority="10"/>
+ <region  type="PLB"     startx="2" endx="33" starty="2" endy="33" priority="4"/> <!-- Logic blocks 31x31 -->
+ <col     type="PIO_R"   startx="34" priority="10"/>
+ <col     type="EMPTY"   startx="35" priority="30"/>
 
- <row     type="EMPTY"          starty="0"  priority="31"/>
- <row     type="BLK_TL-PIO_B"   starty="1"  priority="11"/>
- <!--                           starty="2" endy="33" -->
- <row     type="BLK_TL-PIO_T"   starty="34" priority="11"/>
- <row     type="EMPTY"          starty="35" priority="31"/>
+ <row     type="EMPTY"   starty="0"  priority="31"/>
+ <row     type="PIO_B"   starty="1"  priority="11"/>
+ <!--                    starty="2" endy="33" -->
+ <row     type="PIO_T"   starty="34" priority="11"/>
+ <row     type="EMPTY"   starty="35" priority="31"/>
 
  <!-- Block RAM -->
- <col     type="BLK_TL-RAMB"    startx="9"            starty="2"                      priority="5"/>
- <region  type="EMPTY"          startx="9"  endx="9"  starty="2" endy="2" repeaty="2" priority="6"/>
- <col     type="BLK_TL-RAMB"    startx="26"           starty="2"                      priority="5"/>
- <region  type="EMPTY"          startx="26" endx="26" starty="2" endy="2" repeaty="2" priority="6"/>
+ <col     type="RAMB"    startx="9"            starty="2"                      priority="5"/>
+ <region  type="EMPTY"   startx="9"  endx="9"  starty="2" endy="2" repeaty="2" priority="6"/>
+ <col     type="RAMB"    startx="26"           starty="2"                      priority="5"/>
+ <region  type="EMPTY"   startx="26" endx="26" starty="2" endy="2" repeaty="2" priority="6"/>
 
  <!-- Create empty blocks at all corners -->
  <single  type="EMPTY" x="1"  y="1"  priority="40"/>

--- a/ice40/devices/layouts/test4/test4.fixed_layout.xml
+++ b/ice40/devices/layouts/test4/test4.fixed_layout.xml
@@ -1,15 +1,15 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <fixed_layout name="test4" width="6" height="6">
  <col     type="EMPTY" startx="0" priority="30"/>
- <col     type="BLK_TL-PIO_L"     startx="1" priority="10"/>
- <region  type="BLK_TL-PLB"       startx="2" endx="3" starty="2" endy="3" priority="4"/> <!-- Logic blocks 2x2 -->
- <col     type="BLK_TL-PIO_R"     startx="4" priority="10"/>
+ <col     type="PIO_L" startx="1" priority="10"/>
+ <region  type="PLB"   startx="2" endx="3" starty="2" endy="3" priority="4"/> <!-- Logic blocks 2x2 -->
+ <col     type="PIO_R" startx="4" priority="10"/>
  <col     type="EMPTY" startx="5" priority="30"/>
 
  <row     type="EMPTY" starty="0" priority="31"/>
- <row     type="BLK_TL-PIO_B"     starty="1" priority="11"/>
+ <row     type="PIO_B" starty="1" priority="11"/>
  <!-- starty="2" endy="3" -->
- <row     type="BLK_TL-PIO_T"     starty="4" priority="11"/>
+ <row     type="PIO_T" starty="4" priority="11"/>
  <row     type="EMPTY" starty="5" priority="31"/>
 
  <!-- Create empty blocks at all corners -->

--- a/ice40/devices/tile-routing-virt/arch.xml
+++ b/ice40/devices/tile-routing-virt/arch.xml
@@ -38,17 +38,17 @@
 
  <directlist>
   <!-- Carry chain from one PLB to the next PLB -->
-  <direct name="CARRY"   from_pin="BLK_TL-PLB.carry_out"   to_pin="BLK_TL-PLB.carry_in"    x_offset="0"  y_offset="1" z_offset="0"/>
+  <direct name="CARRY"   from_pin="PLB.carry_out"   to_pin="PLB.carry_in"    x_offset="0"  y_offset="1" z_offset="0"/>
   <!-- Vertical wires from neighbours
-  <direct name="sp4_r2l" from_pin="BLK_TL-PLB.o_sp4_l_v_b" to_pin="BLK_TL-PLB.i_sp4_r_v_b" x_offset="-1" y_offset="0" z_offset="0"/>
-  <direct name="sp4_l2r" from_pin="BLK_TL-PLB.o_sp4_r_v_b" to_pin="BLK_TL-PLB.i_sp4_l_v_b" x_offset= "1" y_offset="0" z_offset="0"/>
+  <direct name="sp4_r2l" from_pin="PLB.o_sp4_l_v_b" to_pin="PLB.i_sp4_r_v_b" x_offset="-1" y_offset="0" z_offset="0"/>
+  <direct name="sp4_l2r" from_pin="PLB.o_sp4_r_v_b" to_pin="PLB.i_sp4_l_v_b" x_offset= "1" y_offset="0" z_offset="0"/>
        -->
   <!-- Neighbourhood wires
-  <direct name="neigh_op_ob2it" from_pin="BLK_TL-PLB.o_neigh_op_bot" to_pin="BLK_TL-PLB.i_neigh_op_top" x_offset="0"  y_offset="-1" z_offset="0"/>
-  <direct name="neigh_op_ot2ib" from_pin="BLK_TL-PLB.o_neigh_op_top" to_pin="BLK_TL-PLB.i_neigh_op_bot" x_offset="0"  y_offset= "1" z_offset="0"/>
+  <direct name="neigh_op_ob2it" from_pin="PLB.o_neigh_op_bot" to_pin="PLB.i_neigh_op_top" x_offset="0"  y_offset="-1" z_offset="0"/>
+  <direct name="neigh_op_ot2ib" from_pin="PLB.o_neigh_op_top" to_pin="PLB.i_neigh_op_bot" x_offset="0"  y_offset= "1" z_offset="0"/>
 
-  <direct name="neigh_op_or2il" from_pin="BLK_TL-PLB.o_neigh_op_rgt" to_pin="BLK_TL-PLB.i_neigh_op_lft" x_offset= "1" y_offset="0"  z_offset="0"/>
-  <direct name="neigh_op_ol2ir" from_pin="BLK_TL-PLB.o_neigh_op_lft" to_pin="BLK_TL-PLB.i_neigh_op_rgt" x_offset="-1" y_offset="0"  z_offset="0"/>
+  <direct name="neigh_op_or2il" from_pin="PLB.o_neigh_op_rgt" to_pin="PLB.i_neigh_op_lft" x_offset= "1" y_offset="0"  z_offset="0"/>
+  <direct name="neigh_op_ol2ir" from_pin="PLB.o_neigh_op_lft" to_pin="PLB.i_neigh_op_rgt" x_offset="-1" y_offset="0"  z_offset="0"/>
        -->
  </directlist>
 

--- a/ice40/devices/tile-routing-virt/tiles/pio-b/pio-b.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-b/pio-b.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO_B" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO_B" xmlns:xi="http://www.w3.org/2001/XInclude">
  <xi:include href="../pio/pio.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  <xi:include href="../pio-tb/pio-tb.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
 
@@ -15,145 +15,149 @@
  <interconnect>
   <xi:include href="../pio/pio.interconnect.xml" xpointer="xpointer(interconnect/child::node())"/>
 
-  <mux name="fabout"          input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[5] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[4] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[6]" output="BLK_TL-PIO_B.fabout" />
+  <mux name="fabout"             input="local_g[0].o[1] local_g[0].o[5] local_g[1].o[0] local_g[1].o[4] local_g[0].o[3] local_g[0].o[7] local_g[1].o[2] local_g[1].o[6]" output="PIO_B.fabout" />
 
-  <mux name="BLK_XX-io_global/i_inclk" input="BLK_TL-PIO_B.i_glb_netwk[0] BLK_TL-PIO_B.i_glb_netwk[1] BLK_TL-PIO_B.i_glb_netwk[4] BLK_TL-PIO_B.i_glb_netwk[5] BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[3] BLK_TL-PIO_B.i_glb_netwk[2] BLK_TL-PIO_B.i_glb_netwk[3] BLK_TL-PIO_B.i_glb_netwk[6] BLK_TL-PIO_B.i_glb_netwk[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[3]" output="BLK_XX-io_global.i_inclk" />
-  <mux name="BLK_XX-io_global/i_outclk" input="BLK_TL-PIO_B.i_glb_netwk[0] BLK_TL-PIO_B.i_glb_netwk[1] BLK_TL-PIO_B.i_glb_netwk[4] BLK_TL-PIO_B.i_glb_netwk[5] BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[4] BLK_TL-PIO_B.i_glb_netwk[2] BLK_TL-PIO_B.i_glb_netwk[3] BLK_TL-PIO_B.i_glb_netwk[6] BLK_TL-PIO_B.i_glb_netwk[7] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[4]" output="BLK_XX-io_global.i_outclk"/>
+  <mux name="io_global/i_inclk"  input="PIO_B.i_glb_netwk[0] PIO_B.i_glb_netwk[1] PIO_B.i_glb_netwk[4] PIO_B.i_glb_netwk[5] local_g[0].o[0] local_g[0].o[3] PIO_B.i_glb_netwk[2] PIO_B.i_glb_netwk[3] PIO_B.i_glb_netwk[6] PIO_B.i_glb_netwk[7] local_g[1].o[0] local_g[1].o[3]" output="io_global.i_inclk" />
+  <mux name="io_global/i_outclk" input="PIO_B.i_glb_netwk[0] PIO_B.i_glb_netwk[1] PIO_B.i_glb_netwk[4] PIO_B.i_glb_netwk[5] local_g[0].o[1] local_g[0].o[4] PIO_B.i_glb_netwk[2] PIO_B.i_glb_netwk[3] PIO_B.i_glb_netwk[6] PIO_B.i_glb_netwk[7] local_g[1].o[1] local_g[1].o[4]" output="io_global.i_outclk"/>
 
   <!-- Local Tracks -->
-  <mux name="BLK_XX-local_g[0].i[0]" input="BLK_TL-PIO_B.i_span12_vert[8]    BLK_TL-PIO_B.i_neigh_op_tnr[0]   BLK_TL-PIO_B.i_span4_vert[16]    BLK_TL-PIO_B.i_span12_vert[16]   BLK_TL-PIO_B.i_span4_horz_r[0]   BLK_TL-PIO_B.i_span4_vert[24]    BLK_TL-PIO_B.i_neigh_op_tnl[0]   BLK_TL-PIO_B.i_span4_vert[0]     BLK_TL-PIO_B.i_span4_horz_r[8]   BLK_TL-PIO_B.i_span4_vert[32]    BLK_TL-PIO_B.i_neigh_op_top[0]   BLK_TL-PIO_B.i_span4_vert[8]     BLK_TL-PIO_B.i_span12_vert[0]    BLK_TL-PIO_B.i_span4_vert[40]" output="BLK_XX-local_g[0].i[0]" />
-  <mux name="BLK_XX-local_g[0].i[1]" input="BLK_TL-PIO_B.i_neigh_op_tnl[1]   BLK_TL-PIO_B.i_neigh_op_top[1]   BLK_TL-PIO_B.i_span12_vert[9]    BLK_TL-PIO_B.i_span12_vert[17]   BLK_TL-PIO_B.i_span4_vert[1]     BLK_TL-PIO_B.i_span4_vert[9]     BLK_TL-PIO_B.i_neigh_op_tnr[1]   BLK_TL-PIO_B.i_span4_horz_r[1]   BLK_TL-PIO_B.i_span4_horz_r[9]   BLK_TL-PIO_B.i_span12_vert[1]    BLK_TL-PIO_B.i_span4_vert[17]    BLK_TL-PIO_B.i_span4_vert[25]    BLK_TL-PIO_B.i_span4_vert[33]    BLK_TL-PIO_B.i_span4_vert[41]" output="BLK_XX-local_g[0].i[1]" />
-  <mux name="BLK_XX-local_g[0].i[2]" input="BLK_TL-PIO_B.i_span12_vert[10]   BLK_TL-PIO_B.i_neigh_op_tnr[2]   BLK_TL-PIO_B.i_span4_vert[18]    BLK_TL-PIO_B.i_span12_vert[18]   BLK_TL-PIO_B.i_span4_horz_r[2]   BLK_TL-PIO_B.i_span4_vert[26]    BLK_TL-PIO_B.i_neigh_op_tnl[2]   BLK_TL-PIO_B.i_span4_vert[2]     BLK_TL-PIO_B.i_span4_horz_r[10]  BLK_TL-PIO_B.i_span4_vert[34]    BLK_TL-PIO_B.i_neigh_op_top[2]   BLK_TL-PIO_B.i_span4_vert[10]    BLK_TL-PIO_B.i_span12_vert[2]    BLK_TL-PIO_B.i_span4_vert[42]" output="BLK_XX-local_g[0].i[2]" />
-  <mux name="BLK_XX-local_g[0].i[3]" input="BLK_TL-PIO_B.i_neigh_op_tnl[3]   BLK_TL-PIO_B.i_neigh_op_top[3]   BLK_TL-PIO_B.i_span12_vert[11]   BLK_TL-PIO_B.i_span12_vert[19]   BLK_TL-PIO_B.i_span4_vert[3]     BLK_TL-PIO_B.i_span4_vert[11]    BLK_TL-PIO_B.i_neigh_op_tnr[3]   BLK_TL-PIO_B.i_span4_horz_r[3]   BLK_TL-PIO_B.i_span4_horz_r[11]  BLK_TL-PIO_B.i_span12_vert[3]    BLK_TL-PIO_B.i_span4_vert[19]    BLK_TL-PIO_B.i_span4_vert[27]    BLK_TL-PIO_B.i_span4_vert[35]    BLK_TL-PIO_B.i_span4_vert[43]" output="BLK_XX-local_g[0].i[3]" />
-  <mux name="BLK_XX-local_g[0].i[4]" input="BLK_TL-PIO_B.i_span12_vert[12]   BLK_TL-PIO_B.i_neigh_op_tnr[4]   BLK_TL-PIO_B.i_span4_vert[20]    BLK_TL-PIO_B.i_span12_vert[20]   BLK_TL-PIO_B.i_span4_horz_r[4]   BLK_TL-PIO_B.i_span4_vert[28]    BLK_TL-PIO_B.i_neigh_op_tnl[4]   BLK_TL-PIO_B.i_span4_vert[4]     BLK_TL-PIO_B.i_span4_horz_r[12]  BLK_TL-PIO_B.i_span4_vert[36]    BLK_TL-PIO_B.i_neigh_op_top[4]   BLK_TL-PIO_B.i_span4_vert[12]    BLK_TL-PIO_B.i_span12_vert[4]    BLK_TL-PIO_B.i_span4_vert[44]" output="BLK_XX-local_g[0].i[4]" />
-  <mux name="BLK_XX-local_g[0].i[5]" input="BLK_TL-PIO_B.i_neigh_op_tnl[5]   BLK_TL-PIO_B.i_neigh_op_top[5]   BLK_TL-PIO_B.i_span12_vert[13]   BLK_TL-PIO_B.i_span12_vert[21]   BLK_TL-PIO_B.i_span4_vert[5]     BLK_TL-PIO_B.i_span4_vert[13]    BLK_TL-PIO_B.i_neigh_op_tnr[5]   BLK_TL-PIO_B.i_span4_horz_r[5]   BLK_TL-PIO_B.i_span4_horz_r[13]  BLK_TL-PIO_B.i_span12_vert[5]    BLK_TL-PIO_B.i_span4_vert[21]    BLK_TL-PIO_B.i_span4_vert[29]    BLK_TL-PIO_B.i_span4_vert[37]    BLK_TL-PIO_B.i_span4_vert[45]" output="BLK_XX-local_g[0].i[5]" />
-  <mux name="BLK_XX-local_g[0].i[6]" input="BLK_TL-PIO_B.i_span12_vert[14]   BLK_TL-PIO_B.i_neigh_op_tnr[6]   BLK_TL-PIO_B.i_span4_vert[22]    BLK_TL-PIO_B.i_span12_vert[22]   BLK_TL-PIO_B.i_span4_horz_r[6]   BLK_TL-PIO_B.i_span4_vert[30]    BLK_TL-PIO_B.i_neigh_op_tnl[6]   BLK_TL-PIO_B.i_span4_vert[6]     BLK_TL-PIO_B.i_span4_horz_r[14]  BLK_TL-PIO_B.i_span4_vert[38]    BLK_TL-PIO_B.i_neigh_op_top[6]   BLK_TL-PIO_B.i_span4_vert[14]    BLK_TL-PIO_B.i_span12_vert[6]    BLK_TL-PIO_B.i_span4_vert[46]" output="BLK_XX-local_g[0].i[6]" />
-  <mux name="BLK_XX-local_g[0].i[7]" input="BLK_TL-PIO_B.i_neigh_op_tnl[7]   BLK_TL-PIO_B.i_neigh_op_top[7]   BLK_TL-PIO_B.i_span12_vert[15]   BLK_TL-PIO_B.i_span12_vert[23]   BLK_TL-PIO_B.i_span4_vert[7]     BLK_TL-PIO_B.i_span4_vert[15]    BLK_TL-PIO_B.i_neigh_op_tnr[7]   BLK_TL-PIO_B.i_span4_horz_r[7]   BLK_TL-PIO_B.i_span4_horz_r[15]  BLK_TL-PIO_B.i_span12_vert[7]    BLK_TL-PIO_B.i_span4_vert[23]    BLK_TL-PIO_B.i_span4_vert[31]    BLK_TL-PIO_B.i_span4_vert[39]    BLK_TL-PIO_B.i_span4_vert[47]" output="BLK_XX-local_g[0].i[7]" />
+  <mux name="local_g[0].i[0]" input="PIO_B.i_span12_vert[8]    PIO_B.i_neigh_op_tnr[0]   PIO_B.i_span4_vert[16]    PIO_B.i_span12_vert[16]   PIO_B.i_span4_horz_r[0]   PIO_B.i_span4_vert[24]    PIO_B.i_neigh_op_tnl[0]   PIO_B.i_span4_vert[0]     PIO_B.i_span4_horz_r[8]   PIO_B.i_span4_vert[32]    PIO_B.i_neigh_op_top[0]   PIO_B.i_span4_vert[8]     PIO_B.i_span12_vert[0]    PIO_B.i_span4_vert[40]" output="local_g[0].i[0]" />
+  <mux name="local_g[0].i[1]" input="PIO_B.i_neigh_op_tnl[1]   PIO_B.i_neigh_op_top[1]   PIO_B.i_span12_vert[9]    PIO_B.i_span12_vert[17]   PIO_B.i_span4_vert[1]     PIO_B.i_span4_vert[9]     PIO_B.i_neigh_op_tnr[1]   PIO_B.i_span4_horz_r[1]   PIO_B.i_span4_horz_r[9]   PIO_B.i_span12_vert[1]    PIO_B.i_span4_vert[17]    PIO_B.i_span4_vert[25]    PIO_B.i_span4_vert[33]    PIO_B.i_span4_vert[41]" output="local_g[0].i[1]" />
+  <mux name="local_g[0].i[2]" input="PIO_B.i_span12_vert[10]   PIO_B.i_neigh_op_tnr[2]   PIO_B.i_span4_vert[18]    PIO_B.i_span12_vert[18]   PIO_B.i_span4_horz_r[2]   PIO_B.i_span4_vert[26]    PIO_B.i_neigh_op_tnl[2]   PIO_B.i_span4_vert[2]     PIO_B.i_span4_horz_r[10]  PIO_B.i_span4_vert[34]    PIO_B.i_neigh_op_top[2]   PIO_B.i_span4_vert[10]    PIO_B.i_span12_vert[2]    PIO_B.i_span4_vert[42]" output="local_g[0].i[2]" />
+  <mux name="local_g[0].i[3]" input="PIO_B.i_neigh_op_tnl[3]   PIO_B.i_neigh_op_top[3]   PIO_B.i_span12_vert[11]   PIO_B.i_span12_vert[19]   PIO_B.i_span4_vert[3]     PIO_B.i_span4_vert[11]    PIO_B.i_neigh_op_tnr[3]   PIO_B.i_span4_horz_r[3]   PIO_B.i_span4_horz_r[11]  PIO_B.i_span12_vert[3]    PIO_B.i_span4_vert[19]    PIO_B.i_span4_vert[27]    PIO_B.i_span4_vert[35]    PIO_B.i_span4_vert[43]" output="local_g[0].i[3]" />
+  <mux name="local_g[0].i[4]" input="PIO_B.i_span12_vert[12]   PIO_B.i_neigh_op_tnr[4]   PIO_B.i_span4_vert[20]    PIO_B.i_span12_vert[20]   PIO_B.i_span4_horz_r[4]   PIO_B.i_span4_vert[28]    PIO_B.i_neigh_op_tnl[4]   PIO_B.i_span4_vert[4]     PIO_B.i_span4_horz_r[12]  PIO_B.i_span4_vert[36]    PIO_B.i_neigh_op_top[4]   PIO_B.i_span4_vert[12]    PIO_B.i_span12_vert[4]    PIO_B.i_span4_vert[44]" output="local_g[0].i[4]" />
+  <mux name="local_g[0].i[5]" input="PIO_B.i_neigh_op_tnl[5]   PIO_B.i_neigh_op_top[5]   PIO_B.i_span12_vert[13]   PIO_B.i_span12_vert[21]   PIO_B.i_span4_vert[5]     PIO_B.i_span4_vert[13]    PIO_B.i_neigh_op_tnr[5]   PIO_B.i_span4_horz_r[5]   PIO_B.i_span4_horz_r[13]  PIO_B.i_span12_vert[5]    PIO_B.i_span4_vert[21]    PIO_B.i_span4_vert[29]    PIO_B.i_span4_vert[37]    PIO_B.i_span4_vert[45]" output="local_g[0].i[5]" />
+  <mux name="local_g[0].i[6]" input="PIO_B.i_span12_vert[14]   PIO_B.i_neigh_op_tnr[6]   PIO_B.i_span4_vert[22]    PIO_B.i_span12_vert[22]   PIO_B.i_span4_horz_r[6]   PIO_B.i_span4_vert[30]    PIO_B.i_neigh_op_tnl[6]   PIO_B.i_span4_vert[6]     PIO_B.i_span4_horz_r[14]  PIO_B.i_span4_vert[38]    PIO_B.i_neigh_op_top[6]   PIO_B.i_span4_vert[14]    PIO_B.i_span12_vert[6]    PIO_B.i_span4_vert[46]" output="local_g[0].i[6]" />
+  <mux name="local_g[0].i[7]" input="PIO_B.i_neigh_op_tnl[7]   PIO_B.i_neigh_op_top[7]   PIO_B.i_span12_vert[15]   PIO_B.i_span12_vert[23]   PIO_B.i_span4_vert[7]     PIO_B.i_span4_vert[15]    PIO_B.i_neigh_op_tnr[7]   PIO_B.i_span4_horz_r[7]   PIO_B.i_span4_horz_r[15]  PIO_B.i_span12_vert[7]    PIO_B.i_span4_vert[23]    PIO_B.i_span4_vert[31]    PIO_B.i_span4_vert[39]    PIO_B.i_span4_vert[47]" output="local_g[0].i[7]" />
 
 
-  <mux name="BLK_XX-local_g[1].i[0]" input="BLK_TL-PIO_B.i_span12_vert[8]    BLK_TL-PIO_B.i_neigh_op_tnr[0]   BLK_TL-PIO_B.i_span4_vert[16]    BLK_TL-PIO_B.i_span12_vert[16]   BLK_TL-PIO_B.i_span4_horz_r[0]   BLK_TL-PIO_B.i_span4_vert[24]    BLK_TL-PIO_B.i_neigh_op_tnl[0]   BLK_TL-PIO_B.i_span4_vert[0]     BLK_TL-PIO_B.i_span4_horz_r[8]   BLK_TL-PIO_B.i_span4_vert[32]    BLK_TL-PIO_B.i_neigh_op_top[0]   BLK_TL-PIO_B.i_span4_vert[8]     BLK_TL-PIO_B.i_span12_vert[0]    BLK_TL-PIO_B.i_span4_vert[40]" output="BLK_XX-local_g[1].i[0]" />
-  <mux name="BLK_XX-local_g[1].i[1]" input="BLK_TL-PIO_B.i_neigh_op_tnl[1]   BLK_TL-PIO_B.i_neigh_op_top[1]   BLK_TL-PIO_B.i_span12_vert[9]    BLK_TL-PIO_B.i_span12_vert[17]   BLK_TL-PIO_B.i_span4_vert[1]     BLK_TL-PIO_B.i_span4_vert[9]     BLK_TL-PIO_B.i_neigh_op_tnr[1]   BLK_TL-PIO_B.i_span4_horz_r[1]   BLK_TL-PIO_B.i_span4_horz_r[9]   BLK_TL-PIO_B.i_span12_vert[1]    BLK_TL-PIO_B.i_span4_vert[17]    BLK_TL-PIO_B.i_span4_vert[25]    BLK_TL-PIO_B.i_span4_vert[33]    BLK_TL-PIO_B.i_span4_vert[41]" output="BLK_XX-local_g[1].i[1]" />
-  <mux name="BLK_XX-local_g[1].i[2]" input="BLK_TL-PIO_B.i_span12_vert[10]   BLK_TL-PIO_B.i_neigh_op_tnr[2]   BLK_TL-PIO_B.i_span4_vert[18]    BLK_TL-PIO_B.i_span12_vert[18]   BLK_TL-PIO_B.i_span4_horz_r[2]   BLK_TL-PIO_B.i_span4_vert[26]    BLK_TL-PIO_B.i_neigh_op_tnl[2]   BLK_TL-PIO_B.i_span4_vert[2]     BLK_TL-PIO_B.i_span4_horz_r[10]  BLK_TL-PIO_B.i_span4_vert[34]    BLK_TL-PIO_B.i_neigh_op_top[2]   BLK_TL-PIO_B.i_span4_vert[10]    BLK_TL-PIO_B.i_span12_vert[2]    BLK_TL-PIO_B.i_span4_vert[42]" output="BLK_XX-local_g[1].i[2]" />
-  <mux name="BLK_XX-local_g[1].i[3]" input="BLK_TL-PIO_B.i_neigh_op_tnl[3]   BLK_TL-PIO_B.i_neigh_op_top[3]   BLK_TL-PIO_B.i_span12_vert[11]   BLK_TL-PIO_B.i_span12_vert[19]   BLK_TL-PIO_B.i_span4_vert[3]     BLK_TL-PIO_B.i_span4_vert[11]    BLK_TL-PIO_B.i_neigh_op_tnr[3]   BLK_TL-PIO_B.i_span4_horz_r[3]   BLK_TL-PIO_B.i_span4_horz_r[11]  BLK_TL-PIO_B.i_span12_vert[3]    BLK_TL-PIO_B.i_span4_vert[19]    BLK_TL-PIO_B.i_span4_vert[27]    BLK_TL-PIO_B.i_span4_vert[35]    BLK_TL-PIO_B.i_span4_vert[43]" output="BLK_XX-local_g[1].i[3]" />
-  <mux name="BLK_XX-local_g[1].i[4]" input="BLK_TL-PIO_B.i_span12_vert[12]   BLK_TL-PIO_B.i_neigh_op_tnr[4]   BLK_TL-PIO_B.i_span4_vert[20]    BLK_TL-PIO_B.i_span12_vert[20]   BLK_TL-PIO_B.i_span4_horz_r[4]   BLK_TL-PIO_B.i_span4_vert[28]    BLK_TL-PIO_B.i_neigh_op_tnl[4]   BLK_TL-PIO_B.i_span4_vert[4]     BLK_TL-PIO_B.i_span4_horz_r[12]  BLK_TL-PIO_B.i_span4_vert[36]    BLK_TL-PIO_B.i_neigh_op_top[4]   BLK_TL-PIO_B.i_span4_vert[12]    BLK_TL-PIO_B.i_span12_vert[4]    BLK_TL-PIO_B.i_span4_vert[44]" output="BLK_XX-local_g[1].i[4]" />
-  <mux name="BLK_XX-local_g[1].i[5]" input="BLK_TL-PIO_B.i_neigh_op_tnl[5]   BLK_TL-PIO_B.i_neigh_op_top[5]   BLK_TL-PIO_B.i_span12_vert[13]   BLK_TL-PIO_B.i_span12_vert[21]   BLK_TL-PIO_B.i_span4_vert[5]     BLK_TL-PIO_B.i_span4_vert[13]    BLK_TL-PIO_B.i_neigh_op_tnr[5]   BLK_TL-PIO_B.i_span4_horz_r[5]   BLK_TL-PIO_B.i_span4_horz_r[13]  BLK_TL-PIO_B.i_span12_vert[5]    BLK_TL-PIO_B.i_span4_vert[21]    BLK_TL-PIO_B.i_span4_vert[29]    BLK_TL-PIO_B.i_span4_vert[37]    BLK_TL-PIO_B.i_span4_vert[45]" output="BLK_XX-local_g[1].i[5]" />
-  <mux name="BLK_XX-local_g[1].i[6]" input="BLK_TL-PIO_B.i_span12_vert[14]   BLK_TL-PIO_B.i_neigh_op_tnr[6]   BLK_TL-PIO_B.i_span4_vert[22]    BLK_TL-PIO_B.i_span12_vert[22]   BLK_TL-PIO_B.i_span4_horz_r[6]   BLK_TL-PIO_B.i_span4_vert[30]    BLK_TL-PIO_B.i_neigh_op_tnl[6]   BLK_TL-PIO_B.i_span4_vert[6]     BLK_TL-PIO_B.i_span4_horz_r[14]  BLK_TL-PIO_B.i_span4_vert[38]    BLK_TL-PIO_B.i_neigh_op_top[6]   BLK_TL-PIO_B.i_span4_vert[14]    BLK_TL-PIO_B.i_span12_vert[6]    BLK_TL-PIO_B.i_span4_vert[46]" output="BLK_XX-local_g[1].i[6]" />
-  <mux name="BLK_XX-local_g[1].i[7]" input="BLK_TL-PIO_B.i_neigh_op_tnl[7]   BLK_TL-PIO_B.i_neigh_op_top[7]   BLK_TL-PIO_B.i_span12_vert[15]   BLK_TL-PIO_B.i_span12_vert[23]   BLK_TL-PIO_B.i_span4_vert[7]     BLK_TL-PIO_B.i_span4_vert[15]    BLK_TL-PIO_B.i_neigh_op_tnr[7]   BLK_TL-PIO_B.i_span4_horz_r[7]   BLK_TL-PIO_B.i_span4_horz_r[15]  BLK_TL-PIO_B.i_span12_vert[7]    BLK_TL-PIO_B.i_span4_vert[23]    BLK_TL-PIO_B.i_span4_vert[31]    BLK_TL-PIO_B.i_span4_vert[39]    BLK_TL-PIO_B.i_span4_vert[47]" output="BLK_XX-local_g[1].i[7]" />
+  <mux name="local_g[1].i[0]" input="PIO_B.i_span12_vert[8]    PIO_B.i_neigh_op_tnr[0]   PIO_B.i_span4_vert[16]    PIO_B.i_span12_vert[16]   PIO_B.i_span4_horz_r[0]   PIO_B.i_span4_vert[24]    PIO_B.i_neigh_op_tnl[0]   PIO_B.i_span4_vert[0]     PIO_B.i_span4_horz_r[8]   PIO_B.i_span4_vert[32]    PIO_B.i_neigh_op_top[0]   PIO_B.i_span4_vert[8]     PIO_B.i_span12_vert[0]    PIO_B.i_span4_vert[40]" output="local_g[1].i[0]" />
+  <mux name="local_g[1].i[1]" input="PIO_B.i_neigh_op_tnl[1]   PIO_B.i_neigh_op_top[1]   PIO_B.i_span12_vert[9]    PIO_B.i_span12_vert[17]   PIO_B.i_span4_vert[1]     PIO_B.i_span4_vert[9]     PIO_B.i_neigh_op_tnr[1]   PIO_B.i_span4_horz_r[1]   PIO_B.i_span4_horz_r[9]   PIO_B.i_span12_vert[1]    PIO_B.i_span4_vert[17]    PIO_B.i_span4_vert[25]    PIO_B.i_span4_vert[33]    PIO_B.i_span4_vert[41]" output="local_g[1].i[1]" />
+  <mux name="local_g[1].i[2]" input="PIO_B.i_span12_vert[10]   PIO_B.i_neigh_op_tnr[2]   PIO_B.i_span4_vert[18]    PIO_B.i_span12_vert[18]   PIO_B.i_span4_horz_r[2]   PIO_B.i_span4_vert[26]    PIO_B.i_neigh_op_tnl[2]   PIO_B.i_span4_vert[2]     PIO_B.i_span4_horz_r[10]  PIO_B.i_span4_vert[34]    PIO_B.i_neigh_op_top[2]   PIO_B.i_span4_vert[10]    PIO_B.i_span12_vert[2]    PIO_B.i_span4_vert[42]" output="local_g[1].i[2]" />
+  <mux name="local_g[1].i[3]" input="PIO_B.i_neigh_op_tnl[3]   PIO_B.i_neigh_op_top[3]   PIO_B.i_span12_vert[11]   PIO_B.i_span12_vert[19]   PIO_B.i_span4_vert[3]     PIO_B.i_span4_vert[11]    PIO_B.i_neigh_op_tnr[3]   PIO_B.i_span4_horz_r[3]   PIO_B.i_span4_horz_r[11]  PIO_B.i_span12_vert[3]    PIO_B.i_span4_vert[19]    PIO_B.i_span4_vert[27]    PIO_B.i_span4_vert[35]    PIO_B.i_span4_vert[43]" output="local_g[1].i[3]" />
+  <mux name="local_g[1].i[4]" input="PIO_B.i_span12_vert[12]   PIO_B.i_neigh_op_tnr[4]   PIO_B.i_span4_vert[20]    PIO_B.i_span12_vert[20]   PIO_B.i_span4_horz_r[4]   PIO_B.i_span4_vert[28]    PIO_B.i_neigh_op_tnl[4]   PIO_B.i_span4_vert[4]     PIO_B.i_span4_horz_r[12]  PIO_B.i_span4_vert[36]    PIO_B.i_neigh_op_top[4]   PIO_B.i_span4_vert[12]    PIO_B.i_span12_vert[4]    PIO_B.i_span4_vert[44]" output="local_g[1].i[4]" />
+  <mux name="local_g[1].i[5]" input="PIO_B.i_neigh_op_tnl[5]   PIO_B.i_neigh_op_top[5]   PIO_B.i_span12_vert[13]   PIO_B.i_span12_vert[21]   PIO_B.i_span4_vert[5]     PIO_B.i_span4_vert[13]    PIO_B.i_neigh_op_tnr[5]   PIO_B.i_span4_horz_r[5]   PIO_B.i_span4_horz_r[13]  PIO_B.i_span12_vert[5]    PIO_B.i_span4_vert[21]    PIO_B.i_span4_vert[29]    PIO_B.i_span4_vert[37]    PIO_B.i_span4_vert[45]" output="local_g[1].i[5]" />
+  <mux name="local_g[1].i[6]" input="PIO_B.i_span12_vert[14]   PIO_B.i_neigh_op_tnr[6]   PIO_B.i_span4_vert[22]    PIO_B.i_span12_vert[22]   PIO_B.i_span4_horz_r[6]   PIO_B.i_span4_vert[30]    PIO_B.i_neigh_op_tnl[6]   PIO_B.i_span4_vert[6]     PIO_B.i_span4_horz_r[14]  PIO_B.i_span4_vert[38]    PIO_B.i_neigh_op_top[6]   PIO_B.i_span4_vert[14]    PIO_B.i_span12_vert[6]    PIO_B.i_span4_vert[46]" output="local_g[1].i[6]" />
+  <mux name="local_g[1].i[7]" input="PIO_B.i_neigh_op_tnl[7]   PIO_B.i_neigh_op_top[7]   PIO_B.i_span12_vert[15]   PIO_B.i_span12_vert[23]   PIO_B.i_span4_vert[7]     PIO_B.i_span4_vert[15]    PIO_B.i_neigh_op_tnr[7]   PIO_B.i_span4_horz_r[7]   PIO_B.i_span4_horz_r[15]  PIO_B.i_span12_vert[7]    PIO_B.i_span4_vert[23]    PIO_B.i_span4_vert[31]    PIO_B.i_span4_vert[39]    PIO_B.i_span4_vert[47]" output="local_g[1].i[7]" />
 
   <!-- D_IN -> Span4 Horz R -->
-  <mux name="span4_horz_r[0]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[0]"  />
-  <mux name="span4_horz_r[1]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[1]"  />
-  <mux name="span4_horz_r[10]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[10]" />
-  <mux name="span4_horz_r[11]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[11]" />
-  <mux name="span4_horz_r[12]" input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[12]" />
-  <mux name="span4_horz_r[13]" input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[13]" />
-  <mux name="span4_horz_r[14]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[14]" />
-  <mux name="span4_horz_r[15]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[15]" />
-  <mux name="span4_horz_r[2]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[2]"  />
-  <mux name="span4_horz_r[3]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[3]"  />
-  <mux name="span4_horz_r[4]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[4]"  />
-  <mux name="span4_horz_r[5]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[5]"  />
-  <mux name="span4_horz_r[6]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[6]"  />
-  <mux name="span4_horz_r[7]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[7]"  />
-  <mux name="span4_horz_r[8]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_horz_r[8]"  />
-  <mux name="span4_horz_r[9]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_horz_r[9]"  />
+  <mux name="span4_horz_r[0]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_horz_r[0]"  />
+  <mux name="span4_horz_r[1]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_horz_r[1]"  />
+  <mux name="span4_horz_r[10]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_horz_r[10]" />
+  <mux name="span4_horz_r[11]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_horz_r[11]" />
+  <mux name="span4_horz_r[12]" input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_horz_r[12]" />
+  <mux name="span4_horz_r[13]" input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_horz_r[13]" />
+  <mux name="span4_horz_r[14]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_horz_r[14]" />
+  <mux name="span4_horz_r[15]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_horz_r[15]" />
+  <mux name="span4_horz_r[2]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_horz_r[2]"  />
+  <mux name="span4_horz_r[3]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_horz_r[3]"  />
+  <mux name="span4_horz_r[4]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_horz_r[4]"  />
+  <mux name="span4_horz_r[5]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_horz_r[5]"  />
+  <mux name="span4_horz_r[6]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_horz_r[6]"  />
+  <mux name="span4_horz_r[7]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_horz_r[7]"  />
+  <mux name="span4_horz_r[8]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_horz_r[8]"  />
+  <mux name="span4_horz_r[9]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_horz_r[9]"  />
 
   <!-- D_IN -> Span4 Vert -->
-  <mux name="span4_vert[0]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[0]"    />
-  <mux name="span4_vert[10]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[10]"   />
-  <mux name="span4_vert[12]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[12]"   />
-  <mux name="span4_vert[14]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[14]"   />
-  <mux name="span4_vert[16]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[16]"   />
-  <mux name="span4_vert[18]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[18]"   />
-  <mux name="span4_vert[2]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[2]"    />
-  <mux name="span4_vert[20]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[20]"   />
-  <mux name="span4_vert[22]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[22]"   />
-  <mux name="span4_vert[24]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[24]"   />
-  <mux name="span4_vert[26]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[26]"   />
-  <mux name="span4_vert[28]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[28]"   />
-  <mux name="span4_vert[30]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[30]"   />
-  <mux name="span4_vert[32]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[32]"   />
-  <mux name="span4_vert[34]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[34]"   />
-  <mux name="span4_vert[36]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[36]"   />
-  <mux name="span4_vert[38]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[38]"   />
-  <mux name="span4_vert[4]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[4]"    />
-  <mux name="span4_vert[40]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[40]"   />
-  <mux name="span4_vert[42]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[42]"   />
-  <mux name="span4_vert[44]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[44]"   />
-  <mux name="span4_vert[46]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[46]"   />
-  <mux name="span4_vert[6]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span4_vert[6]"    />
-  <mux name="span4_vert[8]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span4_vert[8]"    />
+  <mux name="span4_vert[0]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_vert[0]"    />
+  <mux name="span4_vert[10]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_vert[10]"   />
+  <mux name="span4_vert[12]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_vert[12]"   />
+  <mux name="span4_vert[14]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_vert[14]"   />
+  <mux name="span4_vert[16]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_vert[16]"   />
+  <mux name="span4_vert[18]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_vert[18]"   />
+  <mux name="span4_vert[2]"    input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_vert[2]"    />
+  <mux name="span4_vert[20]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_vert[20]"   />
+  <mux name="span4_vert[22]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_vert[22]"   />
+  <mux name="span4_vert[24]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_vert[24]"   />
+  <mux name="span4_vert[26]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_vert[26]"   />
+  <mux name="span4_vert[28]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_vert[28]"   />
+  <mux name="span4_vert[30]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_vert[30]"   />
+  <mux name="span4_vert[32]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_vert[32]"   />
+  <mux name="span4_vert[34]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_vert[34]"   />
+  <mux name="span4_vert[36]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_vert[36]"   />
+  <mux name="span4_vert[38]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_vert[38]"   />
+  <mux name="span4_vert[4]"    input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_vert[4]"    />
+  <mux name="span4_vert[40]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_vert[40]"   />
+  <mux name="span4_vert[42]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span4_vert[42]"   />
+  <mux name="span4_vert[44]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span4_vert[44]"   />
+  <mux name="span4_vert[46]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_vert[46]"   />
+  <mux name="span4_vert[6]"    input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span4_vert[6]"    />
+  <mux name="span4_vert[8]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span4_vert[8]"    />
 
   <!-- D_IN -> Span12 Vert -->
-  <mux name="span12_vert[0]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span12_vert[0]"   />
-  <mux name="span12_vert[10]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span12_vert[10]"  />
-  <mux name="span12_vert[12]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span12_vert[12]"  />
-  <mux name="span12_vert[14]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span12_vert[14]"  />
-  <mux name="span12_vert[16]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span12_vert[16]"  />
-  <mux name="span12_vert[18]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span12_vert[18]"  />
-  <mux name="span12_vert[2]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_B.o_span12_vert[2]"   />
-  <mux name="span12_vert[20]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span12_vert[20]"  />
-  <mux name="span12_vert[22]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span12_vert[22]"  />
-  <mux name="span12_vert[4]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_B.o_span12_vert[4]"   />
-  <mux name="span12_vert[6]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_B.o_span12_vert[6]"   />
-  <mux name="span12_vert[8]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_B.o_span12_vert[8]"   />
+  <mux name="span12_vert[0]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span12_vert[0]"   />
+  <mux name="span12_vert[10]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span12_vert[10]"  />
+  <mux name="span12_vert[12]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span12_vert[12]"  />
+  <mux name="span12_vert[14]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span12_vert[14]"  />
+  <mux name="span12_vert[16]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span12_vert[16]"  />
+  <mux name="span12_vert[18]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span12_vert[18]"  />
+  <mux name="span12_vert[2]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_B.o_span12_vert[2]"   />
+  <mux name="span12_vert[20]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span12_vert[20]"  />
+  <mux name="span12_vert[22]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span12_vert[22]"  />
+  <mux name="span12_vert[4]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_B.o_span12_vert[4]"   />
+  <mux name="span12_vert[6]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_B.o_span12_vert[6]"   />
+  <mux name="span12_vert[8]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_B.o_span12_vert[8]"   />
 
   <!-- Spans -->
   <!--
-  <direct name="span4_horz_r[0]"  input="BLK_TL-PIO_B.i_span4_horz_l[ ]" output="BLK_TL-PIO_B.o_span4_horz_r[0]" />
-  <direct name="span4_horz_r[1]"  input="BLK_TL-PIO_B.i_span4_horz_l[ ]" output="BLK_TL-PIO_B.o_span4_horz_r[1]" />
-  <direct name="span4_horz_r[2]"  input="BLK_TL-PIO_B.i_span4_horz_l[ ]" output="BLK_TL-PIO_B.o_span4_horz_r[2]" />
-  <direct name="span4_horz_r[3]"  input="BLK_TL-PIO_B.i_span4_horz_l[ ]" output="BLK_TL-PIO_B.o_span4_horz_r[3]" />
+  <direct name="span4_horz_r[0]"  input="PIO_B.i_span4_horz_l[ ]" output="PIO_B.o_span4_horz_r[0]" />
+  <direct name="span4_horz_r[1]"  input="PIO_B.i_span4_horz_l[ ]" output="PIO_B.o_span4_horz_r[1]" />
+  <direct name="span4_horz_r[2]"  input="PIO_B.i_span4_horz_l[ ]" output="PIO_B.o_span4_horz_r[2]" />
+  <direct name="span4_horz_r[3]"  input="PIO_B.i_span4_horz_l[ ]" output="PIO_B.o_span4_horz_r[3]" />
   -->
 
-  <direct name="span4_horz_l[0]"  input="BLK_TL-PIO_B.i_span4_horz_l[0]"  output="BLK_TL-PIO_B.o_span4_horz_r[4]"  />
-  <direct name="span4_horz_l[1]"  input="BLK_TL-PIO_B.i_span4_horz_l[1]"  output="BLK_TL-PIO_B.o_span4_horz_r[5]"  />
-  <direct name="span4_horz_l[2]"  input="BLK_TL-PIO_B.i_span4_horz_l[2]"  output="BLK_TL-PIO_B.o_span4_horz_r[6]"  />
-  <direct name="span4_horz_l[3]"  input="BLK_TL-PIO_B.i_span4_horz_l[3]"  output="BLK_TL-PIO_B.o_span4_horz_r[7]"  />
-  <direct name="span4_horz_l[4]"  input="BLK_TL-PIO_B.i_span4_horz_l[4]"  output="BLK_TL-PIO_B.o_span4_horz_r[8]"  />
-  <direct name="span4_horz_l[5]"  input="BLK_TL-PIO_B.i_span4_horz_l[5]"  output="BLK_TL-PIO_B.o_span4_horz_r[9]"  />
-  <direct name="span4_horz_l[6]"  input="BLK_TL-PIO_B.i_span4_horz_l[6]"  output="BLK_TL-PIO_B.o_span4_horz_r[10]" />
-  <direct name="span4_horz_l[7]"  input="BLK_TL-PIO_B.i_span4_horz_l[7]"  output="BLK_TL-PIO_B.o_span4_horz_r[11]" />
-  <direct name="span4_horz_l[8]"  input="BLK_TL-PIO_B.i_span4_horz_l[8]"  output="BLK_TL-PIO_B.o_span4_horz_r[12]" />
-  <direct name="span4_horz_l[9]"  input="BLK_TL-PIO_B.i_span4_horz_l[9]"  output="BLK_TL-PIO_B.o_span4_horz_r[13]" />
-  <direct name="span4_horz_l[10]" input="BLK_TL-PIO_B.i_span4_horz_l[10]" output="BLK_TL-PIO_B.o_span4_horz_r[14]" />
-  <direct name="span4_horz_l[11]" input="BLK_TL-PIO_B.i_span4_horz_l[11]" output="BLK_TL-PIO_B.o_span4_horz_r[15]" />
+  <direct name="span4_horz_l[0]"  input="PIO_B.i_span4_horz_l[0]"  output="PIO_B.o_span4_horz_r[4]"  />
+  <direct name="span4_horz_l[1]"  input="PIO_B.i_span4_horz_l[1]"  output="PIO_B.o_span4_horz_r[5]"  />
+  <direct name="span4_horz_l[2]"  input="PIO_B.i_span4_horz_l[2]"  output="PIO_B.o_span4_horz_r[6]"  />
+  <direct name="span4_horz_l[3]"  input="PIO_B.i_span4_horz_l[3]"  output="PIO_B.o_span4_horz_r[7]"  />
+  <direct name="span4_horz_l[4]"  input="PIO_B.i_span4_horz_l[4]"  output="PIO_B.o_span4_horz_r[8]"  />
+  <direct name="span4_horz_l[5]"  input="PIO_B.i_span4_horz_l[5]"  output="PIO_B.o_span4_horz_r[9]"  />
+  <direct name="span4_horz_l[6]"  input="PIO_B.i_span4_horz_l[6]"  output="PIO_B.o_span4_horz_r[10]" />
+  <direct name="span4_horz_l[7]"  input="PIO_B.i_span4_horz_l[7]"  output="PIO_B.o_span4_horz_r[11]" />
+  <direct name="span4_horz_l[8]"  input="PIO_B.i_span4_horz_l[8]"  output="PIO_B.o_span4_horz_r[12]" />
+  <direct name="span4_horz_l[9]"  input="PIO_B.i_span4_horz_l[9]"  output="PIO_B.o_span4_horz_r[13]" />
+  <direct name="span4_horz_l[10]" input="PIO_B.i_span4_horz_l[10]" output="PIO_B.o_span4_horz_r[14]" />
+  <direct name="span4_horz_l[11]" input="PIO_B.i_span4_horz_l[11]" output="PIO_B.o_span4_horz_r[15]" />
 
   <!--
-  <direct name="span4_horz_l[12]" input="BLK_TL-PIO_B.i_span4_horz_l[12]" output="BLK_TL-PIO_B.o_span4_horz_r[  ]" />
-  <direct name="span4_horz_l[13]" input="BLK_TL-PIO_B.i_span4_horz_l[13]" output="BLK_TL-PIO_B.o_span4_horz_r[  ]" />
-  <direct name="span4_horz_l[14]" input="BLK_TL-PIO_B.i_span4_horz_l[14]" output="BLK_TL-PIO_B.o_span4_horz_r[  ]" />
-  <direct name="span4_horz_l[15]" input="BLK_TL-PIO_B.i_span4_horz_l[15]" output="BLK_TL-PIO_B.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[12]" input="PIO_B.i_span4_horz_l[12]" output="PIO_B.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[13]" input="PIO_B.i_span4_horz_l[13]" output="PIO_B.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[14]" input="PIO_B.i_span4_horz_l[14]" output="PIO_B.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[15]" input="PIO_B.i_span4_horz_l[15]" output="PIO_B.o_span4_horz_r[  ]" />
   -->
 
  </interconnect>
 
  <pinlocations pattern="custom">
   <loc side="left" xoffset="0" yoffset="0">
-   BLK_TL-PIO_B.i_span4_horz_l BLK_TL-PIO_B.o_span4_horz_l
+   PIO_B.i_span4_horz_l PIO_B.o_span4_horz_l
   </loc>
   <loc side="top" xoffset="0" yoffset="0">
-   BLK_TL-PIO_B.i_glb_netwk    BLK_TL-PIO_B.o_glb_netwk
-   BLK_TL-PIO_B.fabout
+   PIO_B.i_glb_netwk    PIO_B.o_glb_netwk
+   PIO_B.fabout
 
-   BLK_TL-PIO_B.i_neigh_op_tnl BLK_TL-PIO_B.o_neigh_op_tnl
-   BLK_TL-PIO_B.i_neigh_op_top BLK_TL-PIO_B.o_neigh_op_top
-   BLK_TL-PIO_B.i_neigh_op_tnr BLK_TL-PIO_B.o_neigh_op_tnr
+   PIO_B.i_neigh_op_tnl PIO_B.o_neigh_op_tnl
+   PIO_B.i_neigh_op_top PIO_B.o_neigh_op_top
+   PIO_B.i_neigh_op_tnr PIO_B.o_neigh_op_tnr
 
-   BLK_TL-PIO_B.i_span4_vert   BLK_TL-PIO_B.o_span4_vert
-   BLK_TL-PIO_B.i_span12_vert  BLK_TL-PIO_B.o_span12_vert
+   PIO_B.i_span4_vert   PIO_B.o_span4_vert
+   PIO_B.i_span12_vert  PIO_B.o_span12_vert
   </loc>
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PIO_B.i_span4_horz_r BLK_TL-PIO_B.o_span4_horz_r
+   PIO_B.i_span4_horz_r PIO_B.o_span4_horz_r
   </loc>
   <loc side="bottom" xoffset="0" yoffset="0">
-   BLK_TL-PIO_B.i_span4_vert   BLK_TL-PIO_B.o_span4_vert
-   BLK_TL-PIO_B.i_span12_vert  BLK_TL-PIO_B.o_span12_vert
+   PIO_B.i_span4_vert   PIO_B.o_span4_vert
+   PIO_B.i_span12_vert  PIO_B.o_span12_vert
   </loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
   <xi:include href="../pio-tb/pio-tb.fc.xml" xpointer="xpointer(fc/child::node())"/>
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/pio-l/pio-l.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-l/pio-l.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO_L" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO_L" xmlns:xi="http://www.w3.org/2001/XInclude">
  <xi:include href="../pio/pio.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  <xi:include href="../pio-lr/pio-lr.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
 
@@ -15,145 +15,149 @@
  <interconnect>
   <xi:include href="../pio/pio.interconnect.xml" xpointer="xpointer(interconnect/child::node())"/>
 
-  <mux name="fabout"          input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[5] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[4] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[6]" output="BLK_TL-PIO_L.fabout" />
+  <mux name="fabout"          input="local_g[0].o[1] local_g[0].o[5] local_g[1].o[0] local_g[1].o[4] local_g[0].o[3] local_g[0].o[7] local_g[1].o[2] local_g[1].o[6]" output="PIO_L.fabout" />
 
-  <mux name="BLK_XX-io_global/i_inclk" input="BLK_TL-PIO_L.i_glb_netwk[0] BLK_TL-PIO_L.i_glb_netwk[1] BLK_TL-PIO_L.i_glb_netwk[4] BLK_TL-PIO_L.i_glb_netwk[5] BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[3] BLK_TL-PIO_L.i_glb_netwk[2] BLK_TL-PIO_L.i_glb_netwk[3] BLK_TL-PIO_L.i_glb_netwk[6] BLK_TL-PIO_L.i_glb_netwk[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[3]" output="BLK_XX-io_global.i_inclk" />
-  <mux name="BLK_XX-io_global/i_outclk" input="BLK_TL-PIO_L.i_glb_netwk[0] BLK_TL-PIO_L.i_glb_netwk[1] BLK_TL-PIO_L.i_glb_netwk[4] BLK_TL-PIO_L.i_glb_netwk[5] BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[4] BLK_TL-PIO_L.i_glb_netwk[2] BLK_TL-PIO_L.i_glb_netwk[3] BLK_TL-PIO_L.i_glb_netwk[6] BLK_TL-PIO_L.i_glb_netwk[7] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[4]" output="BLK_XX-io_global.i_outclk"/>
+  <mux name="io_global/i_inclk" input="PIO_L.i_glb_netwk[0] PIO_L.i_glb_netwk[1] PIO_L.i_glb_netwk[4] PIO_L.i_glb_netwk[5] local_g[0].o[0] local_g[0].o[3] PIO_L.i_glb_netwk[2] PIO_L.i_glb_netwk[3] PIO_L.i_glb_netwk[6] PIO_L.i_glb_netwk[7] local_g[1].o[0] local_g[1].o[3]" output="io_global.i_inclk" />
+  <mux name="io_global/i_outclk" input="PIO_L.i_glb_netwk[0] PIO_L.i_glb_netwk[1] PIO_L.i_glb_netwk[4] PIO_L.i_glb_netwk[5] local_g[0].o[1] local_g[0].o[4] PIO_L.i_glb_netwk[2] PIO_L.i_glb_netwk[3] PIO_L.i_glb_netwk[6] PIO_L.i_glb_netwk[7] local_g[1].o[1] local_g[1].o[4]" output="io_global.i_outclk"/>
 
   <!-- Local Tracks -->
-  <mux name="BLK_XX-local_g[0].i[0]" input="BLK_TL-PIO_L.i_span12_horz[8]    BLK_TL-PIO_L.i_neigh_op_bnr[0]   BLK_TL-PIO_L.i_span4_horz[16]    BLK_TL-PIO_L.i_span12_horz[16]   BLK_TL-PIO_L.i_span4_vert_b[0]   BLK_TL-PIO_L.i_span4_horz[24]    BLK_TL-PIO_L.i_neigh_op_tnr[0]   BLK_TL-PIO_L.i_span4_horz[0]     BLK_TL-PIO_L.i_span4_vert_b[8]   BLK_TL-PIO_L.i_span4_horz[32]    BLK_TL-PIO_L.i_neigh_op_rgt[0]   BLK_TL-PIO_L.i_span4_horz[8]     BLK_TL-PIO_L.i_span12_horz[0]    BLK_TL-PIO_L.i_span4_horz[40]" output="BLK_XX-local_g[0].i[0]" />
-  <mux name="BLK_XX-local_g[0].i[1]" input="BLK_TL-PIO_L.i_neigh_op_tnr[1]   BLK_TL-PIO_L.i_neigh_op_rgt[1]   BLK_TL-PIO_L.i_span12_horz[9]    BLK_TL-PIO_L.i_span12_horz[17]   BLK_TL-PIO_L.i_span4_horz[1]     BLK_TL-PIO_L.i_span4_horz[9]     BLK_TL-PIO_L.i_neigh_op_bnr[1]   BLK_TL-PIO_L.i_span4_vert_b[1]   BLK_TL-PIO_L.i_span4_vert_b[9]   BLK_TL-PIO_L.i_span12_horz[1]    BLK_TL-PIO_L.i_span4_horz[17]    BLK_TL-PIO_L.i_span4_horz[25]    BLK_TL-PIO_L.i_span4_horz[33]    BLK_TL-PIO_L.i_span4_horz[41]" output="BLK_XX-local_g[0].i[1]" />
-  <mux name="BLK_XX-local_g[0].i[2]" input="BLK_TL-PIO_L.i_span12_horz[10]   BLK_TL-PIO_L.i_neigh_op_bnr[2]   BLK_TL-PIO_L.i_span4_horz[18]    BLK_TL-PIO_L.i_span12_horz[18]   BLK_TL-PIO_L.i_span4_vert_b[2]   BLK_TL-PIO_L.i_span4_horz[26]    BLK_TL-PIO_L.i_neigh_op_tnr[2]   BLK_TL-PIO_L.i_span4_horz[2]     BLK_TL-PIO_L.i_span4_vert_b[10]  BLK_TL-PIO_L.i_span4_horz[34]    BLK_TL-PIO_L.i_neigh_op_rgt[2]   BLK_TL-PIO_L.i_span4_horz[10]    BLK_TL-PIO_L.i_span12_horz[2]    BLK_TL-PIO_L.i_span4_horz[42]" output="BLK_XX-local_g[0].i[2]" />
-  <mux name="BLK_XX-local_g[0].i[3]" input="BLK_TL-PIO_L.i_neigh_op_tnr[3]   BLK_TL-PIO_L.i_neigh_op_rgt[3]   BLK_TL-PIO_L.i_span12_horz[11]   BLK_TL-PIO_L.i_span12_horz[19]   BLK_TL-PIO_L.i_span4_horz[3]     BLK_TL-PIO_L.i_span4_horz[11]    BLK_TL-PIO_L.i_neigh_op_bnr[3]   BLK_TL-PIO_L.i_span4_vert_b[3]   BLK_TL-PIO_L.i_span4_vert_b[11]  BLK_TL-PIO_L.i_span12_horz[3]    BLK_TL-PIO_L.i_span4_horz[19]    BLK_TL-PIO_L.i_span4_horz[27]    BLK_TL-PIO_L.i_span4_horz[35]    BLK_TL-PIO_L.i_span4_horz[43]" output="BLK_XX-local_g[0].i[3]" />
-  <mux name="BLK_XX-local_g[0].i[4]" input="BLK_TL-PIO_L.i_span12_horz[12]   BLK_TL-PIO_L.i_neigh_op_bnr[4]   BLK_TL-PIO_L.i_span4_horz[20]    BLK_TL-PIO_L.i_span12_horz[20]   BLK_TL-PIO_L.i_span4_vert_b[4]   BLK_TL-PIO_L.i_span4_horz[28]    BLK_TL-PIO_L.i_neigh_op_tnr[4]   BLK_TL-PIO_L.i_span4_horz[4]     BLK_TL-PIO_L.i_span4_vert_b[12]  BLK_TL-PIO_L.i_span4_horz[36]    BLK_TL-PIO_L.i_neigh_op_rgt[4]   BLK_TL-PIO_L.i_span4_horz[12]    BLK_TL-PIO_L.i_span12_horz[4]    BLK_TL-PIO_L.i_span4_horz[44]" output="BLK_XX-local_g[0].i[4]" />
-  <mux name="BLK_XX-local_g[0].i[5]" input="BLK_TL-PIO_L.i_neigh_op_tnr[5]   BLK_TL-PIO_L.i_neigh_op_rgt[5]   BLK_TL-PIO_L.i_span12_horz[13]   BLK_TL-PIO_L.i_span12_horz[21]   BLK_TL-PIO_L.i_span4_horz[5]     BLK_TL-PIO_L.i_span4_horz[13]    BLK_TL-PIO_L.i_neigh_op_bnr[5]   BLK_TL-PIO_L.i_span4_vert_b[5]   BLK_TL-PIO_L.i_span4_vert_b[13]  BLK_TL-PIO_L.i_span12_horz[5]    BLK_TL-PIO_L.i_span4_horz[21]    BLK_TL-PIO_L.i_span4_horz[29]    BLK_TL-PIO_L.i_span4_horz[37]    BLK_TL-PIO_L.i_span4_horz[45]" output="BLK_XX-local_g[0].i[5]" />
-  <mux name="BLK_XX-local_g[0].i[6]" input="BLK_TL-PIO_L.i_span12_horz[14]   BLK_TL-PIO_L.i_neigh_op_bnr[6]   BLK_TL-PIO_L.i_span4_horz[22]    BLK_TL-PIO_L.i_span12_horz[22]   BLK_TL-PIO_L.i_span4_vert_b[6]   BLK_TL-PIO_L.i_span4_horz[30]    BLK_TL-PIO_L.i_neigh_op_tnr[6]   BLK_TL-PIO_L.i_span4_horz[6]     BLK_TL-PIO_L.i_span4_vert_b[14]  BLK_TL-PIO_L.i_span4_horz[38]    BLK_TL-PIO_L.i_neigh_op_rgt[6]   BLK_TL-PIO_L.i_span4_horz[14]    BLK_TL-PIO_L.i_span12_horz[6]    BLK_TL-PIO_L.i_span4_horz[46]" output="BLK_XX-local_g[0].i[6]" />
-  <mux name="BLK_XX-local_g[0].i[7]" input="BLK_TL-PIO_L.i_neigh_op_tnr[7]   BLK_TL-PIO_L.i_neigh_op_rgt[7]   BLK_TL-PIO_L.i_span12_horz[15]   BLK_TL-PIO_L.i_span12_horz[23]   BLK_TL-PIO_L.i_span4_horz[7]     BLK_TL-PIO_L.i_span4_horz[15]    BLK_TL-PIO_L.i_neigh_op_bnr[7]   BLK_TL-PIO_L.i_span4_vert_b[7]   BLK_TL-PIO_L.i_span4_vert_b[15]  BLK_TL-PIO_L.i_span12_horz[7]    BLK_TL-PIO_L.i_span4_horz[23]    BLK_TL-PIO_L.i_span4_horz[31]    BLK_TL-PIO_L.i_span4_horz[39]    BLK_TL-PIO_L.i_span4_horz[47]" output="BLK_XX-local_g[0].i[7]" />
+  <mux name="local_g[0].i[0]" input="PIO_L.i_span12_horz[8]    PIO_L.i_neigh_op_bnr[0]   PIO_L.i_span4_horz[16]    PIO_L.i_span12_horz[16]   PIO_L.i_span4_vert_b[0]   PIO_L.i_span4_horz[24]    PIO_L.i_neigh_op_tnr[0]   PIO_L.i_span4_horz[0]     PIO_L.i_span4_vert_b[8]   PIO_L.i_span4_horz[32]    PIO_L.i_neigh_op_rgt[0]   PIO_L.i_span4_horz[8]     PIO_L.i_span12_horz[0]    PIO_L.i_span4_horz[40]" output="local_g[0].i[0]" />
+  <mux name="local_g[0].i[1]" input="PIO_L.i_neigh_op_tnr[1]   PIO_L.i_neigh_op_rgt[1]   PIO_L.i_span12_horz[9]    PIO_L.i_span12_horz[17]   PIO_L.i_span4_horz[1]     PIO_L.i_span4_horz[9]     PIO_L.i_neigh_op_bnr[1]   PIO_L.i_span4_vert_b[1]   PIO_L.i_span4_vert_b[9]   PIO_L.i_span12_horz[1]    PIO_L.i_span4_horz[17]    PIO_L.i_span4_horz[25]    PIO_L.i_span4_horz[33]    PIO_L.i_span4_horz[41]" output="local_g[0].i[1]" />
+  <mux name="local_g[0].i[2]" input="PIO_L.i_span12_horz[10]   PIO_L.i_neigh_op_bnr[2]   PIO_L.i_span4_horz[18]    PIO_L.i_span12_horz[18]   PIO_L.i_span4_vert_b[2]   PIO_L.i_span4_horz[26]    PIO_L.i_neigh_op_tnr[2]   PIO_L.i_span4_horz[2]     PIO_L.i_span4_vert_b[10]  PIO_L.i_span4_horz[34]    PIO_L.i_neigh_op_rgt[2]   PIO_L.i_span4_horz[10]    PIO_L.i_span12_horz[2]    PIO_L.i_span4_horz[42]" output="local_g[0].i[2]" />
+  <mux name="local_g[0].i[3]" input="PIO_L.i_neigh_op_tnr[3]   PIO_L.i_neigh_op_rgt[3]   PIO_L.i_span12_horz[11]   PIO_L.i_span12_horz[19]   PIO_L.i_span4_horz[3]     PIO_L.i_span4_horz[11]    PIO_L.i_neigh_op_bnr[3]   PIO_L.i_span4_vert_b[3]   PIO_L.i_span4_vert_b[11]  PIO_L.i_span12_horz[3]    PIO_L.i_span4_horz[19]    PIO_L.i_span4_horz[27]    PIO_L.i_span4_horz[35]    PIO_L.i_span4_horz[43]" output="local_g[0].i[3]" />
+  <mux name="local_g[0].i[4]" input="PIO_L.i_span12_horz[12]   PIO_L.i_neigh_op_bnr[4]   PIO_L.i_span4_horz[20]    PIO_L.i_span12_horz[20]   PIO_L.i_span4_vert_b[4]   PIO_L.i_span4_horz[28]    PIO_L.i_neigh_op_tnr[4]   PIO_L.i_span4_horz[4]     PIO_L.i_span4_vert_b[12]  PIO_L.i_span4_horz[36]    PIO_L.i_neigh_op_rgt[4]   PIO_L.i_span4_horz[12]    PIO_L.i_span12_horz[4]    PIO_L.i_span4_horz[44]" output="local_g[0].i[4]" />
+  <mux name="local_g[0].i[5]" input="PIO_L.i_neigh_op_tnr[5]   PIO_L.i_neigh_op_rgt[5]   PIO_L.i_span12_horz[13]   PIO_L.i_span12_horz[21]   PIO_L.i_span4_horz[5]     PIO_L.i_span4_horz[13]    PIO_L.i_neigh_op_bnr[5]   PIO_L.i_span4_vert_b[5]   PIO_L.i_span4_vert_b[13]  PIO_L.i_span12_horz[5]    PIO_L.i_span4_horz[21]    PIO_L.i_span4_horz[29]    PIO_L.i_span4_horz[37]    PIO_L.i_span4_horz[45]" output="local_g[0].i[5]" />
+  <mux name="local_g[0].i[6]" input="PIO_L.i_span12_horz[14]   PIO_L.i_neigh_op_bnr[6]   PIO_L.i_span4_horz[22]    PIO_L.i_span12_horz[22]   PIO_L.i_span4_vert_b[6]   PIO_L.i_span4_horz[30]    PIO_L.i_neigh_op_tnr[6]   PIO_L.i_span4_horz[6]     PIO_L.i_span4_vert_b[14]  PIO_L.i_span4_horz[38]    PIO_L.i_neigh_op_rgt[6]   PIO_L.i_span4_horz[14]    PIO_L.i_span12_horz[6]    PIO_L.i_span4_horz[46]" output="local_g[0].i[6]" />
+  <mux name="local_g[0].i[7]" input="PIO_L.i_neigh_op_tnr[7]   PIO_L.i_neigh_op_rgt[7]   PIO_L.i_span12_horz[15]   PIO_L.i_span12_horz[23]   PIO_L.i_span4_horz[7]     PIO_L.i_span4_horz[15]    PIO_L.i_neigh_op_bnr[7]   PIO_L.i_span4_vert_b[7]   PIO_L.i_span4_vert_b[15]  PIO_L.i_span12_horz[7]    PIO_L.i_span4_horz[23]    PIO_L.i_span4_horz[31]    PIO_L.i_span4_horz[39]    PIO_L.i_span4_horz[47]" output="local_g[0].i[7]" />
 
 
-  <mux name="BLK_XX-local_g[1].i[0]" input="BLK_TL-PIO_L.i_span12_horz[8]    BLK_TL-PIO_L.i_neigh_op_bnr[0]   BLK_TL-PIO_L.i_span4_horz[16]    BLK_TL-PIO_L.i_span12_horz[16]   BLK_TL-PIO_L.i_span4_vert_b[0]   BLK_TL-PIO_L.i_span4_horz[24]    BLK_TL-PIO_L.i_neigh_op_tnr[0]   BLK_TL-PIO_L.i_span4_horz[0]     BLK_TL-PIO_L.i_span4_vert_b[8]   BLK_TL-PIO_L.i_span4_horz[32]    BLK_TL-PIO_L.i_neigh_op_rgt[0]   BLK_TL-PIO_L.i_span4_horz[8]     BLK_TL-PIO_L.i_span12_horz[0]    BLK_TL-PIO_L.i_span4_horz[40]" output="BLK_XX-local_g[1].i[0]" />
-  <mux name="BLK_XX-local_g[1].i[1]" input="BLK_TL-PIO_L.i_neigh_op_tnr[1]   BLK_TL-PIO_L.i_neigh_op_rgt[1]   BLK_TL-PIO_L.i_span12_horz[9]    BLK_TL-PIO_L.i_span12_horz[17]   BLK_TL-PIO_L.i_span4_horz[1]     BLK_TL-PIO_L.i_span4_horz[9]     BLK_TL-PIO_L.i_neigh_op_bnr[1]   BLK_TL-PIO_L.i_span4_vert_b[1]   BLK_TL-PIO_L.i_span4_vert_b[9]   BLK_TL-PIO_L.i_span12_horz[1]    BLK_TL-PIO_L.i_span4_horz[17]    BLK_TL-PIO_L.i_span4_horz[25]    BLK_TL-PIO_L.i_span4_horz[33]    BLK_TL-PIO_L.i_span4_horz[41]" output="BLK_XX-local_g[1].i[1]" />
-  <mux name="BLK_XX-local_g[1].i[2]" input="BLK_TL-PIO_L.i_span12_horz[10]   BLK_TL-PIO_L.i_neigh_op_bnr[2]   BLK_TL-PIO_L.i_span4_horz[18]    BLK_TL-PIO_L.i_span12_horz[18]   BLK_TL-PIO_L.i_span4_vert_b[2]   BLK_TL-PIO_L.i_span4_horz[26]    BLK_TL-PIO_L.i_neigh_op_tnr[2]   BLK_TL-PIO_L.i_span4_horz[2]     BLK_TL-PIO_L.i_span4_vert_b[10]  BLK_TL-PIO_L.i_span4_horz[34]    BLK_TL-PIO_L.i_neigh_op_rgt[2]   BLK_TL-PIO_L.i_span4_horz[10]    BLK_TL-PIO_L.i_span12_horz[2]    BLK_TL-PIO_L.i_span4_horz[42]" output="BLK_XX-local_g[1].i[2]" />
-  <mux name="BLK_XX-local_g[1].i[3]" input="BLK_TL-PIO_L.i_neigh_op_tnr[3]   BLK_TL-PIO_L.i_neigh_op_rgt[3]   BLK_TL-PIO_L.i_span12_horz[11]   BLK_TL-PIO_L.i_span12_horz[19]   BLK_TL-PIO_L.i_span4_horz[3]     BLK_TL-PIO_L.i_span4_horz[11]    BLK_TL-PIO_L.i_neigh_op_bnr[3]   BLK_TL-PIO_L.i_span4_vert_b[3]   BLK_TL-PIO_L.i_span4_vert_b[11]  BLK_TL-PIO_L.i_span12_horz[3]    BLK_TL-PIO_L.i_span4_horz[19]    BLK_TL-PIO_L.i_span4_horz[27]    BLK_TL-PIO_L.i_span4_horz[35]    BLK_TL-PIO_L.i_span4_horz[43]" output="BLK_XX-local_g[1].i[3]" />
-  <mux name="BLK_XX-local_g[1].i[4]" input="BLK_TL-PIO_L.i_span12_horz[12]   BLK_TL-PIO_L.i_neigh_op_bnr[4]   BLK_TL-PIO_L.i_span4_horz[20]    BLK_TL-PIO_L.i_span12_horz[20]   BLK_TL-PIO_L.i_span4_vert_b[4]   BLK_TL-PIO_L.i_span4_horz[28]    BLK_TL-PIO_L.i_neigh_op_tnr[4]   BLK_TL-PIO_L.i_span4_horz[4]     BLK_TL-PIO_L.i_span4_vert_b[12]  BLK_TL-PIO_L.i_span4_horz[36]    BLK_TL-PIO_L.i_neigh_op_rgt[4]   BLK_TL-PIO_L.i_span4_horz[12]    BLK_TL-PIO_L.i_span12_horz[4]    BLK_TL-PIO_L.i_span4_horz[44]" output="BLK_XX-local_g[1].i[4]" />
-  <mux name="BLK_XX-local_g[1].i[5]" input="BLK_TL-PIO_L.i_neigh_op_tnr[5]   BLK_TL-PIO_L.i_neigh_op_rgt[5]   BLK_TL-PIO_L.i_span12_horz[13]   BLK_TL-PIO_L.i_span12_horz[21]   BLK_TL-PIO_L.i_span4_horz[5]     BLK_TL-PIO_L.i_span4_horz[13]    BLK_TL-PIO_L.i_neigh_op_bnr[5]   BLK_TL-PIO_L.i_span4_vert_b[5]   BLK_TL-PIO_L.i_span4_vert_b[13]  BLK_TL-PIO_L.i_span12_horz[5]    BLK_TL-PIO_L.i_span4_horz[21]    BLK_TL-PIO_L.i_span4_horz[29]    BLK_TL-PIO_L.i_span4_horz[37]    BLK_TL-PIO_L.i_span4_horz[45]" output="BLK_XX-local_g[1].i[5]" />
-  <mux name="BLK_XX-local_g[1].i[6]" input="BLK_TL-PIO_L.i_span12_horz[14]   BLK_TL-PIO_L.i_neigh_op_bnr[6]   BLK_TL-PIO_L.i_span4_horz[22]    BLK_TL-PIO_L.i_span12_horz[22]   BLK_TL-PIO_L.i_span4_vert_b[6]   BLK_TL-PIO_L.i_span4_horz[30]    BLK_TL-PIO_L.i_neigh_op_tnr[6]   BLK_TL-PIO_L.i_span4_horz[6]     BLK_TL-PIO_L.i_span4_vert_b[14]  BLK_TL-PIO_L.i_span4_horz[38]    BLK_TL-PIO_L.i_neigh_op_rgt[6]   BLK_TL-PIO_L.i_span4_horz[14]    BLK_TL-PIO_L.i_span12_horz[6]    BLK_TL-PIO_L.i_span4_horz[46]" output="BLK_XX-local_g[1].i[6]" />
-  <mux name="BLK_XX-local_g[1].i[7]" input="BLK_TL-PIO_L.i_neigh_op_tnr[7]   BLK_TL-PIO_L.i_neigh_op_rgt[7]   BLK_TL-PIO_L.i_span12_horz[15]   BLK_TL-PIO_L.i_span12_horz[23]   BLK_TL-PIO_L.i_span4_horz[7]     BLK_TL-PIO_L.i_span4_horz[15]    BLK_TL-PIO_L.i_neigh_op_bnr[7]   BLK_TL-PIO_L.i_span4_vert_b[7]   BLK_TL-PIO_L.i_span4_vert_b[15]  BLK_TL-PIO_L.i_span12_horz[7]    BLK_TL-PIO_L.i_span4_horz[23]    BLK_TL-PIO_L.i_span4_horz[31]    BLK_TL-PIO_L.i_span4_horz[39]    BLK_TL-PIO_L.i_span4_horz[47]" output="BLK_XX-local_g[1].i[7]" />
+  <mux name="local_g[1].i[0]" input="PIO_L.i_span12_horz[8]    PIO_L.i_neigh_op_bnr[0]   PIO_L.i_span4_horz[16]    PIO_L.i_span12_horz[16]   PIO_L.i_span4_vert_b[0]   PIO_L.i_span4_horz[24]    PIO_L.i_neigh_op_tnr[0]   PIO_L.i_span4_horz[0]     PIO_L.i_span4_vert_b[8]   PIO_L.i_span4_horz[32]    PIO_L.i_neigh_op_rgt[0]   PIO_L.i_span4_horz[8]     PIO_L.i_span12_horz[0]    PIO_L.i_span4_horz[40]" output="local_g[1].i[0]" />
+  <mux name="local_g[1].i[1]" input="PIO_L.i_neigh_op_tnr[1]   PIO_L.i_neigh_op_rgt[1]   PIO_L.i_span12_horz[9]    PIO_L.i_span12_horz[17]   PIO_L.i_span4_horz[1]     PIO_L.i_span4_horz[9]     PIO_L.i_neigh_op_bnr[1]   PIO_L.i_span4_vert_b[1]   PIO_L.i_span4_vert_b[9]   PIO_L.i_span12_horz[1]    PIO_L.i_span4_horz[17]    PIO_L.i_span4_horz[25]    PIO_L.i_span4_horz[33]    PIO_L.i_span4_horz[41]" output="local_g[1].i[1]" />
+  <mux name="local_g[1].i[2]" input="PIO_L.i_span12_horz[10]   PIO_L.i_neigh_op_bnr[2]   PIO_L.i_span4_horz[18]    PIO_L.i_span12_horz[18]   PIO_L.i_span4_vert_b[2]   PIO_L.i_span4_horz[26]    PIO_L.i_neigh_op_tnr[2]   PIO_L.i_span4_horz[2]     PIO_L.i_span4_vert_b[10]  PIO_L.i_span4_horz[34]    PIO_L.i_neigh_op_rgt[2]   PIO_L.i_span4_horz[10]    PIO_L.i_span12_horz[2]    PIO_L.i_span4_horz[42]" output="local_g[1].i[2]" />
+  <mux name="local_g[1].i[3]" input="PIO_L.i_neigh_op_tnr[3]   PIO_L.i_neigh_op_rgt[3]   PIO_L.i_span12_horz[11]   PIO_L.i_span12_horz[19]   PIO_L.i_span4_horz[3]     PIO_L.i_span4_horz[11]    PIO_L.i_neigh_op_bnr[3]   PIO_L.i_span4_vert_b[3]   PIO_L.i_span4_vert_b[11]  PIO_L.i_span12_horz[3]    PIO_L.i_span4_horz[19]    PIO_L.i_span4_horz[27]    PIO_L.i_span4_horz[35]    PIO_L.i_span4_horz[43]" output="local_g[1].i[3]" />
+  <mux name="local_g[1].i[4]" input="PIO_L.i_span12_horz[12]   PIO_L.i_neigh_op_bnr[4]   PIO_L.i_span4_horz[20]    PIO_L.i_span12_horz[20]   PIO_L.i_span4_vert_b[4]   PIO_L.i_span4_horz[28]    PIO_L.i_neigh_op_tnr[4]   PIO_L.i_span4_horz[4]     PIO_L.i_span4_vert_b[12]  PIO_L.i_span4_horz[36]    PIO_L.i_neigh_op_rgt[4]   PIO_L.i_span4_horz[12]    PIO_L.i_span12_horz[4]    PIO_L.i_span4_horz[44]" output="local_g[1].i[4]" />
+  <mux name="local_g[1].i[5]" input="PIO_L.i_neigh_op_tnr[5]   PIO_L.i_neigh_op_rgt[5]   PIO_L.i_span12_horz[13]   PIO_L.i_span12_horz[21]   PIO_L.i_span4_horz[5]     PIO_L.i_span4_horz[13]    PIO_L.i_neigh_op_bnr[5]   PIO_L.i_span4_vert_b[5]   PIO_L.i_span4_vert_b[13]  PIO_L.i_span12_horz[5]    PIO_L.i_span4_horz[21]    PIO_L.i_span4_horz[29]    PIO_L.i_span4_horz[37]    PIO_L.i_span4_horz[45]" output="local_g[1].i[5]" />
+  <mux name="local_g[1].i[6]" input="PIO_L.i_span12_horz[14]   PIO_L.i_neigh_op_bnr[6]   PIO_L.i_span4_horz[22]    PIO_L.i_span12_horz[22]   PIO_L.i_span4_vert_b[6]   PIO_L.i_span4_horz[30]    PIO_L.i_neigh_op_tnr[6]   PIO_L.i_span4_horz[6]     PIO_L.i_span4_vert_b[14]  PIO_L.i_span4_horz[38]    PIO_L.i_neigh_op_rgt[6]   PIO_L.i_span4_horz[14]    PIO_L.i_span12_horz[6]    PIO_L.i_span4_horz[46]" output="local_g[1].i[6]" />
+  <mux name="local_g[1].i[7]" input="PIO_L.i_neigh_op_tnr[7]   PIO_L.i_neigh_op_rgt[7]   PIO_L.i_span12_horz[15]   PIO_L.i_span12_horz[23]   PIO_L.i_span4_horz[7]     PIO_L.i_span4_horz[15]    PIO_L.i_neigh_op_bnr[7]   PIO_L.i_span4_vert_b[7]   PIO_L.i_span4_vert_b[15]  PIO_L.i_span12_horz[7]    PIO_L.i_span4_horz[23]    PIO_L.i_span4_horz[31]    PIO_L.i_span4_horz[39]    PIO_L.i_span4_horz[47]" output="local_g[1].i[7]" />
 
   <!-- D_IN -> Span4 Vert B -->
-  <mux name="span4_vert_b[0]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[0]"  />
-  <mux name="span4_vert_b[1]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[1]"  />
-  <mux name="span4_vert_b[10]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[10]" />
-  <mux name="span4_vert_b[11]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[11]" />
-  <mux name="span4_vert_b[12]" input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[12]" />
-  <mux name="span4_vert_b[13]" input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[13]" />
-  <mux name="span4_vert_b[14]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[14]" />
-  <mux name="span4_vert_b[15]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[15]" />
-  <mux name="span4_vert_b[2]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[2]"  />
-  <mux name="span4_vert_b[3]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[3]"  />
-  <mux name="span4_vert_b[4]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[4]"  />
-  <mux name="span4_vert_b[5]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[5]"  />
-  <mux name="span4_vert_b[6]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[6]"  />
-  <mux name="span4_vert_b[7]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[7]"  />
-  <mux name="span4_vert_b[8]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_vert_b[8]"  />
-  <mux name="span4_vert_b[9]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_vert_b[9]"  />
+  <mux name="span4_vert_b[0]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_vert_b[0]"  />
+  <mux name="span4_vert_b[1]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_vert_b[1]"  />
+  <mux name="span4_vert_b[10]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_vert_b[10]" />
+  <mux name="span4_vert_b[11]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_vert_b[11]" />
+  <mux name="span4_vert_b[12]" input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_vert_b[12]" />
+  <mux name="span4_vert_b[13]" input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_vert_b[13]" />
+  <mux name="span4_vert_b[14]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_vert_b[14]" />
+  <mux name="span4_vert_b[15]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_vert_b[15]" />
+  <mux name="span4_vert_b[2]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_vert_b[2]"  />
+  <mux name="span4_vert_b[3]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_vert_b[3]"  />
+  <mux name="span4_vert_b[4]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_vert_b[4]"  />
+  <mux name="span4_vert_b[5]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_vert_b[5]"  />
+  <mux name="span4_vert_b[6]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_vert_b[6]"  />
+  <mux name="span4_vert_b[7]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_vert_b[7]"  />
+  <mux name="span4_vert_b[8]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_vert_b[8]"  />
+  <mux name="span4_vert_b[9]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_vert_b[9]"  />
 
   <!-- D_IN -> Span4 Horz -->
-  <mux name="span4_horz[0]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[0]"    />
-  <mux name="span4_horz[10]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[10]"   />
-  <mux name="span4_horz[12]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[12]"   />
-  <mux name="span4_horz[14]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[14]"   />
-  <mux name="span4_horz[16]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[16]"   />
-  <mux name="span4_horz[18]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[18]"   />
-  <mux name="span4_horz[2]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[2]"    />
-  <mux name="span4_horz[20]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[20]"   />
-  <mux name="span4_horz[22]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[22]"   />
-  <mux name="span4_horz[24]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[24]"   />
-  <mux name="span4_horz[26]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[26]"   />
-  <mux name="span4_horz[28]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[28]"   />
-  <mux name="span4_horz[30]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[30]"   />
-  <mux name="span4_horz[32]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[32]"   />
-  <mux name="span4_horz[34]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[34]"   />
-  <mux name="span4_horz[36]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[36]"   />
-  <mux name="span4_horz[38]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[38]"   />
-  <mux name="span4_horz[4]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[4]"    />
-  <mux name="span4_horz[40]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[40]"   />
-  <mux name="span4_horz[42]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[42]"   />
-  <mux name="span4_horz[44]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[44]"   />
-  <mux name="span4_horz[46]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[46]"   />
-  <mux name="span4_horz[6]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span4_horz[6]"    />
-  <mux name="span4_horz[8]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span4_horz[8]"    />
+  <mux name="span4_horz[0]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_horz[0]"    />
+  <mux name="span4_horz[10]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_horz[10]"   />
+  <mux name="span4_horz[12]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_horz[12]"   />
+  <mux name="span4_horz[14]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_horz[14]"   />
+  <mux name="span4_horz[16]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_horz[16]"   />
+  <mux name="span4_horz[18]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_horz[18]"   />
+  <mux name="span4_horz[2]"    input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_horz[2]"    />
+  <mux name="span4_horz[20]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_horz[20]"   />
+  <mux name="span4_horz[22]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_horz[22]"   />
+  <mux name="span4_horz[24]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_horz[24]"   />
+  <mux name="span4_horz[26]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_horz[26]"   />
+  <mux name="span4_horz[28]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_horz[28]"   />
+  <mux name="span4_horz[30]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_horz[30]"   />
+  <mux name="span4_horz[32]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_horz[32]"   />
+  <mux name="span4_horz[34]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_horz[34]"   />
+  <mux name="span4_horz[36]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_horz[36]"   />
+  <mux name="span4_horz[38]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_horz[38]"   />
+  <mux name="span4_horz[4]"    input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_horz[4]"    />
+  <mux name="span4_horz[40]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_horz[40]"   />
+  <mux name="span4_horz[42]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span4_horz[42]"   />
+  <mux name="span4_horz[44]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span4_horz[44]"   />
+  <mux name="span4_horz[46]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_horz[46]"   />
+  <mux name="span4_horz[6]"    input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span4_horz[6]"    />
+  <mux name="span4_horz[8]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span4_horz[8]"    />
 
   <!-- D_IN -> Span12 Horz -->
-  <mux name="span12_horz[0]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span12_horz[0]"   />
-  <mux name="span12_horz[10]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span12_horz[10]"  />
-  <mux name="span12_horz[12]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span12_horz[12]"  />
-  <mux name="span12_horz[14]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span12_horz[14]"  />
-  <mux name="span12_horz[16]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span12_horz[16]"  />
-  <mux name="span12_horz[18]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span12_horz[18]"  />
-  <mux name="span12_horz[2]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_L.o_span12_horz[2]"   />
-  <mux name="span12_horz[20]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span12_horz[20]"  />
-  <mux name="span12_horz[22]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span12_horz[22]"  />
-  <mux name="span12_horz[4]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_L.o_span12_horz[4]"   />
-  <mux name="span12_horz[6]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_L.o_span12_horz[6]"   />
-  <mux name="span12_horz[8]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_L.o_span12_horz[8]"   />
+  <mux name="span12_horz[0]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span12_horz[0]"   />
+  <mux name="span12_horz[10]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span12_horz[10]"  />
+  <mux name="span12_horz[12]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span12_horz[12]"  />
+  <mux name="span12_horz[14]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span12_horz[14]"  />
+  <mux name="span12_horz[16]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span12_horz[16]"  />
+  <mux name="span12_horz[18]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span12_horz[18]"  />
+  <mux name="span12_horz[2]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_L.o_span12_horz[2]"   />
+  <mux name="span12_horz[20]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span12_horz[20]"  />
+  <mux name="span12_horz[22]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span12_horz[22]"  />
+  <mux name="span12_horz[4]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_L.o_span12_horz[4]"   />
+  <mux name="span12_horz[6]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_L.o_span12_horz[6]"   />
+  <mux name="span12_horz[8]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_L.o_span12_horz[8]"   />
 
   <!-- Spans -->
   <!--
-  <direct name="span4_vert_b[0]"  input="BLK_TL-PIO_L.i_span4_vert_t[ ]" output="BLK_TL-PIO_L.o_span4_vert_b[0]" />
-  <direct name="span4_vert_b[1]"  input="BLK_TL-PIO_L.i_span4_vert_t[ ]" output="BLK_TL-PIO_L.o_span4_vert_b[1]" />
-  <direct name="span4_vert_b[2]"  input="BLK_TL-PIO_L.i_span4_vert_t[ ]" output="BLK_TL-PIO_L.o_span4_vert_b[2]" />
-  <direct name="span4_vert_b[3]"  input="BLK_TL-PIO_L.i_span4_vert_t[ ]" output="BLK_TL-PIO_L.o_span4_vert_b[3]" />
+  <direct name="span4_vert_b[0]"  input="PIO_L.i_span4_vert_t[ ]" output="PIO_L.o_span4_vert_b[0]" />
+  <direct name="span4_vert_b[1]"  input="PIO_L.i_span4_vert_t[ ]" output="PIO_L.o_span4_vert_b[1]" />
+  <direct name="span4_vert_b[2]"  input="PIO_L.i_span4_vert_t[ ]" output="PIO_L.o_span4_vert_b[2]" />
+  <direct name="span4_vert_b[3]"  input="PIO_L.i_span4_vert_t[ ]" output="PIO_L.o_span4_vert_b[3]" />
   -->
 
-  <direct name="span4_vert_t[0]"  input="BLK_TL-PIO_L.i_span4_vert_t[0]"  output="BLK_TL-PIO_L.o_span4_vert_b[4]"  />
-  <direct name="span4_vert_t[1]"  input="BLK_TL-PIO_L.i_span4_vert_t[1]"  output="BLK_TL-PIO_L.o_span4_vert_b[5]"  />
-  <direct name="span4_vert_t[2]"  input="BLK_TL-PIO_L.i_span4_vert_t[2]"  output="BLK_TL-PIO_L.o_span4_vert_b[6]"  />
-  <direct name="span4_vert_t[3]"  input="BLK_TL-PIO_L.i_span4_vert_t[3]"  output="BLK_TL-PIO_L.o_span4_vert_b[7]"  />
-  <direct name="span4_vert_t[4]"  input="BLK_TL-PIO_L.i_span4_vert_t[4]"  output="BLK_TL-PIO_L.o_span4_vert_b[8]"  />
-  <direct name="span4_vert_t[5]"  input="BLK_TL-PIO_L.i_span4_vert_t[5]"  output="BLK_TL-PIO_L.o_span4_vert_b[9]"  />
-  <direct name="span4_vert_t[6]"  input="BLK_TL-PIO_L.i_span4_vert_t[6]"  output="BLK_TL-PIO_L.o_span4_vert_b[10]" />
-  <direct name="span4_vert_t[7]"  input="BLK_TL-PIO_L.i_span4_vert_t[7]"  output="BLK_TL-PIO_L.o_span4_vert_b[11]" />
-  <direct name="span4_vert_t[8]"  input="BLK_TL-PIO_L.i_span4_vert_t[8]"  output="BLK_TL-PIO_L.o_span4_vert_b[12]" />
-  <direct name="span4_vert_t[9]"  input="BLK_TL-PIO_L.i_span4_vert_t[9]"  output="BLK_TL-PIO_L.o_span4_vert_b[13]" />
-  <direct name="span4_vert_t[10]" input="BLK_TL-PIO_L.i_span4_vert_t[10]" output="BLK_TL-PIO_L.o_span4_vert_b[14]" />
-  <direct name="span4_vert_t[11]" input="BLK_TL-PIO_L.i_span4_vert_t[11]" output="BLK_TL-PIO_L.o_span4_vert_b[15]" />
+  <direct name="span4_vert_t[0]"  input="PIO_L.i_span4_vert_t[0]"  output="PIO_L.o_span4_vert_b[4]"  />
+  <direct name="span4_vert_t[1]"  input="PIO_L.i_span4_vert_t[1]"  output="PIO_L.o_span4_vert_b[5]"  />
+  <direct name="span4_vert_t[2]"  input="PIO_L.i_span4_vert_t[2]"  output="PIO_L.o_span4_vert_b[6]"  />
+  <direct name="span4_vert_t[3]"  input="PIO_L.i_span4_vert_t[3]"  output="PIO_L.o_span4_vert_b[7]"  />
+  <direct name="span4_vert_t[4]"  input="PIO_L.i_span4_vert_t[4]"  output="PIO_L.o_span4_vert_b[8]"  />
+  <direct name="span4_vert_t[5]"  input="PIO_L.i_span4_vert_t[5]"  output="PIO_L.o_span4_vert_b[9]"  />
+  <direct name="span4_vert_t[6]"  input="PIO_L.i_span4_vert_t[6]"  output="PIO_L.o_span4_vert_b[10]" />
+  <direct name="span4_vert_t[7]"  input="PIO_L.i_span4_vert_t[7]"  output="PIO_L.o_span4_vert_b[11]" />
+  <direct name="span4_vert_t[8]"  input="PIO_L.i_span4_vert_t[8]"  output="PIO_L.o_span4_vert_b[12]" />
+  <direct name="span4_vert_t[9]"  input="PIO_L.i_span4_vert_t[9]"  output="PIO_L.o_span4_vert_b[13]" />
+  <direct name="span4_vert_t[10]" input="PIO_L.i_span4_vert_t[10]" output="PIO_L.o_span4_vert_b[14]" />
+  <direct name="span4_vert_t[11]" input="PIO_L.i_span4_vert_t[11]" output="PIO_L.o_span4_vert_b[15]" />
 
   <!--
-  <direct name="span4_vert_t[12]" input="BLK_TL-PIO_L.i_span4_vert_t[12]" output="BLK_TL-PIO_L.o_span4_vert_b[  ]" />
-  <direct name="span4_vert_t[13]" input="BLK_TL-PIO_L.i_span4_vert_t[13]" output="BLK_TL-PIO_L.o_span4_vert_b[  ]" />
-  <direct name="span4_vert_t[14]" input="BLK_TL-PIO_L.i_span4_vert_t[14]" output="BLK_TL-PIO_L.o_span4_vert_b[  ]" />
-  <direct name="span4_vert_t[15]" input="BLK_TL-PIO_L.i_span4_vert_t[15]" output="BLK_TL-PIO_L.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[12]" input="PIO_L.i_span4_vert_t[12]" output="PIO_L.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[13]" input="PIO_L.i_span4_vert_t[13]" output="PIO_L.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[14]" input="PIO_L.i_span4_vert_t[14]" output="PIO_L.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[15]" input="PIO_L.i_span4_vert_t[15]" output="PIO_L.o_span4_vert_b[  ]" />
   -->
 
  </interconnect>
 
  <pinlocations pattern="custom">
   <loc side="left" xoffset="0" yoffset="0">
-   BLK_TL-PIO_L.i_neigh_op_tnr BLK_TL-PIO_L.o_neigh_op_tnr
-   BLK_TL-PIO_L.i_neigh_op_rgt BLK_TL-PIO_L.o_neigh_op_rgt
-   BLK_TL-PIO_L.i_neigh_op_bnr BLK_TL-PIO_L.o_neigh_op_bnr
+   PIO_L.i_neigh_op_tnr PIO_L.o_neigh_op_tnr
+   PIO_L.i_neigh_op_rgt PIO_L.o_neigh_op_rgt
+   PIO_L.i_neigh_op_bnr PIO_L.o_neigh_op_bnr
 
-   BLK_TL-PIO_L.i_span4_horz   BLK_TL-PIO_L.o_span4_horz
-   BLK_TL-PIO_L.i_span12_horz  BLK_TL-PIO_L.o_span12_horz
+   PIO_L.i_span4_horz   PIO_L.o_span4_horz
+   PIO_L.i_span12_horz  PIO_L.o_span12_horz
   </loc>
   <loc side="top" xoffset="0" yoffset="0">
-   BLK_TL-PIO_L.i_glb_netwk    BLK_TL-PIO_L.o_glb_netwk
-   BLK_TL-PIO_L.fabout
+   PIO_L.i_glb_netwk    PIO_L.o_glb_netwk
+   PIO_L.fabout
 
-   BLK_TL-PIO_L.i_span4_vert_t BLK_TL-PIO_L.o_span4_vert_t
+   PIO_L.i_span4_vert_t PIO_L.o_span4_vert_t
   </loc>
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PIO_L.i_span4_horz   BLK_TL-PIO_L.o_span4_horz
-   BLK_TL-PIO_L.i_span12_horz  BLK_TL-PIO_L.o_span12_horz
+   PIO_L.i_span4_horz   PIO_L.o_span4_horz
+   PIO_L.i_span12_horz  PIO_L.o_span12_horz
   </loc>
   <loc side="bottom" xoffset="0" yoffset="0">
-   BLK_TL-PIO_L.i_span4_vert_b  BLK_TL-PIO_L.o_span4_vert_b
+   PIO_L.i_span4_vert_b  PIO_L.o_span4_vert_b
   </loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
   <xi:include href="../pio-lr/pio-lr.fc.xml" xpointer="xpointer(fc/child::node())"/>
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/pio-lr/pio-lr.interconnect.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-lr/pio-lr.interconnect.xml
@@ -1,11 +1,11 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <interconnect xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- Fabric Span wires -->
- <direct name="span4_vert"  input="BLK_TL-PLR_LR.i_span4_vert"  output="BLK_TL-PLR_LR.o_span4_vert" />
- <direct name="span12_vert" input="BLK_TL-PLR_LR.i_span12_vert" output="BLK_TL-PLR_LR.o_span12_vert" />
+ <direct name="span4_vert"  input="PLR_LR.i_span4_vert"  output="PLR_LR.o_span4_vert" />
+ <direct name="span12_vert" input="PLR_LR.i_span12_vert" output="PLR_LR.o_span12_vert" />
 
  <!-- IO Span wires -->
- <direct name="span4_horz_l" input="BLK_TL-PLR_LR.i_span4_horz_l" output="BLK_TL-PLR_LR.o_span4_horz_l" />
- <direct name="span4_horz_r" input="BLK_TL-PLR_LR.i_span4_horz_r" output="BLK_TL-PLR_LR.o_span4_horz_r" />
+ <direct name="span4_horz_l" input="PLR_LR.i_span4_horz_l" output="PLR_LR.o_span4_horz_l" />
+ <direct name="span4_horz_r" input="PLR_LR.i_span4_horz_r" output="PLR_LR.o_span4_horz_r" />
 
 </interconnect>

--- a/ice40/devices/tile-routing-virt/tiles/pio-lr/pio-lr.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-lr/pio-lr.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO_LR" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO_LR" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <!-- Horizontal spans ############################################### -->
  <!-- Span-4 Horizontal -->
@@ -17,4 +17,8 @@
  <input  name="i_span4_vert_b" num_pins="16"/>
  <output name="o_span4_vert_b" num_pins="16"/>
 
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/pio-r/pio-r.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-r/pio-r.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO_R" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO_R" xmlns:xi="http://www.w3.org/2001/XInclude">
  <xi:include href="../pio/pio.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  <xi:include href="../pio-lr/pio-lr.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
 
@@ -15,145 +15,149 @@
  <interconnect>
   <xi:include href="../pio/pio.interconnect.xml" xpointer="xpointer(interconnect/child::node())"/>
 
-  <mux name="fabout"          input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[5] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[4] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[6]" output="BLK_TL-PIO_R.fabout" />
+  <mux name="fabout"          input="local_g[0].o[1] local_g[0].o[5] local_g[1].o[0] local_g[1].o[4] local_g[0].o[3] local_g[0].o[7] local_g[1].o[2] local_g[1].o[6]" output="PIO_R.fabout" />
 
-  <mux name="BLK_XX-io_global/i_inclk" input="BLK_TL-PIO_R.i_glb_netwk[0] BLK_TL-PIO_R.i_glb_netwk[1] BLK_TL-PIO_R.i_glb_netwk[4] BLK_TL-PIO_R.i_glb_netwk[5] BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[3] BLK_TL-PIO_R.i_glb_netwk[2] BLK_TL-PIO_R.i_glb_netwk[3] BLK_TL-PIO_R.i_glb_netwk[6] BLK_TL-PIO_R.i_glb_netwk[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[3]" output="BLK_XX-io_global.i_inclk" />
-  <mux name="BLK_XX-io_global/i_outclk" input="BLK_TL-PIO_R.i_glb_netwk[0] BLK_TL-PIO_R.i_glb_netwk[1] BLK_TL-PIO_R.i_glb_netwk[4] BLK_TL-PIO_R.i_glb_netwk[5] BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[4] BLK_TL-PIO_R.i_glb_netwk[2] BLK_TL-PIO_R.i_glb_netwk[3] BLK_TL-PIO_R.i_glb_netwk[6] BLK_TL-PIO_R.i_glb_netwk[7] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[4]" output="BLK_XX-io_global.i_outclk"/>
+  <mux name="io_global/i_inclk" input="PIO_R.i_glb_netwk[0] PIO_R.i_glb_netwk[1] PIO_R.i_glb_netwk[4] PIO_R.i_glb_netwk[5] local_g[0].o[0] local_g[0].o[3] PIO_R.i_glb_netwk[2] PIO_R.i_glb_netwk[3] PIO_R.i_glb_netwk[6] PIO_R.i_glb_netwk[7] local_g[1].o[0] local_g[1].o[3]" output="io_global.i_inclk" />
+  <mux name="io_global/i_outclk" input="PIO_R.i_glb_netwk[0] PIO_R.i_glb_netwk[1] PIO_R.i_glb_netwk[4] PIO_R.i_glb_netwk[5] local_g[0].o[1] local_g[0].o[4] PIO_R.i_glb_netwk[2] PIO_R.i_glb_netwk[3] PIO_R.i_glb_netwk[6] PIO_R.i_glb_netwk[7] local_g[1].o[1] local_g[1].o[4]" output="io_global.i_outclk"/>
 
   <!-- Local Tracks -->
-  <mux name="BLK_XX-local_g[0].i[0]" input="BLK_TL-PIO_R.i_span12_horz[8]    BLK_TL-PIO_R.i_neigh_op_bnl[0]   BLK_TL-PIO_R.i_span4_horz[16]    BLK_TL-PIO_R.i_span12_horz[16]   BLK_TL-PIO_R.i_span4_vert_b[0]   BLK_TL-PIO_R.i_span4_horz[24]    BLK_TL-PIO_R.i_neigh_op_tnl[0]   BLK_TL-PIO_R.i_span4_horz[0]     BLK_TL-PIO_R.i_span4_vert_b[8]   BLK_TL-PIO_R.i_span4_horz[32]    BLK_TL-PIO_R.i_neigh_op_lft[0]   BLK_TL-PIO_R.i_span4_horz[8]     BLK_TL-PIO_R.i_span12_horz[0]    BLK_TL-PIO_R.i_span4_horz[40]" output="BLK_XX-local_g[0].i[0]" />
-  <mux name="BLK_XX-local_g[0].i[1]" input="BLK_TL-PIO_R.i_neigh_op_tnl[1]   BLK_TL-PIO_R.i_neigh_op_lft[1]   BLK_TL-PIO_R.i_span12_horz[9]    BLK_TL-PIO_R.i_span12_horz[17]   BLK_TL-PIO_R.i_span4_horz[1]     BLK_TL-PIO_R.i_span4_horz[9]     BLK_TL-PIO_R.i_neigh_op_bnl[1]   BLK_TL-PIO_R.i_span4_vert_b[1]   BLK_TL-PIO_R.i_span4_vert_b[9]   BLK_TL-PIO_R.i_span12_horz[1]    BLK_TL-PIO_R.i_span4_horz[17]    BLK_TL-PIO_R.i_span4_horz[25]    BLK_TL-PIO_R.i_span4_horz[33]    BLK_TL-PIO_R.i_span4_horz[41]" output="BLK_XX-local_g[0].i[1]" />
-  <mux name="BLK_XX-local_g[0].i[2]" input="BLK_TL-PIO_R.i_span12_horz[10]   BLK_TL-PIO_R.i_neigh_op_bnl[2]   BLK_TL-PIO_R.i_span4_horz[18]    BLK_TL-PIO_R.i_span12_horz[18]   BLK_TL-PIO_R.i_span4_vert_b[2]   BLK_TL-PIO_R.i_span4_horz[26]    BLK_TL-PIO_R.i_neigh_op_tnl[2]   BLK_TL-PIO_R.i_span4_horz[2]     BLK_TL-PIO_R.i_span4_vert_b[10]  BLK_TL-PIO_R.i_span4_horz[34]    BLK_TL-PIO_R.i_neigh_op_lft[2]   BLK_TL-PIO_R.i_span4_horz[10]    BLK_TL-PIO_R.i_span12_horz[2]    BLK_TL-PIO_R.i_span4_horz[42]" output="BLK_XX-local_g[0].i[2]" />
-  <mux name="BLK_XX-local_g[0].i[3]" input="BLK_TL-PIO_R.i_neigh_op_tnl[3]   BLK_TL-PIO_R.i_neigh_op_lft[3]   BLK_TL-PIO_R.i_span12_horz[11]   BLK_TL-PIO_R.i_span12_horz[19]   BLK_TL-PIO_R.i_span4_horz[3]     BLK_TL-PIO_R.i_span4_horz[11]    BLK_TL-PIO_R.i_neigh_op_bnl[3]   BLK_TL-PIO_R.i_span4_vert_b[3]   BLK_TL-PIO_R.i_span4_vert_b[11]  BLK_TL-PIO_R.i_span12_horz[3]    BLK_TL-PIO_R.i_span4_horz[19]    BLK_TL-PIO_R.i_span4_horz[27]    BLK_TL-PIO_R.i_span4_horz[35]    BLK_TL-PIO_R.i_span4_horz[43]" output="BLK_XX-local_g[0].i[3]" />
-  <mux name="BLK_XX-local_g[0].i[4]" input="BLK_TL-PIO_R.i_span12_horz[12]   BLK_TL-PIO_R.i_neigh_op_bnl[4]   BLK_TL-PIO_R.i_span4_horz[20]    BLK_TL-PIO_R.i_span12_horz[20]   BLK_TL-PIO_R.i_span4_vert_b[4]   BLK_TL-PIO_R.i_span4_horz[28]    BLK_TL-PIO_R.i_neigh_op_tnl[4]   BLK_TL-PIO_R.i_span4_horz[4]     BLK_TL-PIO_R.i_span4_vert_b[12]  BLK_TL-PIO_R.i_span4_horz[36]    BLK_TL-PIO_R.i_neigh_op_lft[4]   BLK_TL-PIO_R.i_span4_horz[12]    BLK_TL-PIO_R.i_span12_horz[4]    BLK_TL-PIO_R.i_span4_horz[44]" output="BLK_XX-local_g[0].i[4]" />
-  <mux name="BLK_XX-local_g[0].i[5]" input="BLK_TL-PIO_R.i_neigh_op_tnl[5]   BLK_TL-PIO_R.i_neigh_op_lft[5]   BLK_TL-PIO_R.i_span12_horz[13]   BLK_TL-PIO_R.i_span12_horz[21]   BLK_TL-PIO_R.i_span4_horz[5]     BLK_TL-PIO_R.i_span4_horz[13]    BLK_TL-PIO_R.i_neigh_op_bnl[5]   BLK_TL-PIO_R.i_span4_vert_b[5]   BLK_TL-PIO_R.i_span4_vert_b[13]  BLK_TL-PIO_R.i_span12_horz[5]    BLK_TL-PIO_R.i_span4_horz[21]    BLK_TL-PIO_R.i_span4_horz[29]    BLK_TL-PIO_R.i_span4_horz[37]    BLK_TL-PIO_R.i_span4_horz[45]" output="BLK_XX-local_g[0].i[5]" />
-  <mux name="BLK_XX-local_g[0].i[6]" input="BLK_TL-PIO_R.i_span12_horz[14]   BLK_TL-PIO_R.i_neigh_op_bnl[6]   BLK_TL-PIO_R.i_span4_horz[22]    BLK_TL-PIO_R.i_span12_horz[22]   BLK_TL-PIO_R.i_span4_vert_b[6]   BLK_TL-PIO_R.i_span4_horz[30]    BLK_TL-PIO_R.i_neigh_op_tnl[6]   BLK_TL-PIO_R.i_span4_horz[6]     BLK_TL-PIO_R.i_span4_vert_b[14]  BLK_TL-PIO_R.i_span4_horz[38]    BLK_TL-PIO_R.i_neigh_op_lft[6]   BLK_TL-PIO_R.i_span4_horz[14]    BLK_TL-PIO_R.i_span12_horz[6]    BLK_TL-PIO_R.i_span4_horz[46]" output="BLK_XX-local_g[0].i[6]" />
-  <mux name="BLK_XX-local_g[0].i[7]" input="BLK_TL-PIO_R.i_neigh_op_tnl[7]   BLK_TL-PIO_R.i_neigh_op_lft[7]   BLK_TL-PIO_R.i_span12_horz[15]   BLK_TL-PIO_R.i_span12_horz[23]   BLK_TL-PIO_R.i_span4_horz[7]     BLK_TL-PIO_R.i_span4_horz[15]    BLK_TL-PIO_R.i_neigh_op_bnl[7]   BLK_TL-PIO_R.i_span4_vert_b[7]   BLK_TL-PIO_R.i_span4_vert_b[15]  BLK_TL-PIO_R.i_span12_horz[7]    BLK_TL-PIO_R.i_span4_horz[23]    BLK_TL-PIO_R.i_span4_horz[31]    BLK_TL-PIO_R.i_span4_horz[39]    BLK_TL-PIO_R.i_span4_horz[47]" output="BLK_XX-local_g[0].i[7]" />
+  <mux name="local_g[0].i[0]" input="PIO_R.i_span12_horz[8]    PIO_R.i_neigh_op_bnl[0]   PIO_R.i_span4_horz[16]    PIO_R.i_span12_horz[16]   PIO_R.i_span4_vert_b[0]   PIO_R.i_span4_horz[24]    PIO_R.i_neigh_op_tnl[0]   PIO_R.i_span4_horz[0]     PIO_R.i_span4_vert_b[8]   PIO_R.i_span4_horz[32]    PIO_R.i_neigh_op_lft[0]   PIO_R.i_span4_horz[8]     PIO_R.i_span12_horz[0]    PIO_R.i_span4_horz[40]" output="local_g[0].i[0]" />
+  <mux name="local_g[0].i[1]" input="PIO_R.i_neigh_op_tnl[1]   PIO_R.i_neigh_op_lft[1]   PIO_R.i_span12_horz[9]    PIO_R.i_span12_horz[17]   PIO_R.i_span4_horz[1]     PIO_R.i_span4_horz[9]     PIO_R.i_neigh_op_bnl[1]   PIO_R.i_span4_vert_b[1]   PIO_R.i_span4_vert_b[9]   PIO_R.i_span12_horz[1]    PIO_R.i_span4_horz[17]    PIO_R.i_span4_horz[25]    PIO_R.i_span4_horz[33]    PIO_R.i_span4_horz[41]" output="local_g[0].i[1]" />
+  <mux name="local_g[0].i[2]" input="PIO_R.i_span12_horz[10]   PIO_R.i_neigh_op_bnl[2]   PIO_R.i_span4_horz[18]    PIO_R.i_span12_horz[18]   PIO_R.i_span4_vert_b[2]   PIO_R.i_span4_horz[26]    PIO_R.i_neigh_op_tnl[2]   PIO_R.i_span4_horz[2]     PIO_R.i_span4_vert_b[10]  PIO_R.i_span4_horz[34]    PIO_R.i_neigh_op_lft[2]   PIO_R.i_span4_horz[10]    PIO_R.i_span12_horz[2]    PIO_R.i_span4_horz[42]" output="local_g[0].i[2]" />
+  <mux name="local_g[0].i[3]" input="PIO_R.i_neigh_op_tnl[3]   PIO_R.i_neigh_op_lft[3]   PIO_R.i_span12_horz[11]   PIO_R.i_span12_horz[19]   PIO_R.i_span4_horz[3]     PIO_R.i_span4_horz[11]    PIO_R.i_neigh_op_bnl[3]   PIO_R.i_span4_vert_b[3]   PIO_R.i_span4_vert_b[11]  PIO_R.i_span12_horz[3]    PIO_R.i_span4_horz[19]    PIO_R.i_span4_horz[27]    PIO_R.i_span4_horz[35]    PIO_R.i_span4_horz[43]" output="local_g[0].i[3]" />
+  <mux name="local_g[0].i[4]" input="PIO_R.i_span12_horz[12]   PIO_R.i_neigh_op_bnl[4]   PIO_R.i_span4_horz[20]    PIO_R.i_span12_horz[20]   PIO_R.i_span4_vert_b[4]   PIO_R.i_span4_horz[28]    PIO_R.i_neigh_op_tnl[4]   PIO_R.i_span4_horz[4]     PIO_R.i_span4_vert_b[12]  PIO_R.i_span4_horz[36]    PIO_R.i_neigh_op_lft[4]   PIO_R.i_span4_horz[12]    PIO_R.i_span12_horz[4]    PIO_R.i_span4_horz[44]" output="local_g[0].i[4]" />
+  <mux name="local_g[0].i[5]" input="PIO_R.i_neigh_op_tnl[5]   PIO_R.i_neigh_op_lft[5]   PIO_R.i_span12_horz[13]   PIO_R.i_span12_horz[21]   PIO_R.i_span4_horz[5]     PIO_R.i_span4_horz[13]    PIO_R.i_neigh_op_bnl[5]   PIO_R.i_span4_vert_b[5]   PIO_R.i_span4_vert_b[13]  PIO_R.i_span12_horz[5]    PIO_R.i_span4_horz[21]    PIO_R.i_span4_horz[29]    PIO_R.i_span4_horz[37]    PIO_R.i_span4_horz[45]" output="local_g[0].i[5]" />
+  <mux name="local_g[0].i[6]" input="PIO_R.i_span12_horz[14]   PIO_R.i_neigh_op_bnl[6]   PIO_R.i_span4_horz[22]    PIO_R.i_span12_horz[22]   PIO_R.i_span4_vert_b[6]   PIO_R.i_span4_horz[30]    PIO_R.i_neigh_op_tnl[6]   PIO_R.i_span4_horz[6]     PIO_R.i_span4_vert_b[14]  PIO_R.i_span4_horz[38]    PIO_R.i_neigh_op_lft[6]   PIO_R.i_span4_horz[14]    PIO_R.i_span12_horz[6]    PIO_R.i_span4_horz[46]" output="local_g[0].i[6]" />
+  <mux name="local_g[0].i[7]" input="PIO_R.i_neigh_op_tnl[7]   PIO_R.i_neigh_op_lft[7]   PIO_R.i_span12_horz[15]   PIO_R.i_span12_horz[23]   PIO_R.i_span4_horz[7]     PIO_R.i_span4_horz[15]    PIO_R.i_neigh_op_bnl[7]   PIO_R.i_span4_vert_b[7]   PIO_R.i_span4_vert_b[15]  PIO_R.i_span12_horz[7]    PIO_R.i_span4_horz[23]    PIO_R.i_span4_horz[31]    PIO_R.i_span4_horz[39]    PIO_R.i_span4_horz[47]" output="local_g[0].i[7]" />
 
 
-  <mux name="BLK_XX-local_g[1].i[0]" input="BLK_TL-PIO_R.i_span12_horz[8]    BLK_TL-PIO_R.i_neigh_op_bnl[0]   BLK_TL-PIO_R.i_span4_horz[16]    BLK_TL-PIO_R.i_span12_horz[16]   BLK_TL-PIO_R.i_span4_vert_b[0]   BLK_TL-PIO_R.i_span4_horz[24]    BLK_TL-PIO_R.i_neigh_op_tnl[0]   BLK_TL-PIO_R.i_span4_horz[0]     BLK_TL-PIO_R.i_span4_vert_b[8]   BLK_TL-PIO_R.i_span4_horz[32]    BLK_TL-PIO_R.i_neigh_op_lft[0]   BLK_TL-PIO_R.i_span4_horz[8]     BLK_TL-PIO_R.i_span12_horz[0]    BLK_TL-PIO_R.i_span4_horz[40]" output="BLK_XX-local_g[1].i[0]" />
-  <mux name="BLK_XX-local_g[1].i[1]" input="BLK_TL-PIO_R.i_neigh_op_tnl[1]   BLK_TL-PIO_R.i_neigh_op_lft[1]   BLK_TL-PIO_R.i_span12_horz[9]    BLK_TL-PIO_R.i_span12_horz[17]   BLK_TL-PIO_R.i_span4_horz[1]     BLK_TL-PIO_R.i_span4_horz[9]     BLK_TL-PIO_R.i_neigh_op_bnl[1]   BLK_TL-PIO_R.i_span4_vert_b[1]   BLK_TL-PIO_R.i_span4_vert_b[9]   BLK_TL-PIO_R.i_span12_horz[1]    BLK_TL-PIO_R.i_span4_horz[17]    BLK_TL-PIO_R.i_span4_horz[25]    BLK_TL-PIO_R.i_span4_horz[33]    BLK_TL-PIO_R.i_span4_horz[41]" output="BLK_XX-local_g[1].i[1]" />
-  <mux name="BLK_XX-local_g[1].i[2]" input="BLK_TL-PIO_R.i_span12_horz[10]   BLK_TL-PIO_R.i_neigh_op_bnl[2]   BLK_TL-PIO_R.i_span4_horz[18]    BLK_TL-PIO_R.i_span12_horz[18]   BLK_TL-PIO_R.i_span4_vert_b[2]   BLK_TL-PIO_R.i_span4_horz[26]    BLK_TL-PIO_R.i_neigh_op_tnl[2]   BLK_TL-PIO_R.i_span4_horz[2]     BLK_TL-PIO_R.i_span4_vert_b[10]  BLK_TL-PIO_R.i_span4_horz[34]    BLK_TL-PIO_R.i_neigh_op_lft[2]   BLK_TL-PIO_R.i_span4_horz[10]    BLK_TL-PIO_R.i_span12_horz[2]    BLK_TL-PIO_R.i_span4_horz[42]" output="BLK_XX-local_g[1].i[2]" />
-  <mux name="BLK_XX-local_g[1].i[3]" input="BLK_TL-PIO_R.i_neigh_op_tnl[3]   BLK_TL-PIO_R.i_neigh_op_lft[3]   BLK_TL-PIO_R.i_span12_horz[11]   BLK_TL-PIO_R.i_span12_horz[19]   BLK_TL-PIO_R.i_span4_horz[3]     BLK_TL-PIO_R.i_span4_horz[11]    BLK_TL-PIO_R.i_neigh_op_bnl[3]   BLK_TL-PIO_R.i_span4_vert_b[3]   BLK_TL-PIO_R.i_span4_vert_b[11]  BLK_TL-PIO_R.i_span12_horz[3]    BLK_TL-PIO_R.i_span4_horz[19]    BLK_TL-PIO_R.i_span4_horz[27]    BLK_TL-PIO_R.i_span4_horz[35]    BLK_TL-PIO_R.i_span4_horz[43]" output="BLK_XX-local_g[1].i[3]" />
-  <mux name="BLK_XX-local_g[1].i[4]" input="BLK_TL-PIO_R.i_span12_horz[12]   BLK_TL-PIO_R.i_neigh_op_bnl[4]   BLK_TL-PIO_R.i_span4_horz[20]    BLK_TL-PIO_R.i_span12_horz[20]   BLK_TL-PIO_R.i_span4_vert_b[4]   BLK_TL-PIO_R.i_span4_horz[28]    BLK_TL-PIO_R.i_neigh_op_tnl[4]   BLK_TL-PIO_R.i_span4_horz[4]     BLK_TL-PIO_R.i_span4_vert_b[12]  BLK_TL-PIO_R.i_span4_horz[36]    BLK_TL-PIO_R.i_neigh_op_lft[4]   BLK_TL-PIO_R.i_span4_horz[12]    BLK_TL-PIO_R.i_span12_horz[4]    BLK_TL-PIO_R.i_span4_horz[44]" output="BLK_XX-local_g[1].i[4]" />
-  <mux name="BLK_XX-local_g[1].i[5]" input="BLK_TL-PIO_R.i_neigh_op_tnl[5]   BLK_TL-PIO_R.i_neigh_op_lft[5]   BLK_TL-PIO_R.i_span12_horz[13]   BLK_TL-PIO_R.i_span12_horz[21]   BLK_TL-PIO_R.i_span4_horz[5]     BLK_TL-PIO_R.i_span4_horz[13]    BLK_TL-PIO_R.i_neigh_op_bnl[5]   BLK_TL-PIO_R.i_span4_vert_b[5]   BLK_TL-PIO_R.i_span4_vert_b[13]  BLK_TL-PIO_R.i_span12_horz[5]    BLK_TL-PIO_R.i_span4_horz[21]    BLK_TL-PIO_R.i_span4_horz[29]    BLK_TL-PIO_R.i_span4_horz[37]    BLK_TL-PIO_R.i_span4_horz[45]" output="BLK_XX-local_g[1].i[5]" />
-  <mux name="BLK_XX-local_g[1].i[6]" input="BLK_TL-PIO_R.i_span12_horz[14]   BLK_TL-PIO_R.i_neigh_op_bnl[6]   BLK_TL-PIO_R.i_span4_horz[22]    BLK_TL-PIO_R.i_span12_horz[22]   BLK_TL-PIO_R.i_span4_vert_b[6]   BLK_TL-PIO_R.i_span4_horz[30]    BLK_TL-PIO_R.i_neigh_op_tnl[6]   BLK_TL-PIO_R.i_span4_horz[6]     BLK_TL-PIO_R.i_span4_vert_b[14]  BLK_TL-PIO_R.i_span4_horz[38]    BLK_TL-PIO_R.i_neigh_op_lft[6]   BLK_TL-PIO_R.i_span4_horz[14]    BLK_TL-PIO_R.i_span12_horz[6]    BLK_TL-PIO_R.i_span4_horz[46]" output="BLK_XX-local_g[1].i[6]" />
-  <mux name="BLK_XX-local_g[1].i[7]" input="BLK_TL-PIO_R.i_neigh_op_tnl[7]   BLK_TL-PIO_R.i_neigh_op_lft[7]   BLK_TL-PIO_R.i_span12_horz[15]   BLK_TL-PIO_R.i_span12_horz[23]   BLK_TL-PIO_R.i_span4_horz[7]     BLK_TL-PIO_R.i_span4_horz[15]    BLK_TL-PIO_R.i_neigh_op_bnl[7]   BLK_TL-PIO_R.i_span4_vert_b[7]   BLK_TL-PIO_R.i_span4_vert_b[15]  BLK_TL-PIO_R.i_span12_horz[7]    BLK_TL-PIO_R.i_span4_horz[23]    BLK_TL-PIO_R.i_span4_horz[31]    BLK_TL-PIO_R.i_span4_horz[39]    BLK_TL-PIO_R.i_span4_horz[47]" output="BLK_XX-local_g[1].i[7]" />
+  <mux name="local_g[1].i[0]" input="PIO_R.i_span12_horz[8]    PIO_R.i_neigh_op_bnl[0]   PIO_R.i_span4_horz[16]    PIO_R.i_span12_horz[16]   PIO_R.i_span4_vert_b[0]   PIO_R.i_span4_horz[24]    PIO_R.i_neigh_op_tnl[0]   PIO_R.i_span4_horz[0]     PIO_R.i_span4_vert_b[8]   PIO_R.i_span4_horz[32]    PIO_R.i_neigh_op_lft[0]   PIO_R.i_span4_horz[8]     PIO_R.i_span12_horz[0]    PIO_R.i_span4_horz[40]" output="local_g[1].i[0]" />
+  <mux name="local_g[1].i[1]" input="PIO_R.i_neigh_op_tnl[1]   PIO_R.i_neigh_op_lft[1]   PIO_R.i_span12_horz[9]    PIO_R.i_span12_horz[17]   PIO_R.i_span4_horz[1]     PIO_R.i_span4_horz[9]     PIO_R.i_neigh_op_bnl[1]   PIO_R.i_span4_vert_b[1]   PIO_R.i_span4_vert_b[9]   PIO_R.i_span12_horz[1]    PIO_R.i_span4_horz[17]    PIO_R.i_span4_horz[25]    PIO_R.i_span4_horz[33]    PIO_R.i_span4_horz[41]" output="local_g[1].i[1]" />
+  <mux name="local_g[1].i[2]" input="PIO_R.i_span12_horz[10]   PIO_R.i_neigh_op_bnl[2]   PIO_R.i_span4_horz[18]    PIO_R.i_span12_horz[18]   PIO_R.i_span4_vert_b[2]   PIO_R.i_span4_horz[26]    PIO_R.i_neigh_op_tnl[2]   PIO_R.i_span4_horz[2]     PIO_R.i_span4_vert_b[10]  PIO_R.i_span4_horz[34]    PIO_R.i_neigh_op_lft[2]   PIO_R.i_span4_horz[10]    PIO_R.i_span12_horz[2]    PIO_R.i_span4_horz[42]" output="local_g[1].i[2]" />
+  <mux name="local_g[1].i[3]" input="PIO_R.i_neigh_op_tnl[3]   PIO_R.i_neigh_op_lft[3]   PIO_R.i_span12_horz[11]   PIO_R.i_span12_horz[19]   PIO_R.i_span4_horz[3]     PIO_R.i_span4_horz[11]    PIO_R.i_neigh_op_bnl[3]   PIO_R.i_span4_vert_b[3]   PIO_R.i_span4_vert_b[11]  PIO_R.i_span12_horz[3]    PIO_R.i_span4_horz[19]    PIO_R.i_span4_horz[27]    PIO_R.i_span4_horz[35]    PIO_R.i_span4_horz[43]" output="local_g[1].i[3]" />
+  <mux name="local_g[1].i[4]" input="PIO_R.i_span12_horz[12]   PIO_R.i_neigh_op_bnl[4]   PIO_R.i_span4_horz[20]    PIO_R.i_span12_horz[20]   PIO_R.i_span4_vert_b[4]   PIO_R.i_span4_horz[28]    PIO_R.i_neigh_op_tnl[4]   PIO_R.i_span4_horz[4]     PIO_R.i_span4_vert_b[12]  PIO_R.i_span4_horz[36]    PIO_R.i_neigh_op_lft[4]   PIO_R.i_span4_horz[12]    PIO_R.i_span12_horz[4]    PIO_R.i_span4_horz[44]" output="local_g[1].i[4]" />
+  <mux name="local_g[1].i[5]" input="PIO_R.i_neigh_op_tnl[5]   PIO_R.i_neigh_op_lft[5]   PIO_R.i_span12_horz[13]   PIO_R.i_span12_horz[21]   PIO_R.i_span4_horz[5]     PIO_R.i_span4_horz[13]    PIO_R.i_neigh_op_bnl[5]   PIO_R.i_span4_vert_b[5]   PIO_R.i_span4_vert_b[13]  PIO_R.i_span12_horz[5]    PIO_R.i_span4_horz[21]    PIO_R.i_span4_horz[29]    PIO_R.i_span4_horz[37]    PIO_R.i_span4_horz[45]" output="local_g[1].i[5]" />
+  <mux name="local_g[1].i[6]" input="PIO_R.i_span12_horz[14]   PIO_R.i_neigh_op_bnl[6]   PIO_R.i_span4_horz[22]    PIO_R.i_span12_horz[22]   PIO_R.i_span4_vert_b[6]   PIO_R.i_span4_horz[30]    PIO_R.i_neigh_op_tnl[6]   PIO_R.i_span4_horz[6]     PIO_R.i_span4_vert_b[14]  PIO_R.i_span4_horz[38]    PIO_R.i_neigh_op_lft[6]   PIO_R.i_span4_horz[14]    PIO_R.i_span12_horz[6]    PIO_R.i_span4_horz[46]" output="local_g[1].i[6]" />
+  <mux name="local_g[1].i[7]" input="PIO_R.i_neigh_op_tnl[7]   PIO_R.i_neigh_op_lft[7]   PIO_R.i_span12_horz[15]   PIO_R.i_span12_horz[23]   PIO_R.i_span4_horz[7]     PIO_R.i_span4_horz[15]    PIO_R.i_neigh_op_bnl[7]   PIO_R.i_span4_vert_b[7]   PIO_R.i_span4_vert_b[15]  PIO_R.i_span12_horz[7]    PIO_R.i_span4_horz[23]    PIO_R.i_span4_horz[31]    PIO_R.i_span4_horz[39]    PIO_R.i_span4_horz[47]" output="local_g[1].i[7]" />
 
   <!-- D_IN -> Span4 Vert B -->
-  <mux name="span4_vert_b[0]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[0]"  />
-  <mux name="span4_vert_b[1]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[1]"  />
-  <mux name="span4_vert_b[10]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[10]" />
-  <mux name="span4_vert_b[11]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[11]" />
-  <mux name="span4_vert_b[12]" input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[12]" />
-  <mux name="span4_vert_b[13]" input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[13]" />
-  <mux name="span4_vert_b[14]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[14]" />
-  <mux name="span4_vert_b[15]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[15]" />
-  <mux name="span4_vert_b[2]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[2]"  />
-  <mux name="span4_vert_b[3]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[3]"  />
-  <mux name="span4_vert_b[4]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[4]"  />
-  <mux name="span4_vert_b[5]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[5]"  />
-  <mux name="span4_vert_b[6]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[6]"  />
-  <mux name="span4_vert_b[7]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[7]"  />
-  <mux name="span4_vert_b[8]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_vert_b[8]"  />
-  <mux name="span4_vert_b[9]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_vert_b[9]"  />
+  <mux name="span4_vert_b[0]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_vert_b[0]"  />
+  <mux name="span4_vert_b[1]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_vert_b[1]"  />
+  <mux name="span4_vert_b[10]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_vert_b[10]" />
+  <mux name="span4_vert_b[11]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_vert_b[11]" />
+  <mux name="span4_vert_b[12]" input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_vert_b[12]" />
+  <mux name="span4_vert_b[13]" input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_vert_b[13]" />
+  <mux name="span4_vert_b[14]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_vert_b[14]" />
+  <mux name="span4_vert_b[15]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_vert_b[15]" />
+  <mux name="span4_vert_b[2]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_vert_b[2]"  />
+  <mux name="span4_vert_b[3]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_vert_b[3]"  />
+  <mux name="span4_vert_b[4]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_vert_b[4]"  />
+  <mux name="span4_vert_b[5]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_vert_b[5]"  />
+  <mux name="span4_vert_b[6]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_vert_b[6]"  />
+  <mux name="span4_vert_b[7]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_vert_b[7]"  />
+  <mux name="span4_vert_b[8]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_vert_b[8]"  />
+  <mux name="span4_vert_b[9]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_vert_b[9]"  />
 
   <!-- D_IN -> Span4 Horz -->
-  <mux name="span4_horz[0]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[0]"    />
-  <mux name="span4_horz[10]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[10]"   />
-  <mux name="span4_horz[12]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[12]"   />
-  <mux name="span4_horz[14]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[14]"   />
-  <mux name="span4_horz[16]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[16]"   />
-  <mux name="span4_horz[18]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[18]"   />
-  <mux name="span4_horz[2]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[2]"    />
-  <mux name="span4_horz[20]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[20]"   />
-  <mux name="span4_horz[22]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[22]"   />
-  <mux name="span4_horz[24]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[24]"   />
-  <mux name="span4_horz[26]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[26]"   />
-  <mux name="span4_horz[28]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[28]"   />
-  <mux name="span4_horz[30]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[30]"   />
-  <mux name="span4_horz[32]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[32]"   />
-  <mux name="span4_horz[34]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[34]"   />
-  <mux name="span4_horz[36]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[36]"   />
-  <mux name="span4_horz[38]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[38]"   />
-  <mux name="span4_horz[4]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[4]"    />
-  <mux name="span4_horz[40]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[40]"   />
-  <mux name="span4_horz[42]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[42]"   />
-  <mux name="span4_horz[44]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[44]"   />
-  <mux name="span4_horz[46]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[46]"   />
-  <mux name="span4_horz[6]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span4_horz[6]"    />
-  <mux name="span4_horz[8]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span4_horz[8]"    />
+  <mux name="span4_horz[0]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_horz[0]"    />
+  <mux name="span4_horz[10]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_horz[10]"   />
+  <mux name="span4_horz[12]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_horz[12]"   />
+  <mux name="span4_horz[14]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_horz[14]"   />
+  <mux name="span4_horz[16]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_horz[16]"   />
+  <mux name="span4_horz[18]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_horz[18]"   />
+  <mux name="span4_horz[2]"    input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_horz[2]"    />
+  <mux name="span4_horz[20]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_horz[20]"   />
+  <mux name="span4_horz[22]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_horz[22]"   />
+  <mux name="span4_horz[24]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_horz[24]"   />
+  <mux name="span4_horz[26]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_horz[26]"   />
+  <mux name="span4_horz[28]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_horz[28]"   />
+  <mux name="span4_horz[30]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_horz[30]"   />
+  <mux name="span4_horz[32]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_horz[32]"   />
+  <mux name="span4_horz[34]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_horz[34]"   />
+  <mux name="span4_horz[36]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_horz[36]"   />
+  <mux name="span4_horz[38]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_horz[38]"   />
+  <mux name="span4_horz[4]"    input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_horz[4]"    />
+  <mux name="span4_horz[40]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_horz[40]"   />
+  <mux name="span4_horz[42]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span4_horz[42]"   />
+  <mux name="span4_horz[44]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span4_horz[44]"   />
+  <mux name="span4_horz[46]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_horz[46]"   />
+  <mux name="span4_horz[6]"    input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span4_horz[6]"    />
+  <mux name="span4_horz[8]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span4_horz[8]"    />
 
   <!-- D_IN -> Span12 Horz -->
-  <mux name="span12_horz[0]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span12_horz[0]"   />
-  <mux name="span12_horz[10]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span12_horz[10]"  />
-  <mux name="span12_horz[12]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span12_horz[12]"  />
-  <mux name="span12_horz[14]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span12_horz[14]"  />
-  <mux name="span12_horz[16]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span12_horz[16]"  />
-  <mux name="span12_horz[18]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span12_horz[18]"  />
-  <mux name="span12_horz[2]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_R.o_span12_horz[2]"   />
-  <mux name="span12_horz[20]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span12_horz[20]"  />
-  <mux name="span12_horz[22]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span12_horz[22]"  />
-  <mux name="span12_horz[4]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_R.o_span12_horz[4]"   />
-  <mux name="span12_horz[6]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_R.o_span12_horz[6]"   />
-  <mux name="span12_horz[8]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_R.o_span12_horz[8]"   />
+  <mux name="span12_horz[0]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span12_horz[0]"   />
+  <mux name="span12_horz[10]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span12_horz[10]"  />
+  <mux name="span12_horz[12]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span12_horz[12]"  />
+  <mux name="span12_horz[14]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span12_horz[14]"  />
+  <mux name="span12_horz[16]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span12_horz[16]"  />
+  <mux name="span12_horz[18]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span12_horz[18]"  />
+  <mux name="span12_horz[2]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_R.o_span12_horz[2]"   />
+  <mux name="span12_horz[20]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span12_horz[20]"  />
+  <mux name="span12_horz[22]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span12_horz[22]"  />
+  <mux name="span12_horz[4]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_R.o_span12_horz[4]"   />
+  <mux name="span12_horz[6]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_R.o_span12_horz[6]"   />
+  <mux name="span12_horz[8]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_R.o_span12_horz[8]"   />
 
   <!-- Spans -->
   <!--
-  <direct name="span4_vert_b[0]"  input="BLK_TL-PIO_R.i_span4_vert_t[ ]" output="BLK_TL-PIO_R.o_span4_vert_b[0]" />
-  <direct name="span4_vert_b[1]"  input="BLK_TL-PIO_R.i_span4_vert_t[ ]" output="BLK_TL-PIO_R.o_span4_vert_b[1]" />
-  <direct name="span4_vert_b[2]"  input="BLK_TL-PIO_R.i_span4_vert_t[ ]" output="BLK_TL-PIO_R.o_span4_vert_b[2]" />
-  <direct name="span4_vert_b[3]"  input="BLK_TL-PIO_R.i_span4_vert_t[ ]" output="BLK_TL-PIO_R.o_span4_vert_b[3]" />
+  <direct name="span4_vert_b[0]"  input="PIO_R.i_span4_vert_t[ ]" output="PIO_R.o_span4_vert_b[0]" />
+  <direct name="span4_vert_b[1]"  input="PIO_R.i_span4_vert_t[ ]" output="PIO_R.o_span4_vert_b[1]" />
+  <direct name="span4_vert_b[2]"  input="PIO_R.i_span4_vert_t[ ]" output="PIO_R.o_span4_vert_b[2]" />
+  <direct name="span4_vert_b[3]"  input="PIO_R.i_span4_vert_t[ ]" output="PIO_R.o_span4_vert_b[3]" />
   -->
 
-  <direct name="span4_vert_t[0]"  input="BLK_TL-PIO_R.i_span4_vert_t[0]"  output="BLK_TL-PIO_R.o_span4_vert_b[4]"  />
-  <direct name="span4_vert_t[1]"  input="BLK_TL-PIO_R.i_span4_vert_t[1]"  output="BLK_TL-PIO_R.o_span4_vert_b[5]"  />
-  <direct name="span4_vert_t[2]"  input="BLK_TL-PIO_R.i_span4_vert_t[2]"  output="BLK_TL-PIO_R.o_span4_vert_b[6]"  />
-  <direct name="span4_vert_t[3]"  input="BLK_TL-PIO_R.i_span4_vert_t[3]"  output="BLK_TL-PIO_R.o_span4_vert_b[7]"  />
-  <direct name="span4_vert_t[4]"  input="BLK_TL-PIO_R.i_span4_vert_t[4]"  output="BLK_TL-PIO_R.o_span4_vert_b[8]"  />
-  <direct name="span4_vert_t[5]"  input="BLK_TL-PIO_R.i_span4_vert_t[5]"  output="BLK_TL-PIO_R.o_span4_vert_b[9]"  />
-  <direct name="span4_vert_t[6]"  input="BLK_TL-PIO_R.i_span4_vert_t[6]"  output="BLK_TL-PIO_R.o_span4_vert_b[10]" />
-  <direct name="span4_vert_t[7]"  input="BLK_TL-PIO_R.i_span4_vert_t[7]"  output="BLK_TL-PIO_R.o_span4_vert_b[11]" />
-  <direct name="span4_vert_t[8]"  input="BLK_TL-PIO_R.i_span4_vert_t[8]"  output="BLK_TL-PIO_R.o_span4_vert_b[12]" />
-  <direct name="span4_vert_t[9]"  input="BLK_TL-PIO_R.i_span4_vert_t[9]"  output="BLK_TL-PIO_R.o_span4_vert_b[13]" />
-  <direct name="span4_vert_t[10]" input="BLK_TL-PIO_R.i_span4_vert_t[10]" output="BLK_TL-PIO_R.o_span4_vert_b[14]" />
-  <direct name="span4_vert_t[11]" input="BLK_TL-PIO_R.i_span4_vert_t[11]" output="BLK_TL-PIO_R.o_span4_vert_b[15]" />
+  <direct name="span4_vert_t[0]"  input="PIO_R.i_span4_vert_t[0]"  output="PIO_R.o_span4_vert_b[4]"  />
+  <direct name="span4_vert_t[1]"  input="PIO_R.i_span4_vert_t[1]"  output="PIO_R.o_span4_vert_b[5]"  />
+  <direct name="span4_vert_t[2]"  input="PIO_R.i_span4_vert_t[2]"  output="PIO_R.o_span4_vert_b[6]"  />
+  <direct name="span4_vert_t[3]"  input="PIO_R.i_span4_vert_t[3]"  output="PIO_R.o_span4_vert_b[7]"  />
+  <direct name="span4_vert_t[4]"  input="PIO_R.i_span4_vert_t[4]"  output="PIO_R.o_span4_vert_b[8]"  />
+  <direct name="span4_vert_t[5]"  input="PIO_R.i_span4_vert_t[5]"  output="PIO_R.o_span4_vert_b[9]"  />
+  <direct name="span4_vert_t[6]"  input="PIO_R.i_span4_vert_t[6]"  output="PIO_R.o_span4_vert_b[10]" />
+  <direct name="span4_vert_t[7]"  input="PIO_R.i_span4_vert_t[7]"  output="PIO_R.o_span4_vert_b[11]" />
+  <direct name="span4_vert_t[8]"  input="PIO_R.i_span4_vert_t[8]"  output="PIO_R.o_span4_vert_b[12]" />
+  <direct name="span4_vert_t[9]"  input="PIO_R.i_span4_vert_t[9]"  output="PIO_R.o_span4_vert_b[13]" />
+  <direct name="span4_vert_t[10]" input="PIO_R.i_span4_vert_t[10]" output="PIO_R.o_span4_vert_b[14]" />
+  <direct name="span4_vert_t[11]" input="PIO_R.i_span4_vert_t[11]" output="PIO_R.o_span4_vert_b[15]" />
 
   <!--
-  <direct name="span4_vert_t[12]" input="BLK_TL-PIO_R.i_span4_vert_t[12]" output="BLK_TL-PIO_R.o_span4_vert_b[  ]" />
-  <direct name="span4_vert_t[13]" input="BLK_TL-PIO_R.i_span4_vert_t[13]" output="BLK_TL-PIO_R.o_span4_vert_b[  ]" />
-  <direct name="span4_vert_t[14]" input="BLK_TL-PIO_R.i_span4_vert_t[14]" output="BLK_TL-PIO_R.o_span4_vert_b[  ]" />
-  <direct name="span4_vert_t[15]" input="BLK_TL-PIO_R.i_span4_vert_t[15]" output="BLK_TL-PIO_R.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[12]" input="PIO_R.i_span4_vert_t[12]" output="PIO_R.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[13]" input="PIO_R.i_span4_vert_t[13]" output="PIO_R.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[14]" input="PIO_R.i_span4_vert_t[14]" output="PIO_R.o_span4_vert_b[  ]" />
+  <direct name="span4_vert_t[15]" input="PIO_R.i_span4_vert_t[15]" output="PIO_R.o_span4_vert_b[  ]" />
   -->
 
  </interconnect>
 
  <pinlocations pattern="custom">
   <loc side="left" xoffset="0" yoffset="0">
-   BLK_TL-PIO_R.i_neigh_op_tnl BLK_TL-PIO_R.o_neigh_op_tnl
-   BLK_TL-PIO_R.i_neigh_op_lft BLK_TL-PIO_R.o_neigh_op_lft
-   BLK_TL-PIO_R.i_neigh_op_bnl BLK_TL-PIO_R.o_neigh_op_bnl
+   PIO_R.i_neigh_op_tnl PIO_R.o_neigh_op_tnl
+   PIO_R.i_neigh_op_lft PIO_R.o_neigh_op_lft
+   PIO_R.i_neigh_op_bnl PIO_R.o_neigh_op_bnl
 
-   BLK_TL-PIO_R.i_span4_horz   BLK_TL-PIO_R.o_span4_horz
-   BLK_TL-PIO_R.i_span12_horz  BLK_TL-PIO_R.o_span12_horz
+   PIO_R.i_span4_horz   PIO_R.o_span4_horz
+   PIO_R.i_span12_horz  PIO_R.o_span12_horz
   </loc>
   <loc side="top" xoffset="0" yoffset="0">
-   BLK_TL-PIO_R.i_glb_netwk    BLK_TL-PIO_R.o_glb_netwk
-   BLK_TL-PIO_R.fabout
+   PIO_R.i_glb_netwk    PIO_R.o_glb_netwk
+   PIO_R.fabout
 
-   BLK_TL-PIO_R.i_span4_vert_t BLK_TL-PIO_R.o_span4_vert_t
+   PIO_R.i_span4_vert_t PIO_R.o_span4_vert_t
   </loc>
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PIO_R.i_span4_horz   BLK_TL-PIO_R.o_span4_horz
-   BLK_TL-PIO_R.i_span12_horz  BLK_TL-PIO_R.o_span12_horz
+   PIO_R.i_span4_horz   PIO_R.o_span4_horz
+   PIO_R.i_span12_horz  PIO_R.o_span12_horz
   </loc>
   <loc side="bottom" xoffset="0" yoffset="0">
-   BLK_TL-PIO_R.i_span4_vert_b  BLK_TL-PIO_R.o_span4_vert_b
+   PIO_R.i_span4_vert_b  PIO_R.o_span4_vert_b
   </loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
   <xi:include href="../pio-lr/pio-lr.fc.xml" xpointer="xpointer(fc/child::node())"/>
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/pio-t/pio-t.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-t/pio-t.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO_T" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO_T" xmlns:xi="http://www.w3.org/2001/XInclude">
  <xi:include href="../pio/pio.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  <xi:include href="../pio-tb/pio-tb.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
 
@@ -15,145 +15,149 @@
  <interconnect>
   <xi:include href="../pio/pio.interconnect.xml" xpointer="xpointer(interconnect/child::node())"/>
 
-  <mux name="fabout"          input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[5] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[4] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[6]" output="BLK_TL-PIO_T.fabout" />
+  <mux name="fabout"          input="local_g[0].o[1] local_g[0].o[5] local_g[1].o[0] local_g[1].o[4] local_g[0].o[3] local_g[0].o[7] local_g[1].o[2] local_g[1].o[6]" output="PIO_T.fabout" />
 
-  <mux name="BLK_XX-io_global/i_inclk" input="BLK_TL-PIO_T.i_glb_netwk[0] BLK_TL-PIO_T.i_glb_netwk[1] BLK_TL-PIO_T.i_glb_netwk[4] BLK_TL-PIO_T.i_glb_netwk[5] BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[3] BLK_TL-PIO_T.i_glb_netwk[2] BLK_TL-PIO_T.i_glb_netwk[3] BLK_TL-PIO_T.i_glb_netwk[6] BLK_TL-PIO_T.i_glb_netwk[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[3]" output="BLK_XX-io_global.i_inclk" />
-  <mux name="BLK_XX-io_global/i_outclk" input="BLK_TL-PIO_T.i_glb_netwk[0] BLK_TL-PIO_T.i_glb_netwk[1] BLK_TL-PIO_T.i_glb_netwk[4] BLK_TL-PIO_T.i_glb_netwk[5] BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[4] BLK_TL-PIO_T.i_glb_netwk[2] BLK_TL-PIO_T.i_glb_netwk[3] BLK_TL-PIO_T.i_glb_netwk[6] BLK_TL-PIO_T.i_glb_netwk[7] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[4]" output="BLK_XX-io_global.i_outclk"/>
+  <mux name="io_global/i_inclk" input="PIO_T.i_glb_netwk[0] PIO_T.i_glb_netwk[1] PIO_T.i_glb_netwk[4] PIO_T.i_glb_netwk[5] local_g[0].o[0] local_g[0].o[3] PIO_T.i_glb_netwk[2] PIO_T.i_glb_netwk[3] PIO_T.i_glb_netwk[6] PIO_T.i_glb_netwk[7] local_g[1].o[0] local_g[1].o[3]" output="io_global.i_inclk" />
+  <mux name="io_global/i_outclk" input="PIO_T.i_glb_netwk[0] PIO_T.i_glb_netwk[1] PIO_T.i_glb_netwk[4] PIO_T.i_glb_netwk[5] local_g[0].o[1] local_g[0].o[4] PIO_T.i_glb_netwk[2] PIO_T.i_glb_netwk[3] PIO_T.i_glb_netwk[6] PIO_T.i_glb_netwk[7] local_g[1].o[1] local_g[1].o[4]" output="io_global.i_outclk"/>
 
   <!-- Local Tracks -->
-  <mux name="BLK_XX-local_g[0].i[0]" input="BLK_TL-PIO_T.i_span12_vert[8]    BLK_TL-PIO_T.i_neigh_op_bnr[0]   BLK_TL-PIO_T.i_span4_vert[16]    BLK_TL-PIO_T.i_span12_vert[16]   BLK_TL-PIO_T.i_span4_horz_r[0]   BLK_TL-PIO_T.i_span4_vert[24]    BLK_TL-PIO_T.i_neigh_op_bnl[0]   BLK_TL-PIO_T.i_span4_vert[0]     BLK_TL-PIO_T.i_span4_horz_r[8]   BLK_TL-PIO_T.i_span4_vert[32]    BLK_TL-PIO_T.i_neigh_op_bot[0]   BLK_TL-PIO_T.i_span4_vert[8]     BLK_TL-PIO_T.i_span12_vert[0]    BLK_TL-PIO_T.i_span4_vert[40]" output="BLK_XX-local_g[0].i[0]" />
-  <mux name="BLK_XX-local_g[0].i[1]" input="BLK_TL-PIO_T.i_neigh_op_bnl[1]   BLK_TL-PIO_T.i_neigh_op_bot[1]   BLK_TL-PIO_T.i_span12_vert[9]    BLK_TL-PIO_T.i_span12_vert[17]   BLK_TL-PIO_T.i_span4_vert[1]     BLK_TL-PIO_T.i_span4_vert[9]     BLK_TL-PIO_T.i_neigh_op_bnr[1]   BLK_TL-PIO_T.i_span4_horz_r[1]   BLK_TL-PIO_T.i_span4_horz_r[9]   BLK_TL-PIO_T.i_span12_vert[1]    BLK_TL-PIO_T.i_span4_vert[17]    BLK_TL-PIO_T.i_span4_vert[25]    BLK_TL-PIO_T.i_span4_vert[33]    BLK_TL-PIO_T.i_span4_vert[41]" output="BLK_XX-local_g[0].i[1]" />
-  <mux name="BLK_XX-local_g[0].i[2]" input="BLK_TL-PIO_T.i_span12_vert[10]   BLK_TL-PIO_T.i_neigh_op_bnr[2]   BLK_TL-PIO_T.i_span4_vert[18]    BLK_TL-PIO_T.i_span12_vert[18]   BLK_TL-PIO_T.i_span4_horz_r[2]   BLK_TL-PIO_T.i_span4_vert[26]    BLK_TL-PIO_T.i_neigh_op_bnl[2]   BLK_TL-PIO_T.i_span4_vert[2]     BLK_TL-PIO_T.i_span4_horz_r[10]  BLK_TL-PIO_T.i_span4_vert[34]    BLK_TL-PIO_T.i_neigh_op_bot[2]   BLK_TL-PIO_T.i_span4_vert[10]    BLK_TL-PIO_T.i_span12_vert[2]    BLK_TL-PIO_T.i_span4_vert[42]" output="BLK_XX-local_g[0].i[2]" />
-  <mux name="BLK_XX-local_g[0].i[3]" input="BLK_TL-PIO_T.i_neigh_op_bnl[3]   BLK_TL-PIO_T.i_neigh_op_bot[3]   BLK_TL-PIO_T.i_span12_vert[11]   BLK_TL-PIO_T.i_span12_vert[19]   BLK_TL-PIO_T.i_span4_vert[3]     BLK_TL-PIO_T.i_span4_vert[11]    BLK_TL-PIO_T.i_neigh_op_bnr[3]   BLK_TL-PIO_T.i_span4_horz_r[3]   BLK_TL-PIO_T.i_span4_horz_r[11]  BLK_TL-PIO_T.i_span12_vert[3]    BLK_TL-PIO_T.i_span4_vert[19]    BLK_TL-PIO_T.i_span4_vert[27]    BLK_TL-PIO_T.i_span4_vert[35]    BLK_TL-PIO_T.i_span4_vert[43]" output="BLK_XX-local_g[0].i[3]" />
-  <mux name="BLK_XX-local_g[0].i[4]" input="BLK_TL-PIO_T.i_span12_vert[12]   BLK_TL-PIO_T.i_neigh_op_bnr[4]   BLK_TL-PIO_T.i_span4_vert[20]    BLK_TL-PIO_T.i_span12_vert[20]   BLK_TL-PIO_T.i_span4_horz_r[4]   BLK_TL-PIO_T.i_span4_vert[28]    BLK_TL-PIO_T.i_neigh_op_bnl[4]   BLK_TL-PIO_T.i_span4_vert[4]     BLK_TL-PIO_T.i_span4_horz_r[12]  BLK_TL-PIO_T.i_span4_vert[36]    BLK_TL-PIO_T.i_neigh_op_bot[4]   BLK_TL-PIO_T.i_span4_vert[12]    BLK_TL-PIO_T.i_span12_vert[4]    BLK_TL-PIO_T.i_span4_vert[44]" output="BLK_XX-local_g[0].i[4]" />
-  <mux name="BLK_XX-local_g[0].i[5]" input="BLK_TL-PIO_T.i_neigh_op_bnl[5]   BLK_TL-PIO_T.i_neigh_op_bot[5]   BLK_TL-PIO_T.i_span12_vert[13]   BLK_TL-PIO_T.i_span12_vert[21]   BLK_TL-PIO_T.i_span4_vert[5]     BLK_TL-PIO_T.i_span4_vert[13]    BLK_TL-PIO_T.i_neigh_op_bnr[5]   BLK_TL-PIO_T.i_span4_horz_r[5]   BLK_TL-PIO_T.i_span4_horz_r[13]  BLK_TL-PIO_T.i_span12_vert[5]    BLK_TL-PIO_T.i_span4_vert[21]    BLK_TL-PIO_T.i_span4_vert[29]    BLK_TL-PIO_T.i_span4_vert[37]    BLK_TL-PIO_T.i_span4_vert[45]" output="BLK_XX-local_g[0].i[5]" />
-  <mux name="BLK_XX-local_g[0].i[6]" input="BLK_TL-PIO_T.i_span12_vert[14]   BLK_TL-PIO_T.i_neigh_op_bnr[6]   BLK_TL-PIO_T.i_span4_vert[22]    BLK_TL-PIO_T.i_span12_vert[22]   BLK_TL-PIO_T.i_span4_horz_r[6]   BLK_TL-PIO_T.i_span4_vert[30]    BLK_TL-PIO_T.i_neigh_op_bnl[6]   BLK_TL-PIO_T.i_span4_vert[6]     BLK_TL-PIO_T.i_span4_horz_r[14]  BLK_TL-PIO_T.i_span4_vert[38]    BLK_TL-PIO_T.i_neigh_op_bot[6]   BLK_TL-PIO_T.i_span4_vert[14]    BLK_TL-PIO_T.i_span12_vert[6]    BLK_TL-PIO_T.i_span4_vert[46]" output="BLK_XX-local_g[0].i[6]" />
-  <mux name="BLK_XX-local_g[0].i[7]" input="BLK_TL-PIO_T.i_neigh_op_bnl[7]   BLK_TL-PIO_T.i_neigh_op_bot[7]   BLK_TL-PIO_T.i_span12_vert[15]   BLK_TL-PIO_T.i_span12_vert[23]   BLK_TL-PIO_T.i_span4_vert[7]     BLK_TL-PIO_T.i_span4_vert[15]    BLK_TL-PIO_T.i_neigh_op_bnr[7]   BLK_TL-PIO_T.i_span4_horz_r[7]   BLK_TL-PIO_T.i_span4_horz_r[15]  BLK_TL-PIO_T.i_span12_vert[7]    BLK_TL-PIO_T.i_span4_vert[23]    BLK_TL-PIO_T.i_span4_vert[31]    BLK_TL-PIO_T.i_span4_vert[39]    BLK_TL-PIO_T.i_span4_vert[47]" output="BLK_XX-local_g[0].i[7]" />
+  <mux name="local_g[0].i[0]" input="PIO_T.i_span12_vert[8]    PIO_T.i_neigh_op_bnr[0]   PIO_T.i_span4_vert[16]    PIO_T.i_span12_vert[16]   PIO_T.i_span4_horz_r[0]   PIO_T.i_span4_vert[24]    PIO_T.i_neigh_op_bnl[0]   PIO_T.i_span4_vert[0]     PIO_T.i_span4_horz_r[8]   PIO_T.i_span4_vert[32]    PIO_T.i_neigh_op_bot[0]   PIO_T.i_span4_vert[8]     PIO_T.i_span12_vert[0]    PIO_T.i_span4_vert[40]" output="local_g[0].i[0]" />
+  <mux name="local_g[0].i[1]" input="PIO_T.i_neigh_op_bnl[1]   PIO_T.i_neigh_op_bot[1]   PIO_T.i_span12_vert[9]    PIO_T.i_span12_vert[17]   PIO_T.i_span4_vert[1]     PIO_T.i_span4_vert[9]     PIO_T.i_neigh_op_bnr[1]   PIO_T.i_span4_horz_r[1]   PIO_T.i_span4_horz_r[9]   PIO_T.i_span12_vert[1]    PIO_T.i_span4_vert[17]    PIO_T.i_span4_vert[25]    PIO_T.i_span4_vert[33]    PIO_T.i_span4_vert[41]" output="local_g[0].i[1]" />
+  <mux name="local_g[0].i[2]" input="PIO_T.i_span12_vert[10]   PIO_T.i_neigh_op_bnr[2]   PIO_T.i_span4_vert[18]    PIO_T.i_span12_vert[18]   PIO_T.i_span4_horz_r[2]   PIO_T.i_span4_vert[26]    PIO_T.i_neigh_op_bnl[2]   PIO_T.i_span4_vert[2]     PIO_T.i_span4_horz_r[10]  PIO_T.i_span4_vert[34]    PIO_T.i_neigh_op_bot[2]   PIO_T.i_span4_vert[10]    PIO_T.i_span12_vert[2]    PIO_T.i_span4_vert[42]" output="local_g[0].i[2]" />
+  <mux name="local_g[0].i[3]" input="PIO_T.i_neigh_op_bnl[3]   PIO_T.i_neigh_op_bot[3]   PIO_T.i_span12_vert[11]   PIO_T.i_span12_vert[19]   PIO_T.i_span4_vert[3]     PIO_T.i_span4_vert[11]    PIO_T.i_neigh_op_bnr[3]   PIO_T.i_span4_horz_r[3]   PIO_T.i_span4_horz_r[11]  PIO_T.i_span12_vert[3]    PIO_T.i_span4_vert[19]    PIO_T.i_span4_vert[27]    PIO_T.i_span4_vert[35]    PIO_T.i_span4_vert[43]" output="local_g[0].i[3]" />
+  <mux name="local_g[0].i[4]" input="PIO_T.i_span12_vert[12]   PIO_T.i_neigh_op_bnr[4]   PIO_T.i_span4_vert[20]    PIO_T.i_span12_vert[20]   PIO_T.i_span4_horz_r[4]   PIO_T.i_span4_vert[28]    PIO_T.i_neigh_op_bnl[4]   PIO_T.i_span4_vert[4]     PIO_T.i_span4_horz_r[12]  PIO_T.i_span4_vert[36]    PIO_T.i_neigh_op_bot[4]   PIO_T.i_span4_vert[12]    PIO_T.i_span12_vert[4]    PIO_T.i_span4_vert[44]" output="local_g[0].i[4]" />
+  <mux name="local_g[0].i[5]" input="PIO_T.i_neigh_op_bnl[5]   PIO_T.i_neigh_op_bot[5]   PIO_T.i_span12_vert[13]   PIO_T.i_span12_vert[21]   PIO_T.i_span4_vert[5]     PIO_T.i_span4_vert[13]    PIO_T.i_neigh_op_bnr[5]   PIO_T.i_span4_horz_r[5]   PIO_T.i_span4_horz_r[13]  PIO_T.i_span12_vert[5]    PIO_T.i_span4_vert[21]    PIO_T.i_span4_vert[29]    PIO_T.i_span4_vert[37]    PIO_T.i_span4_vert[45]" output="local_g[0].i[5]" />
+  <mux name="local_g[0].i[6]" input="PIO_T.i_span12_vert[14]   PIO_T.i_neigh_op_bnr[6]   PIO_T.i_span4_vert[22]    PIO_T.i_span12_vert[22]   PIO_T.i_span4_horz_r[6]   PIO_T.i_span4_vert[30]    PIO_T.i_neigh_op_bnl[6]   PIO_T.i_span4_vert[6]     PIO_T.i_span4_horz_r[14]  PIO_T.i_span4_vert[38]    PIO_T.i_neigh_op_bot[6]   PIO_T.i_span4_vert[14]    PIO_T.i_span12_vert[6]    PIO_T.i_span4_vert[46]" output="local_g[0].i[6]" />
+  <mux name="local_g[0].i[7]" input="PIO_T.i_neigh_op_bnl[7]   PIO_T.i_neigh_op_bot[7]   PIO_T.i_span12_vert[15]   PIO_T.i_span12_vert[23]   PIO_T.i_span4_vert[7]     PIO_T.i_span4_vert[15]    PIO_T.i_neigh_op_bnr[7]   PIO_T.i_span4_horz_r[7]   PIO_T.i_span4_horz_r[15]  PIO_T.i_span12_vert[7]    PIO_T.i_span4_vert[23]    PIO_T.i_span4_vert[31]    PIO_T.i_span4_vert[39]    PIO_T.i_span4_vert[47]" output="local_g[0].i[7]" />
 
 
-  <mux name="BLK_XX-local_g[1].i[0]" input="BLK_TL-PIO_T.i_span12_vert[8]    BLK_TL-PIO_T.i_neigh_op_bnr[0]   BLK_TL-PIO_T.i_span4_vert[16]    BLK_TL-PIO_T.i_span12_vert[16]   BLK_TL-PIO_T.i_span4_horz_r[0]   BLK_TL-PIO_T.i_span4_vert[24]    BLK_TL-PIO_T.i_neigh_op_bnl[0]   BLK_TL-PIO_T.i_span4_vert[0]     BLK_TL-PIO_T.i_span4_horz_r[8]   BLK_TL-PIO_T.i_span4_vert[32]    BLK_TL-PIO_T.i_neigh_op_bot[0]   BLK_TL-PIO_T.i_span4_vert[8]     BLK_TL-PIO_T.i_span12_vert[0]    BLK_TL-PIO_T.i_span4_vert[40]" output="BLK_XX-local_g[1].i[0]" />
-  <mux name="BLK_XX-local_g[1].i[1]" input="BLK_TL-PIO_T.i_neigh_op_bnl[1]   BLK_TL-PIO_T.i_neigh_op_bot[1]   BLK_TL-PIO_T.i_span12_vert[9]    BLK_TL-PIO_T.i_span12_vert[17]   BLK_TL-PIO_T.i_span4_vert[1]     BLK_TL-PIO_T.i_span4_vert[9]     BLK_TL-PIO_T.i_neigh_op_bnr[1]   BLK_TL-PIO_T.i_span4_horz_r[1]   BLK_TL-PIO_T.i_span4_horz_r[9]   BLK_TL-PIO_T.i_span12_vert[1]    BLK_TL-PIO_T.i_span4_vert[17]    BLK_TL-PIO_T.i_span4_vert[25]    BLK_TL-PIO_T.i_span4_vert[33]    BLK_TL-PIO_T.i_span4_vert[41]" output="BLK_XX-local_g[1].i[1]" />
-  <mux name="BLK_XX-local_g[1].i[2]" input="BLK_TL-PIO_T.i_span12_vert[10]   BLK_TL-PIO_T.i_neigh_op_bnr[2]   BLK_TL-PIO_T.i_span4_vert[18]    BLK_TL-PIO_T.i_span12_vert[18]   BLK_TL-PIO_T.i_span4_horz_r[2]   BLK_TL-PIO_T.i_span4_vert[26]    BLK_TL-PIO_T.i_neigh_op_bnl[2]   BLK_TL-PIO_T.i_span4_vert[2]     BLK_TL-PIO_T.i_span4_horz_r[10]  BLK_TL-PIO_T.i_span4_vert[34]    BLK_TL-PIO_T.i_neigh_op_bot[2]   BLK_TL-PIO_T.i_span4_vert[10]    BLK_TL-PIO_T.i_span12_vert[2]    BLK_TL-PIO_T.i_span4_vert[42]" output="BLK_XX-local_g[1].i[2]" />
-  <mux name="BLK_XX-local_g[1].i[3]" input="BLK_TL-PIO_T.i_neigh_op_bnl[3]   BLK_TL-PIO_T.i_neigh_op_bot[3]   BLK_TL-PIO_T.i_span12_vert[11]   BLK_TL-PIO_T.i_span12_vert[19]   BLK_TL-PIO_T.i_span4_vert[3]     BLK_TL-PIO_T.i_span4_vert[11]    BLK_TL-PIO_T.i_neigh_op_bnr[3]   BLK_TL-PIO_T.i_span4_horz_r[3]   BLK_TL-PIO_T.i_span4_horz_r[11]  BLK_TL-PIO_T.i_span12_vert[3]    BLK_TL-PIO_T.i_span4_vert[19]    BLK_TL-PIO_T.i_span4_vert[27]    BLK_TL-PIO_T.i_span4_vert[35]    BLK_TL-PIO_T.i_span4_vert[43]" output="BLK_XX-local_g[1].i[3]" />
-  <mux name="BLK_XX-local_g[1].i[4]" input="BLK_TL-PIO_T.i_span12_vert[12]   BLK_TL-PIO_T.i_neigh_op_bnr[4]   BLK_TL-PIO_T.i_span4_vert[20]    BLK_TL-PIO_T.i_span12_vert[20]   BLK_TL-PIO_T.i_span4_horz_r[4]   BLK_TL-PIO_T.i_span4_vert[28]    BLK_TL-PIO_T.i_neigh_op_bnl[4]   BLK_TL-PIO_T.i_span4_vert[4]     BLK_TL-PIO_T.i_span4_horz_r[12]  BLK_TL-PIO_T.i_span4_vert[36]    BLK_TL-PIO_T.i_neigh_op_bot[4]   BLK_TL-PIO_T.i_span4_vert[12]    BLK_TL-PIO_T.i_span12_vert[4]    BLK_TL-PIO_T.i_span4_vert[44]" output="BLK_XX-local_g[1].i[4]" />
-  <mux name="BLK_XX-local_g[1].i[5]" input="BLK_TL-PIO_T.i_neigh_op_bnl[5]   BLK_TL-PIO_T.i_neigh_op_bot[5]   BLK_TL-PIO_T.i_span12_vert[13]   BLK_TL-PIO_T.i_span12_vert[21]   BLK_TL-PIO_T.i_span4_vert[5]     BLK_TL-PIO_T.i_span4_vert[13]    BLK_TL-PIO_T.i_neigh_op_bnr[5]   BLK_TL-PIO_T.i_span4_horz_r[5]   BLK_TL-PIO_T.i_span4_horz_r[13]  BLK_TL-PIO_T.i_span12_vert[5]    BLK_TL-PIO_T.i_span4_vert[21]    BLK_TL-PIO_T.i_span4_vert[29]    BLK_TL-PIO_T.i_span4_vert[37]    BLK_TL-PIO_T.i_span4_vert[45]" output="BLK_XX-local_g[1].i[5]" />
-  <mux name="BLK_XX-local_g[1].i[6]" input="BLK_TL-PIO_T.i_span12_vert[14]   BLK_TL-PIO_T.i_neigh_op_bnr[6]   BLK_TL-PIO_T.i_span4_vert[22]    BLK_TL-PIO_T.i_span12_vert[22]   BLK_TL-PIO_T.i_span4_horz_r[6]   BLK_TL-PIO_T.i_span4_vert[30]    BLK_TL-PIO_T.i_neigh_op_bnl[6]   BLK_TL-PIO_T.i_span4_vert[6]     BLK_TL-PIO_T.i_span4_horz_r[14]  BLK_TL-PIO_T.i_span4_vert[38]    BLK_TL-PIO_T.i_neigh_op_bot[6]   BLK_TL-PIO_T.i_span4_vert[14]    BLK_TL-PIO_T.i_span12_vert[6]    BLK_TL-PIO_T.i_span4_vert[46]" output="BLK_XX-local_g[1].i[6]" />
-  <mux name="BLK_XX-local_g[1].i[7]" input="BLK_TL-PIO_T.i_neigh_op_bnl[7]   BLK_TL-PIO_T.i_neigh_op_bot[7]   BLK_TL-PIO_T.i_span12_vert[15]   BLK_TL-PIO_T.i_span12_vert[23]   BLK_TL-PIO_T.i_span4_vert[7]     BLK_TL-PIO_T.i_span4_vert[15]    BLK_TL-PIO_T.i_neigh_op_bnr[7]   BLK_TL-PIO_T.i_span4_horz_r[7]   BLK_TL-PIO_T.i_span4_horz_r[15]  BLK_TL-PIO_T.i_span12_vert[7]    BLK_TL-PIO_T.i_span4_vert[23]    BLK_TL-PIO_T.i_span4_vert[31]    BLK_TL-PIO_T.i_span4_vert[39]    BLK_TL-PIO_T.i_span4_vert[47]" output="BLK_XX-local_g[1].i[7]" />
+  <mux name="local_g[1].i[0]" input="PIO_T.i_span12_vert[8]    PIO_T.i_neigh_op_bnr[0]   PIO_T.i_span4_vert[16]    PIO_T.i_span12_vert[16]   PIO_T.i_span4_horz_r[0]   PIO_T.i_span4_vert[24]    PIO_T.i_neigh_op_bnl[0]   PIO_T.i_span4_vert[0]     PIO_T.i_span4_horz_r[8]   PIO_T.i_span4_vert[32]    PIO_T.i_neigh_op_bot[0]   PIO_T.i_span4_vert[8]     PIO_T.i_span12_vert[0]    PIO_T.i_span4_vert[40]" output="local_g[1].i[0]" />
+  <mux name="local_g[1].i[1]" input="PIO_T.i_neigh_op_bnl[1]   PIO_T.i_neigh_op_bot[1]   PIO_T.i_span12_vert[9]    PIO_T.i_span12_vert[17]   PIO_T.i_span4_vert[1]     PIO_T.i_span4_vert[9]     PIO_T.i_neigh_op_bnr[1]   PIO_T.i_span4_horz_r[1]   PIO_T.i_span4_horz_r[9]   PIO_T.i_span12_vert[1]    PIO_T.i_span4_vert[17]    PIO_T.i_span4_vert[25]    PIO_T.i_span4_vert[33]    PIO_T.i_span4_vert[41]" output="local_g[1].i[1]" />
+  <mux name="local_g[1].i[2]" input="PIO_T.i_span12_vert[10]   PIO_T.i_neigh_op_bnr[2]   PIO_T.i_span4_vert[18]    PIO_T.i_span12_vert[18]   PIO_T.i_span4_horz_r[2]   PIO_T.i_span4_vert[26]    PIO_T.i_neigh_op_bnl[2]   PIO_T.i_span4_vert[2]     PIO_T.i_span4_horz_r[10]  PIO_T.i_span4_vert[34]    PIO_T.i_neigh_op_bot[2]   PIO_T.i_span4_vert[10]    PIO_T.i_span12_vert[2]    PIO_T.i_span4_vert[42]" output="local_g[1].i[2]" />
+  <mux name="local_g[1].i[3]" input="PIO_T.i_neigh_op_bnl[3]   PIO_T.i_neigh_op_bot[3]   PIO_T.i_span12_vert[11]   PIO_T.i_span12_vert[19]   PIO_T.i_span4_vert[3]     PIO_T.i_span4_vert[11]    PIO_T.i_neigh_op_bnr[3]   PIO_T.i_span4_horz_r[3]   PIO_T.i_span4_horz_r[11]  PIO_T.i_span12_vert[3]    PIO_T.i_span4_vert[19]    PIO_T.i_span4_vert[27]    PIO_T.i_span4_vert[35]    PIO_T.i_span4_vert[43]" output="local_g[1].i[3]" />
+  <mux name="local_g[1].i[4]" input="PIO_T.i_span12_vert[12]   PIO_T.i_neigh_op_bnr[4]   PIO_T.i_span4_vert[20]    PIO_T.i_span12_vert[20]   PIO_T.i_span4_horz_r[4]   PIO_T.i_span4_vert[28]    PIO_T.i_neigh_op_bnl[4]   PIO_T.i_span4_vert[4]     PIO_T.i_span4_horz_r[12]  PIO_T.i_span4_vert[36]    PIO_T.i_neigh_op_bot[4]   PIO_T.i_span4_vert[12]    PIO_T.i_span12_vert[4]    PIO_T.i_span4_vert[44]" output="local_g[1].i[4]" />
+  <mux name="local_g[1].i[5]" input="PIO_T.i_neigh_op_bnl[5]   PIO_T.i_neigh_op_bot[5]   PIO_T.i_span12_vert[13]   PIO_T.i_span12_vert[21]   PIO_T.i_span4_vert[5]     PIO_T.i_span4_vert[13]    PIO_T.i_neigh_op_bnr[5]   PIO_T.i_span4_horz_r[5]   PIO_T.i_span4_horz_r[13]  PIO_T.i_span12_vert[5]    PIO_T.i_span4_vert[21]    PIO_T.i_span4_vert[29]    PIO_T.i_span4_vert[37]    PIO_T.i_span4_vert[45]" output="local_g[1].i[5]" />
+  <mux name="local_g[1].i[6]" input="PIO_T.i_span12_vert[14]   PIO_T.i_neigh_op_bnr[6]   PIO_T.i_span4_vert[22]    PIO_T.i_span12_vert[22]   PIO_T.i_span4_horz_r[6]   PIO_T.i_span4_vert[30]    PIO_T.i_neigh_op_bnl[6]   PIO_T.i_span4_vert[6]     PIO_T.i_span4_horz_r[14]  PIO_T.i_span4_vert[38]    PIO_T.i_neigh_op_bot[6]   PIO_T.i_span4_vert[14]    PIO_T.i_span12_vert[6]    PIO_T.i_span4_vert[46]" output="local_g[1].i[6]" />
+  <mux name="local_g[1].i[7]" input="PIO_T.i_neigh_op_bnl[7]   PIO_T.i_neigh_op_bot[7]   PIO_T.i_span12_vert[15]   PIO_T.i_span12_vert[23]   PIO_T.i_span4_vert[7]     PIO_T.i_span4_vert[15]    PIO_T.i_neigh_op_bnr[7]   PIO_T.i_span4_horz_r[7]   PIO_T.i_span4_horz_r[15]  PIO_T.i_span12_vert[7]    PIO_T.i_span4_vert[23]    PIO_T.i_span4_vert[31]    PIO_T.i_span4_vert[39]    PIO_T.i_span4_vert[47]" output="local_g[1].i[7]" />
 
   <!-- D_IN -> Span4 Horz R -->
-  <mux name="span4_horz_r[0]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[0]"  />
-  <mux name="span4_horz_r[1]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[1]"  />
-  <mux name="span4_horz_r[10]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[10]" />
-  <mux name="span4_horz_r[11]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[11]" />
-  <mux name="span4_horz_r[12]" input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[12]" />
-  <mux name="span4_horz_r[13]" input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[13]" />
-  <mux name="span4_horz_r[14]" input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[14]" />
-  <mux name="span4_horz_r[15]" input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[15]" />
-  <mux name="span4_horz_r[2]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[2]"  />
-  <mux name="span4_horz_r[3]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[3]"  />
-  <mux name="span4_horz_r[4]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[4]"  />
-  <mux name="span4_horz_r[5]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[5]"  />
-  <mux name="span4_horz_r[6]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[6]"  />
-  <mux name="span4_horz_r[7]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[7]"  />
-  <mux name="span4_horz_r[8]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_horz_r[8]"  />
-  <mux name="span4_horz_r[9]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_horz_r[9]"  />
+  <mux name="span4_horz_r[0]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_horz_r[0]"  />
+  <mux name="span4_horz_r[1]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_horz_r[1]"  />
+  <mux name="span4_horz_r[10]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_horz_r[10]" />
+  <mux name="span4_horz_r[11]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_horz_r[11]" />
+  <mux name="span4_horz_r[12]" input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_horz_r[12]" />
+  <mux name="span4_horz_r[13]" input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_horz_r[13]" />
+  <mux name="span4_horz_r[14]" input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_horz_r[14]" />
+  <mux name="span4_horz_r[15]" input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_horz_r[15]" />
+  <mux name="span4_horz_r[2]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_horz_r[2]"  />
+  <mux name="span4_horz_r[3]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_horz_r[3]"  />
+  <mux name="span4_horz_r[4]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_horz_r[4]"  />
+  <mux name="span4_horz_r[5]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_horz_r[5]"  />
+  <mux name="span4_horz_r[6]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_horz_r[6]"  />
+  <mux name="span4_horz_r[7]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_horz_r[7]"  />
+  <mux name="span4_horz_r[8]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_horz_r[8]"  />
+  <mux name="span4_horz_r[9]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_horz_r[9]"  />
 
   <!-- D_IN -> Span4 Vert -->
-  <mux name="span4_vert[0]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[0]"    />
-  <mux name="span4_vert[10]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[10]"   />
-  <mux name="span4_vert[12]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[12]"   />
-  <mux name="span4_vert[14]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[14]"   />
-  <mux name="span4_vert[16]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[16]"   />
-  <mux name="span4_vert[18]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[18]"   />
-  <mux name="span4_vert[2]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[2]"    />
-  <mux name="span4_vert[20]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[20]"   />
-  <mux name="span4_vert[22]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[22]"   />
-  <mux name="span4_vert[24]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[24]"   />
-  <mux name="span4_vert[26]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[26]"   />
-  <mux name="span4_vert[28]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[28]"   />
-  <mux name="span4_vert[30]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[30]"   />
-  <mux name="span4_vert[32]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[32]"   />
-  <mux name="span4_vert[34]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[34]"   />
-  <mux name="span4_vert[36]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[36]"   />
-  <mux name="span4_vert[38]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[38]"   />
-  <mux name="span4_vert[4]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[4]"    />
-  <mux name="span4_vert[40]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[40]"   />
-  <mux name="span4_vert[42]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[42]"   />
-  <mux name="span4_vert[44]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[44]"   />
-  <mux name="span4_vert[46]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[46]"   />
-  <mux name="span4_vert[6]"    input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span4_vert[6]"    />
-  <mux name="span4_vert[8]"    input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span4_vert[8]"    />
+  <mux name="span4_vert[0]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_vert[0]"    />
+  <mux name="span4_vert[10]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_vert[10]"   />
+  <mux name="span4_vert[12]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_vert[12]"   />
+  <mux name="span4_vert[14]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_vert[14]"   />
+  <mux name="span4_vert[16]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_vert[16]"   />
+  <mux name="span4_vert[18]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_vert[18]"   />
+  <mux name="span4_vert[2]"    input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_vert[2]"    />
+  <mux name="span4_vert[20]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_vert[20]"   />
+  <mux name="span4_vert[22]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_vert[22]"   />
+  <mux name="span4_vert[24]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_vert[24]"   />
+  <mux name="span4_vert[26]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_vert[26]"   />
+  <mux name="span4_vert[28]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_vert[28]"   />
+  <mux name="span4_vert[30]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_vert[30]"   />
+  <mux name="span4_vert[32]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_vert[32]"   />
+  <mux name="span4_vert[34]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_vert[34]"   />
+  <mux name="span4_vert[36]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_vert[36]"   />
+  <mux name="span4_vert[38]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_vert[38]"   />
+  <mux name="span4_vert[4]"    input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_vert[4]"    />
+  <mux name="span4_vert[40]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_vert[40]"   />
+  <mux name="span4_vert[42]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span4_vert[42]"   />
+  <mux name="span4_vert[44]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span4_vert[44]"   />
+  <mux name="span4_vert[46]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_vert[46]"   />
+  <mux name="span4_vert[6]"    input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span4_vert[6]"    />
+  <mux name="span4_vert[8]"    input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span4_vert[8]"    />
 
   <!-- D_IN -> Span12 Vert -->
-  <mux name="span12_vert[0]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span12_vert[0]"   />
-  <mux name="span12_vert[10]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span12_vert[10]"  />
-  <mux name="span12_vert[12]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span12_vert[12]"  />
-  <mux name="span12_vert[14]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span12_vert[14]"  />
-  <mux name="span12_vert[16]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span12_vert[16]"  />
-  <mux name="span12_vert[18]"  input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span12_vert[18]"  />
-  <mux name="span12_vert[2]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[1]" output="BLK_TL-PIO_T.o_span12_vert[2]"   />
-  <mux name="span12_vert[20]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span12_vert[20]"  />
-  <mux name="span12_vert[22]"  input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span12_vert[22]"  />
-  <mux name="span12_vert[4]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[0]" output="BLK_TL-PIO_T.o_span12_vert[4]"   />
-  <mux name="span12_vert[6]"   input="BLK_IG-IO_LOCAL.io_1_D_IN[1]" output="BLK_TL-PIO_T.o_span12_vert[6]"   />
-  <mux name="span12_vert[8]"   input="BLK_IG-IO_LOCAL.io_0_D_IN[0]" output="BLK_TL-PIO_T.o_span12_vert[8]"   />
+  <mux name="span12_vert[0]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span12_vert[0]"   />
+  <mux name="span12_vert[10]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span12_vert[10]"  />
+  <mux name="span12_vert[12]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span12_vert[12]"  />
+  <mux name="span12_vert[14]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span12_vert[14]"  />
+  <mux name="span12_vert[16]"  input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span12_vert[16]"  />
+  <mux name="span12_vert[18]"  input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span12_vert[18]"  />
+  <mux name="span12_vert[2]"   input="IO_LOCAL.io_0_D_IN[1]" output="PIO_T.o_span12_vert[2]"   />
+  <mux name="span12_vert[20]"  input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span12_vert[20]"  />
+  <mux name="span12_vert[22]"  input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span12_vert[22]"  />
+  <mux name="span12_vert[4]"   input="IO_LOCAL.io_1_D_IN[0]" output="PIO_T.o_span12_vert[4]"   />
+  <mux name="span12_vert[6]"   input="IO_LOCAL.io_1_D_IN[1]" output="PIO_T.o_span12_vert[6]"   />
+  <mux name="span12_vert[8]"   input="IO_LOCAL.io_0_D_IN[0]" output="PIO_T.o_span12_vert[8]"   />
 
   <!-- Spans -->
   <!--
-  <direct name="span4_horz_r[0]"  input="BLK_TL-PIO_T.i_span4_horz_l[ ]" output="BLK_TL-PIO_T.o_span4_horz_r[0]" />
-  <direct name="span4_horz_r[1]"  input="BLK_TL-PIO_T.i_span4_horz_l[ ]" output="BLK_TL-PIO_T.o_span4_horz_r[1]" />
-  <direct name="span4_horz_r[2]"  input="BLK_TL-PIO_T.i_span4_horz_l[ ]" output="BLK_TL-PIO_T.o_span4_horz_r[2]" />
-  <direct name="span4_horz_r[3]"  input="BLK_TL-PIO_T.i_span4_horz_l[ ]" output="BLK_TL-PIO_T.o_span4_horz_r[3]" />
+  <direct name="span4_horz_r[0]"  input="PIO_T.i_span4_horz_l[ ]" output="PIO_T.o_span4_horz_r[0]" />
+  <direct name="span4_horz_r[1]"  input="PIO_T.i_span4_horz_l[ ]" output="PIO_T.o_span4_horz_r[1]" />
+  <direct name="span4_horz_r[2]"  input="PIO_T.i_span4_horz_l[ ]" output="PIO_T.o_span4_horz_r[2]" />
+  <direct name="span4_horz_r[3]"  input="PIO_T.i_span4_horz_l[ ]" output="PIO_T.o_span4_horz_r[3]" />
   -->
 
-  <direct name="span4_horz_l[0]"  input="BLK_TL-PIO_T.i_span4_horz_l[0]"  output="BLK_TL-PIO_T.o_span4_horz_r[4]"  />
-  <direct name="span4_horz_l[1]"  input="BLK_TL-PIO_T.i_span4_horz_l[1]"  output="BLK_TL-PIO_T.o_span4_horz_r[5]"  />
-  <direct name="span4_horz_l[2]"  input="BLK_TL-PIO_T.i_span4_horz_l[2]"  output="BLK_TL-PIO_T.o_span4_horz_r[6]"  />
-  <direct name="span4_horz_l[3]"  input="BLK_TL-PIO_T.i_span4_horz_l[3]"  output="BLK_TL-PIO_T.o_span4_horz_r[7]"  />
-  <direct name="span4_horz_l[4]"  input="BLK_TL-PIO_T.i_span4_horz_l[4]"  output="BLK_TL-PIO_T.o_span4_horz_r[8]"  />
-  <direct name="span4_horz_l[5]"  input="BLK_TL-PIO_T.i_span4_horz_l[5]"  output="BLK_TL-PIO_T.o_span4_horz_r[9]"  />
-  <direct name="span4_horz_l[6]"  input="BLK_TL-PIO_T.i_span4_horz_l[6]"  output="BLK_TL-PIO_T.o_span4_horz_r[10]" />
-  <direct name="span4_horz_l[7]"  input="BLK_TL-PIO_T.i_span4_horz_l[7]"  output="BLK_TL-PIO_T.o_span4_horz_r[11]" />
-  <direct name="span4_horz_l[8]"  input="BLK_TL-PIO_T.i_span4_horz_l[8]"  output="BLK_TL-PIO_T.o_span4_horz_r[12]" />
-  <direct name="span4_horz_l[9]"  input="BLK_TL-PIO_T.i_span4_horz_l[9]"  output="BLK_TL-PIO_T.o_span4_horz_r[13]" />
-  <direct name="span4_horz_l[10]" input="BLK_TL-PIO_T.i_span4_horz_l[10]" output="BLK_TL-PIO_T.o_span4_horz_r[14]" />
-  <direct name="span4_horz_l[11]" input="BLK_TL-PIO_T.i_span4_horz_l[11]" output="BLK_TL-PIO_T.o_span4_horz_r[15]" />
+  <direct name="span4_horz_l[0]"  input="PIO_T.i_span4_horz_l[0]"  output="PIO_T.o_span4_horz_r[4]"  />
+  <direct name="span4_horz_l[1]"  input="PIO_T.i_span4_horz_l[1]"  output="PIO_T.o_span4_horz_r[5]"  />
+  <direct name="span4_horz_l[2]"  input="PIO_T.i_span4_horz_l[2]"  output="PIO_T.o_span4_horz_r[6]"  />
+  <direct name="span4_horz_l[3]"  input="PIO_T.i_span4_horz_l[3]"  output="PIO_T.o_span4_horz_r[7]"  />
+  <direct name="span4_horz_l[4]"  input="PIO_T.i_span4_horz_l[4]"  output="PIO_T.o_span4_horz_r[8]"  />
+  <direct name="span4_horz_l[5]"  input="PIO_T.i_span4_horz_l[5]"  output="PIO_T.o_span4_horz_r[9]"  />
+  <direct name="span4_horz_l[6]"  input="PIO_T.i_span4_horz_l[6]"  output="PIO_T.o_span4_horz_r[10]" />
+  <direct name="span4_horz_l[7]"  input="PIO_T.i_span4_horz_l[7]"  output="PIO_T.o_span4_horz_r[11]" />
+  <direct name="span4_horz_l[8]"  input="PIO_T.i_span4_horz_l[8]"  output="PIO_T.o_span4_horz_r[12]" />
+  <direct name="span4_horz_l[9]"  input="PIO_T.i_span4_horz_l[9]"  output="PIO_T.o_span4_horz_r[13]" />
+  <direct name="span4_horz_l[10]" input="PIO_T.i_span4_horz_l[10]" output="PIO_T.o_span4_horz_r[14]" />
+  <direct name="span4_horz_l[11]" input="PIO_T.i_span4_horz_l[11]" output="PIO_T.o_span4_horz_r[15]" />
 
   <!--
-  <direct name="span4_horz_l[12]" input="BLK_TL-PIO_T.i_span4_horz_l[12]" output="BLK_TL-PIO_T.o_span4_horz_r[  ]" />
-  <direct name="span4_horz_l[13]" input="BLK_TL-PIO_T.i_span4_horz_l[13]" output="BLK_TL-PIO_T.o_span4_horz_r[  ]" />
-  <direct name="span4_horz_l[14]" input="BLK_TL-PIO_T.i_span4_horz_l[14]" output="BLK_TL-PIO_T.o_span4_horz_r[  ]" />
-  <direct name="span4_horz_l[15]" input="BLK_TL-PIO_T.i_span4_horz_l[15]" output="BLK_TL-PIO_T.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[12]" input="PIO_T.i_span4_horz_l[12]" output="PIO_T.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[13]" input="PIO_T.i_span4_horz_l[13]" output="PIO_T.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[14]" input="PIO_T.i_span4_horz_l[14]" output="PIO_T.o_span4_horz_r[  ]" />
+  <direct name="span4_horz_l[15]" input="PIO_T.i_span4_horz_l[15]" output="PIO_T.o_span4_horz_r[  ]" />
   -->
 
  </interconnect>
 
  <pinlocations pattern="custom">
   <loc side="left" xoffset="0" yoffset="0">
-   BLK_TL-PIO_T.i_span4_horz_l BLK_TL-PIO_T.o_span4_horz_l
+   PIO_T.i_span4_horz_l PIO_T.o_span4_horz_l
   </loc>
   <loc side="top" xoffset="0" yoffset="0">
-   BLK_TL-PIO_T.i_glb_netwk    BLK_TL-PIO_T.o_glb_netwk
-   BLK_TL-PIO_T.fabout
+   PIO_T.i_glb_netwk    PIO_T.o_glb_netwk
+   PIO_T.fabout
 
-   BLK_TL-PIO_T.i_span4_vert   BLK_TL-PIO_T.o_span4_vert
-   BLK_TL-PIO_T.i_span12_vert  BLK_TL-PIO_T.o_span12_vert
+   PIO_T.i_span4_vert   PIO_T.o_span4_vert
+   PIO_T.i_span12_vert  PIO_T.o_span12_vert
   </loc>
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PIO_T.i_span4_horz_r BLK_TL-PIO_T.o_span4_horz_r
+   PIO_T.i_span4_horz_r PIO_T.o_span4_horz_r
   </loc>
   <loc side="bottom" xoffset="0" yoffset="0">
-   BLK_TL-PIO_T.i_neigh_op_bnl BLK_TL-PIO_T.o_neigh_op_bnl
-   BLK_TL-PIO_T.i_neigh_op_bot BLK_TL-PIO_T.o_neigh_op_bot
-   BLK_TL-PIO_T.i_neigh_op_bnr BLK_TL-PIO_T.o_neigh_op_bnr
+   PIO_T.i_neigh_op_bnl PIO_T.o_neigh_op_bnl
+   PIO_T.i_neigh_op_bot PIO_T.o_neigh_op_bot
+   PIO_T.i_neigh_op_bnr PIO_T.o_neigh_op_bnr
 
-   BLK_TL-PIO_T.i_span4_vert   BLK_TL-PIO_T.o_span4_vert
-   BLK_TL-PIO_T.i_span12_vert  BLK_TL-PIO_T.o_span12_vert
+   PIO_T.i_span4_vert   PIO_T.o_span4_vert
+   PIO_T.i_span12_vert  PIO_T.o_span12_vert
   </loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="0.5" out_type="frac" out_val="1.0">
   <xi:include href="../pio-tb/pio-tb.fc.xml" xpointer="xpointer(fc/child::node())"/>
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/pio-tb/pio-tb.interconnect.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-tb/pio-tb.interconnect.xml
@@ -5,89 +5,89 @@
  <!-- ################################################################ -->
 
  <!-- Fabric Span wires -->
- <direct name="span4_horz"  input="BLK_TL-PLR_LR.i_span4_horz"  output="BLK_TL-PLR_LR.o_span4_horz" />
- <direct name="span12_horz" input="BLK_TL-PLR_LR.i_span12_horz" output="BLK_TL-PLR_LR.o_span12_horz" />
+ <direct name="span4_horz"  input="PLR_LR.i_span4_horz"  output="PLR_LR.o_span4_horz" />
+ <direct name="span12_horz" input="PLR_LR.i_span12_horz" output="PLR_LR.o_span12_horz" />
 
  <!-- IO Span wires -->
- <direct name="span4_vert_l" input="BLK_TL-PLR_LR.i_span4_vert_l" output="BLK_TL-PLR_LR.o_span4_vert_l" />
- <direct name="span4_vert_r" input="BLK_TL-PLR_LR.i_span4_vert_r" output="BLK_TL-PLR_LR.o_span4_vert_r" />
+ <direct name="span4_vert_l" input="PLR_LR.i_span4_vert_l" output="PLR_LR.o_span4_vert_l" />
+ <direct name="span4_vert_r" input="PLR_LR.i_span4_vert_r" output="PLR_LR.o_span4_vert_r" />
  <!--"Configuration Stamps" - ??? -->
 
  <!-- io           -> span4_vert_r -->
  <!-- io[0]        -> span4_vert_r -->
  <!-- io[0].D_IN_0 -> span4_vert_r -->
- <mux name="io[0].D_IN_0->span4_vert_r[0]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[0]"  />
- <mux name="io[0].D_IN_0->span4_vert_r[4]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[4]"  />
- <mux name="io[0].D_IN_0->span4_vert_r[8]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[8]"  />
- <mux name="io[0].D_IN_0->span4_vert_r[12]" input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[12]" />
+ <mux name="io[0].D_IN_0->span4_vert_r[0]"  input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_vert_r[0]"  />
+ <mux name="io[0].D_IN_0->span4_vert_r[4]"  input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_vert_r[4]"  />
+ <mux name="io[0].D_IN_0->span4_vert_r[8]"  input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_vert_r[8]"  />
+ <mux name="io[0].D_IN_0->span4_vert_r[12]" input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_vert_r[12]" />
  <!-- io[0].D_IN_1 -> span4_vert_r -->
- <mux name="io[0].D_IN_1->span4_vert_r[1]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[1]"  />
- <mux name="io[0].D_IN_1->span4_vert_r[5]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[5]"  />
- <mux name="io[0].D_IN_1->span4_vert_r[9]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[9]"  />
- <mux name="io[0].D_IN_1->span4_vert_r[13]" input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[13]" />
+ <mux name="io[0].D_IN_1->span4_vert_r[1]"  input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_vert_r[1]"  />
+ <mux name="io[0].D_IN_1->span4_vert_r[5]"  input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_vert_r[5]"  />
+ <mux name="io[0].D_IN_1->span4_vert_r[9]"  input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_vert_r[9]"  />
+ <mux name="io[0].D_IN_1->span4_vert_r[13]" input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_vert_r[13]" />
  <!-- io[1]        -> span4_vert_r -->
  <!-- io[1].D_IN_0 -> span4_vert_r -->
- <mux name="io[1].D_IN_0->span4_vert_r[2]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[2]"  />
- <mux name="io[1].D_IN_0->span4_vert_r[6]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[6]"  />
- <mux name="io[1].D_IN_0->span4_vert_r[10]" input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[10]" />
- <mux name="io[1].D_IN_0->span4_vert_r[14]" input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_vert_r[14]" />
+ <mux name="io[1].D_IN_0->span4_vert_r[2]"  input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_vert_r[2]"  />
+ <mux name="io[1].D_IN_0->span4_vert_r[6]"  input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_vert_r[6]"  />
+ <mux name="io[1].D_IN_0->span4_vert_r[10]" input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_vert_r[10]" />
+ <mux name="io[1].D_IN_0->span4_vert_r[14]" input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_vert_r[14]" />
  <!-- io[1].D_IN_1 -> span4_vert_r -->
- <mux name="io[1].D_IN_1->span4_vert_r[3]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[3]"  />
- <mux name="io[1].D_IN_1->span4_vert_r[7]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[7]"  />
- <mux name="io[1].D_IN_1->span4_vert_r[11]" input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[11]" />
- <mux name="io[1].D_IN_1->span4_vert_r[15]" input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_vert_r[15]" />
+ <mux name="io[1].D_IN_1->span4_vert_r[3]"  input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_vert_r[3]"  />
+ <mux name="io[1].D_IN_1->span4_vert_r[7]"  input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_vert_r[7]"  />
+ <mux name="io[1].D_IN_1->span4_vert_r[11]" input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_vert_r[11]" />
+ <mux name="io[1].D_IN_1->span4_vert_r[15]" input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_vert_r[15]" />
 
  <!-- io           -> span4_horz -->
  <!-- io[0]        -> span4_horz -->
  <!-- io[0].D_IN_0 -> span4_horz -->
- <mux name="io[0].D_IN_0->span4_horz[0]"    input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[0]"    />
- <mux name="io[0].D_IN_0->span4_horz[8]"    input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[8]"    />
- <mux name="io[0].D_IN_0->span4_horz[16]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[16]"   />
- <mux name="io[0].D_IN_0->span4_horz[24]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[24]"   />
- <mux name="io[0].D_IN_0->span4_horz[32]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[32]"   />
- <mux name="io[0].D_IN_0->span4_horz[40]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[40]"   />
+ <mux name="io[0].D_IN_0->span4_horz[0]"    input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_horz[0]"    />
+ <mux name="io[0].D_IN_0->span4_horz[8]"    input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_horz[8]"    />
+ <mux name="io[0].D_IN_0->span4_horz[16]"   input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_horz[16]"   />
+ <mux name="io[0].D_IN_0->span4_horz[24]"   input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_horz[24]"   />
+ <mux name="io[0].D_IN_0->span4_horz[32]"   input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_horz[32]"   />
+ <mux name="io[0].D_IN_0->span4_horz[40]"   input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span4_horz[40]"   />
  <!-- io[0].D_IN_1 -> span4_horz -->
- <mux name="io[0].D_IN_1->span4_horz[2]"    input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[2]"    />
- <mux name="io[0].D_IN_1->span4_horz[10]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[10]"   />
- <mux name="io[0].D_IN_1->span4_horz[18]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[18]"   />
- <mux name="io[0].D_IN_1->span4_horz[26]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[26]"   />
- <mux name="io[0].D_IN_1->span4_horz[34]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[34]"   />
- <mux name="io[0].D_IN_1->span4_horz[42]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[42]"   />
+ <mux name="io[0].D_IN_1->span4_horz[2]"    input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_horz[2]"    />
+ <mux name="io[0].D_IN_1->span4_horz[10]"   input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_horz[10]"   />
+ <mux name="io[0].D_IN_1->span4_horz[18]"   input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_horz[18]"   />
+ <mux name="io[0].D_IN_1->span4_horz[26]"   input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_horz[26]"   />
+ <mux name="io[0].D_IN_1->span4_horz[34]"   input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_horz[34]"   />
+ <mux name="io[0].D_IN_1->span4_horz[42]"   input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span4_horz[42]"   />
  <!-- io[1]        -> span4_horz -->
  <!-- io[1].D_IN_0 -> span4_horz -->
- <mux name="io[1].D_IN_0->span4_horz[4]"    input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[4]"    />
- <mux name="io[1].D_IN_0->span4_horz[12]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[12]"   />
- <mux name="io[1].D_IN_0->span4_horz[20]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[20]"   />
- <mux name="io[1].D_IN_0->span4_horz[28]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[28]"   />
- <mux name="io[1].D_IN_0->span4_horz[36]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[36]"   />
- <mux name="io[1].D_IN_0->span4_horz[44]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span4_horz[44]"   />
+ <mux name="io[1].D_IN_0->span4_horz[4]"    input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_horz[4]"    />
+ <mux name="io[1].D_IN_0->span4_horz[12]"   input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_horz[12]"   />
+ <mux name="io[1].D_IN_0->span4_horz[20]"   input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_horz[20]"   />
+ <mux name="io[1].D_IN_0->span4_horz[28]"   input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_horz[28]"   />
+ <mux name="io[1].D_IN_0->span4_horz[36]"   input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_horz[36]"   />
+ <mux name="io[1].D_IN_0->span4_horz[44]"   input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span4_horz[44]"   />
  <!-- io[1].D_IN_1 -> span4_horz -->
- <mux name="io[1].D_IN_1->span4_horz[6]"    input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[6]"    />
- <mux name="io[1].D_IN_1->span4_horz[14]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[14]"   />
- <mux name="io[1].D_IN_1->span4_horz[22]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[22]"   />
- <mux name="io[1].D_IN_1->span4_horz[30]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[30]"   />
- <mux name="io[1].D_IN_1->span4_horz[38]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[38]"   />
- <mux name="io[1].D_IN_1->span4_horz[46]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span4_horz[46]"   />
+ <mux name="io[1].D_IN_1->span4_horz[6]"    input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_horz[6]"    />
+ <mux name="io[1].D_IN_1->span4_horz[14]"   input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_horz[14]"   />
+ <mux name="io[1].D_IN_1->span4_horz[22]"   input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_horz[22]"   />
+ <mux name="io[1].D_IN_1->span4_horz[30]"   input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_horz[30]"   />
+ <mux name="io[1].D_IN_1->span4_horz[38]"   input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_horz[38]"   />
+ <mux name="io[1].D_IN_1->span4_horz[46]"   input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span4_horz[46]"   />
 
  <!-- io           -> span12_horz -->
  <!-- io[0]        -> span12_horz -->
  <!-- io[0].D_IN_0 -> span12_horz -->
- <mux name="io[0].D_IN_0->span12_horz[0]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span12_horz[0]"   />
- <mux name="io[0].D_IN_0->span12_horz[8]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span12_horz[8]"   />
- <mux name="io[0].D_IN_0->span12_horz[16]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_0" output="BLK_TL-PLR_LR.i_span12_horz[16]"  />
+ <mux name="io[0].D_IN_0->span12_horz[0]"   input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span12_horz[0]"   />
+ <mux name="io[0].D_IN_0->span12_horz[8]"   input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span12_horz[8]"   />
+ <mux name="io[0].D_IN_0->span12_horz[16]"  input="IO_LOCAL.io_0_D_IN_0" output="PLR_LR.i_span12_horz[16]"  />
  <!-- io[0].D_IN_1 -> span12_horz -->
- <mux name="io[0].D_IN_1->span12_horz[2]"   input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span12_horz[2]"   />
- <mux name="io[0].D_IN_1->span12_horz[10]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span12_horz[10]"  />
- <mux name="io[0].D_IN_1->span12_horz[18]"  input="BLK_IG-IO_LOCAL.io_0_D_IN_1" output="BLK_TL-PLR_LR.i_span12_horz[18]"  />
+ <mux name="io[0].D_IN_1->span12_horz[2]"   input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span12_horz[2]"   />
+ <mux name="io[0].D_IN_1->span12_horz[10]"  input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span12_horz[10]"  />
+ <mux name="io[0].D_IN_1->span12_horz[18]"  input="IO_LOCAL.io_0_D_IN_1" output="PLR_LR.i_span12_horz[18]"  />
  <!-- io[1]        -> span12_horz -->
  <!-- io[1].D_IN_0 -> span12_horz -->
- <mux name="io[1].D_IN_0->span12_horz[4]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span12_horz[4]"   />
- <mux name="io[1].D_IN_0->span12_horz[12]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span12_horz[12]"  />
- <mux name="io[1].D_IN_0->span12_horz[20]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_0" output="BLK_TL-PLR_LR.i_span12_horz[20]"  />
+ <mux name="io[1].D_IN_0->span12_horz[4]"   input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span12_horz[4]"   />
+ <mux name="io[1].D_IN_0->span12_horz[12]"  input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span12_horz[12]"  />
+ <mux name="io[1].D_IN_0->span12_horz[20]"  input="IO_LOCAL.io_1_D_IN_0" output="PLR_LR.i_span12_horz[20]"  />
  <!-- io[1].D_IN_1 -> span12_horz -->
- <mux name="io[1].D_IN_1->span12_horz[6]"   input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span12_horz[6]"   />
- <mux name="io[1].D_IN_1->span12_horz[14]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span12_horz[14]"  />
- <mux name="io[1].D_IN_1->span12_horz[22]"  input="BLK_IG-IO_LOCAL.io_1_D_IN_1" output="BLK_TL-PLR_LR.i_span12_horz[22]"  />
+ <mux name="io[1].D_IN_1->span12_horz[6]"   input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span12_horz[6]"   />
+ <mux name="io[1].D_IN_1->span12_horz[14]"  input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span12_horz[14]"  />
+ <mux name="io[1].D_IN_1->span12_horz[22]"  input="IO_LOCAL.io_1_D_IN_1" output="PLR_LR.i_span12_horz[22]"  />
 
 
  <!-- ================================================================ -->

--- a/ice40/devices/tile-routing-virt/tiles/pio-tb/pio-tb.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio-tb/pio-tb.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO_TB" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO_TB" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <!-- Horizontal spans ############################################### -->
  <!-- Span-4 Horizontal -->
@@ -16,5 +16,10 @@
  <!-- Span-12 Vertical -->
  <input  name="i_span12_vert"  num_pins="24"/>
  <output name="o_span12_vert"  num_pins="24"/>
+
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/pio/pio.interconnect.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio/pio.interconnect.xml
@@ -1,17 +1,17 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <interconnect xmlns:xi="http://www.w3.org/2001/XInclude">
 
- <mux name="io[0]/D_OUT_0"   input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7]" output="BLK_IG-IO_LOCAL.io_0_D_OUT[0]" />
- <mux name="io[0]/D_OUT_1"   input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6]" output="BLK_IG-IO_LOCAL.io_0_D_OUT[1]" />
- <mux name="io[0]/OUT_ENB"   input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6]" output="BLK_IG-IO_LOCAL.io_0_OUT_ENB" />
+ <mux name="io[0]/D_OUT_0"   input="local_g[0].o[0] local_g[0].o[2] local_g[0].o[4] local_g[0].o[6] local_g[1].o[1] local_g[1].o[3] local_g[1].o[5] local_g[1].o[7]" output="IO_LOCAL.io_0_D_OUT[0]" />
+ <mux name="io[0]/D_OUT_1"   input="local_g[0].o[1] local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6]" output="IO_LOCAL.io_0_D_OUT[1]" />
+ <mux name="io[0]/OUT_ENB"   input="local_g[0].o[1] local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6]" output="IO_LOCAL.io_0_OUT_ENB" />
 
- <mux name="io[1]/D_OUT_0"   input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6]" output="BLK_IG-IO_LOCAL.io_1_D_OUT[0]" />
- <mux name="io[1]/D_OUT_1"   input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7]" output="BLK_IG-IO_LOCAL.io_1_D_OUT[1]" />
- <mux name="io[1]/OUT_ENB"   input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7]" output="BLK_IG-IO_LOCAL.io_1_OUT_ENB" />
+ <mux name="io[1]/D_OUT_0"   input="local_g[0].o[1] local_g[0].o[3] local_g[0].o[5] local_g[0].o[7] local_g[1].o[0] local_g[1].o[2] local_g[1].o[4] local_g[1].o[6]" output="IO_LOCAL.io_1_D_OUT[0]" />
+ <mux name="io[1]/D_OUT_1"   input="local_g[0].o[0] local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7]" output="IO_LOCAL.io_1_D_OUT[1]" />
+ <mux name="io[1]/OUT_ENB"   input="local_g[0].o[0] local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7]" output="IO_LOCAL.io_1_OUT_ENB" />
 
- <mux name="BLK_XX-io_global/i_cen"   input="BLK_XX-local_g[0].o[2]  BLK_XX-local_g[1].o[2]  BLK_XX-local_g[0].o[5]  BLK_XX-local_g[1].o[5]"                                                                                                      output="BLK_XX-io_global.i_cen" />
- <direct name="BLK_XX-io_global->BLK_IG-PLB_LOCAL.io_global_cen"   input="BLK_XX-io_global.o_cen"   output="BLK_IG-IO_LOCAL.io_global_cen"/>
- <direct name="BLK_XX-io_global->BLK_IG-PLB_LOCAL.io_global_inclk" input="BLK_XX-io_global.o_inclk" output="BLK_IG-IO_LOCAL.io_global_inclk"/>
- <direct name="BLK_XX-io_global->BLK_IG-PLB_LOCAL.io_global_outclk" input="BLK_XX-io_global.o_outclk" output="BLK_IG-IO_LOCAL.io_global_outclk"/>
+ <mux name="io_global/i_cen" input="local_g[0].o[2] local_g[1].o[2] local_g[0].o[5] local_g[1].o[5]"                                                                 output="io_global.i_cen" />
+ <direct name="io_global->PLB_LOCAL.io_global_cen"   input="io_global.o_cen"   output="IO_LOCAL.io_global_cen"/>
+ <direct name="io_global->PLB_LOCAL.io_global_inclk" input="io_global.o_inclk" output="IO_LOCAL.io_global_inclk"/>
+ <direct name="io_global->PLB_LOCAL.io_global_outclk" input="io_global.o_outclk" output="IO_LOCAL.io_global_outclk"/>
 
 </interconnect>

--- a/ice40/devices/tile-routing-virt/tiles/pio/pio.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/pio/pio.pb_type.xml
@@ -11,40 +11,57 @@
  <!-- ################################################################ -->
  <!-- # Local tracks                                                 # -->
  <!-- ################################################################ -->
- <pb_type name="BLK_XX-local_g" num_pb="2">
+ <pb_type name="local_g" num_pb="2">
   <input  name="i"  num_pins="8"/>
   <output name="o"  num_pins="8"/>
 
   <interconnect>
-   <direct name="i_to_o" input="BLK_XX-local_g.i" output="BLK_XX-local_g.o" />
+   <direct name="i_to_o" input="local_g.i" output="local_g.o" />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">ignore</meta>
+  </metadata>
  </pb_type>
 
- <pb_type name="BLK_XX-glb_netwk" num_pb="8">
+ <pb_type name="glb_netwk" num_pb="8">
   <input  name="i" num_pins="1"/>
   <output name="o" num_pins="1"/>
   <interconnect>
-   <direct name="i_to_o" input="BLK_XX-glb_netwk.i" output="BLK_XX-glb_netwk.o" />
+   <direct name="i_to_o" input="glb_netwk.i" output="glb_netwk.o" />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">ignore</meta>
+  </metadata>
  </pb_type>
 
  <!-- ################################################################ -->
  <!-- # IO units                                                     # -->
  <!-- ################################################################ -->
 
- <pb_type name="BLK_XX-io_global" num_pb="1">
+ <pb_type name="io_global" num_pb="1">
   <input name="i_cen" num_pins="1" /><output name="o_cen" num_pins="1" />
   <clock name="i_inclk" num_pins="1" /><output name="o_inclk" num_pins="1" />
   <clock name="i_outclk" num_pins="1" /><output name="o_outclk" num_pins="1" />
   <input name="i_latch" num_pins="1" /><output name="o_latch" num_pins="1" />
   <interconnect>
-   <direct name="EN" input="BLK_XX-io_global.i_cen" output="BLK_XX-io_global.o_cen"/>
-   <direct name="ICLK" input="BLK_XX-io_global.i_inclk" output="BLK_XX-io_global.o_inclk"/>
-   <direct name="OCLK" input="BLK_XX-io_global.i_outclk" output="BLK_XX-io_global.o_outclk"/>
-   <direct name="io_global_latch" input="BLK_XX-io_global.i_latch" output="BLK_XX-io_global.o_latch"/>
+   <direct name="EN" input="io_global.i_cen" output="io_global.o_cen"/>
+   <direct name="ICLK" input="io_global.i_inclk" output="io_global.o_inclk"/>
+   <direct name="OCLK" input="io_global.i_outclk" output="io_global.o_outclk"/>
+   <direct name="io_global_latch" input="io_global.i_latch" output="io_global.o_latch"/>
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">ignore</meta>
+  </metadata>
  </pb_type>
 
  <xi:include href="../../../../cells/io_local/io_local.pb_type.xml"/>
+
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/plb/plb.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/plb/plb.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PLB" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PLB" xmlns:xi="http://www.w3.org/2001/XInclude">
 
  <clock  name="glb_netwk_0"  num_pins="1"/>
 
@@ -67,54 +67,74 @@
  <!-- ################################################################ -->
  <!-- # Local tracks                                                 # -->
  <!-- ################################################################ -->
- <pb_type name="BLK_XX-local_g" num_pb="4">
+ <pb_type name="local_g" num_pb="4">
   <input  name="i"  num_pins="8"/>
   <output name="o"  num_pins="8"/>
 
   <interconnect>
-   <direct name="i_to_o" input="BLK_XX-local_g.i" output="BLK_XX-local_g.o" />
+   <direct name="i_to_o" input="local_g.i" output="local_g.o" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
- <pb_type name="BLK_XX-glb2local" num_pb="4">
+ <pb_type name="glb2local" num_pb="4">
   <input  name="i" num_pins="1"/>
   <output name="o" num_pins="1"/>
   <interconnect>
-   <direct name="i_to_o" input="BLK_XX-glb2local.i" output="BLK_XX-glb2local.o" />
+   <direct name="i_to_o" input="glb2local.i" output="glb2local.o" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
- <pb_type name="BLK_XX-glb_netwk" num_pb="8">
+ <pb_type name="glb_netwk" num_pb="8">
   <input  name="i" num_pins="1"/>
   <output name="o" num_pins="1"/>
   <interconnect>
-   <direct name="i_to_o" input="BLK_XX-glb_netwk.i" output="BLK_XX-glb_netwk.o" />
+   <direct name="i_to_o" input="glb_netwk.i" output="glb_netwk.o" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
- <pb_type name="BLK_XX-carry_in_mux" num_pb="1">
+ <pb_type name="carry_in_mux" num_pb="1">
   <input  name="i" num_pins="1"/>
   <output name="o" num_pins="1"/>
   <interconnect>
-   <mux name="i_to_o" input="BLK_XX-carry_in_mux.i" output="BLK_XX-carry_in_mux.o">
-    <pack_pattern name="CARRYCHAIN" in_port="BLK_XX-carry_in_mux.i" out_port="BLK_XX-carry_in_mux.o" />
+   <mux name="i_to_o" input="carry_in_mux.i" output="carry_in_mux.o">
+    <pack_pattern name="CARRYCHAIN" in_port="carry_in_mux.i" out_port="carry_in_mux.o" />
    </mux>
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
  <!-- ################################################################ -->
  <!-- # Logic units                                                  # -->
  <!-- ################################################################ -->
 
- <pb_type name="BEL_BB-lutff_global" num_pb="1">
+ <pb_type name="lutff_global" num_pb="1">
   <input name="i_cen"  num_pins="1" /><output name="o_cen"  num_pins="1" />
   <clock name="i_clk" num_pins="1" /><output name="o_clk" num_pins="1" />
   <input name="i_s_r"  num_pins="1" /><output name="o_s_r"  num_pins="1" />
   <interconnect>
-   <direct name="EN"  input="BEL_BB-lutff_global.i_cen"  output="BEL_BB-lutff_global.o_cen"/>
-   <direct name="CLK" input="BEL_BB-lutff_global.i_clk" output="BEL_BB-lutff_global.o_clk"/>
-   <direct name="SR"  input="BEL_BB-lutff_global.i_s_r"  output="BEL_BB-lutff_global.o_s_r"/>
+   <direct name="EN"  input="lutff_global.i_cen"  output="lutff_global.o_cen"/>
+   <direct name="CLK" input="lutff_global.i_clk" output="lutff_global.o_clk"/>
+   <direct name="SR"  input="lutff_global.i_s_r"  output="lutff_global.o_s_r"/>
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">blackbox</meta>
+  </metadata>
  </pb_type>
 
  <xi:include href="../../../../cells/plb/plb.pb_type.xml"/>
@@ -125,33 +145,33 @@
   <!-- ################################################################ -->
 
   <!-- Span-4 Vertical -->
-  <direct name="sp4_v_t"   input="BLK_TL-PLB.i_sp4_v_t"   output="BLK_TL-PLB.o_sp4_v_t" />
-  <direct name="sp4_v_b"   input="BLK_TL-PLB.i_sp4_v_b"   output="BLK_TL-PLB.o_sp4_v_b" />
+  <direct name="sp4_v_t"   input="PLB.i_sp4_v_t"   output="PLB.o_sp4_v_t" />
+  <direct name="sp4_v_b"   input="PLB.i_sp4_v_b"   output="PLB.o_sp4_v_b" />
 
   <!-- Span-4 Right Vertical
-  <direct name="sp4_r_v_b" input="BLK_TL-PLB.i_sp4_r_v_b" output="BLK_TL-PLB.o_sp4_r_v_b" />
-  <direct name="sp4_l_v_b" input="BLK_TL-PLB.i_sp4_l_v_b" output="BLK_TL-PLB.o_sp4_l_v_b" />
+  <direct name="sp4_r_v_b" input="PLB.i_sp4_r_v_b" output="PLB.o_sp4_r_v_b" />
+  <direct name="sp4_l_v_b" input="PLB.i_sp4_l_v_b" output="PLB.o_sp4_l_v_b" />
        -->
 
   <!-- Span-12 Vertical -->
-  <direct name="sp12_v_t"  input="BLK_TL-PLB.i_sp12_v_t"  output="BLK_TL-PLB.o_sp12_v_t" />
-  <direct name="sp12_v_b"  input="BLK_TL-PLB.i_sp12_v_b"  output="BLK_TL-PLB.o_sp12_v_b" />
+  <direct name="sp12_v_t"  input="PLB.i_sp12_v_t"  output="PLB.o_sp12_v_t" />
+  <direct name="sp12_v_b"  input="PLB.i_sp12_v_b"  output="PLB.o_sp12_v_b" />
 
   <!-- ================================================================ -->
 
   <!-- Span-4 Horizontal -->
-  <direct name="sp4_h_r"   input="BLK_TL-PLB.i_sp4_h_r"   output="BLK_TL-PLB.o_sp4_h_r" />
-  <direct name="sp4_h_l"   input="BLK_TL-PLB.i_sp4_h_l"   output="BLK_TL-PLB.o_sp4_h_l" />
+  <direct name="sp4_h_r"   input="PLB.i_sp4_h_r"   output="PLB.o_sp4_h_r" />
+  <direct name="sp4_h_l"   input="PLB.i_sp4_h_l"   output="PLB.o_sp4_h_l" />
 
   <!-- Span-12 Horizontal -->
-  <direct name="sp12_h_r"  input="BLK_TL-PLB.i_sp12_h_r"  output="BLK_TL-PLB.o_sp12_h_r" />
-  <direct name="sp12_h_l"  input="BLK_TL-PLB.i_sp12_h_l"  output="BLK_TL-PLB.o_sp12_h_l" />
+  <direct name="sp12_h_r"  input="PLB.i_sp12_h_r"  output="PLB.o_sp12_h_r" />
+  <direct name="sp12_h_l"  input="PLB.i_sp12_h_l"  output="PLB.o_sp12_h_l" />
 
   <!-- ================================================================ -->
 
   <!-- Span-4 Right Vertical
-  <direct name="sp4_l_v_b io sp4_v_b" input="BLK_TL-PLB.i_sp4_l_v_b" output="BLK_TL-PLB.o_sp4_v_b"   />
-  <direct name="sp4_l_v_b oi sp4_v_b" input="BLK_TL-PLB.i_sp4_v_b"   output="BLK_TL-PLB.o_sp4_l_v_b" />
+  <direct name="sp4_l_v_b io sp4_v_b" input="PLB.i_sp4_l_v_b" output="PLB.o_sp4_v_b"   />
+  <direct name="sp4_l_v_b oi sp4_v_b" input="PLB.i_sp4_v_b"   output="PLB.o_sp4_l_v_b" />
        -->
 
   <!-- ################################################################ -->
@@ -159,319 +179,319 @@
   <!-- ################################################################ -->
 
   <!-- Global Networks -> glb2Local Tracks -->
-  <mux name="BLK_XX-glb2local[0]" input="BLK_TL-PLB.i_glb_netwk[0] BLK_TL-PLB.i_glb_netwk[1] BLK_TL-PLB.i_glb_netwk[2] BLK_TL-PLB.i_glb_netwk[3] BLK_TL-PLB.i_glb_netwk[4] BLK_TL-PLB.i_glb_netwk[5] BLK_TL-PLB.i_glb_netwk[6] BLK_TL-PLB.i_glb_netwk[7]" output="BLK_XX-glb2local[0].i" />
-  <mux name="BLK_XX-glb2local[1]" input="BLK_TL-PLB.i_glb_netwk[0] BLK_TL-PLB.i_glb_netwk[1] BLK_TL-PLB.i_glb_netwk[2] BLK_TL-PLB.i_glb_netwk[3] BLK_TL-PLB.i_glb_netwk[4] BLK_TL-PLB.i_glb_netwk[5] BLK_TL-PLB.i_glb_netwk[6] BLK_TL-PLB.i_glb_netwk[7]" output="BLK_XX-glb2local[1].i" />
-  <mux name="BLK_XX-glb2local[2]" input="BLK_TL-PLB.i_glb_netwk[0] BLK_TL-PLB.i_glb_netwk[1] BLK_TL-PLB.i_glb_netwk[2] BLK_TL-PLB.i_glb_netwk[3] BLK_TL-PLB.i_glb_netwk[4] BLK_TL-PLB.i_glb_netwk[5] BLK_TL-PLB.i_glb_netwk[6] BLK_TL-PLB.i_glb_netwk[7]" output="BLK_XX-glb2local[2].i" />
-  <mux name="BLK_XX-glb2local[3]" input="BLK_TL-PLB.i_glb_netwk[0] BLK_TL-PLB.i_glb_netwk[1] BLK_TL-PLB.i_glb_netwk[2] BLK_TL-PLB.i_glb_netwk[3] BLK_TL-PLB.i_glb_netwk[4] BLK_TL-PLB.i_glb_netwk[5] BLK_TL-PLB.i_glb_netwk[6] BLK_TL-PLB.i_glb_netwk[7]" output="BLK_XX-glb2local[3].i" />
+  <mux name="glb2local[0]" input="PLB.i_glb_netwk[0] PLB.i_glb_netwk[1] PLB.i_glb_netwk[2] PLB.i_glb_netwk[3] PLB.i_glb_netwk[4] PLB.i_glb_netwk[5] PLB.i_glb_netwk[6] PLB.i_glb_netwk[7]" output="glb2local[0].i" />
+  <mux name="glb2local[1]" input="PLB.i_glb_netwk[0] PLB.i_glb_netwk[1] PLB.i_glb_netwk[2] PLB.i_glb_netwk[3] PLB.i_glb_netwk[4] PLB.i_glb_netwk[5] PLB.i_glb_netwk[6] PLB.i_glb_netwk[7]" output="glb2local[1].i" />
+  <mux name="glb2local[2]" input="PLB.i_glb_netwk[0] PLB.i_glb_netwk[1] PLB.i_glb_netwk[2] PLB.i_glb_netwk[3] PLB.i_glb_netwk[4] PLB.i_glb_netwk[5] PLB.i_glb_netwk[6] PLB.i_glb_netwk[7]" output="glb2local[2].i" />
+  <mux name="glb2local[3]" input="PLB.i_glb_netwk[0] PLB.i_glb_netwk[1] PLB.i_glb_netwk[2] PLB.i_glb_netwk[3] PLB.i_glb_netwk[4] PLB.i_glb_netwk[5] PLB.i_glb_netwk[6] PLB.i_glb_netwk[7]" output="glb2local[3].i" />
 
   <!-- XXXX -> Local Tracks
-    BLK_TL-PLB.i_sp4_r_v_b[24] BLK_TL-PLB.i_sp4_r_v_b[35]  BLK_TL-PLB.i_neigh_op_bot[0] BLK_TL-PLB.i_neigh_op_bnr[0] BLK_TL-PLB.i_neigh_op_top[0] BLK_TL-PLB.i_neigh_op_lft[0]
-    BLK_TL-PLB.i_sp4_r_v_b[25] BLK_TL-PLB.i_sp4_r_v_b[34]  BLK_TL-PLB.i_neigh_op_bot[1] BLK_TL-PLB.i_neigh_op_bnr[1] BLK_TL-PLB.i_neigh_op_top[1] BLK_TL-PLB.i_neigh_op_lft[1]
-    BLK_TL-PLB.i_sp4_r_v_b[26] BLK_TL-PLB.i_sp4_r_v_b[33]  BLK_TL-PLB.i_neigh_op_bot[2] BLK_TL-PLB.i_neigh_op_bnr[2] BLK_TL-PLB.i_neigh_op_top[2] BLK_TL-PLB.i_neigh_op_lft[2]
-    BLK_TL-PLB.i_sp4_r_v_b[27] BLK_TL-PLB.i_sp4_r_v_b[32]  BLK_TL-PLB.i_neigh_op_bot[3] BLK_TL-PLB.i_neigh_op_bnr[3] BLK_TL-PLB.i_neigh_op_top[3] BLK_TL-PLB.i_neigh_op_lft[3]
-    glb2local[0].o             BLK_TL-PLB.i_sp4_r_v_b[28]  BLK_TL-PLB.i_neigh_op_bot[4] BLK_TL-PLB.i_neigh_op_bnr[4] BLK_TL-PLB.i_neigh_op_top[4] BLK_TL-PLB.i_neigh_op_lft[4]
-    glb2local[1].o             BLK_TL-PLB.i_sp4_r_v_b[29]  BLK_TL-PLB.i_neigh_op_bot[5] BLK_TL-PLB.i_neigh_op_bnr[5] BLK_TL-PLB.i_neigh_op_top[5] BLK_TL-PLB.i_neigh_op_lft[5]
-    glb2local[2].o             BLK_TL-PLB.i_sp4_r_v_b[30]  BLK_TL-PLB.i_neigh_op_bot[6] BLK_TL-PLB.i_neigh_op_bnr[6] BLK_TL-PLB.i_neigh_op_top[6] BLK_TL-PLB.i_neigh_op_lft[6]
-    glb2local[3].o             BLK_TL-PLB.i_sp4_r_v_b[31]  BLK_TL-PLB.i_neigh_op_bot[7] BLK_TL-PLB.i_neigh_op_bnr[7] BLK_TL-PLB.i_neigh_op_top[7] BLK_TL-PLB.i_neigh_op_lft[7]
+    PLB.i_sp4_r_v_b[24] PLB.i_sp4_r_v_b[35]  PLB.i_neigh_op_bot[0] PLB.i_neigh_op_bnr[0] PLB.i_neigh_op_top[0] PLB.i_neigh_op_lft[0]
+    PLB.i_sp4_r_v_b[25] PLB.i_sp4_r_v_b[34]  PLB.i_neigh_op_bot[1] PLB.i_neigh_op_bnr[1] PLB.i_neigh_op_top[1] PLB.i_neigh_op_lft[1]
+    PLB.i_sp4_r_v_b[26] PLB.i_sp4_r_v_b[33]  PLB.i_neigh_op_bot[2] PLB.i_neigh_op_bnr[2] PLB.i_neigh_op_top[2] PLB.i_neigh_op_lft[2]
+    PLB.i_sp4_r_v_b[27] PLB.i_sp4_r_v_b[32]  PLB.i_neigh_op_bot[3] PLB.i_neigh_op_bnr[3] PLB.i_neigh_op_top[3] PLB.i_neigh_op_lft[3]
+    glb2local[0].o      PLB.i_sp4_r_v_b[28]  PLB.i_neigh_op_bot[4] PLB.i_neigh_op_bnr[4] PLB.i_neigh_op_top[4] PLB.i_neigh_op_lft[4]
+    glb2local[1].o      PLB.i_sp4_r_v_b[29]  PLB.i_neigh_op_bot[5] PLB.i_neigh_op_bnr[5] PLB.i_neigh_op_top[5] PLB.i_neigh_op_lft[5]
+    glb2local[2].o      PLB.i_sp4_r_v_b[30]  PLB.i_neigh_op_bot[6] PLB.i_neigh_op_bnr[6] PLB.i_neigh_op_top[6] PLB.i_neigh_op_lft[6]
+    glb2local[3].o      PLB.i_sp4_r_v_b[31]  PLB.i_neigh_op_bot[7] PLB.i_neigh_op_bnr[7] PLB.i_neigh_op_top[7] PLB.i_neigh_op_lft[7]
 
-    BLK_TL-PLB.i_sp4_r_v_b[0]  BLK_TL-PLB.i_sp4_r_v_b[24]  BLK_TL-PLB.i_neigh_op_bot[0] BLK_TL-PLB.i_neigh_op_bnr[0] BLK_TL-PLB.i_neigh_op_top[0] BLK_TL-PLB.i_neigh_op_lft[0]
-    BLK_TL-PLB.i_sp4_r_v_b[1]  BLK_TL-PLB.i_sp4_r_v_b[25]  BLK_TL-PLB.i_neigh_op_bot[1] BLK_TL-PLB.i_neigh_op_bnr[1] BLK_TL-PLB.i_neigh_op_top[1] BLK_TL-PLB.i_neigh_op_lft[1]
-    BLK_TL-PLB.i_sp4_r_v_b[2]  BLK_TL-PLB.i_sp4_r_v_b[26]  BLK_TL-PLB.i_neigh_op_bot[2] BLK_TL-PLB.i_neigh_op_bnr[2] BLK_TL-PLB.i_neigh_op_top[2] BLK_TL-PLB.i_neigh_op_lft[2]
-    BLK_TL-PLB.i_sp4_r_v_b[3]  BLK_TL-PLB.i_sp4_r_v_b[27]  BLK_TL-PLB.i_neigh_op_bot[3] BLK_TL-PLB.i_neigh_op_bnr[3] BLK_TL-PLB.i_neigh_op_top[3] BLK_TL-PLB.i_neigh_op_lft[3]
-    BLK_TL-PLB.i_sp4_r_v_b[4]  BLK_TL-PLB.i_sp4_r_v_b[28]  BLK_TL-PLB.i_neigh_op_bot[4] BLK_TL-PLB.i_neigh_op_bnr[4] BLK_TL-PLB.i_neigh_op_top[4] BLK_TL-PLB.i_neigh_op_lft[4]
-    BLK_TL-PLB.i_sp4_r_v_b[5]  BLK_TL-PLB.i_sp4_r_v_b[29]  BLK_TL-PLB.i_neigh_op_bot[5] BLK_TL-PLB.i_neigh_op_bnr[5] BLK_TL-PLB.i_neigh_op_top[5] BLK_TL-PLB.i_neigh_op_lft[5]
-    BLK_TL-PLB.i_sp4_r_v_b[6]  BLK_TL-PLB.i_sp4_r_v_b[30]  BLK_TL-PLB.i_neigh_op_bot[6] BLK_TL-PLB.i_neigh_op_bnr[6] BLK_TL-PLB.i_neigh_op_top[6] BLK_TL-PLB.i_neigh_op_lft[6]
-    BLK_TL-PLB.i_sp4_r_v_b[7]  BLK_TL-PLB.i_sp4_r_v_b[31]  BLK_TL-PLB.i_neigh_op_bot[7] BLK_TL-PLB.i_neigh_op_bnr[7] BLK_TL-PLB.i_neigh_op_top[7] BLK_TL-PLB.i_neigh_op_lft[7]
+    PLB.i_sp4_r_v_b[0]  PLB.i_sp4_r_v_b[24]  PLB.i_neigh_op_bot[0] PLB.i_neigh_op_bnr[0] PLB.i_neigh_op_top[0] PLB.i_neigh_op_lft[0]
+    PLB.i_sp4_r_v_b[1]  PLB.i_sp4_r_v_b[25]  PLB.i_neigh_op_bot[1] PLB.i_neigh_op_bnr[1] PLB.i_neigh_op_top[1] PLB.i_neigh_op_lft[1]
+    PLB.i_sp4_r_v_b[2]  PLB.i_sp4_r_v_b[26]  PLB.i_neigh_op_bot[2] PLB.i_neigh_op_bnr[2] PLB.i_neigh_op_top[2] PLB.i_neigh_op_lft[2]
+    PLB.i_sp4_r_v_b[3]  PLB.i_sp4_r_v_b[27]  PLB.i_neigh_op_bot[3] PLB.i_neigh_op_bnr[3] PLB.i_neigh_op_top[3] PLB.i_neigh_op_lft[3]
+    PLB.i_sp4_r_v_b[4]  PLB.i_sp4_r_v_b[28]  PLB.i_neigh_op_bot[4] PLB.i_neigh_op_bnr[4] PLB.i_neigh_op_top[4] PLB.i_neigh_op_lft[4]
+    PLB.i_sp4_r_v_b[5]  PLB.i_sp4_r_v_b[29]  PLB.i_neigh_op_bot[5] PLB.i_neigh_op_bnr[5] PLB.i_neigh_op_top[5] PLB.i_neigh_op_lft[5]
+    PLB.i_sp4_r_v_b[6]  PLB.i_sp4_r_v_b[30]  PLB.i_neigh_op_bot[6] PLB.i_neigh_op_bnr[6] PLB.i_neigh_op_top[6] PLB.i_neigh_op_lft[6]
+    PLB.i_sp4_r_v_b[7]  PLB.i_sp4_r_v_b[31]  PLB.i_neigh_op_bot[7] PLB.i_neigh_op_bnr[7] PLB.i_neigh_op_top[7] PLB.i_neigh_op_lft[7]
 
-    BLK_TL-PLB.i_sp4_r_v_b[8]  BLK_TL-PLB.i_sp4_r_v_b[32]  BLK_TL-PLB.i_neigh_op_tnr[0] BLK_TL-PLB.i_neigh_op_tnl[0] BLK_TL-PLB.i_neigh_op_bnl[0] BLK_TL-PLB.i_neigh_op_rgt[0]
-    BLK_TL-PLB.i_sp4_r_v_b[9]  BLK_TL-PLB.i_sp4_r_v_b[33]  BLK_TL-PLB.i_neigh_op_tnr[1] BLK_TL-PLB.i_neigh_op_tnl[1] BLK_TL-PLB.i_neigh_op_bnl[1] BLK_TL-PLB.i_neigh_op_rgt[1]
-    BLK_TL-PLB.i_sp4_r_v_b[10] BLK_TL-PLB.i_sp4_r_v_b[34]  BLK_TL-PLB.i_neigh_op_tnr[2] BLK_TL-PLB.i_neigh_op_tnl[2] BLK_TL-PLB.i_neigh_op_bnl[2] BLK_TL-PLB.i_neigh_op_rgt[2]
-    BLK_TL-PLB.i_sp4_r_v_b[11] BLK_TL-PLB.i_sp4_r_v_b[35]  BLK_TL-PLB.i_neigh_op_tnr[3] BLK_TL-PLB.i_neigh_op_tnl[3] BLK_TL-PLB.i_neigh_op_bnl[3] BLK_TL-PLB.i_neigh_op_rgt[3]
-    BLK_TL-PLB.i_sp4_r_v_b[12] BLK_TL-PLB.i_sp4_r_v_b[36]  BLK_TL-PLB.i_neigh_op_tnr[4] BLK_TL-PLB.i_neigh_op_tnl[4] BLK_TL-PLB.i_neigh_op_bnl[4] BLK_TL-PLB.i_neigh_op_rgt[4]
-    BLK_TL-PLB.i_sp4_r_v_b[13] BLK_TL-PLB.i_sp4_r_v_b[37]  BLK_TL-PLB.i_neigh_op_tnr[5] BLK_TL-PLB.i_neigh_op_tnl[5] BLK_TL-PLB.i_neigh_op_bnl[5] BLK_TL-PLB.i_neigh_op_rgt[5]
-    BLK_TL-PLB.i_sp4_r_v_b[14] BLK_TL-PLB.i_sp4_r_v_b[38]  BLK_TL-PLB.i_neigh_op_tnr[6] BLK_TL-PLB.i_neigh_op_tnl[6] BLK_TL-PLB.i_neigh_op_bnl[6] BLK_TL-PLB.i_neigh_op_rgt[6]
-    BLK_TL-PLB.i_sp4_r_v_b[15] BLK_TL-PLB.i_sp4_r_v_b[39]  BLK_TL-PLB.i_neigh_op_tnr[7] BLK_TL-PLB.i_neigh_op_tnl[7] BLK_TL-PLB.i_neigh_op_bnl[7] BLK_TL-PLB.i_neigh_op_rgt[7]
+    PLB.i_sp4_r_v_b[8]  PLB.i_sp4_r_v_b[32]  PLB.i_neigh_op_tnr[0] PLB.i_neigh_op_tnl[0] PLB.i_neigh_op_bnl[0] PLB.i_neigh_op_rgt[0]
+    PLB.i_sp4_r_v_b[9]  PLB.i_sp4_r_v_b[33]  PLB.i_neigh_op_tnr[1] PLB.i_neigh_op_tnl[1] PLB.i_neigh_op_bnl[1] PLB.i_neigh_op_rgt[1]
+    PLB.i_sp4_r_v_b[10] PLB.i_sp4_r_v_b[34]  PLB.i_neigh_op_tnr[2] PLB.i_neigh_op_tnl[2] PLB.i_neigh_op_bnl[2] PLB.i_neigh_op_rgt[2]
+    PLB.i_sp4_r_v_b[11] PLB.i_sp4_r_v_b[35]  PLB.i_neigh_op_tnr[3] PLB.i_neigh_op_tnl[3] PLB.i_neigh_op_bnl[3] PLB.i_neigh_op_rgt[3]
+    PLB.i_sp4_r_v_b[12] PLB.i_sp4_r_v_b[36]  PLB.i_neigh_op_tnr[4] PLB.i_neigh_op_tnl[4] PLB.i_neigh_op_bnl[4] PLB.i_neigh_op_rgt[4]
+    PLB.i_sp4_r_v_b[13] PLB.i_sp4_r_v_b[37]  PLB.i_neigh_op_tnr[5] PLB.i_neigh_op_tnl[5] PLB.i_neigh_op_bnl[5] PLB.i_neigh_op_rgt[5]
+    PLB.i_sp4_r_v_b[14] PLB.i_sp4_r_v_b[38]  PLB.i_neigh_op_tnr[6] PLB.i_neigh_op_tnl[6] PLB.i_neigh_op_bnl[6] PLB.i_neigh_op_rgt[6]
+    PLB.i_sp4_r_v_b[15] PLB.i_sp4_r_v_b[39]  PLB.i_neigh_op_tnr[7] PLB.i_neigh_op_tnl[7] PLB.i_neigh_op_bnl[7] PLB.i_neigh_op_rgt[7]
 
-    BLK_TL-PLB.i_sp4_r_v_b[16] BLK_TL-PLB.i_sp4_r_v_b[40]  BLK_TL-PLB.i_neigh_op_tnr[0] BLK_TL-PLB.i_neigh_op_tnl[0] BLK_TL-PLB.i_neigh_op_bnl[0] BLK_TL-PLB.i_neigh_op_rgt[0]
-    BLK_TL-PLB.i_sp4_r_v_b[17] BLK_TL-PLB.i_sp4_r_v_b[41]  BLK_TL-PLB.i_neigh_op_tnr[1] BLK_TL-PLB.i_neigh_op_tnl[1] BLK_TL-PLB.i_neigh_op_bnl[1] BLK_TL-PLB.i_neigh_op_rgt[1]
-    BLK_TL-PLB.i_sp4_r_v_b[18] BLK_TL-PLB.i_sp4_r_v_b[42]  BLK_TL-PLB.i_neigh_op_tnr[2] BLK_TL-PLB.i_neigh_op_tnl[2] BLK_TL-PLB.i_neigh_op_bnl[2] BLK_TL-PLB.i_neigh_op_rgt[2]
-    BLK_TL-PLB.i_sp4_r_v_b[19] BLK_TL-PLB.i_sp4_r_v_b[43]  BLK_TL-PLB.i_neigh_op_tnr[3] BLK_TL-PLB.i_neigh_op_tnl[3] BLK_TL-PLB.i_neigh_op_bnl[3] BLK_TL-PLB.i_neigh_op_rgt[3]
-    BLK_TL-PLB.i_sp4_r_v_b[20] BLK_TL-PLB.i_sp4_r_v_b[44]  BLK_TL-PLB.i_neigh_op_tnr[4] BLK_TL-PLB.i_neigh_op_tnl[4] BLK_TL-PLB.i_neigh_op_bnl[4] BLK_TL-PLB.i_neigh_op_rgt[4]
-    BLK_TL-PLB.i_sp4_r_v_b[21] BLK_TL-PLB.i_sp4_r_v_b[45]  BLK_TL-PLB.i_neigh_op_tnr[5] BLK_TL-PLB.i_neigh_op_tnl[5] BLK_TL-PLB.i_neigh_op_bnl[5] BLK_TL-PLB.i_neigh_op_rgt[5]
-    BLK_TL-PLB.i_sp4_r_v_b[22] BLK_TL-PLB.i_sp4_r_v_b[46]  BLK_TL-PLB.i_neigh_op_tnr[6] BLK_TL-PLB.i_neigh_op_tnl[6] BLK_TL-PLB.i_neigh_op_bnl[6] BLK_TL-PLB.i_neigh_op_rgt[6]
-    BLK_TL-PLB.i_sp4_r_v_b[23] BLK_TL-PLB.i_sp4_r_v_b[47]  BLK_TL-PLB.i_neigh_op_tnr[7] BLK_TL-PLB.i_neigh_op_tnl[7] BLK_TL-PLB.i_neigh_op_bnl[7] BLK_TL-PLB.i_neigh_op_rgt[7]
+    PLB.i_sp4_r_v_b[16] PLB.i_sp4_r_v_b[40]  PLB.i_neigh_op_tnr[0] PLB.i_neigh_op_tnl[0] PLB.i_neigh_op_bnl[0] PLB.i_neigh_op_rgt[0]
+    PLB.i_sp4_r_v_b[17] PLB.i_sp4_r_v_b[41]  PLB.i_neigh_op_tnr[1] PLB.i_neigh_op_tnl[1] PLB.i_neigh_op_bnl[1] PLB.i_neigh_op_rgt[1]
+    PLB.i_sp4_r_v_b[18] PLB.i_sp4_r_v_b[42]  PLB.i_neigh_op_tnr[2] PLB.i_neigh_op_tnl[2] PLB.i_neigh_op_bnl[2] PLB.i_neigh_op_rgt[2]
+    PLB.i_sp4_r_v_b[19] PLB.i_sp4_r_v_b[43]  PLB.i_neigh_op_tnr[3] PLB.i_neigh_op_tnl[3] PLB.i_neigh_op_bnl[3] PLB.i_neigh_op_rgt[3]
+    PLB.i_sp4_r_v_b[20] PLB.i_sp4_r_v_b[44]  PLB.i_neigh_op_tnr[4] PLB.i_neigh_op_tnl[4] PLB.i_neigh_op_bnl[4] PLB.i_neigh_op_rgt[4]
+    PLB.i_sp4_r_v_b[21] PLB.i_sp4_r_v_b[45]  PLB.i_neigh_op_tnr[5] PLB.i_neigh_op_tnl[5] PLB.i_neigh_op_bnl[5] PLB.i_neigh_op_rgt[5]
+    PLB.i_sp4_r_v_b[22] PLB.i_sp4_r_v_b[46]  PLB.i_neigh_op_tnr[6] PLB.i_neigh_op_tnl[6] PLB.i_neigh_op_bnl[6] PLB.i_neigh_op_rgt[6]
+    PLB.i_sp4_r_v_b[23] PLB.i_sp4_r_v_b[47]  PLB.i_neigh_op_tnr[7] PLB.i_neigh_op_tnl[7] PLB.i_neigh_op_bnl[7] PLB.i_neigh_op_rgt[7]
        -->
-  <mux name="local_g0[0]" input="                       BLK_IG-PLB_LOCAL.O0   BLK_TL-PLB.i_sp4_v_b[0]  BLK_TL-PLB.i_sp4_v_b[8]  BLK_TL-PLB.i_sp4_v_b[16]                                                     BLK_TL-PLB.i_sp4_h_r[0]  BLK_TL-PLB.i_sp4_h_r[8]  BLK_TL-PLB.i_sp4_h_r[16]                                                     BLK_TL-PLB.i_sp12_h_r[0] BLK_TL-PLB.i_sp12_h_r[8]  BLK_TL-PLB.i_sp12_h_r[16]" output="BLK_XX-local_g[0].i[0]" />
-  <mux name="local_g0[1]" input="                       BLK_IG-PLB_LOCAL.O1   BLK_TL-PLB.i_sp4_v_b[1]  BLK_TL-PLB.i_sp4_v_b[9]  BLK_TL-PLB.i_sp4_v_b[17]                                                     BLK_TL-PLB.i_sp4_h_r[1]  BLK_TL-PLB.i_sp4_h_r[9]  BLK_TL-PLB.i_sp4_h_r[17]                                                     BLK_TL-PLB.i_sp12_h_r[1] BLK_TL-PLB.i_sp12_h_r[9]  BLK_TL-PLB.i_sp12_h_r[17]" output="BLK_XX-local_g[0].i[1]" />
-  <mux name="local_g0[2]" input="                       BLK_IG-PLB_LOCAL.O2   BLK_TL-PLB.i_sp4_v_b[2]  BLK_TL-PLB.i_sp4_v_b[10] BLK_TL-PLB.i_sp4_v_b[18]                                                     BLK_TL-PLB.i_sp4_h_r[2]  BLK_TL-PLB.i_sp4_h_r[10] BLK_TL-PLB.i_sp4_h_r[18]                                                     BLK_TL-PLB.i_sp12_h_r[2] BLK_TL-PLB.i_sp12_h_r[10] BLK_TL-PLB.i_sp12_h_r[18]" output="BLK_XX-local_g[0].i[2]" />
-  <mux name="local_g0[3]" input="                       BLK_IG-PLB_LOCAL.O3   BLK_TL-PLB.i_sp4_v_b[3]  BLK_TL-PLB.i_sp4_v_b[11] BLK_TL-PLB.i_sp4_v_b[19]                                                     BLK_TL-PLB.i_sp4_h_r[3]  BLK_TL-PLB.i_sp4_h_r[11] BLK_TL-PLB.i_sp4_h_r[19]                                                     BLK_TL-PLB.i_sp12_h_r[3] BLK_TL-PLB.i_sp12_h_r[11] BLK_TL-PLB.i_sp12_h_r[19]" output="BLK_XX-local_g[0].i[3]" />
-  <mux name="local_g0[4]" input="BLK_XX-glb2local[0].o  BLK_IG-PLB_LOCAL.O4   BLK_TL-PLB.i_sp4_v_b[4]  BLK_TL-PLB.i_sp4_v_b[12] BLK_TL-PLB.i_sp4_v_b[20]                                                     BLK_TL-PLB.i_sp4_h_r[4]  BLK_TL-PLB.i_sp4_h_r[12] BLK_TL-PLB.i_sp4_h_r[20]                                                     BLK_TL-PLB.i_sp12_h_r[4] BLK_TL-PLB.i_sp12_h_r[12] BLK_TL-PLB.i_sp12_h_r[20]" output="BLK_XX-local_g[0].i[4]" />
-  <mux name="local_g0[5]" input="BLK_XX-glb2local[1].o  BLK_IG-PLB_LOCAL.O5   BLK_TL-PLB.i_sp4_v_b[5]  BLK_TL-PLB.i_sp4_v_b[13] BLK_TL-PLB.i_sp4_v_b[21]                                                     BLK_TL-PLB.i_sp4_h_r[5]  BLK_TL-PLB.i_sp4_h_r[13] BLK_TL-PLB.i_sp4_h_r[21]                                                     BLK_TL-PLB.i_sp12_h_r[5] BLK_TL-PLB.i_sp12_h_r[13] BLK_TL-PLB.i_sp12_h_r[21]" output="BLK_XX-local_g[0].i[5]" />
-  <mux name="local_g0[6]" input="BLK_XX-glb2local[2].o  BLK_IG-PLB_LOCAL.O6   BLK_TL-PLB.i_sp4_v_b[6]  BLK_TL-PLB.i_sp4_v_b[14] BLK_TL-PLB.i_sp4_v_b[22]                                                     BLK_TL-PLB.i_sp4_h_r[6]  BLK_TL-PLB.i_sp4_h_r[14] BLK_TL-PLB.i_sp4_h_r[22]                                                     BLK_TL-PLB.i_sp12_h_r[6] BLK_TL-PLB.i_sp12_h_r[14] BLK_TL-PLB.i_sp12_h_r[22]" output="BLK_XX-local_g[0].i[6]" />
-  <mux name="local_g0[7]" input="BLK_XX-glb2local[3].o  BLK_IG-PLB_LOCAL.O7   BLK_TL-PLB.i_sp4_v_b[7]  BLK_TL-PLB.i_sp4_v_b[15] BLK_TL-PLB.i_sp4_v_b[23]                                                     BLK_TL-PLB.i_sp4_h_r[7]  BLK_TL-PLB.i_sp4_h_r[15] BLK_TL-PLB.i_sp4_h_r[23]                                                     BLK_TL-PLB.i_sp12_h_r[7] BLK_TL-PLB.i_sp12_h_r[15] BLK_TL-PLB.i_sp12_h_r[23]" output="BLK_XX-local_g[0].i[7]" />
+  <mux name="local_g0[0]" input="                PLB_LOCAL.O0   PLB.i_sp4_v_b[0]  PLB.i_sp4_v_b[8]  PLB.i_sp4_v_b[16]                                     PLB.i_sp4_h_r[0]  PLB.i_sp4_h_r[8]  PLB.i_sp4_h_r[16]                                       PLB.i_sp12_h_r[0] PLB.i_sp12_h_r[8]  PLB.i_sp12_h_r[16]" output="local_g[0].i[0]" />
+  <mux name="local_g0[1]" input="                PLB_LOCAL.O1   PLB.i_sp4_v_b[1]  PLB.i_sp4_v_b[9]  PLB.i_sp4_v_b[17]                                     PLB.i_sp4_h_r[1]  PLB.i_sp4_h_r[9]  PLB.i_sp4_h_r[17]                                       PLB.i_sp12_h_r[1] PLB.i_sp12_h_r[9]  PLB.i_sp12_h_r[17]" output="local_g[0].i[1]" />
+  <mux name="local_g0[2]" input="                PLB_LOCAL.O2   PLB.i_sp4_v_b[2]  PLB.i_sp4_v_b[10] PLB.i_sp4_v_b[18]                                     PLB.i_sp4_h_r[2]  PLB.i_sp4_h_r[10] PLB.i_sp4_h_r[18]                                       PLB.i_sp12_h_r[2] PLB.i_sp12_h_r[10] PLB.i_sp12_h_r[18]" output="local_g[0].i[2]" />
+  <mux name="local_g0[3]" input="                PLB_LOCAL.O3   PLB.i_sp4_v_b[3]  PLB.i_sp4_v_b[11] PLB.i_sp4_v_b[19]                                     PLB.i_sp4_h_r[3]  PLB.i_sp4_h_r[11] PLB.i_sp4_h_r[19]                                       PLB.i_sp12_h_r[3] PLB.i_sp12_h_r[11] PLB.i_sp12_h_r[19]" output="local_g[0].i[3]" />
+  <mux name="local_g0[4]" input="glb2local[0].o  PLB_LOCAL.O4   PLB.i_sp4_v_b[4]  PLB.i_sp4_v_b[12] PLB.i_sp4_v_b[20]                                     PLB.i_sp4_h_r[4]  PLB.i_sp4_h_r[12] PLB.i_sp4_h_r[20]                                       PLB.i_sp12_h_r[4] PLB.i_sp12_h_r[12] PLB.i_sp12_h_r[20]" output="local_g[0].i[4]" />
+  <mux name="local_g0[5]" input="glb2local[1].o  PLB_LOCAL.O5   PLB.i_sp4_v_b[5]  PLB.i_sp4_v_b[13] PLB.i_sp4_v_b[21]                                     PLB.i_sp4_h_r[5]  PLB.i_sp4_h_r[13] PLB.i_sp4_h_r[21]                                       PLB.i_sp12_h_r[5] PLB.i_sp12_h_r[13] PLB.i_sp12_h_r[21]" output="local_g[0].i[5]" />
+  <mux name="local_g0[6]" input="glb2local[2].o  PLB_LOCAL.O6   PLB.i_sp4_v_b[6]  PLB.i_sp4_v_b[14] PLB.i_sp4_v_b[22]                                     PLB.i_sp4_h_r[6]  PLB.i_sp4_h_r[14] PLB.i_sp4_h_r[22]                                       PLB.i_sp12_h_r[6] PLB.i_sp12_h_r[14] PLB.i_sp12_h_r[22]" output="local_g[0].i[6]" />
+  <mux name="local_g0[7]" input="glb2local[3].o  PLB_LOCAL.O7   PLB.i_sp4_v_b[7]  PLB.i_sp4_v_b[15] PLB.i_sp4_v_b[23]                                     PLB.i_sp4_h_r[7]  PLB.i_sp4_h_r[15] PLB.i_sp4_h_r[23]                                       PLB.i_sp12_h_r[7] PLB.i_sp12_h_r[15] PLB.i_sp12_h_r[23]" output="local_g[0].i[7]" />
 
-  <mux name="local_g1[0]" input="                       BLK_IG-PLB_LOCAL.O0   BLK_TL-PLB.i_sp4_v_b[0]  BLK_TL-PLB.i_sp4_v_b[8]  BLK_TL-PLB.i_sp4_v_b[16]                                                     BLK_TL-PLB.i_sp4_h_r[0]  BLK_TL-PLB.i_sp4_h_r[8]  BLK_TL-PLB.i_sp4_h_r[16]                                                     BLK_TL-PLB.i_sp12_h_r[0] BLK_TL-PLB.i_sp12_h_r[8]  BLK_TL-PLB.i_sp12_h_r[16]" output="BLK_XX-local_g[1].i[0]" />
-  <mux name="local_g1[1]" input="                       BLK_IG-PLB_LOCAL.O1   BLK_TL-PLB.i_sp4_v_b[1]  BLK_TL-PLB.i_sp4_v_b[9]  BLK_TL-PLB.i_sp4_v_b[17]                                                     BLK_TL-PLB.i_sp4_h_r[1]  BLK_TL-PLB.i_sp4_h_r[9]  BLK_TL-PLB.i_sp4_h_r[17]                                                     BLK_TL-PLB.i_sp12_h_r[1] BLK_TL-PLB.i_sp12_h_r[9]  BLK_TL-PLB.i_sp12_h_r[17]" output="BLK_XX-local_g[1].i[1]" />
-  <mux name="local_g1[2]" input="                       BLK_IG-PLB_LOCAL.O2   BLK_TL-PLB.i_sp4_v_b[2]  BLK_TL-PLB.i_sp4_v_b[10] BLK_TL-PLB.i_sp4_v_b[18]                                                     BLK_TL-PLB.i_sp4_h_r[2]  BLK_TL-PLB.i_sp4_h_r[10] BLK_TL-PLB.i_sp4_h_r[18]                                                     BLK_TL-PLB.i_sp12_h_r[2] BLK_TL-PLB.i_sp12_h_r[10] BLK_TL-PLB.i_sp12_h_r[18]" output="BLK_XX-local_g[1].i[2]" />
-  <mux name="local_g1[3]" input="                       BLK_IG-PLB_LOCAL.O3   BLK_TL-PLB.i_sp4_v_b[3]  BLK_TL-PLB.i_sp4_v_b[11] BLK_TL-PLB.i_sp4_v_b[19]                                                     BLK_TL-PLB.i_sp4_h_r[3]  BLK_TL-PLB.i_sp4_h_r[11] BLK_TL-PLB.i_sp4_h_r[19]                                                     BLK_TL-PLB.i_sp12_h_r[3] BLK_TL-PLB.i_sp12_h_r[11] BLK_TL-PLB.i_sp12_h_r[19]" output="BLK_XX-local_g[1].i[3]" />
-  <mux name="local_g1[4]" input="                       BLK_IG-PLB_LOCAL.O4   BLK_TL-PLB.i_sp4_v_b[4]  BLK_TL-PLB.i_sp4_v_b[12] BLK_TL-PLB.i_sp4_v_b[20]                                                     BLK_TL-PLB.i_sp4_h_r[4]  BLK_TL-PLB.i_sp4_h_r[12] BLK_TL-PLB.i_sp4_h_r[20]                                                     BLK_TL-PLB.i_sp12_h_r[4] BLK_TL-PLB.i_sp12_h_r[12] BLK_TL-PLB.i_sp12_h_r[20]" output="BLK_XX-local_g[1].i[4]" />
-  <mux name="local_g1[5]" input="                       BLK_IG-PLB_LOCAL.O5   BLK_TL-PLB.i_sp4_v_b[5]  BLK_TL-PLB.i_sp4_v_b[21] BLK_TL-PLB.i_sp4_v_b[13]                                                     BLK_TL-PLB.i_sp4_h_r[5]  BLK_TL-PLB.i_sp4_h_r[13] BLK_TL-PLB.i_sp4_h_r[21]                                                     BLK_TL-PLB.i_sp12_h_r[5] BLK_TL-PLB.i_sp12_h_r[13] BLK_TL-PLB.i_sp12_h_r[21]" output="BLK_XX-local_g[1].i[5]" />
-  <mux name="local_g1[6]" input="                       BLK_IG-PLB_LOCAL.O6   BLK_TL-PLB.i_sp4_v_b[6]  BLK_TL-PLB.i_sp4_v_b[14] BLK_TL-PLB.i_sp4_v_b[22]                                                     BLK_TL-PLB.i_sp4_h_r[6]  BLK_TL-PLB.i_sp4_h_r[14] BLK_TL-PLB.i_sp4_h_r[22]                                                     BLK_TL-PLB.i_sp12_h_r[6] BLK_TL-PLB.i_sp12_h_r[14] BLK_TL-PLB.i_sp12_h_r[22]" output="BLK_XX-local_g[1].i[6]" />
-  <mux name="local_g1[7]" input="                       BLK_IG-PLB_LOCAL.O7   BLK_TL-PLB.i_sp4_v_b[7]  BLK_TL-PLB.i_sp4_v_b[15] BLK_TL-PLB.i_sp4_v_b[23]                                                     BLK_TL-PLB.i_sp4_h_r[7]  BLK_TL-PLB.i_sp4_h_r[15] BLK_TL-PLB.i_sp4_h_r[23]                                                     BLK_TL-PLB.i_sp12_h_r[7] BLK_TL-PLB.i_sp12_h_r[15] BLK_TL-PLB.i_sp12_h_r[23]" output="BLK_XX-local_g[1].i[7]" />
+  <mux name="local_g1[0]" input="                PLB_LOCAL.O0   PLB.i_sp4_v_b[0]  PLB.i_sp4_v_b[8]  PLB.i_sp4_v_b[16]                                     PLB.i_sp4_h_r[0]  PLB.i_sp4_h_r[8]  PLB.i_sp4_h_r[16]                                       PLB.i_sp12_h_r[0] PLB.i_sp12_h_r[8]  PLB.i_sp12_h_r[16]" output="local_g[1].i[0]" />
+  <mux name="local_g1[1]" input="                PLB_LOCAL.O1   PLB.i_sp4_v_b[1]  PLB.i_sp4_v_b[9]  PLB.i_sp4_v_b[17]                                     PLB.i_sp4_h_r[1]  PLB.i_sp4_h_r[9]  PLB.i_sp4_h_r[17]                                       PLB.i_sp12_h_r[1] PLB.i_sp12_h_r[9]  PLB.i_sp12_h_r[17]" output="local_g[1].i[1]" />
+  <mux name="local_g1[2]" input="                PLB_LOCAL.O2   PLB.i_sp4_v_b[2]  PLB.i_sp4_v_b[10] PLB.i_sp4_v_b[18]                                     PLB.i_sp4_h_r[2]  PLB.i_sp4_h_r[10] PLB.i_sp4_h_r[18]                                       PLB.i_sp12_h_r[2] PLB.i_sp12_h_r[10] PLB.i_sp12_h_r[18]" output="local_g[1].i[2]" />
+  <mux name="local_g1[3]" input="                PLB_LOCAL.O3   PLB.i_sp4_v_b[3]  PLB.i_sp4_v_b[11] PLB.i_sp4_v_b[19]                                     PLB.i_sp4_h_r[3]  PLB.i_sp4_h_r[11] PLB.i_sp4_h_r[19]                                       PLB.i_sp12_h_r[3] PLB.i_sp12_h_r[11] PLB.i_sp12_h_r[19]" output="local_g[1].i[3]" />
+  <mux name="local_g1[4]" input="                PLB_LOCAL.O4   PLB.i_sp4_v_b[4]  PLB.i_sp4_v_b[12] PLB.i_sp4_v_b[20]                                     PLB.i_sp4_h_r[4]  PLB.i_sp4_h_r[12] PLB.i_sp4_h_r[20]                                       PLB.i_sp12_h_r[4] PLB.i_sp12_h_r[12] PLB.i_sp12_h_r[20]" output="local_g[1].i[4]" />
+  <mux name="local_g1[5]" input="                PLB_LOCAL.O5   PLB.i_sp4_v_b[5]  PLB.i_sp4_v_b[21] PLB.i_sp4_v_b[13]                                     PLB.i_sp4_h_r[5]  PLB.i_sp4_h_r[13] PLB.i_sp4_h_r[21]                                       PLB.i_sp12_h_r[5] PLB.i_sp12_h_r[13] PLB.i_sp12_h_r[21]" output="local_g[1].i[5]" />
+  <mux name="local_g1[6]" input="                PLB_LOCAL.O6   PLB.i_sp4_v_b[6]  PLB.i_sp4_v_b[14] PLB.i_sp4_v_b[22]                                     PLB.i_sp4_h_r[6]  PLB.i_sp4_h_r[14] PLB.i_sp4_h_r[22]                                       PLB.i_sp12_h_r[6] PLB.i_sp12_h_r[14] PLB.i_sp12_h_r[22]" output="local_g[1].i[6]" />
+  <mux name="local_g1[7]" input="                PLB_LOCAL.O7   PLB.i_sp4_v_b[7]  PLB.i_sp4_v_b[15] PLB.i_sp4_v_b[23]                                     PLB.i_sp4_h_r[7]  PLB.i_sp4_h_r[15] PLB.i_sp4_h_r[23]                                       PLB.i_sp12_h_r[7] PLB.i_sp12_h_r[15] PLB.i_sp12_h_r[23]" output="local_g[1].i[7]" />
 
-  <mux name="local_g2[0]" input="                       BLK_IG-PLB_LOCAL.O0                                                     BLK_TL-PLB.i_sp4_v_b[24] BLK_TL-PLB.i_sp4_v_b[32] BLK_TL-PLB.i_sp4_v_b[40]                                                     BLK_TL-PLB.i_sp4_h_r[24] BLK_TL-PLB.i_sp4_h_r[32] BLK_TL-PLB.i_sp4_h_r[40]   BLK_TL-PLB.i_sp12_v_b[0] BLK_TL-PLB.i_sp12_v_b[8]  BLK_TL-PLB.i_sp12_v_b[16]" output="BLK_XX-local_g[2].i[0]" />
-  <mux name="local_g2[1]" input="                       BLK_IG-PLB_LOCAL.O1                                                     BLK_TL-PLB.i_sp4_v_b[25] BLK_TL-PLB.i_sp4_v_b[33] BLK_TL-PLB.i_sp4_v_b[41]                                                     BLK_TL-PLB.i_sp4_h_r[25] BLK_TL-PLB.i_sp4_h_r[33] BLK_TL-PLB.i_sp4_h_r[41]   BLK_TL-PLB.i_sp12_v_b[1] BLK_TL-PLB.i_sp12_v_b[9]  BLK_TL-PLB.i_sp12_v_b[17]" output="BLK_XX-local_g[2].i[1]" />
-  <mux name="local_g2[2]" input="                       BLK_IG-PLB_LOCAL.O2                                                     BLK_TL-PLB.i_sp4_v_b[26] BLK_TL-PLB.i_sp4_v_b[34] BLK_TL-PLB.i_sp4_v_b[42]                                                     BLK_TL-PLB.i_sp4_h_r[26] BLK_TL-PLB.i_sp4_h_r[34] BLK_TL-PLB.i_sp4_h_r[42]   BLK_TL-PLB.i_sp12_v_b[2] BLK_TL-PLB.i_sp12_v_b[10] BLK_TL-PLB.i_sp12_v_b[18]" output="BLK_XX-local_g[2].i[2]" />
-  <mux name="local_g2[3]" input="                       BLK_IG-PLB_LOCAL.O3                                                     BLK_TL-PLB.i_sp4_v_b[27] BLK_TL-PLB.i_sp4_v_b[35] BLK_TL-PLB.i_sp4_v_b[43]                                                     BLK_TL-PLB.i_sp4_h_r[27] BLK_TL-PLB.i_sp4_h_r[35] BLK_TL-PLB.i_sp4_h_r[43]   BLK_TL-PLB.i_sp12_v_b[3] BLK_TL-PLB.i_sp12_v_b[11] BLK_TL-PLB.i_sp12_v_b[19]" output="BLK_XX-local_g[2].i[3]" />
-  <mux name="local_g2[4]" input="                       BLK_IG-PLB_LOCAL.O4                                                     BLK_TL-PLB.i_sp4_v_b[28] BLK_TL-PLB.i_sp4_v_b[36] BLK_TL-PLB.i_sp4_v_b[44]                                                     BLK_TL-PLB.i_sp4_h_r[28] BLK_TL-PLB.i_sp4_h_r[36] BLK_TL-PLB.i_sp4_h_r[44]   BLK_TL-PLB.i_sp12_v_b[4] BLK_TL-PLB.i_sp12_v_b[12] BLK_TL-PLB.i_sp12_v_b[20]" output="BLK_XX-local_g[2].i[4]" />
-  <mux name="local_g2[5]" input="                       BLK_IG-PLB_LOCAL.O5                                                     BLK_TL-PLB.i_sp4_v_b[29] BLK_TL-PLB.i_sp4_v_b[37] BLK_TL-PLB.i_sp4_v_b[45]                                                     BLK_TL-PLB.i_sp4_h_r[29] BLK_TL-PLB.i_sp4_h_r[37] BLK_TL-PLB.i_sp4_h_r[45]   BLK_TL-PLB.i_sp12_v_b[5] BLK_TL-PLB.i_sp12_v_b[13] BLK_TL-PLB.i_sp12_v_b[21]" output="BLK_XX-local_g[2].i[5]" />
-  <mux name="local_g2[6]" input="                       BLK_IG-PLB_LOCAL.O6                                                     BLK_TL-PLB.i_sp4_v_b[30] BLK_TL-PLB.i_sp4_v_b[38] BLK_TL-PLB.i_sp4_v_b[46]                                                     BLK_TL-PLB.i_sp4_h_r[30] BLK_TL-PLB.i_sp4_h_r[38] BLK_TL-PLB.i_sp4_h_r[46]   BLK_TL-PLB.i_sp12_v_b[6] BLK_TL-PLB.i_sp12_v_b[14] BLK_TL-PLB.i_sp12_v_b[22]" output="BLK_XX-local_g[2].i[6]" />
-  <mux name="local_g2[7]" input="                       BLK_IG-PLB_LOCAL.O7                                                     BLK_TL-PLB.i_sp4_v_b[31] BLK_TL-PLB.i_sp4_v_b[39] BLK_TL-PLB.i_sp4_v_b[47]                                                     BLK_TL-PLB.i_sp4_h_r[31] BLK_TL-PLB.i_sp4_h_r[39] BLK_TL-PLB.i_sp4_h_r[47]   BLK_TL-PLB.i_sp12_v_b[7] BLK_TL-PLB.i_sp12_v_b[15] BLK_TL-PLB.i_sp12_v_b[23]" output="BLK_XX-local_g[2].i[7]" />
+  <mux name="local_g2[0]" input="                PLB_LOCAL.O0                                       PLB.i_sp4_v_b[24] PLB.i_sp4_v_b[32] PLB.i_sp4_v_b[40]                                     PLB.i_sp4_h_r[24] PLB.i_sp4_h_r[32] PLB.i_sp4_h_r[40]   PLB.i_sp12_v_b[0] PLB.i_sp12_v_b[8]  PLB.i_sp12_v_b[16]" output="local_g[2].i[0]" />
+  <mux name="local_g2[1]" input="                PLB_LOCAL.O1                                       PLB.i_sp4_v_b[25] PLB.i_sp4_v_b[33] PLB.i_sp4_v_b[41]                                     PLB.i_sp4_h_r[25] PLB.i_sp4_h_r[33] PLB.i_sp4_h_r[41]   PLB.i_sp12_v_b[1] PLB.i_sp12_v_b[9]  PLB.i_sp12_v_b[17]" output="local_g[2].i[1]" />
+  <mux name="local_g2[2]" input="                PLB_LOCAL.O2                                       PLB.i_sp4_v_b[26] PLB.i_sp4_v_b[34] PLB.i_sp4_v_b[42]                                     PLB.i_sp4_h_r[26] PLB.i_sp4_h_r[34] PLB.i_sp4_h_r[42]   PLB.i_sp12_v_b[2] PLB.i_sp12_v_b[10] PLB.i_sp12_v_b[18]" output="local_g[2].i[2]" />
+  <mux name="local_g2[3]" input="                PLB_LOCAL.O3                                       PLB.i_sp4_v_b[27] PLB.i_sp4_v_b[35] PLB.i_sp4_v_b[43]                                     PLB.i_sp4_h_r[27] PLB.i_sp4_h_r[35] PLB.i_sp4_h_r[43]   PLB.i_sp12_v_b[3] PLB.i_sp12_v_b[11] PLB.i_sp12_v_b[19]" output="local_g[2].i[3]" />
+  <mux name="local_g2[4]" input="                PLB_LOCAL.O4                                       PLB.i_sp4_v_b[28] PLB.i_sp4_v_b[36] PLB.i_sp4_v_b[44]                                     PLB.i_sp4_h_r[28] PLB.i_sp4_h_r[36] PLB.i_sp4_h_r[44]   PLB.i_sp12_v_b[4] PLB.i_sp12_v_b[12] PLB.i_sp12_v_b[20]" output="local_g[2].i[4]" />
+  <mux name="local_g2[5]" input="                PLB_LOCAL.O5                                       PLB.i_sp4_v_b[29] PLB.i_sp4_v_b[37] PLB.i_sp4_v_b[45]                                     PLB.i_sp4_h_r[29] PLB.i_sp4_h_r[37] PLB.i_sp4_h_r[45]   PLB.i_sp12_v_b[5] PLB.i_sp12_v_b[13] PLB.i_sp12_v_b[21]" output="local_g[2].i[5]" />
+  <mux name="local_g2[6]" input="                PLB_LOCAL.O6                                       PLB.i_sp4_v_b[30] PLB.i_sp4_v_b[38] PLB.i_sp4_v_b[46]                                     PLB.i_sp4_h_r[30] PLB.i_sp4_h_r[38] PLB.i_sp4_h_r[46]   PLB.i_sp12_v_b[6] PLB.i_sp12_v_b[14] PLB.i_sp12_v_b[22]" output="local_g[2].i[6]" />
+  <mux name="local_g2[7]" input="                PLB_LOCAL.O7                                       PLB.i_sp4_v_b[31] PLB.i_sp4_v_b[39] PLB.i_sp4_v_b[47]                                     PLB.i_sp4_h_r[31] PLB.i_sp4_h_r[39] PLB.i_sp4_h_r[47]   PLB.i_sp12_v_b[7] PLB.i_sp12_v_b[15] PLB.i_sp12_v_b[23]" output="local_g[2].i[7]" />
 
-  <mux name="local_g3[0]" input="                       BLK_IG-PLB_LOCAL.O0                                                     BLK_TL-PLB.i_sp4_v_b[24] BLK_TL-PLB.i_sp4_v_b[32] BLK_TL-PLB.i_sp4_v_b[40]                                                     BLK_TL-PLB.i_sp4_h_r[24] BLK_TL-PLB.i_sp4_h_r[32] BLK_TL-PLB.i_sp4_h_r[40]   BLK_TL-PLB.i_sp12_v_b[0] BLK_TL-PLB.i_sp12_v_b[8]  BLK_TL-PLB.i_sp12_v_b[16]" output="BLK_XX-local_g[3].i[0]" />
-  <mux name="local_g3[1]" input="                       BLK_IG-PLB_LOCAL.O1                                                     BLK_TL-PLB.i_sp4_v_b[25] BLK_TL-PLB.i_sp4_v_b[33] BLK_TL-PLB.i_sp4_v_b[41]                                                     BLK_TL-PLB.i_sp4_h_r[25] BLK_TL-PLB.i_sp4_h_r[33] BLK_TL-PLB.i_sp4_h_r[41]   BLK_TL-PLB.i_sp12_v_b[1] BLK_TL-PLB.i_sp12_v_b[9]  BLK_TL-PLB.i_sp12_v_b[17]" output="BLK_XX-local_g[3].i[1]" />
-  <mux name="local_g3[2]" input="                       BLK_IG-PLB_LOCAL.O2                                                     BLK_TL-PLB.i_sp4_v_b[26] BLK_TL-PLB.i_sp4_v_b[34] BLK_TL-PLB.i_sp4_v_b[42]                                                     BLK_TL-PLB.i_sp4_h_r[26] BLK_TL-PLB.i_sp4_h_r[34] BLK_TL-PLB.i_sp4_h_r[42]   BLK_TL-PLB.i_sp12_v_b[2] BLK_TL-PLB.i_sp12_v_b[10] BLK_TL-PLB.i_sp12_v_b[18]" output="BLK_XX-local_g[3].i[2]" />
-  <mux name="local_g3[3]" input="                       BLK_IG-PLB_LOCAL.O3                                                     BLK_TL-PLB.i_sp4_v_b[27] BLK_TL-PLB.i_sp4_v_b[35] BLK_TL-PLB.i_sp4_v_b[43]                                                     BLK_TL-PLB.i_sp4_h_r[27] BLK_TL-PLB.i_sp4_h_r[35] BLK_TL-PLB.i_sp4_h_r[43]   BLK_TL-PLB.i_sp12_v_b[3] BLK_TL-PLB.i_sp12_v_b[11] BLK_TL-PLB.i_sp12_v_b[19]" output="BLK_XX-local_g[3].i[3]" />
-  <mux name="local_g3[4]" input="                       BLK_IG-PLB_LOCAL.O4                                                     BLK_TL-PLB.i_sp4_v_b[28] BLK_TL-PLB.i_sp4_v_b[36] BLK_TL-PLB.i_sp4_v_b[44]                                                     BLK_TL-PLB.i_sp4_h_r[28] BLK_TL-PLB.i_sp4_h_r[36] BLK_TL-PLB.i_sp4_h_r[44]   BLK_TL-PLB.i_sp12_v_b[4] BLK_TL-PLB.i_sp12_v_b[12] BLK_TL-PLB.i_sp12_v_b[20]" output="BLK_XX-local_g[3].i[4]" />
-  <mux name="local_g3[5]" input="                       BLK_IG-PLB_LOCAL.O5                                                     BLK_TL-PLB.i_sp4_v_b[29] BLK_TL-PLB.i_sp4_v_b[37] BLK_TL-PLB.i_sp4_v_b[45]                                                     BLK_TL-PLB.i_sp4_h_r[29] BLK_TL-PLB.i_sp4_h_r[37] BLK_TL-PLB.i_sp4_h_r[45]   BLK_TL-PLB.i_sp12_v_b[5] BLK_TL-PLB.i_sp12_v_b[13] BLK_TL-PLB.i_sp12_v_b[21]" output="BLK_XX-local_g[3].i[5]" />
-  <mux name="local_g3[6]" input="                       BLK_IG-PLB_LOCAL.O6                                                     BLK_TL-PLB.i_sp4_v_b[30] BLK_TL-PLB.i_sp4_v_b[38] BLK_TL-PLB.i_sp4_v_b[46]                                                     BLK_TL-PLB.i_sp4_h_r[30] BLK_TL-PLB.i_sp4_h_r[38] BLK_TL-PLB.i_sp4_h_r[46]   BLK_TL-PLB.i_sp12_v_b[6] BLK_TL-PLB.i_sp12_v_b[14] BLK_TL-PLB.i_sp12_v_b[22]" output="BLK_XX-local_g[3].i[6]" />
-  <mux name="local_g3[7]" input="                       BLK_IG-PLB_LOCAL.O7                                                     BLK_TL-PLB.i_sp4_v_b[31] BLK_TL-PLB.i_sp4_v_b[39] BLK_TL-PLB.i_sp4_v_b[47]                                                     BLK_TL-PLB.i_sp4_h_r[31] BLK_TL-PLB.i_sp4_h_r[39] BLK_TL-PLB.i_sp4_h_r[47]   BLK_TL-PLB.i_sp12_v_b[7] BLK_TL-PLB.i_sp12_v_b[15] BLK_TL-PLB.i_sp12_v_b[23]" output="BLK_XX-local_g[3].i[7]" />
+  <mux name="local_g3[0]" input="                PLB_LOCAL.O0                                       PLB.i_sp4_v_b[24] PLB.i_sp4_v_b[32] PLB.i_sp4_v_b[40]                                     PLB.i_sp4_h_r[24] PLB.i_sp4_h_r[32] PLB.i_sp4_h_r[40]   PLB.i_sp12_v_b[0] PLB.i_sp12_v_b[8]  PLB.i_sp12_v_b[16]" output="local_g[3].i[0]" />
+  <mux name="local_g3[1]" input="                PLB_LOCAL.O1                                       PLB.i_sp4_v_b[25] PLB.i_sp4_v_b[33] PLB.i_sp4_v_b[41]                                     PLB.i_sp4_h_r[25] PLB.i_sp4_h_r[33] PLB.i_sp4_h_r[41]   PLB.i_sp12_v_b[1] PLB.i_sp12_v_b[9]  PLB.i_sp12_v_b[17]" output="local_g[3].i[1]" />
+  <mux name="local_g3[2]" input="                PLB_LOCAL.O2                                       PLB.i_sp4_v_b[26] PLB.i_sp4_v_b[34] PLB.i_sp4_v_b[42]                                     PLB.i_sp4_h_r[26] PLB.i_sp4_h_r[34] PLB.i_sp4_h_r[42]   PLB.i_sp12_v_b[2] PLB.i_sp12_v_b[10] PLB.i_sp12_v_b[18]" output="local_g[3].i[2]" />
+  <mux name="local_g3[3]" input="                PLB_LOCAL.O3                                       PLB.i_sp4_v_b[27] PLB.i_sp4_v_b[35] PLB.i_sp4_v_b[43]                                     PLB.i_sp4_h_r[27] PLB.i_sp4_h_r[35] PLB.i_sp4_h_r[43]   PLB.i_sp12_v_b[3] PLB.i_sp12_v_b[11] PLB.i_sp12_v_b[19]" output="local_g[3].i[3]" />
+  <mux name="local_g3[4]" input="                PLB_LOCAL.O4                                       PLB.i_sp4_v_b[28] PLB.i_sp4_v_b[36] PLB.i_sp4_v_b[44]                                     PLB.i_sp4_h_r[28] PLB.i_sp4_h_r[36] PLB.i_sp4_h_r[44]   PLB.i_sp12_v_b[4] PLB.i_sp12_v_b[12] PLB.i_sp12_v_b[20]" output="local_g[3].i[4]" />
+  <mux name="local_g3[5]" input="                PLB_LOCAL.O5                                       PLB.i_sp4_v_b[29] PLB.i_sp4_v_b[37] PLB.i_sp4_v_b[45]                                     PLB.i_sp4_h_r[29] PLB.i_sp4_h_r[37] PLB.i_sp4_h_r[45]   PLB.i_sp12_v_b[5] PLB.i_sp12_v_b[13] PLB.i_sp12_v_b[21]" output="local_g[3].i[5]" />
+  <mux name="local_g3[6]" input="                PLB_LOCAL.O6                                       PLB.i_sp4_v_b[30] PLB.i_sp4_v_b[38] PLB.i_sp4_v_b[46]                                     PLB.i_sp4_h_r[30] PLB.i_sp4_h_r[38] PLB.i_sp4_h_r[46]   PLB.i_sp12_v_b[6] PLB.i_sp12_v_b[14] PLB.i_sp12_v_b[22]" output="local_g[3].i[6]" />
+  <mux name="local_g3[7]" input="                PLB_LOCAL.O7                                       PLB.i_sp4_v_b[31] PLB.i_sp4_v_b[39] PLB.i_sp4_v_b[47]                                     PLB.i_sp4_h_r[31] PLB.i_sp4_h_r[39] PLB.i_sp4_h_r[47]   PLB.i_sp12_v_b[7] PLB.i_sp12_v_b[15] PLB.i_sp12_v_b[23]" output="local_g[3].i[7]" />
 
   <!-- LUTFF.O   to Span-4 Vertical -->
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_v_b[0]"  input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_v_b[0]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_v_b[16]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_v_b[16]" />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_v_b[32]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_v_b[32]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_v_b[18]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_v_b[18]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_v_b[2]"  input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_v_b[2]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_v_b[34]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_v_b[34]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_v_b[20]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_v_b[20]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_v_b[36]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_v_b[36]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_v_b[4]"  input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_v_b[4]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_v_b[22]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_v_b[22]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_v_b[38]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_v_b[38]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_v_b[6]"  input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_v_b[6]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_v_b[24]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_v_b[24]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_v_b[40]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_v_b[40]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_v_b[8]"  input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_v_b[8]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_v_b[10]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_v_b[10]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_v_b[26]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_v_b[26]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_v_b[42]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_v_b[42]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_v_b[12]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_v_b[12]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_v_b[28]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_v_b[28]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_v_b[44]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_v_b[44]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_v_b[14]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_v_b[14]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_v_b[30]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_v_b[30]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_v_b[46]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_v_b[46]" />
+  <mux name="PLB_LOCAL.O0->sp4_v_b[0]"  input="PLB_LOCAL.O0" output="PLB.o_sp4_v_b[0]"  />
+  <mux name="PLB_LOCAL.O0->sp4_v_b[16]" input="PLB_LOCAL.O0" output="PLB.o_sp4_v_b[16]" />
+  <mux name="PLB_LOCAL.O0->sp4_v_b[32]" input="PLB_LOCAL.O0" output="PLB.o_sp4_v_b[32]" />
+  <mux name="PLB_LOCAL.O1->sp4_v_b[18]" input="PLB_LOCAL.O1" output="PLB.o_sp4_v_b[18]" />
+  <mux name="PLB_LOCAL.O1->sp4_v_b[2]"  input="PLB_LOCAL.O1" output="PLB.o_sp4_v_b[2]"  />
+  <mux name="PLB_LOCAL.O1->sp4_v_b[34]" input="PLB_LOCAL.O1" output="PLB.o_sp4_v_b[34]" />
+  <mux name="PLB_LOCAL.O2->sp4_v_b[20]" input="PLB_LOCAL.O2" output="PLB.o_sp4_v_b[20]" />
+  <mux name="PLB_LOCAL.O2->sp4_v_b[36]" input="PLB_LOCAL.O2" output="PLB.o_sp4_v_b[36]" />
+  <mux name="PLB_LOCAL.O2->sp4_v_b[4]"  input="PLB_LOCAL.O2" output="PLB.o_sp4_v_b[4]"  />
+  <mux name="PLB_LOCAL.O3->sp4_v_b[22]" input="PLB_LOCAL.O3" output="PLB.o_sp4_v_b[22]" />
+  <mux name="PLB_LOCAL.O3->sp4_v_b[38]" input="PLB_LOCAL.O3" output="PLB.o_sp4_v_b[38]" />
+  <mux name="PLB_LOCAL.O3->sp4_v_b[6]"  input="PLB_LOCAL.O3" output="PLB.o_sp4_v_b[6]"  />
+  <mux name="PLB_LOCAL.O4->sp4_v_b[24]" input="PLB_LOCAL.O4" output="PLB.o_sp4_v_b[24]" />
+  <mux name="PLB_LOCAL.O4->sp4_v_b[40]" input="PLB_LOCAL.O4" output="PLB.o_sp4_v_b[40]" />
+  <mux name="PLB_LOCAL.O4->sp4_v_b[8]"  input="PLB_LOCAL.O4" output="PLB.o_sp4_v_b[8]"  />
+  <mux name="PLB_LOCAL.O5->sp4_v_b[10]" input="PLB_LOCAL.O5" output="PLB.o_sp4_v_b[10]" />
+  <mux name="PLB_LOCAL.O5->sp4_v_b[26]" input="PLB_LOCAL.O5" output="PLB.o_sp4_v_b[26]" />
+  <mux name="PLB_LOCAL.O5->sp4_v_b[42]" input="PLB_LOCAL.O5" output="PLB.o_sp4_v_b[42]" />
+  <mux name="PLB_LOCAL.O6->sp4_v_b[12]" input="PLB_LOCAL.O6" output="PLB.o_sp4_v_b[12]" />
+  <mux name="PLB_LOCAL.O6->sp4_v_b[28]" input="PLB_LOCAL.O6" output="PLB.o_sp4_v_b[28]" />
+  <mux name="PLB_LOCAL.O6->sp4_v_b[44]" input="PLB_LOCAL.O6" output="PLB.o_sp4_v_b[44]" />
+  <mux name="PLB_LOCAL.O7->sp4_v_b[14]" input="PLB_LOCAL.O7" output="PLB.o_sp4_v_b[14]" />
+  <mux name="PLB_LOCAL.O7->sp4_v_b[30]" input="PLB_LOCAL.O7" output="PLB.o_sp4_v_b[30]" />
+  <mux name="PLB_LOCAL.O7->sp4_v_b[46]" input="PLB_LOCAL.O7" output="PLB.o_sp4_v_b[46]" />
 
   <!--
-  <mux name="mux_sp12_v_b[1]"  input="BLK_TL-PLB.i_sp12_v_b[1]"  output="BLK_TL-PLB.o_sp4_v_b[12]" />
-  <mux name="mux_sp12_v_b[11]" input="BLK_TL-PLB.i_sp12_v_b[11]" output="BLK_TL-PLB.o_sp4_v_b[17]" />
-  <mux name="mux_sp12_v_b[13]" input="BLK_TL-PLB.i_sp12_v_b[13]" output="BLK_TL-PLB.o_sp4_v_b[18]" />
-  <mux name="mux_sp12_v_b[15]" input="BLK_TL-PLB.i_sp12_v_b[15]" output="BLK_TL-PLB.o_sp4_v_b[19]" />
-  <mux name="mux_sp12_v_b[17]" input="BLK_TL-PLB.i_sp12_v_b[17]" output="BLK_TL-PLB.o_sp4_v_b[20]" />
-  <mux name="mux_sp12_v_b[19]" input="BLK_TL-PLB.i_sp12_v_b[19]" output="BLK_TL-PLB.o_sp4_v_b[21]" />
-  <mux name="mux_sp12_v_b[21]" input="BLK_TL-PLB.i_sp12_v_b[21]" output="BLK_TL-PLB.o_sp4_v_b[22]" />
-  <mux name="mux_sp12_v_b[23]" input="BLK_TL-PLB.i_sp12_v_b[23]" output="BLK_TL-PLB.o_sp4_v_b[23]" />
-  <mux name="mux_sp12_v_b[3]"  input="BLK_TL-PLB.i_sp12_v_b[3]"  output="BLK_TL-PLB.o_sp4_v_b[13]" />
-  <mux name="mux_sp12_v_b[5]"  input="BLK_TL-PLB.i_sp12_v_b[5]"  output="BLK_TL-PLB.o_sp4_v_b[14]" />
-  <mux name="mux_sp12_v_b[7]"  input="BLK_TL-PLB.i_sp12_v_b[7]"  output="BLK_TL-PLB.o_sp4_v_b[15]" />
-  <mux name="mux_sp12_v_b[9]"  input="BLK_TL-PLB.i_sp12_v_b[9]"  output="BLK_TL-PLB.o_sp4_v_b[16]" />
+  <mux name="mux_sp12_v_b[1]"  input="PLB.i_sp12_v_b[1]"  output="PLB.o_sp4_v_b[12]" />
+  <mux name="mux_sp12_v_b[11]" input="PLB.i_sp12_v_b[11]" output="PLB.o_sp4_v_b[17]" />
+  <mux name="mux_sp12_v_b[13]" input="PLB.i_sp12_v_b[13]" output="PLB.o_sp4_v_b[18]" />
+  <mux name="mux_sp12_v_b[15]" input="PLB.i_sp12_v_b[15]" output="PLB.o_sp4_v_b[19]" />
+  <mux name="mux_sp12_v_b[17]" input="PLB.i_sp12_v_b[17]" output="PLB.o_sp4_v_b[20]" />
+  <mux name="mux_sp12_v_b[19]" input="PLB.i_sp12_v_b[19]" output="PLB.o_sp4_v_b[21]" />
+  <mux name="mux_sp12_v_b[21]" input="PLB.i_sp12_v_b[21]" output="PLB.o_sp4_v_b[22]" />
+  <mux name="mux_sp12_v_b[23]" input="PLB.i_sp12_v_b[23]" output="PLB.o_sp4_v_b[23]" />
+  <mux name="mux_sp12_v_b[3]"  input="PLB.i_sp12_v_b[3]"  output="PLB.o_sp4_v_b[13]" />
+  <mux name="mux_sp12_v_b[5]"  input="PLB.i_sp12_v_b[5]"  output="PLB.o_sp4_v_b[14]" />
+  <mux name="mux_sp12_v_b[7]"  input="PLB.i_sp12_v_b[7]"  output="PLB.o_sp4_v_b[15]" />
+  <mux name="mux_sp12_v_b[9]"  input="PLB.i_sp12_v_b[9]"  output="PLB.o_sp4_v_b[16]" />
   -->
 
   <!-- LUTFF.O   to Span-4 Right Vertical
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_r_v_b[1]"  input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_r_v_b[1]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_r_v_b[17]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_r_v_b[17]" />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_r_v_b[33]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_r_v_b[33]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_r_v_b[19]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_r_v_b[19]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_r_v_b[3]"  input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_r_v_b[3]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_r_v_b[35]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_r_v_b[35]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_r_v_b[21]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_r_v_b[21]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_r_v_b[37]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_r_v_b[37]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_r_v_b[5] " input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_r_v_b[5] " />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_r_v_b[23]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_r_v_b[23]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_r_v_b[39]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_r_v_b[39]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_r_v_b[7] " input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_r_v_b[7] " />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_r_v_b[25]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_r_v_b[25]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_r_v_b[41]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_r_v_b[41]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_r_v_b[9]"  input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_r_v_b[9]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_r_v_b[11]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_r_v_b[11]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_r_v_b[27]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_r_v_b[27]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_r_v_b[43]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_r_v_b[43]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_r_v_b[13]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_r_v_b[13]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_r_v_b[29]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_r_v_b[29]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_r_v_b[45]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_r_v_b[45]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_r_v_b[15]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_r_v_b[15]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_r_v_b[31]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_r_v_b[31]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_r_v_b[47]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_r_v_b[47]" />
+  <mux name="PLB_LOCAL.O0->sp4_r_v_b[1]"  input="PLB_LOCAL.O0" output="PLB.o_sp4_r_v_b[1]"  />
+  <mux name="PLB_LOCAL.O0->sp4_r_v_b[17]" input="PLB_LOCAL.O0" output="PLB.o_sp4_r_v_b[17]" />
+  <mux name="PLB_LOCAL.O0->sp4_r_v_b[33]" input="PLB_LOCAL.O0" output="PLB.o_sp4_r_v_b[33]" />
+  <mux name="PLB_LOCAL.O1->sp4_r_v_b[19]" input="PLB_LOCAL.O1" output="PLB.o_sp4_r_v_b[19]" />
+  <mux name="PLB_LOCAL.O1->sp4_r_v_b[3]"  input="PLB_LOCAL.O1" output="PLB.o_sp4_r_v_b[3]"  />
+  <mux name="PLB_LOCAL.O1->sp4_r_v_b[35]" input="PLB_LOCAL.O1" output="PLB.o_sp4_r_v_b[35]" />
+  <mux name="PLB_LOCAL.O2->sp4_r_v_b[21]" input="PLB_LOCAL.O2" output="PLB.o_sp4_r_v_b[21]" />
+  <mux name="PLB_LOCAL.O2->sp4_r_v_b[37]" input="PLB_LOCAL.O2" output="PLB.o_sp4_r_v_b[37]" />
+  <mux name="PLB_LOCAL.O2->sp4_r_v_b[5] " input="PLB_LOCAL.O2" output="PLB.o_sp4_r_v_b[5] " />
+  <mux name="PLB_LOCAL.O3->sp4_r_v_b[23]" input="PLB_LOCAL.O3" output="PLB.o_sp4_r_v_b[23]" />
+  <mux name="PLB_LOCAL.O3->sp4_r_v_b[39]" input="PLB_LOCAL.O3" output="PLB.o_sp4_r_v_b[39]" />
+  <mux name="PLB_LOCAL.O3->sp4_r_v_b[7] " input="PLB_LOCAL.O3" output="PLB.o_sp4_r_v_b[7] " />
+  <mux name="PLB_LOCAL.O4->sp4_r_v_b[25]" input="PLB_LOCAL.O4" output="PLB.o_sp4_r_v_b[25]" />
+  <mux name="PLB_LOCAL.O4->sp4_r_v_b[41]" input="PLB_LOCAL.O4" output="PLB.o_sp4_r_v_b[41]" />
+  <mux name="PLB_LOCAL.O4->sp4_r_v_b[9]"  input="PLB_LOCAL.O4" output="PLB.o_sp4_r_v_b[9]"  />
+  <mux name="PLB_LOCAL.O5->sp4_r_v_b[11]" input="PLB_LOCAL.O5" output="PLB.o_sp4_r_v_b[11]" />
+  <mux name="PLB_LOCAL.O5->sp4_r_v_b[27]" input="PLB_LOCAL.O5" output="PLB.o_sp4_r_v_b[27]" />
+  <mux name="PLB_LOCAL.O5->sp4_r_v_b[43]" input="PLB_LOCAL.O5" output="PLB.o_sp4_r_v_b[43]" />
+  <mux name="PLB_LOCAL.O6->sp4_r_v_b[13]" input="PLB_LOCAL.O6" output="PLB.o_sp4_r_v_b[13]" />
+  <mux name="PLB_LOCAL.O6->sp4_r_v_b[29]" input="PLB_LOCAL.O6" output="PLB.o_sp4_r_v_b[29]" />
+  <mux name="PLB_LOCAL.O6->sp4_r_v_b[45]" input="PLB_LOCAL.O6" output="PLB.o_sp4_r_v_b[45]" />
+  <mux name="PLB_LOCAL.O7->sp4_r_v_b[15]" input="PLB_LOCAL.O7" output="PLB.o_sp4_r_v_b[15]" />
+  <mux name="PLB_LOCAL.O7->sp4_r_v_b[31]" input="PLB_LOCAL.O7" output="PLB.o_sp4_r_v_b[31]" />
+  <mux name="PLB_LOCAL.O7->sp4_r_v_b[47]" input="PLB_LOCAL.O7" output="PLB.o_sp4_r_v_b[47]" />
        -->
 
   <!-- LUTFF.O   to Span-4 Horizontal -->
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_h_r[0]"  input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_h_r[0]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_h_r[16]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_h_r[16]" />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp4_h_r[32]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp4_h_r[32]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_h_r[18]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_h_r[18]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_h_r[2]"  input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_h_r[2]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp4_h_r[34]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp4_h_r[34]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_h_r[20]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_h_r[20]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_h_r[36]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_h_r[36]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp4_h_r[4]"  input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp4_h_r[4]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_h_r[22]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_h_r[22]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_h_r[38]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_h_r[38]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp4_h_r[6]"  input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp4_h_r[6]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_h_r[24]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_h_r[24]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_h_r[40]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_h_r[40]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp4_h_r[8]"  input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp4_h_r[8]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_h_r[10]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_h_r[10]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_h_r[26]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_h_r[26]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp4_h_r[42]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp4_h_r[42]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_h_r[12]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_h_r[12]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_h_r[28]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_h_r[28]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp4_h_r[44]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp4_h_r[44]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_h_r[14]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_h_r[14]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_h_r[30]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_h_r[30]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp4_h_r[46]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp4_h_r[46]" />
+  <mux name="PLB_LOCAL.O0->sp4_h_r[0]"  input="PLB_LOCAL.O0" output="PLB.o_sp4_h_r[0]"  />
+  <mux name="PLB_LOCAL.O0->sp4_h_r[16]" input="PLB_LOCAL.O0" output="PLB.o_sp4_h_r[16]" />
+  <mux name="PLB_LOCAL.O0->sp4_h_r[32]" input="PLB_LOCAL.O0" output="PLB.o_sp4_h_r[32]" />
+  <mux name="PLB_LOCAL.O1->sp4_h_r[18]" input="PLB_LOCAL.O1" output="PLB.o_sp4_h_r[18]" />
+  <mux name="PLB_LOCAL.O1->sp4_h_r[2]"  input="PLB_LOCAL.O1" output="PLB.o_sp4_h_r[2]"  />
+  <mux name="PLB_LOCAL.O1->sp4_h_r[34]" input="PLB_LOCAL.O1" output="PLB.o_sp4_h_r[34]" />
+  <mux name="PLB_LOCAL.O2->sp4_h_r[20]" input="PLB_LOCAL.O2" output="PLB.o_sp4_h_r[20]" />
+  <mux name="PLB_LOCAL.O2->sp4_h_r[36]" input="PLB_LOCAL.O2" output="PLB.o_sp4_h_r[36]" />
+  <mux name="PLB_LOCAL.O2->sp4_h_r[4]"  input="PLB_LOCAL.O2" output="PLB.o_sp4_h_r[4]"  />
+  <mux name="PLB_LOCAL.O3->sp4_h_r[22]" input="PLB_LOCAL.O3" output="PLB.o_sp4_h_r[22]" />
+  <mux name="PLB_LOCAL.O3->sp4_h_r[38]" input="PLB_LOCAL.O3" output="PLB.o_sp4_h_r[38]" />
+  <mux name="PLB_LOCAL.O3->sp4_h_r[6]"  input="PLB_LOCAL.O3" output="PLB.o_sp4_h_r[6]"  />
+  <mux name="PLB_LOCAL.O4->sp4_h_r[24]" input="PLB_LOCAL.O4" output="PLB.o_sp4_h_r[24]" />
+  <mux name="PLB_LOCAL.O4->sp4_h_r[40]" input="PLB_LOCAL.O4" output="PLB.o_sp4_h_r[40]" />
+  <mux name="PLB_LOCAL.O4->sp4_h_r[8]"  input="PLB_LOCAL.O4" output="PLB.o_sp4_h_r[8]"  />
+  <mux name="PLB_LOCAL.O5->sp4_h_r[10]" input="PLB_LOCAL.O5" output="PLB.o_sp4_h_r[10]" />
+  <mux name="PLB_LOCAL.O5->sp4_h_r[26]" input="PLB_LOCAL.O5" output="PLB.o_sp4_h_r[26]" />
+  <mux name="PLB_LOCAL.O5->sp4_h_r[42]" input="PLB_LOCAL.O5" output="PLB.o_sp4_h_r[42]" />
+  <mux name="PLB_LOCAL.O6->sp4_h_r[12]" input="PLB_LOCAL.O6" output="PLB.o_sp4_h_r[12]" />
+  <mux name="PLB_LOCAL.O6->sp4_h_r[28]" input="PLB_LOCAL.O6" output="PLB.o_sp4_h_r[28]" />
+  <mux name="PLB_LOCAL.O6->sp4_h_r[44]" input="PLB_LOCAL.O6" output="PLB.o_sp4_h_r[44]" />
+  <mux name="PLB_LOCAL.O7->sp4_h_r[14]" input="PLB_LOCAL.O7" output="PLB.o_sp4_h_r[14]" />
+  <mux name="PLB_LOCAL.O7->sp4_h_r[30]" input="PLB_LOCAL.O7" output="PLB.o_sp4_h_r[30]" />
+  <mux name="PLB_LOCAL.O7->sp4_h_r[46]" input="PLB_LOCAL.O7" output="PLB.o_sp4_h_r[46]" />
 
   <!--
-  <mux name="mux_sp12_h_r[0]"  input="BLK_TL-PLB.i_sp12_h_r[0]"  output="BLK_TL-PLB.o_sp4_h_r[12]" />
-  <mux name="mux_sp12_h_r[10]" input="BLK_TL-PLB.i_sp12_h_r[10]" output="BLK_TL-PLB.o_sp4_h_r[17]" />
-  <mux name="mux_sp12_h_r[12]" input="BLK_TL-PLB.i_sp12_h_r[12]" output="BLK_TL-PLB.o_sp4_h_r[18]" />
-  <mux name="mux_sp12_h_r[14]" input="BLK_TL-PLB.i_sp12_h_r[14]" output="BLK_TL-PLB.o_sp4_h_r[19]" />
-  <mux name="mux_sp12_h_r[16]" input="BLK_TL-PLB.i_sp12_h_r[16]" output="BLK_TL-PLB.o_sp4_h_r[20]" />
-  <mux name="mux_sp12_h_r[18]" input="BLK_TL-PLB.i_sp12_h_r[18]" output="BLK_TL-PLB.o_sp4_h_r[21]" />
-  <mux name="mux_sp12_h_r[2]"  input="BLK_TL-PLB.i_sp12_h_r[2]"  output="BLK_TL-PLB.o_sp4_h_r[13]" />
-  <mux name="mux_sp12_h_r[20]" input="BLK_TL-PLB.i_sp12_h_r[20]" output="BLK_TL-PLB.o_sp4_h_r[22]" />
-  <mux name="mux_sp12_h_r[22]" input="BLK_TL-PLB.i_sp12_h_r[22]" output="BLK_TL-PLB.o_sp4_h_r[23]" />
-  <mux name="mux_sp12_h_r[4]"  input="BLK_TL-PLB.i_sp12_h_r[4]"  output="BLK_TL-PLB.o_sp4_h_r[14]" />
-  <mux name="mux_sp12_h_r[6]"  input="BLK_TL-PLB.i_sp12_h_r[6]"  output="BLK_TL-PLB.o_sp4_h_r[15]" />
-  <mux name="mux_sp12_h_r[8]"  input="BLK_TL-PLB.i_sp12_h_r[8]"  output="BLK_TL-PLB.o_sp4_h_r[16]" />
+  <mux name="mux_sp12_h_r[0]"  input="PLB.i_sp12_h_r[0]"  output="PLB.o_sp4_h_r[12]" />
+  <mux name="mux_sp12_h_r[10]" input="PLB.i_sp12_h_r[10]" output="PLB.o_sp4_h_r[17]" />
+  <mux name="mux_sp12_h_r[12]" input="PLB.i_sp12_h_r[12]" output="PLB.o_sp4_h_r[18]" />
+  <mux name="mux_sp12_h_r[14]" input="PLB.i_sp12_h_r[14]" output="PLB.o_sp4_h_r[19]" />
+  <mux name="mux_sp12_h_r[16]" input="PLB.i_sp12_h_r[16]" output="PLB.o_sp4_h_r[20]" />
+  <mux name="mux_sp12_h_r[18]" input="PLB.i_sp12_h_r[18]" output="PLB.o_sp4_h_r[21]" />
+  <mux name="mux_sp12_h_r[2]"  input="PLB.i_sp12_h_r[2]"  output="PLB.o_sp4_h_r[13]" />
+  <mux name="mux_sp12_h_r[20]" input="PLB.i_sp12_h_r[20]" output="PLB.o_sp4_h_r[22]" />
+  <mux name="mux_sp12_h_r[22]" input="PLB.i_sp12_h_r[22]" output="PLB.o_sp4_h_r[23]" />
+  <mux name="mux_sp12_h_r[4]"  input="PLB.i_sp12_h_r[4]"  output="PLB.o_sp4_h_r[14]" />
+  <mux name="mux_sp12_h_r[6]"  input="PLB.i_sp12_h_r[6]"  output="PLB.o_sp4_h_r[15]" />
+  <mux name="mux_sp12_h_r[8]"  input="PLB.i_sp12_h_r[8]"  output="PLB.o_sp4_h_r[16]" />
   -->
 
   <!-- LUTFF.O   to Span-12 Vertical -->
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp12_v_b[0]"  input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp12_v_b[0]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp12_v_b[16]" input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp12_v_b[16]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp12_v_b[18]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp12_v_b[18]" />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp12_v_b[2]"  input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp12_v_b[2]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp12_v_b[20]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp12_v_b[20]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp12_v_b[4]"  input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp12_v_b[4]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp12_v_b[22]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp12_v_b[22]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp12_v_b[6]"  input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp12_v_b[6]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp12_v_b[8]"  input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp12_v_b[8]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp12_v_b[10]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp12_v_b[10]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp12_v_b[12]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp12_v_b[12]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp12_v_b[14]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp12_v_b[14]" />
+  <mux name="PLB_LOCAL.O0->sp12_v_b[0]"  input="PLB_LOCAL.O0" output="PLB.o_sp12_v_b[0]"  />
+  <mux name="PLB_LOCAL.O0->sp12_v_b[16]" input="PLB_LOCAL.O0" output="PLB.o_sp12_v_b[16]" />
+  <mux name="PLB_LOCAL.O1->sp12_v_b[18]" input="PLB_LOCAL.O1" output="PLB.o_sp12_v_b[18]" />
+  <mux name="PLB_LOCAL.O1->sp12_v_b[2]"  input="PLB_LOCAL.O1" output="PLB.o_sp12_v_b[2]"  />
+  <mux name="PLB_LOCAL.O2->sp12_v_b[20]" input="PLB_LOCAL.O2" output="PLB.o_sp12_v_b[20]" />
+  <mux name="PLB_LOCAL.O2->sp12_v_b[4]"  input="PLB_LOCAL.O2" output="PLB.o_sp12_v_b[4]"  />
+  <mux name="PLB_LOCAL.O3->sp12_v_b[22]" input="PLB_LOCAL.O3" output="PLB.o_sp12_v_b[22]" />
+  <mux name="PLB_LOCAL.O3->sp12_v_b[6]"  input="PLB_LOCAL.O3" output="PLB.o_sp12_v_b[6]"  />
+  <mux name="PLB_LOCAL.O4->sp12_v_b[8]"  input="PLB_LOCAL.O4" output="PLB.o_sp12_v_b[8]"  />
+  <mux name="PLB_LOCAL.O5->sp12_v_b[10]" input="PLB_LOCAL.O5" output="PLB.o_sp12_v_b[10]" />
+  <mux name="PLB_LOCAL.O6->sp12_v_b[12]" input="PLB_LOCAL.O6" output="PLB.o_sp12_v_b[12]" />
+  <mux name="PLB_LOCAL.O7->sp12_v_b[14]" input="PLB_LOCAL.O7" output="PLB.o_sp12_v_b[14]" />
 
   <!-- LUTFF.O   to Span-12 Horizontal -->
-  <mux name="BLK_IG-PLB_LOCAL.O0->sp12_h_r[8]"  input="BLK_IG-PLB_LOCAL.O0" output="BLK_TL-PLB.o_sp12_h_r[8]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O1->sp12_h_r[10]" input="BLK_IG-PLB_LOCAL.O1" output="BLK_TL-PLB.o_sp12_h_r[10]" />
-  <mux name="BLK_IG-PLB_LOCAL.O2->sp12_h_r[12]" input="BLK_IG-PLB_LOCAL.O2" output="BLK_TL-PLB.o_sp12_h_r[12]" />
-  <mux name="BLK_IG-PLB_LOCAL.O3->sp12_h_r[14]" input="BLK_IG-PLB_LOCAL.O3" output="BLK_TL-PLB.o_sp12_h_r[14]" />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp12_h_r[0]"  input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp12_h_r[0]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O4->sp12_h_r[16]" input="BLK_IG-PLB_LOCAL.O4" output="BLK_TL-PLB.o_sp12_h_r[16]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp12_h_r[18]" input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp12_h_r[18]" />
-  <mux name="BLK_IG-PLB_LOCAL.O5->sp12_h_r[2]"  input="BLK_IG-PLB_LOCAL.O5" output="BLK_TL-PLB.o_sp12_h_r[2]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp12_h_r[20]" input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp12_h_r[20]" />
-  <mux name="BLK_IG-PLB_LOCAL.O6->sp12_h_r[4]"  input="BLK_IG-PLB_LOCAL.O6" output="BLK_TL-PLB.o_sp12_h_r[4]"  />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp12_h_r[22]" input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp12_h_r[22]" />
-  <mux name="BLK_IG-PLB_LOCAL.O7->sp12_h_r[6]"  input="BLK_IG-PLB_LOCAL.O7" output="BLK_TL-PLB.o_sp12_h_r[6]"  />
+  <mux name="PLB_LOCAL.O0->sp12_h_r[8]"  input="PLB_LOCAL.O0" output="PLB.o_sp12_h_r[8]"  />
+  <mux name="PLB_LOCAL.O1->sp12_h_r[10]" input="PLB_LOCAL.O1" output="PLB.o_sp12_h_r[10]" />
+  <mux name="PLB_LOCAL.O2->sp12_h_r[12]" input="PLB_LOCAL.O2" output="PLB.o_sp12_h_r[12]" />
+  <mux name="PLB_LOCAL.O3->sp12_h_r[14]" input="PLB_LOCAL.O3" output="PLB.o_sp12_h_r[14]" />
+  <mux name="PLB_LOCAL.O4->sp12_h_r[0]"  input="PLB_LOCAL.O4" output="PLB.o_sp12_h_r[0]"  />
+  <mux name="PLB_LOCAL.O4->sp12_h_r[16]" input="PLB_LOCAL.O4" output="PLB.o_sp12_h_r[16]" />
+  <mux name="PLB_LOCAL.O5->sp12_h_r[18]" input="PLB_LOCAL.O5" output="PLB.o_sp12_h_r[18]" />
+  <mux name="PLB_LOCAL.O5->sp12_h_r[2]"  input="PLB_LOCAL.O5" output="PLB.o_sp12_h_r[2]"  />
+  <mux name="PLB_LOCAL.O6->sp12_h_r[20]" input="PLB_LOCAL.O6" output="PLB.o_sp12_h_r[20]" />
+  <mux name="PLB_LOCAL.O6->sp12_h_r[4]"  input="PLB_LOCAL.O6" output="PLB.o_sp12_h_r[4]"  />
+  <mux name="PLB_LOCAL.O7->sp12_h_r[22]" input="PLB_LOCAL.O7" output="PLB.o_sp12_h_r[22]" />
+  <mux name="PLB_LOCAL.O7->sp12_h_r[6]"  input="PLB_LOCAL.O7" output="PLB.o_sp12_h_r[6]"  />
 
   <!-- Span-4 Vertical -->
   <!-- ================================================================ -->
   <!--
-  <direct name="sp4_v_b[0]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[1]"  />
-  <direct name="sp4_v_b[1]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[0]"  />
-  <direct name="sp4_v_b[2]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[3]"  />
-  <direct name="sp4_v_b[3]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[2]"  />
-  <direct name="sp4_v_b[4]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[5]"  />
-  <direct name="sp4_v_b[5]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[4]"  />
-  <direct name="sp4_v_b[6]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[7]"  />
-  <direct name="sp4_v_b[7]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[6]"  />
-  <direct name="sp4_v_b[8]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[9]"  />
-  <direct name="sp4_v_b[9]"  input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[8]"  />
-  <direct name="sp4_v_b[10]" input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[11]" />
-  <direct name="sp4_v_b[11]" input="BLK_TL-PLB.i_sp4_v_t[  ]" output="BLK_TL-PLB.o_sp4_v_b[10]" />
+  <direct name="sp4_v_b[0]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[1]"  />
+  <direct name="sp4_v_b[1]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[0]"  />
+  <direct name="sp4_v_b[2]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[3]"  />
+  <direct name="sp4_v_b[3]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[2]"  />
+  <direct name="sp4_v_b[4]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[5]"  />
+  <direct name="sp4_v_b[5]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[4]"  />
+  <direct name="sp4_v_b[6]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[7]"  />
+  <direct name="sp4_v_b[7]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[6]"  />
+  <direct name="sp4_v_b[8]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[9]"  />
+  <direct name="sp4_v_b[9]"  input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[8]"  />
+  <direct name="sp4_v_b[10]" input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[11]" />
+  <direct name="sp4_v_b[11]" input="PLB.i_sp4_v_t[  ]" output="PLB.o_sp4_v_b[10]" />
    -->
-  <direct name="sp4_v_t[0]"  input="BLK_TL-PLB.i_sp4_v_t[0]"  output="BLK_TL-PLB.o_sp4_v_b[13]" />
-  <direct name="sp4_v_t[1]"  input="BLK_TL-PLB.i_sp4_v_t[1]"  output="BLK_TL-PLB.o_sp4_v_b[12]" />
-  <direct name="sp4_v_t[2]"  input="BLK_TL-PLB.i_sp4_v_t[2]"  output="BLK_TL-PLB.o_sp4_v_b[15]" />
-  <direct name="sp4_v_t[3]"  input="BLK_TL-PLB.i_sp4_v_t[3]"  output="BLK_TL-PLB.o_sp4_v_b[14]" />
-  <direct name="sp4_v_t[4]"  input="BLK_TL-PLB.i_sp4_v_t[4]"  output="BLK_TL-PLB.o_sp4_v_b[17]" />
-  <direct name="sp4_v_t[5]"  input="BLK_TL-PLB.i_sp4_v_t[5]"  output="BLK_TL-PLB.o_sp4_v_b[16]" />
-  <direct name="sp4_v_t[6]"  input="BLK_TL-PLB.i_sp4_v_t[6]"  output="BLK_TL-PLB.o_sp4_v_b[19]" />
-  <direct name="sp4_v_t[7]"  input="BLK_TL-PLB.i_sp4_v_t[7]"  output="BLK_TL-PLB.o_sp4_v_b[18]" />
-  <direct name="sp4_v_t[8]"  input="BLK_TL-PLB.i_sp4_v_t[8]"  output="BLK_TL-PLB.o_sp4_v_b[21]" />
-  <direct name="sp4_v_t[9]"  input="BLK_TL-PLB.i_sp4_v_t[9]"  output="BLK_TL-PLB.o_sp4_v_b[20]" />
-  <direct name="sp4_v_t[10]" input="BLK_TL-PLB.i_sp4_v_t[10]" output="BLK_TL-PLB.o_sp4_v_b[23]" />
-  <direct name="sp4_v_t[11]" input="BLK_TL-PLB.i_sp4_v_t[11]" output="BLK_TL-PLB.o_sp4_v_b[22]" />
-  <direct name="sp4_v_t[12]" input="BLK_TL-PLB.i_sp4_v_t[12]" output="BLK_TL-PLB.o_sp4_v_b[25]" />
-  <direct name="sp4_v_t[13]" input="BLK_TL-PLB.i_sp4_v_t[13]" output="BLK_TL-PLB.o_sp4_v_b[24]" />
-  <direct name="sp4_v_t[14]" input="BLK_TL-PLB.i_sp4_v_t[14]" output="BLK_TL-PLB.o_sp4_v_b[27]" />
-  <direct name="sp4_v_t[15]" input="BLK_TL-PLB.i_sp4_v_t[15]" output="BLK_TL-PLB.o_sp4_v_b[26]" />
-  <direct name="sp4_v_t[16]" input="BLK_TL-PLB.i_sp4_v_t[16]" output="BLK_TL-PLB.o_sp4_v_b[29]" />
-  <direct name="sp4_v_t[17]" input="BLK_TL-PLB.i_sp4_v_t[17]" output="BLK_TL-PLB.o_sp4_v_b[28]" />
-  <direct name="sp4_v_t[18]" input="BLK_TL-PLB.i_sp4_v_t[18]" output="BLK_TL-PLB.o_sp4_v_b[31]" />
-  <direct name="sp4_v_t[19]" input="BLK_TL-PLB.i_sp4_v_t[19]" output="BLK_TL-PLB.o_sp4_v_b[30]" />
-  <direct name="sp4_v_t[20]" input="BLK_TL-PLB.i_sp4_v_t[20]" output="BLK_TL-PLB.o_sp4_v_b[33]" />
-  <direct name="sp4_v_t[21]" input="BLK_TL-PLB.i_sp4_v_t[21]" output="BLK_TL-PLB.o_sp4_v_b[32]" />
-  <direct name="sp4_v_t[22]" input="BLK_TL-PLB.i_sp4_v_t[22]" output="BLK_TL-PLB.o_sp4_v_b[35]" />
-  <direct name="sp4_v_t[23]" input="BLK_TL-PLB.i_sp4_v_t[23]" output="BLK_TL-PLB.o_sp4_v_b[34]" />
-  <direct name="sp4_v_t[24]" input="BLK_TL-PLB.i_sp4_v_t[24]" output="BLK_TL-PLB.o_sp4_v_b[37]" />
-  <direct name="sp4_v_t[25]" input="BLK_TL-PLB.i_sp4_v_t[25]" output="BLK_TL-PLB.o_sp4_v_b[36]" />
-  <direct name="sp4_v_t[26]" input="BLK_TL-PLB.i_sp4_v_t[26]" output="BLK_TL-PLB.o_sp4_v_b[39]" />
-  <direct name="sp4_v_t[27]" input="BLK_TL-PLB.i_sp4_v_t[27]" output="BLK_TL-PLB.o_sp4_v_b[38]" />
-  <direct name="sp4_v_t[28]" input="BLK_TL-PLB.i_sp4_v_t[28]" output="BLK_TL-PLB.o_sp4_v_b[41]" />
-  <direct name="sp4_v_t[29]" input="BLK_TL-PLB.i_sp4_v_t[29]" output="BLK_TL-PLB.o_sp4_v_b[40]" />
-  <direct name="sp4_v_t[30]" input="BLK_TL-PLB.i_sp4_v_t[30]" output="BLK_TL-PLB.o_sp4_v_b[43]" />
-  <direct name="sp4_v_t[31]" input="BLK_TL-PLB.i_sp4_v_t[31]" output="BLK_TL-PLB.o_sp4_v_b[42]" />
-  <direct name="sp4_v_t[32]" input="BLK_TL-PLB.i_sp4_v_t[32]" output="BLK_TL-PLB.o_sp4_v_b[45]" />
-  <direct name="sp4_v_t[33]" input="BLK_TL-PLB.i_sp4_v_t[33]" output="BLK_TL-PLB.o_sp4_v_b[44]" />
-  <direct name="sp4_v_t[34]" input="BLK_TL-PLB.i_sp4_v_t[34]" output="BLK_TL-PLB.o_sp4_v_b[47]" />
-  <direct name="sp4_v_t[35]" input="BLK_TL-PLB.i_sp4_v_t[35]" output="BLK_TL-PLB.o_sp4_v_b[46]" />
+  <direct name="sp4_v_t[0]"  input="PLB.i_sp4_v_t[0]"  output="PLB.o_sp4_v_b[13]" />
+  <direct name="sp4_v_t[1]"  input="PLB.i_sp4_v_t[1]"  output="PLB.o_sp4_v_b[12]" />
+  <direct name="sp4_v_t[2]"  input="PLB.i_sp4_v_t[2]"  output="PLB.o_sp4_v_b[15]" />
+  <direct name="sp4_v_t[3]"  input="PLB.i_sp4_v_t[3]"  output="PLB.o_sp4_v_b[14]" />
+  <direct name="sp4_v_t[4]"  input="PLB.i_sp4_v_t[4]"  output="PLB.o_sp4_v_b[17]" />
+  <direct name="sp4_v_t[5]"  input="PLB.i_sp4_v_t[5]"  output="PLB.o_sp4_v_b[16]" />
+  <direct name="sp4_v_t[6]"  input="PLB.i_sp4_v_t[6]"  output="PLB.o_sp4_v_b[19]" />
+  <direct name="sp4_v_t[7]"  input="PLB.i_sp4_v_t[7]"  output="PLB.o_sp4_v_b[18]" />
+  <direct name="sp4_v_t[8]"  input="PLB.i_sp4_v_t[8]"  output="PLB.o_sp4_v_b[21]" />
+  <direct name="sp4_v_t[9]"  input="PLB.i_sp4_v_t[9]"  output="PLB.o_sp4_v_b[20]" />
+  <direct name="sp4_v_t[10]" input="PLB.i_sp4_v_t[10]" output="PLB.o_sp4_v_b[23]" />
+  <direct name="sp4_v_t[11]" input="PLB.i_sp4_v_t[11]" output="PLB.o_sp4_v_b[22]" />
+  <direct name="sp4_v_t[12]" input="PLB.i_sp4_v_t[12]" output="PLB.o_sp4_v_b[25]" />
+  <direct name="sp4_v_t[13]" input="PLB.i_sp4_v_t[13]" output="PLB.o_sp4_v_b[24]" />
+  <direct name="sp4_v_t[14]" input="PLB.i_sp4_v_t[14]" output="PLB.o_sp4_v_b[27]" />
+  <direct name="sp4_v_t[15]" input="PLB.i_sp4_v_t[15]" output="PLB.o_sp4_v_b[26]" />
+  <direct name="sp4_v_t[16]" input="PLB.i_sp4_v_t[16]" output="PLB.o_sp4_v_b[29]" />
+  <direct name="sp4_v_t[17]" input="PLB.i_sp4_v_t[17]" output="PLB.o_sp4_v_b[28]" />
+  <direct name="sp4_v_t[18]" input="PLB.i_sp4_v_t[18]" output="PLB.o_sp4_v_b[31]" />
+  <direct name="sp4_v_t[19]" input="PLB.i_sp4_v_t[19]" output="PLB.o_sp4_v_b[30]" />
+  <direct name="sp4_v_t[20]" input="PLB.i_sp4_v_t[20]" output="PLB.o_sp4_v_b[33]" />
+  <direct name="sp4_v_t[21]" input="PLB.i_sp4_v_t[21]" output="PLB.o_sp4_v_b[32]" />
+  <direct name="sp4_v_t[22]" input="PLB.i_sp4_v_t[22]" output="PLB.o_sp4_v_b[35]" />
+  <direct name="sp4_v_t[23]" input="PLB.i_sp4_v_t[23]" output="PLB.o_sp4_v_b[34]" />
+  <direct name="sp4_v_t[24]" input="PLB.i_sp4_v_t[24]" output="PLB.o_sp4_v_b[37]" />
+  <direct name="sp4_v_t[25]" input="PLB.i_sp4_v_t[25]" output="PLB.o_sp4_v_b[36]" />
+  <direct name="sp4_v_t[26]" input="PLB.i_sp4_v_t[26]" output="PLB.o_sp4_v_b[39]" />
+  <direct name="sp4_v_t[27]" input="PLB.i_sp4_v_t[27]" output="PLB.o_sp4_v_b[38]" />
+  <direct name="sp4_v_t[28]" input="PLB.i_sp4_v_t[28]" output="PLB.o_sp4_v_b[41]" />
+  <direct name="sp4_v_t[29]" input="PLB.i_sp4_v_t[29]" output="PLB.o_sp4_v_b[40]" />
+  <direct name="sp4_v_t[30]" input="PLB.i_sp4_v_t[30]" output="PLB.o_sp4_v_b[43]" />
+  <direct name="sp4_v_t[31]" input="PLB.i_sp4_v_t[31]" output="PLB.o_sp4_v_b[42]" />
+  <direct name="sp4_v_t[32]" input="PLB.i_sp4_v_t[32]" output="PLB.o_sp4_v_b[45]" />
+  <direct name="sp4_v_t[33]" input="PLB.i_sp4_v_t[33]" output="PLB.o_sp4_v_b[44]" />
+  <direct name="sp4_v_t[34]" input="PLB.i_sp4_v_t[34]" output="PLB.o_sp4_v_b[47]" />
+  <direct name="sp4_v_t[35]" input="PLB.i_sp4_v_t[35]" output="PLB.o_sp4_v_b[46]" />
   <!--
-  <direct name="sp4_v_t[36]" input="BLK_TL-PLB.i_sp4_v_t[36]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[37]" input="BLK_TL-PLB.i_sp4_v_t[37]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[38]" input="BLK_TL-PLB.i_sp4_v_t[38]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[39]" input="BLK_TL-PLB.i_sp4_v_t[39]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[40]" input="BLK_TL-PLB.i_sp4_v_t[40]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[41]" input="BLK_TL-PLB.i_sp4_v_t[41]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[42]" input="BLK_TL-PLB.i_sp4_v_t[42]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[43]" input="BLK_TL-PLB.i_sp4_v_t[43]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[44]" input="BLK_TL-PLB.i_sp4_v_t[44]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[45]" input="BLK_TL-PLB.i_sp4_v_t[45]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[46]" input="BLK_TL-PLB.i_sp4_v_t[46]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
-  <direct name="sp4_v_t[47]" input="BLK_TL-PLB.i_sp4_v_t[47]" output="BLK_TL-PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[36]" input="PLB.i_sp4_v_t[36]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[37]" input="PLB.i_sp4_v_t[37]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[38]" input="PLB.i_sp4_v_t[38]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[39]" input="PLB.i_sp4_v_t[39]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[40]" input="PLB.i_sp4_v_t[40]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[41]" input="PLB.i_sp4_v_t[41]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[42]" input="PLB.i_sp4_v_t[42]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[43]" input="PLB.i_sp4_v_t[43]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[44]" input="PLB.i_sp4_v_t[44]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[45]" input="PLB.i_sp4_v_t[45]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[46]" input="PLB.i_sp4_v_t[46]" output="PLB.o_sp4_v_b[  ]" />
+  <direct name="sp4_v_t[47]" input="PLB.i_sp4_v_t[47]" output="PLB.o_sp4_v_b[  ]" />
    -->
 
   <!-- Span-12 Vertical -->
   <!-- ================================================================ -->
   <!--
-  <direct name="sp12_v_b[0]"  input="BLK_TL-PLB.i_sp12_v_t[  ]" output="BLK_TL-PLB.o_sp12_v_b[1]"  />
-  <direct name="sp12_v_b[1]"  input="BLK_TL-PLB.i_sp12_v_t[  ]" output="BLK_TL-PLB.o_sp12_v_b[0]"  />
+  <direct name="sp12_v_b[0]"  input="PLB.i_sp12_v_t[  ]" output="PLB.o_sp12_v_b[1]"  />
+  <direct name="sp12_v_b[1]"  input="PLB.i_sp12_v_t[  ]" output="PLB.o_sp12_v_b[0]"  />
    -->
-  <direct name="sp12_v_t[0]"  input="BLK_TL-PLB.i_sp12_v_t[0]"  output="BLK_TL-PLB.o_sp12_v_b[3]"  />
-  <direct name="sp12_v_t[1]"  input="BLK_TL-PLB.i_sp12_v_t[1]"  output="BLK_TL-PLB.o_sp12_v_b[2]"  />
-  <direct name="sp12_v_t[2]"  input="BLK_TL-PLB.i_sp12_v_t[2]"  output="BLK_TL-PLB.o_sp12_v_b[5]"  />
-  <direct name="sp12_v_t[3]"  input="BLK_TL-PLB.i_sp12_v_t[3]"  output="BLK_TL-PLB.o_sp12_v_b[4]"  />
-  <direct name="sp12_v_t[4]"  input="BLK_TL-PLB.i_sp12_v_t[4]"  output="BLK_TL-PLB.o_sp12_v_b[7]"  />
-  <direct name="sp12_v_t[5]"  input="BLK_TL-PLB.i_sp12_v_t[5]"  output="BLK_TL-PLB.o_sp12_v_b[6]"  />
-  <direct name="sp12_v_t[6]"  input="BLK_TL-PLB.i_sp12_v_t[6]"  output="BLK_TL-PLB.o_sp12_v_b[9]"  />
-  <direct name="sp12_v_t[7]"  input="BLK_TL-PLB.i_sp12_v_t[7]"  output="BLK_TL-PLB.o_sp12_v_b[8]"  />
-  <direct name="sp12_v_t[8]"  input="BLK_TL-PLB.i_sp12_v_t[8]"  output="BLK_TL-PLB.o_sp12_v_b[11]" />
-  <direct name="sp12_v_t[9]"  input="BLK_TL-PLB.i_sp12_v_t[9]"  output="BLK_TL-PLB.o_sp12_v_b[10]" />
-  <direct name="sp12_v_t[10]" input="BLK_TL-PLB.i_sp12_v_t[10]" output="BLK_TL-PLB.o_sp12_v_b[13]" />
-  <direct name="sp12_v_t[11]" input="BLK_TL-PLB.i_sp12_v_t[11]" output="BLK_TL-PLB.o_sp12_v_b[12]" />
-  <direct name="sp12_v_t[12]" input="BLK_TL-PLB.i_sp12_v_t[12]" output="BLK_TL-PLB.o_sp12_v_b[15]" />
-  <direct name="sp12_v_t[13]" input="BLK_TL-PLB.i_sp12_v_t[13]" output="BLK_TL-PLB.o_sp12_v_b[14]" />
-  <direct name="sp12_v_t[14]" input="BLK_TL-PLB.i_sp12_v_t[14]" output="BLK_TL-PLB.o_sp12_v_b[17]" />
-  <direct name="sp12_v_t[15]" input="BLK_TL-PLB.i_sp12_v_t[15]" output="BLK_TL-PLB.o_sp12_v_b[16]" />
-  <direct name="sp12_v_t[16]" input="BLK_TL-PLB.i_sp12_v_t[16]" output="BLK_TL-PLB.o_sp12_v_b[19]" />
-  <direct name="sp12_v_t[17]" input="BLK_TL-PLB.i_sp12_v_t[17]" output="BLK_TL-PLB.o_sp12_v_b[18]" />
-  <direct name="sp12_v_t[18]" input="BLK_TL-PLB.i_sp12_v_t[18]" output="BLK_TL-PLB.o_sp12_v_b[21]" />
-  <direct name="sp12_v_t[19]" input="BLK_TL-PLB.i_sp12_v_t[19]" output="BLK_TL-PLB.o_sp12_v_b[20]" />
-  <direct name="sp12_v_t[20]" input="BLK_TL-PLB.i_sp12_v_t[20]" output="BLK_TL-PLB.o_sp12_v_b[23]" />
-  <direct name="sp12_v_t[21]" input="BLK_TL-PLB.i_sp12_v_t[21]" output="BLK_TL-PLB.o_sp12_v_b[22]" />
+  <direct name="sp12_v_t[0]"  input="PLB.i_sp12_v_t[0]"  output="PLB.o_sp12_v_b[3]"  />
+  <direct name="sp12_v_t[1]"  input="PLB.i_sp12_v_t[1]"  output="PLB.o_sp12_v_b[2]"  />
+  <direct name="sp12_v_t[2]"  input="PLB.i_sp12_v_t[2]"  output="PLB.o_sp12_v_b[5]"  />
+  <direct name="sp12_v_t[3]"  input="PLB.i_sp12_v_t[3]"  output="PLB.o_sp12_v_b[4]"  />
+  <direct name="sp12_v_t[4]"  input="PLB.i_sp12_v_t[4]"  output="PLB.o_sp12_v_b[7]"  />
+  <direct name="sp12_v_t[5]"  input="PLB.i_sp12_v_t[5]"  output="PLB.o_sp12_v_b[6]"  />
+  <direct name="sp12_v_t[6]"  input="PLB.i_sp12_v_t[6]"  output="PLB.o_sp12_v_b[9]"  />
+  <direct name="sp12_v_t[7]"  input="PLB.i_sp12_v_t[7]"  output="PLB.o_sp12_v_b[8]"  />
+  <direct name="sp12_v_t[8]"  input="PLB.i_sp12_v_t[8]"  output="PLB.o_sp12_v_b[11]" />
+  <direct name="sp12_v_t[9]"  input="PLB.i_sp12_v_t[9]"  output="PLB.o_sp12_v_b[10]" />
+  <direct name="sp12_v_t[10]" input="PLB.i_sp12_v_t[10]" output="PLB.o_sp12_v_b[13]" />
+  <direct name="sp12_v_t[11]" input="PLB.i_sp12_v_t[11]" output="PLB.o_sp12_v_b[12]" />
+  <direct name="sp12_v_t[12]" input="PLB.i_sp12_v_t[12]" output="PLB.o_sp12_v_b[15]" />
+  <direct name="sp12_v_t[13]" input="PLB.i_sp12_v_t[13]" output="PLB.o_sp12_v_b[14]" />
+  <direct name="sp12_v_t[14]" input="PLB.i_sp12_v_t[14]" output="PLB.o_sp12_v_b[17]" />
+  <direct name="sp12_v_t[15]" input="PLB.i_sp12_v_t[15]" output="PLB.o_sp12_v_b[16]" />
+  <direct name="sp12_v_t[16]" input="PLB.i_sp12_v_t[16]" output="PLB.o_sp12_v_b[19]" />
+  <direct name="sp12_v_t[17]" input="PLB.i_sp12_v_t[17]" output="PLB.o_sp12_v_b[18]" />
+  <direct name="sp12_v_t[18]" input="PLB.i_sp12_v_t[18]" output="PLB.o_sp12_v_b[21]" />
+  <direct name="sp12_v_t[19]" input="PLB.i_sp12_v_t[19]" output="PLB.o_sp12_v_b[20]" />
+  <direct name="sp12_v_t[20]" input="PLB.i_sp12_v_t[20]" output="PLB.o_sp12_v_b[23]" />
+  <direct name="sp12_v_t[21]" input="PLB.i_sp12_v_t[21]" output="PLB.o_sp12_v_b[22]" />
   <!--
-  <direct name="sp12_v_t[22]" input="BLK_TL-PLB.i_sp12_v_t[22]" output="BLK_TL-PLB.o_sp12_v_b[  ]" />
-  <direct name="sp12_v_t[23]" input="BLK_TL-PLB.i_sp12_v_t[23]" output="BLK_TL-PLB.o_sp12_v_b[  ]" />
+  <direct name="sp12_v_t[22]" input="PLB.i_sp12_v_t[22]" output="PLB.o_sp12_v_b[  ]" />
+  <direct name="sp12_v_t[23]" input="PLB.i_sp12_v_t[23]" output="PLB.o_sp12_v_b[  ]" />
    -->
 
   <!-- ################################################################ -->
@@ -479,68 +499,68 @@
   <!-- Span-4 Horizontal -->
   <!-- ================================================================ -->
   <!--
-  <direct name="sp4_h_r[0]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[1]"  />
-  <direct name="sp4_h_r[1]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[0]"  />
-  <direct name="sp4_h_r[2]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[3]"  />
-  <direct name="sp4_h_r[3]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[2]"  />
-  <direct name="sp4_h_r[4]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[5]"  />
-  <direct name="sp4_h_r[5]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[4]"  />
-  <direct name="sp4_h_r[6]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[7]"  />
-  <direct name="sp4_h_r[7]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[6]"  />
-  <direct name="sp4_h_r[8]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[9]"  />
-  <direct name="sp4_h_r[9]"  input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[8]"  />
-  <direct name="sp4_h_r[10]" input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[11]" />
-  <direct name="sp4_h_r[11]" input="BLK_TL-PLB.i_sp4_h_l[  ]" output="BLK_TL-PLB.o_sp4_h_r[10]" />
+  <direct name="sp4_h_r[0]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[1]"  />
+  <direct name="sp4_h_r[1]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[0]"  />
+  <direct name="sp4_h_r[2]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[3]"  />
+  <direct name="sp4_h_r[3]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[2]"  />
+  <direct name="sp4_h_r[4]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[5]"  />
+  <direct name="sp4_h_r[5]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[4]"  />
+  <direct name="sp4_h_r[6]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[7]"  />
+  <direct name="sp4_h_r[7]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[6]"  />
+  <direct name="sp4_h_r[8]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[9]"  />
+  <direct name="sp4_h_r[9]"  input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[8]"  />
+  <direct name="sp4_h_r[10]" input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[11]" />
+  <direct name="sp4_h_r[11]" input="PLB.i_sp4_h_l[  ]" output="PLB.o_sp4_h_r[10]" />
    -->
-  <direct name="sp4_h_l[0]"  input="BLK_TL-PLB.i_sp4_h_l[0]"  output="BLK_TL-PLB.o_sp4_h_r[13]" />
-  <direct name="sp4_h_l[1]"  input="BLK_TL-PLB.i_sp4_h_l[1]"  output="BLK_TL-PLB.o_sp4_h_r[12]" />
-  <direct name="sp4_h_l[2]"  input="BLK_TL-PLB.i_sp4_h_l[2]"  output="BLK_TL-PLB.o_sp4_h_r[15]" />
-  <direct name="sp4_h_l[3]"  input="BLK_TL-PLB.i_sp4_h_l[3]"  output="BLK_TL-PLB.o_sp4_h_r[14]" />
-  <direct name="sp4_h_l[4]"  input="BLK_TL-PLB.i_sp4_h_l[4]"  output="BLK_TL-PLB.o_sp4_h_r[17]" />
-  <direct name="sp4_h_l[5]"  input="BLK_TL-PLB.i_sp4_h_l[5]"  output="BLK_TL-PLB.o_sp4_h_r[16]" />
-  <direct name="sp4_h_l[6]"  input="BLK_TL-PLB.i_sp4_h_l[6]"  output="BLK_TL-PLB.o_sp4_h_r[19]" />
-  <direct name="sp4_h_l[7]"  input="BLK_TL-PLB.i_sp4_h_l[7]"  output="BLK_TL-PLB.o_sp4_h_r[18]" />
-  <direct name="sp4_h_l[8]"  input="BLK_TL-PLB.i_sp4_h_l[8]"  output="BLK_TL-PLB.o_sp4_h_r[21]" />
-  <direct name="sp4_h_l[9]"  input="BLK_TL-PLB.i_sp4_h_l[9]"  output="BLK_TL-PLB.o_sp4_h_r[20]" />
-  <direct name="sp4_h_l[10]" input="BLK_TL-PLB.i_sp4_h_l[10]" output="BLK_TL-PLB.o_sp4_h_r[23]" />
-  <direct name="sp4_h_l[11]" input="BLK_TL-PLB.i_sp4_h_l[11]" output="BLK_TL-PLB.o_sp4_h_r[22]" />
-  <direct name="sp4_h_l[12]" input="BLK_TL-PLB.i_sp4_h_l[12]" output="BLK_TL-PLB.o_sp4_h_r[25]" />
-  <direct name="sp4_h_l[13]" input="BLK_TL-PLB.i_sp4_h_l[13]" output="BLK_TL-PLB.o_sp4_h_r[24]" />
-  <direct name="sp4_h_l[14]" input="BLK_TL-PLB.i_sp4_h_l[14]" output="BLK_TL-PLB.o_sp4_h_r[27]" />
-  <direct name="sp4_h_l[15]" input="BLK_TL-PLB.i_sp4_h_l[15]" output="BLK_TL-PLB.o_sp4_h_r[26]" />
-  <direct name="sp4_h_l[16]" input="BLK_TL-PLB.i_sp4_h_l[16]" output="BLK_TL-PLB.o_sp4_h_r[29]" />
-  <direct name="sp4_h_l[17]" input="BLK_TL-PLB.i_sp4_h_l[17]" output="BLK_TL-PLB.o_sp4_h_r[28]" />
-  <direct name="sp4_h_l[18]" input="BLK_TL-PLB.i_sp4_h_l[18]" output="BLK_TL-PLB.o_sp4_h_r[31]" />
-  <direct name="sp4_h_l[19]" input="BLK_TL-PLB.i_sp4_h_l[19]" output="BLK_TL-PLB.o_sp4_h_r[30]" />
-  <direct name="sp4_h_l[20]" input="BLK_TL-PLB.i_sp4_h_l[20]" output="BLK_TL-PLB.o_sp4_h_r[33]" />
-  <direct name="sp4_h_l[21]" input="BLK_TL-PLB.i_sp4_h_l[21]" output="BLK_TL-PLB.o_sp4_h_r[32]" />
-  <direct name="sp4_h_l[22]" input="BLK_TL-PLB.i_sp4_h_l[22]" output="BLK_TL-PLB.o_sp4_h_r[35]" />
-  <direct name="sp4_h_l[23]" input="BLK_TL-PLB.i_sp4_h_l[23]" output="BLK_TL-PLB.o_sp4_h_r[34]" />
-  <direct name="sp4_h_l[24]" input="BLK_TL-PLB.i_sp4_h_l[24]" output="BLK_TL-PLB.o_sp4_h_r[37]" />
-  <direct name="sp4_h_l[25]" input="BLK_TL-PLB.i_sp4_h_l[25]" output="BLK_TL-PLB.o_sp4_h_r[36]" />
-  <direct name="sp4_h_l[26]" input="BLK_TL-PLB.i_sp4_h_l[26]" output="BLK_TL-PLB.o_sp4_h_r[39]" />
-  <direct name="sp4_h_l[27]" input="BLK_TL-PLB.i_sp4_h_l[27]" output="BLK_TL-PLB.o_sp4_h_r[38]" />
-  <direct name="sp4_h_l[28]" input="BLK_TL-PLB.i_sp4_h_l[28]" output="BLK_TL-PLB.o_sp4_h_r[41]" />
-  <direct name="sp4_h_l[29]" input="BLK_TL-PLB.i_sp4_h_l[29]" output="BLK_TL-PLB.o_sp4_h_r[40]" />
-  <direct name="sp4_h_l[30]" input="BLK_TL-PLB.i_sp4_h_l[30]" output="BLK_TL-PLB.o_sp4_h_r[43]" />
-  <direct name="sp4_h_l[31]" input="BLK_TL-PLB.i_sp4_h_l[31]" output="BLK_TL-PLB.o_sp4_h_r[42]" />
-  <direct name="sp4_h_l[32]" input="BLK_TL-PLB.i_sp4_h_l[32]" output="BLK_TL-PLB.o_sp4_h_r[45]" />
-  <direct name="sp4_h_l[33]" input="BLK_TL-PLB.i_sp4_h_l[33]" output="BLK_TL-PLB.o_sp4_h_r[44]" />
-  <direct name="sp4_h_l[34]" input="BLK_TL-PLB.i_sp4_h_l[34]" output="BLK_TL-PLB.o_sp4_h_r[47]" />
-  <direct name="sp4_h_l[35]" input="BLK_TL-PLB.i_sp4_h_l[35]" output="BLK_TL-PLB.o_sp4_h_r[46]" />
+  <direct name="sp4_h_l[0]"  input="PLB.i_sp4_h_l[0]"  output="PLB.o_sp4_h_r[13]" />
+  <direct name="sp4_h_l[1]"  input="PLB.i_sp4_h_l[1]"  output="PLB.o_sp4_h_r[12]" />
+  <direct name="sp4_h_l[2]"  input="PLB.i_sp4_h_l[2]"  output="PLB.o_sp4_h_r[15]" />
+  <direct name="sp4_h_l[3]"  input="PLB.i_sp4_h_l[3]"  output="PLB.o_sp4_h_r[14]" />
+  <direct name="sp4_h_l[4]"  input="PLB.i_sp4_h_l[4]"  output="PLB.o_sp4_h_r[17]" />
+  <direct name="sp4_h_l[5]"  input="PLB.i_sp4_h_l[5]"  output="PLB.o_sp4_h_r[16]" />
+  <direct name="sp4_h_l[6]"  input="PLB.i_sp4_h_l[6]"  output="PLB.o_sp4_h_r[19]" />
+  <direct name="sp4_h_l[7]"  input="PLB.i_sp4_h_l[7]"  output="PLB.o_sp4_h_r[18]" />
+  <direct name="sp4_h_l[8]"  input="PLB.i_sp4_h_l[8]"  output="PLB.o_sp4_h_r[21]" />
+  <direct name="sp4_h_l[9]"  input="PLB.i_sp4_h_l[9]"  output="PLB.o_sp4_h_r[20]" />
+  <direct name="sp4_h_l[10]" input="PLB.i_sp4_h_l[10]" output="PLB.o_sp4_h_r[23]" />
+  <direct name="sp4_h_l[11]" input="PLB.i_sp4_h_l[11]" output="PLB.o_sp4_h_r[22]" />
+  <direct name="sp4_h_l[12]" input="PLB.i_sp4_h_l[12]" output="PLB.o_sp4_h_r[25]" />
+  <direct name="sp4_h_l[13]" input="PLB.i_sp4_h_l[13]" output="PLB.o_sp4_h_r[24]" />
+  <direct name="sp4_h_l[14]" input="PLB.i_sp4_h_l[14]" output="PLB.o_sp4_h_r[27]" />
+  <direct name="sp4_h_l[15]" input="PLB.i_sp4_h_l[15]" output="PLB.o_sp4_h_r[26]" />
+  <direct name="sp4_h_l[16]" input="PLB.i_sp4_h_l[16]" output="PLB.o_sp4_h_r[29]" />
+  <direct name="sp4_h_l[17]" input="PLB.i_sp4_h_l[17]" output="PLB.o_sp4_h_r[28]" />
+  <direct name="sp4_h_l[18]" input="PLB.i_sp4_h_l[18]" output="PLB.o_sp4_h_r[31]" />
+  <direct name="sp4_h_l[19]" input="PLB.i_sp4_h_l[19]" output="PLB.o_sp4_h_r[30]" />
+  <direct name="sp4_h_l[20]" input="PLB.i_sp4_h_l[20]" output="PLB.o_sp4_h_r[33]" />
+  <direct name="sp4_h_l[21]" input="PLB.i_sp4_h_l[21]" output="PLB.o_sp4_h_r[32]" />
+  <direct name="sp4_h_l[22]" input="PLB.i_sp4_h_l[22]" output="PLB.o_sp4_h_r[35]" />
+  <direct name="sp4_h_l[23]" input="PLB.i_sp4_h_l[23]" output="PLB.o_sp4_h_r[34]" />
+  <direct name="sp4_h_l[24]" input="PLB.i_sp4_h_l[24]" output="PLB.o_sp4_h_r[37]" />
+  <direct name="sp4_h_l[25]" input="PLB.i_sp4_h_l[25]" output="PLB.o_sp4_h_r[36]" />
+  <direct name="sp4_h_l[26]" input="PLB.i_sp4_h_l[26]" output="PLB.o_sp4_h_r[39]" />
+  <direct name="sp4_h_l[27]" input="PLB.i_sp4_h_l[27]" output="PLB.o_sp4_h_r[38]" />
+  <direct name="sp4_h_l[28]" input="PLB.i_sp4_h_l[28]" output="PLB.o_sp4_h_r[41]" />
+  <direct name="sp4_h_l[29]" input="PLB.i_sp4_h_l[29]" output="PLB.o_sp4_h_r[40]" />
+  <direct name="sp4_h_l[30]" input="PLB.i_sp4_h_l[30]" output="PLB.o_sp4_h_r[43]" />
+  <direct name="sp4_h_l[31]" input="PLB.i_sp4_h_l[31]" output="PLB.o_sp4_h_r[42]" />
+  <direct name="sp4_h_l[32]" input="PLB.i_sp4_h_l[32]" output="PLB.o_sp4_h_r[45]" />
+  <direct name="sp4_h_l[33]" input="PLB.i_sp4_h_l[33]" output="PLB.o_sp4_h_r[44]" />
+  <direct name="sp4_h_l[34]" input="PLB.i_sp4_h_l[34]" output="PLB.o_sp4_h_r[47]" />
+  <direct name="sp4_h_l[35]" input="PLB.i_sp4_h_l[35]" output="PLB.o_sp4_h_r[46]" />
   <!--
-  <direct name="sp4_h_l[36]" input="BLK_TL-PLB.i_sp4_h_l[36]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[37]" input="BLK_TL-PLB.i_sp4_h_l[37]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[38]" input="BLK_TL-PLB.i_sp4_h_l[38]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[39]" input="BLK_TL-PLB.i_sp4_h_l[39]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[40]" input="BLK_TL-PLB.i_sp4_h_l[40]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[41]" input="BLK_TL-PLB.i_sp4_h_l[41]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[42]" input="BLK_TL-PLB.i_sp4_h_l[42]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[43]" input="BLK_TL-PLB.i_sp4_h_l[43]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[44]" input="BLK_TL-PLB.i_sp4_h_l[44]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[45]" input="BLK_TL-PLB.i_sp4_h_l[45]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[46]" input="BLK_TL-PLB.i_sp4_h_l[46]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
-  <direct name="sp4_h_l[47]" input="BLK_TL-PLB.i_sp4_h_l[47]" output="BLK_TL-PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[36]" input="PLB.i_sp4_h_l[36]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[37]" input="PLB.i_sp4_h_l[37]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[38]" input="PLB.i_sp4_h_l[38]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[39]" input="PLB.i_sp4_h_l[39]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[40]" input="PLB.i_sp4_h_l[40]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[41]" input="PLB.i_sp4_h_l[41]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[42]" input="PLB.i_sp4_h_l[42]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[43]" input="PLB.i_sp4_h_l[43]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[44]" input="PLB.i_sp4_h_l[44]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[45]" input="PLB.i_sp4_h_l[45]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[46]" input="PLB.i_sp4_h_l[46]" output="PLB.o_sp4_h_r[  ]" />
+  <direct name="sp4_h_l[47]" input="PLB.i_sp4_h_l[47]" output="PLB.o_sp4_h_r[  ]" />
    -->
 
   <!-- ################################################################ -->
@@ -548,156 +568,156 @@
   <!-- Span-12 Horizontal -->
   <!-- ================================================================ -->
   <!--
-  <direct name="sp12_h_r[0]"  input="BLK_TL-PLB.i_sp12_h_l[  ]" output="BLK_TL-PLB.o_sp12_h_r[1]"  />
-  <direct name="sp12_h_r[1]"  input="BLK_TL-PLB.i_sp12_h_l[  ]" output="BLK_TL-PLB.o_sp12_h_r[0]"  />
+  <direct name="sp12_h_r[0]"  input="PLB.i_sp12_h_l[  ]" output="PLB.o_sp12_h_r[1]"  />
+  <direct name="sp12_h_r[1]"  input="PLB.i_sp12_h_l[  ]" output="PLB.o_sp12_h_r[0]"  />
    -->
-  <direct name="sp12_h_l[0]"  input="BLK_TL-PLB.i_sp12_h_l[0]"  output="BLK_TL-PLB.o_sp12_h_r[3]"  />
-  <direct name="sp12_h_l[1]"  input="BLK_TL-PLB.i_sp12_h_l[1]"  output="BLK_TL-PLB.o_sp12_h_r[2]"  />
-  <direct name="sp12_h_l[2]"  input="BLK_TL-PLB.i_sp12_h_l[2]"  output="BLK_TL-PLB.o_sp12_h_r[5]"  />
-  <direct name="sp12_h_l[3]"  input="BLK_TL-PLB.i_sp12_h_l[3]"  output="BLK_TL-PLB.o_sp12_h_r[4]"  />
-  <direct name="sp12_h_l[4]"  input="BLK_TL-PLB.i_sp12_h_l[4]"  output="BLK_TL-PLB.o_sp12_h_r[7]"  />
-  <direct name="sp12_h_l[5]"  input="BLK_TL-PLB.i_sp12_h_l[5]"  output="BLK_TL-PLB.o_sp12_h_r[6]"  />
-  <direct name="sp12_h_l[6]"  input="BLK_TL-PLB.i_sp12_h_l[6]"  output="BLK_TL-PLB.o_sp12_h_r[9]"  />
-  <direct name="sp12_h_l[7]"  input="BLK_TL-PLB.i_sp12_h_l[7]"  output="BLK_TL-PLB.o_sp12_h_r[8]"  />
-  <direct name="sp12_h_l[8]"  input="BLK_TL-PLB.i_sp12_h_l[8]"  output="BLK_TL-PLB.o_sp12_h_r[11]" />
-  <direct name="sp12_h_l[9]"  input="BLK_TL-PLB.i_sp12_h_l[9]"  output="BLK_TL-PLB.o_sp12_h_r[10]" />
-  <direct name="sp12_h_l[10]" input="BLK_TL-PLB.i_sp12_h_l[10]" output="BLK_TL-PLB.o_sp12_h_r[13]" />
-  <direct name="sp12_h_l[11]" input="BLK_TL-PLB.i_sp12_h_l[11]" output="BLK_TL-PLB.o_sp12_h_r[12]" />
-  <direct name="sp12_h_l[12]" input="BLK_TL-PLB.i_sp12_h_l[12]" output="BLK_TL-PLB.o_sp12_h_r[15]" />
-  <direct name="sp12_h_l[13]" input="BLK_TL-PLB.i_sp12_h_l[13]" output="BLK_TL-PLB.o_sp12_h_r[14]" />
-  <direct name="sp12_h_l[14]" input="BLK_TL-PLB.i_sp12_h_l[14]" output="BLK_TL-PLB.o_sp12_h_r[17]" />
-  <direct name="sp12_h_l[15]" input="BLK_TL-PLB.i_sp12_h_l[15]" output="BLK_TL-PLB.o_sp12_h_r[16]" />
-  <direct name="sp12_h_l[16]" input="BLK_TL-PLB.i_sp12_h_l[16]" output="BLK_TL-PLB.o_sp12_h_r[19]" />
-  <direct name="sp12_h_l[17]" input="BLK_TL-PLB.i_sp12_h_l[17]" output="BLK_TL-PLB.o_sp12_h_r[18]" />
-  <direct name="sp12_h_l[18]" input="BLK_TL-PLB.i_sp12_h_l[18]" output="BLK_TL-PLB.o_sp12_h_r[21]" />
-  <direct name="sp12_h_l[19]" input="BLK_TL-PLB.i_sp12_h_l[19]" output="BLK_TL-PLB.o_sp12_h_r[20]" />
-  <direct name="sp12_h_l[20]" input="BLK_TL-PLB.i_sp12_h_l[20]" output="BLK_TL-PLB.o_sp12_h_r[23]" />
-  <direct name="sp12_h_l[21]" input="BLK_TL-PLB.i_sp12_h_l[21]" output="BLK_TL-PLB.o_sp12_h_r[22]" />
+  <direct name="sp12_h_l[0]"  input="PLB.i_sp12_h_l[0]"  output="PLB.o_sp12_h_r[3]"  />
+  <direct name="sp12_h_l[1]"  input="PLB.i_sp12_h_l[1]"  output="PLB.o_sp12_h_r[2]"  />
+  <direct name="sp12_h_l[2]"  input="PLB.i_sp12_h_l[2]"  output="PLB.o_sp12_h_r[5]"  />
+  <direct name="sp12_h_l[3]"  input="PLB.i_sp12_h_l[3]"  output="PLB.o_sp12_h_r[4]"  />
+  <direct name="sp12_h_l[4]"  input="PLB.i_sp12_h_l[4]"  output="PLB.o_sp12_h_r[7]"  />
+  <direct name="sp12_h_l[5]"  input="PLB.i_sp12_h_l[5]"  output="PLB.o_sp12_h_r[6]"  />
+  <direct name="sp12_h_l[6]"  input="PLB.i_sp12_h_l[6]"  output="PLB.o_sp12_h_r[9]"  />
+  <direct name="sp12_h_l[7]"  input="PLB.i_sp12_h_l[7]"  output="PLB.o_sp12_h_r[8]"  />
+  <direct name="sp12_h_l[8]"  input="PLB.i_sp12_h_l[8]"  output="PLB.o_sp12_h_r[11]" />
+  <direct name="sp12_h_l[9]"  input="PLB.i_sp12_h_l[9]"  output="PLB.o_sp12_h_r[10]" />
+  <direct name="sp12_h_l[10]" input="PLB.i_sp12_h_l[10]" output="PLB.o_sp12_h_r[13]" />
+  <direct name="sp12_h_l[11]" input="PLB.i_sp12_h_l[11]" output="PLB.o_sp12_h_r[12]" />
+  <direct name="sp12_h_l[12]" input="PLB.i_sp12_h_l[12]" output="PLB.o_sp12_h_r[15]" />
+  <direct name="sp12_h_l[13]" input="PLB.i_sp12_h_l[13]" output="PLB.o_sp12_h_r[14]" />
+  <direct name="sp12_h_l[14]" input="PLB.i_sp12_h_l[14]" output="PLB.o_sp12_h_r[17]" />
+  <direct name="sp12_h_l[15]" input="PLB.i_sp12_h_l[15]" output="PLB.o_sp12_h_r[16]" />
+  <direct name="sp12_h_l[16]" input="PLB.i_sp12_h_l[16]" output="PLB.o_sp12_h_r[19]" />
+  <direct name="sp12_h_l[17]" input="PLB.i_sp12_h_l[17]" output="PLB.o_sp12_h_r[18]" />
+  <direct name="sp12_h_l[18]" input="PLB.i_sp12_h_l[18]" output="PLB.o_sp12_h_r[21]" />
+  <direct name="sp12_h_l[19]" input="PLB.i_sp12_h_l[19]" output="PLB.o_sp12_h_r[20]" />
+  <direct name="sp12_h_l[20]" input="PLB.i_sp12_h_l[20]" output="PLB.o_sp12_h_r[23]" />
+  <direct name="sp12_h_l[21]" input="PLB.i_sp12_h_l[21]" output="PLB.o_sp12_h_r[22]" />
   <!--
-  <direct name="sp12_h_l[22]" input="BLK_TL-PLB.i_sp12_h_l[22]" output="BLK_TL-PLB.o_sp12_h_r[  ]" />
-  <direct name="sp12_h_l[23]" input="BLK_TL-PLB.i_sp12_h_l[23]" output="BLK_TL-PLB.o_sp12_h_r[  ]" />
+  <direct name="sp12_h_l[22]" input="PLB.i_sp12_h_l[22]" output="PLB.o_sp12_h_r[  ]" />
+  <direct name="sp12_h_l[23]" input="PLB.i_sp12_h_l[23]" output="PLB.o_sp12_h_r[  ]" />
    -->
 
   <!-- ################################################################ -->
   <!-- # Internal Logic tracks                                        # -->
   <!-- ################################################################ -->
   <!-- Carry chain -->
-  <direct name="carry_in" input="BLK_TL-PLB.carry_in" output="BLK_XX-carry_in_mux.i">
-   <pack_pattern name="CARRYCHAIN" in_port="BLK_TL-PLB.carry_in" out_port="BLK_XX-carry_in_mux.i"/>
+  <direct name="carry_in" input="PLB.carry_in" output="carry_in_mux.i">
+   <pack_pattern name="CARRYCHAIN" in_port="PLB.carry_in" out_port="carry_in_mux.i"/>
   </direct>
-  <direct name="BLK_XX-carry_in_mux" input="BLK_XX-carry_in_mux.o" output="BLK_IG-PLB_LOCAL.FCIN">
-   <pack_pattern name="CARRYCHAIN" in_port="BLK_XX-carry_in_mux.o" out_port="BLK_IG-PLB_LOCAL.FCIN"/>
+  <direct name="carry_in_mux" input="carry_in_mux.o" output="PLB_LOCAL.FCIN">
+   <pack_pattern name="CARRYCHAIN" in_port="carry_in_mux.o" out_port="PLB_LOCAL.FCIN"/>
   </direct>
-  <direct name="carry_out" input="BLK_IG-PLB_LOCAL.FCOUT" output="BLK_TL-PLB.carry_out">
-   <pack_pattern name="CARRYCHAIN" in_port="BLK_IG-PLB_LOCAL.FCOUT" out_port="BLK_TL-PLB.carry_out"/>
+  <direct name="carry_out" input="PLB_LOCAL.FCOUT" output="PLB.carry_out">
+   <pack_pattern name="CARRYCHAIN" in_port="PLB_LOCAL.FCOUT" out_port="PLB.carry_out"/>
   </direct>
 
   <!-- Logic Unit 0 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I0[0]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[2].o[0] BLK_XX-local_g[1].o[1] BLK_XX-local_g[3].o[1] BLK_XX-local_g[0].o[2] BLK_XX-local_g[2].o[2] BLK_XX-local_g[1].o[3] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[2].o[4] BLK_XX-local_g[1].o[5] BLK_XX-local_g[3].o[5] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I0[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I0[1]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I0[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I0[2]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I0[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I0[3]" input="BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        BLK_XX-carry_in_mux.o  " output="BLK_IG-PLB_LOCAL.I0[3]" />
+  <mux name="PLB_LOCAL.I0[0]"     input="local_g[0].o[0] local_g[2].o[0] local_g[1].o[1] local_g[3].o[1] local_g[0].o[2] local_g[2].o[2] local_g[1].o[3] local_g[3].o[3] local_g[0].o[4] local_g[2].o[4] local_g[1].o[5] local_g[3].o[5] local_g[0].o[6] local_g[2].o[6] local_g[1].o[7] local_g[3].o[7]                 " output="PLB_LOCAL.I0[0]" />
+  <mux name="PLB_LOCAL.I0[1]"     input="local_g[0].o[1] local_g[0].o[3] local_g[0].o[5] local_g[0].o[7] local_g[2].o[1] local_g[2].o[3] local_g[2].o[5] local_g[2].o[7] local_g[1].o[0] local_g[1].o[2] local_g[1].o[4] local_g[1].o[6] local_g[3].o[0] local_g[3].o[2] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I0[1]" />
+  <mux name="PLB_LOCAL.I0[2]"     input="local_g[0].o[0] local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I0[2]" />
+  <mux name="PLB_LOCAL.I0[3]"     input="local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 carry_in_mux.o  " output="PLB_LOCAL.I0[3]" />
   <!-- Logic Unit 1 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I1[0]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[2].o[1] BLK_XX-local_g[1].o[0] BLK_XX-local_g[3].o[0] BLK_XX-local_g[0].o[3] BLK_XX-local_g[2].o[3] BLK_XX-local_g[1].o[2] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[2].o[5] BLK_XX-local_g[1].o[4] BLK_XX-local_g[3].o[4] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I1[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I1[1]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I1[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I1[2]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I1[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I1[3]" input="BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        BLK_IG-PLB_LOCAL.FCOUT0" output="BLK_IG-PLB_LOCAL.I1[3]" />
+  <mux name="PLB_LOCAL.I1[0]"     input="local_g[0].o[1] local_g[2].o[1] local_g[1].o[0] local_g[3].o[0] local_g[0].o[3] local_g[2].o[3] local_g[1].o[2] local_g[3].o[2] local_g[0].o[5] local_g[2].o[5] local_g[1].o[4] local_g[3].o[4] local_g[0].o[7] local_g[2].o[7] local_g[1].o[6] local_g[3].o[6]                 " output="PLB_LOCAL.I1[0]" />
+  <mux name="PLB_LOCAL.I1[1]"     input="local_g[0].o[0] local_g[0].o[2] local_g[0].o[4] local_g[0].o[6] local_g[2].o[0] local_g[2].o[2] local_g[2].o[4] local_g[2].o[6] local_g[1].o[1] local_g[1].o[3] local_g[1].o[5] local_g[1].o[7] local_g[3].o[1] local_g[3].o[3] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I1[1]" />
+  <mux name="PLB_LOCAL.I1[2]"     input="local_g[0].o[1] local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I1[2]" />
+  <mux name="PLB_LOCAL.I1[3]"     input="local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 PLB_LOCAL.FCOUT0" output="PLB_LOCAL.I1[3]" />
   <!-- Logic Unit 2 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I2[0]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[2].o[0] BLK_XX-local_g[1].o[1] BLK_XX-local_g[3].o[1] BLK_XX-local_g[0].o[2] BLK_XX-local_g[2].o[2] BLK_XX-local_g[1].o[3] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[2].o[4] BLK_XX-local_g[1].o[5] BLK_XX-local_g[3].o[5] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I2[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I2[1]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I2[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I2[2]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I2[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I2[3]" input="BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        BLK_IG-PLB_LOCAL.FCOUT1" output="BLK_IG-PLB_LOCAL.I2[3]" />
+  <mux name="PLB_LOCAL.I2[0]"     input="local_g[0].o[0] local_g[2].o[0] local_g[1].o[1] local_g[3].o[1] local_g[0].o[2] local_g[2].o[2] local_g[1].o[3] local_g[3].o[3] local_g[0].o[4] local_g[2].o[4] local_g[1].o[5] local_g[3].o[5] local_g[0].o[6] local_g[2].o[6] local_g[1].o[7] local_g[3].o[7]                 " output="PLB_LOCAL.I2[0]" />
+  <mux name="PLB_LOCAL.I2[1]"     input="local_g[0].o[1] local_g[0].o[3] local_g[0].o[5] local_g[0].o[7] local_g[2].o[1] local_g[2].o[3] local_g[2].o[5] local_g[2].o[7] local_g[1].o[0] local_g[1].o[2] local_g[1].o[4] local_g[1].o[6] local_g[3].o[0] local_g[3].o[2] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I2[1]" />
+  <mux name="PLB_LOCAL.I2[2]"     input="local_g[0].o[0] local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I2[2]" />
+  <mux name="PLB_LOCAL.I2[3]"     input="local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 PLB_LOCAL.FCOUT1" output="PLB_LOCAL.I2[3]" />
   <!-- Logic Unit 3 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I3[0]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[2].o[1] BLK_XX-local_g[1].o[0] BLK_XX-local_g[3].o[0] BLK_XX-local_g[0].o[3] BLK_XX-local_g[2].o[3] BLK_XX-local_g[1].o[2] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[2].o[5] BLK_XX-local_g[1].o[4] BLK_XX-local_g[3].o[4] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I3[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I3[1]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I3[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I3[2]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I3[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I3[3]" input="BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        BLK_IG-PLB_LOCAL.FCOUT2" output="BLK_IG-PLB_LOCAL.I3[3]" />
+  <mux name="PLB_LOCAL.I3[0]"     input="local_g[0].o[1] local_g[2].o[1] local_g[1].o[0] local_g[3].o[0] local_g[0].o[3] local_g[2].o[3] local_g[1].o[2] local_g[3].o[2] local_g[0].o[5] local_g[2].o[5] local_g[1].o[4] local_g[3].o[4] local_g[0].o[7] local_g[2].o[7] local_g[1].o[6] local_g[3].o[6]                 " output="PLB_LOCAL.I3[0]" />
+  <mux name="PLB_LOCAL.I3[1]"     input="local_g[0].o[0] local_g[0].o[2] local_g[0].o[4] local_g[0].o[6] local_g[2].o[0] local_g[2].o[2] local_g[2].o[4] local_g[2].o[6] local_g[1].o[1] local_g[1].o[3] local_g[1].o[5] local_g[1].o[7] local_g[3].o[1] local_g[3].o[3] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I3[1]" />
+  <mux name="PLB_LOCAL.I3[2]"     input="local_g[0].o[1] local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I3[2]" />
+  <mux name="PLB_LOCAL.I3[3]"     input="local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 PLB_LOCAL.FCOUT2" output="PLB_LOCAL.I3[3]" />
   <!-- Logic Unit 4 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I4[0]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[2].o[0] BLK_XX-local_g[1].o[1] BLK_XX-local_g[3].o[1] BLK_XX-local_g[0].o[2] BLK_XX-local_g[2].o[2] BLK_XX-local_g[1].o[3] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[2].o[4] BLK_XX-local_g[1].o[5] BLK_XX-local_g[3].o[5] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I4[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I4[1]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I4[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I4[2]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I4[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I4[3]" input="BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        BLK_IG-PLB_LOCAL.FCOUT3" output="BLK_IG-PLB_LOCAL.I4[3]" />
+  <mux name="PLB_LOCAL.I4[0]"     input="local_g[0].o[0] local_g[2].o[0] local_g[1].o[1] local_g[3].o[1] local_g[0].o[2] local_g[2].o[2] local_g[1].o[3] local_g[3].o[3] local_g[0].o[4] local_g[2].o[4] local_g[1].o[5] local_g[3].o[5] local_g[0].o[6] local_g[2].o[6] local_g[1].o[7] local_g[3].o[7]                 " output="PLB_LOCAL.I4[0]" />
+  <mux name="PLB_LOCAL.I4[1]"     input="local_g[0].o[1] local_g[0].o[3] local_g[0].o[5] local_g[0].o[7] local_g[2].o[1] local_g[2].o[3] local_g[2].o[5] local_g[2].o[7] local_g[1].o[0] local_g[1].o[2] local_g[1].o[4] local_g[1].o[6] local_g[3].o[0] local_g[3].o[2] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I4[1]" />
+  <mux name="PLB_LOCAL.I4[2]"     input="local_g[0].o[0] local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I4[2]" />
+  <mux name="PLB_LOCAL.I4[3]"     input="local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 PLB_LOCAL.FCOUT3" output="PLB_LOCAL.I4[3]" />
   <!-- Logic Unit 5 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I5[0]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[2].o[1] BLK_XX-local_g[1].o[0] BLK_XX-local_g[3].o[0] BLK_XX-local_g[0].o[3] BLK_XX-local_g[2].o[3] BLK_XX-local_g[1].o[2] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[2].o[5] BLK_XX-local_g[1].o[4] BLK_XX-local_g[3].o[4] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I5[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I5[1]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I5[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I5[2]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I5[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I5[3]" input="BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        BLK_IG-PLB_LOCAL.FCOUT4" output="BLK_IG-PLB_LOCAL.I5[3]" />
+  <mux name="PLB_LOCAL.I5[0]"     input="local_g[0].o[1] local_g[2].o[1] local_g[1].o[0] local_g[3].o[0] local_g[0].o[3] local_g[2].o[3] local_g[1].o[2] local_g[3].o[2] local_g[0].o[5] local_g[2].o[5] local_g[1].o[4] local_g[3].o[4] local_g[0].o[7] local_g[2].o[7] local_g[1].o[6] local_g[3].o[6]                 " output="PLB_LOCAL.I5[0]" />
+  <mux name="PLB_LOCAL.I5[1]"     input="local_g[0].o[0] local_g[0].o[2] local_g[0].o[4] local_g[0].o[6] local_g[2].o[0] local_g[2].o[2] local_g[2].o[4] local_g[2].o[6] local_g[1].o[1] local_g[1].o[3] local_g[1].o[5] local_g[1].o[7] local_g[3].o[1] local_g[3].o[3] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I5[1]" />
+  <mux name="PLB_LOCAL.I5[2]"     input="local_g[0].o[1] local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I5[2]" />
+  <mux name="PLB_LOCAL.I5[3]"     input="local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 PLB_LOCAL.FCOUT4" output="PLB_LOCAL.I5[3]" />
   <!-- Logic Unit 6 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I6[0]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[2].o[0] BLK_XX-local_g[1].o[1] BLK_XX-local_g[3].o[1] BLK_XX-local_g[0].o[2] BLK_XX-local_g[2].o[2] BLK_XX-local_g[1].o[3] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[2].o[4] BLK_XX-local_g[1].o[5] BLK_XX-local_g[3].o[5] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I6[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I6[1]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I6[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I6[2]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I6[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I6[3]" input="BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        BLK_IG-PLB_LOCAL.FCOUT5" output="BLK_IG-PLB_LOCAL.I6[3]" />
+  <mux name="PLB_LOCAL.I6[0]"     input="local_g[0].o[0] local_g[2].o[0] local_g[1].o[1] local_g[3].o[1] local_g[0].o[2] local_g[2].o[2] local_g[1].o[3] local_g[3].o[3] local_g[0].o[4] local_g[2].o[4] local_g[1].o[5] local_g[3].o[5] local_g[0].o[6] local_g[2].o[6] local_g[1].o[7] local_g[3].o[7]                 " output="PLB_LOCAL.I6[0]" />
+  <mux name="PLB_LOCAL.I6[1]"     input="local_g[0].o[1] local_g[0].o[3] local_g[0].o[5] local_g[0].o[7] local_g[2].o[1] local_g[2].o[3] local_g[2].o[5] local_g[2].o[7] local_g[1].o[0] local_g[1].o[2] local_g[1].o[4] local_g[1].o[6] local_g[3].o[0] local_g[3].o[2] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I6[1]" />
+  <mux name="PLB_LOCAL.I6[2]"     input="local_g[0].o[0] local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I6[2]" />
+  <mux name="PLB_LOCAL.I6[3]"     input="local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 PLB_LOCAL.FCOUT5" output="PLB_LOCAL.I6[3]" />
   <!-- Logic Unit 7 inputs -->
-  <mux name="BLK_IG-PLB_LOCAL.I7[0]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[2].o[1] BLK_XX-local_g[1].o[0] BLK_XX-local_g[3].o[0] BLK_XX-local_g[0].o[3] BLK_XX-local_g[2].o[3] BLK_XX-local_g[1].o[2] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[2].o[5] BLK_XX-local_g[1].o[4] BLK_XX-local_g[3].o[4] BLK_XX-local_g[0].o[7] BLK_XX-local_g[2].o[7] BLK_XX-local_g[1].o[6] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I7[0]" />
-  <mux name="BLK_IG-PLB_LOCAL.I7[1]" input="BLK_XX-local_g[0].o[0] BLK_XX-local_g[0].o[2] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        " output="BLK_IG-PLB_LOCAL.I7[1]" />
-  <mux name="BLK_IG-PLB_LOCAL.I7[2]" input="BLK_XX-local_g[0].o[1] BLK_XX-local_g[0].o[3] BLK_XX-local_g[1].o[0] BLK_XX-local_g[1].o[2] BLK_XX-local_g[2].o[1] BLK_XX-local_g[2].o[3] BLK_XX-local_g[3].o[0] BLK_XX-local_g[3].o[2] BLK_XX-local_g[0].o[5] BLK_XX-local_g[0].o[7] BLK_XX-local_g[1].o[4] BLK_XX-local_g[1].o[6] BLK_XX-local_g[2].o[5] BLK_XX-local_g[2].o[7] BLK_XX-local_g[3].o[4] BLK_XX-local_g[3].o[6]                        " output="BLK_IG-PLB_LOCAL.I7[2]" />
-  <mux name="BLK_IG-PLB_LOCAL.I7[3]" input="BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[1] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[0] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[1] BLK_XX-local_g[3].o[3] BLK_XX-local_g[0].o[4] BLK_XX-local_g[0].o[6] BLK_XX-local_g[1].o[5] BLK_XX-local_g[1].o[7] BLK_XX-local_g[2].o[4] BLK_XX-local_g[2].o[6] BLK_XX-local_g[3].o[5] BLK_XX-local_g[3].o[7]                        BLK_IG-PLB_LOCAL.FCOUT6" output="BLK_IG-PLB_LOCAL.I7[3]" />
+  <mux name="PLB_LOCAL.I7[0]"     input="local_g[0].o[1] local_g[2].o[1] local_g[1].o[0] local_g[3].o[0] local_g[0].o[3] local_g[2].o[3] local_g[1].o[2] local_g[3].o[2] local_g[0].o[5] local_g[2].o[5] local_g[1].o[4] local_g[3].o[4] local_g[0].o[7] local_g[2].o[7] local_g[1].o[6] local_g[3].o[6]                 " output="PLB_LOCAL.I7[0]" />
+  <mux name="PLB_LOCAL.I7[1]"     input="local_g[0].o[0] local_g[0].o[2] local_g[0].o[4] local_g[0].o[6] local_g[2].o[0] local_g[2].o[2] local_g[2].o[4] local_g[2].o[6] local_g[1].o[1] local_g[1].o[3] local_g[1].o[5] local_g[1].o[7] local_g[3].o[1] local_g[3].o[3] local_g[3].o[5] local_g[3].o[7]                 " output="PLB_LOCAL.I7[1]" />
+  <mux name="PLB_LOCAL.I7[2]"     input="local_g[0].o[1] local_g[0].o[3] local_g[1].o[0] local_g[1].o[2] local_g[2].o[1] local_g[2].o[3] local_g[3].o[0] local_g[3].o[2] local_g[0].o[5] local_g[0].o[7] local_g[1].o[4] local_g[1].o[6] local_g[2].o[5] local_g[2].o[7] local_g[3].o[4] local_g[3].o[6]                 " output="PLB_LOCAL.I7[2]" />
+  <mux name="PLB_LOCAL.I7[3]"     input="local_g[0].o[2] local_g[1].o[1] local_g[1].o[3] local_g[2].o[0] local_g[2].o[2] local_g[3].o[1] local_g[3].o[3] local_g[0].o[4] local_g[0].o[6] local_g[1].o[5] local_g[1].o[7] local_g[2].o[4] local_g[2].o[6] local_g[3].o[5] local_g[3].o[7]                 PLB_LOCAL.FCOUT6" output="PLB_LOCAL.I7[3]" />
   <!-- Logic Global -->
-  <mux name="lutff_global/i_cen"  input="BLK_XX-local_g[0].o[2] BLK_XX-local_g[1].o[3] BLK_XX-local_g[2].o[2] BLK_XX-local_g[3].o[3] BLK_XX-glb_netwk[1].o BLK_XX-glb_netwk[3].o BLK_XX-glb_netwk[5].o BLK_XX-glb_netwk[7].o" output="BEL_BB-lutff_global.i_cen" />
-  <mux name="lutff_global/i_s_r"  input="BLK_XX-local_g[0].o[4] BLK_XX-local_g[1].o[5] BLK_XX-local_g[2].o[4] BLK_XX-local_g[3].o[5] BLK_XX-glb_netwk[0].o BLK_XX-glb_netwk[2].o BLK_XX-glb_netwk[4].o BLK_XX-glb_netwk[6].o" output="BEL_BB-lutff_global.i_s_r" />
+  <mux name="lutff_global/i_cen"  input="local_g[0].o[2] local_g[1].o[3] local_g[2].o[2] local_g[3].o[3] glb_netwk[1].o glb_netwk[3].o glb_netwk[5].o glb_netwk[7].o" output="lutff_global.i_cen" />
+  <mux name="lutff_global/i_s_r"  input="local_g[0].o[4] local_g[1].o[5] local_g[2].o[4] local_g[3].o[5] glb_netwk[0].o glb_netwk[2].o glb_netwk[4].o glb_netwk[6].o" output="lutff_global.i_s_r" />
   <!--
-  <mux name="lutff_global/i_clk" input="local_g[0].o[0] local_g[1].o[1] local_g[2].o[0] local_g[3].o[1] glb_netwk[0].o glb_netwk[1].o glb_netwk[2].o glb_netwk[3].o glb_netwk[4].o glb_netwk[5].o glb_netwk[6].o glb_netwk[7].o" output="BEL_BB-lutff_global._CLK" />
+  <mux name="lutff_global/i_clk" input="local_g[0].o[0] local_g[1].o[1] local_g[2].o[0] local_g[3].o[1] glb_netwk[0].o glb_netwk[1].o glb_netwk[2].o glb_netwk[3].o glb_netwk[4].o glb_netwk[5].o glb_netwk[6].o glb_netwk[7].o" output="lutff_global._CLK" />
   -->
-  <mux name="lutff_global/i_clk" input="BLK_TL-PLB.glb_netwk_0" output="BEL_BB-lutff_global.i_clk" />
-  <direct name="BEL_BB-lutff_global->BLK_IG-PLB_LOCAL.EN" input="BEL_BB-lutff_global.o_cen" output="BLK_IG-PLB_LOCAL.EN" />
+  <mux name="lutff_global/i_clk" input="PLB.glb_netwk_0" output="lutff_global.i_clk" />
+  <direct name="lutff_global->PLB_LOCAL.EN" input="lutff_global.o_cen" output="PLB_LOCAL.EN" />
   <!--
-  <direct name="BEL_BB-lutff_global->BLK_IG-PLB_LOCAL.CLK" input="BEL_BB-lutff_global.o_clk" output="BLK_IG-PLB_LOCAL.CLK" />
+  <direct name="lutff_global->PLB_LOCAL.CLK" input="lutff_global.o_clk" output="PLB_LOCAL.CLK" />
   -->
-  <direct name="BEL_BB-lutff_global->BLK_IG-PLB_LOCAL.CLK" input="BEL_BB-lutff_global.o_clk" output="BLK_IG-PLB_LOCAL.CLK" />
-  <direct name="BEL_BB-lutff_global->BLK_IG-PLB_LOCAL.SR" input="BEL_BB-lutff_global.o_s_r" output="BLK_IG-PLB_LOCAL.SR" />
+  <direct name="lutff_global->PLB_LOCAL.CLK" input="lutff_global.o_clk" output="PLB_LOCAL.CLK" />
+  <direct name="lutff_global->PLB_LOCAL.SR"  input="lutff_global.o_s_r" output="PLB_LOCAL.SR" />
  </interconnect>
 
  <pinlocations pattern="custom">
   <!-- ##
-   BLK_TL-PLB.o_neigh_op_tnr BLK_TL-PLB.i_neigh_op_tnr
-   BLK_TL-PLB.o_neigh_op_top BLK_TL-PLB.i_neigh_op_top
-   BLK_TL-PLB.o_neigh_op_tnl BLK_TL-PLB.i_neigh_op_tnl
+   PLB.o_neigh_op_tnr PLB.i_neigh_op_tnr
+   PLB.o_neigh_op_top PLB.i_neigh_op_top
+   PLB.o_neigh_op_tnl PLB.i_neigh_op_tnl
        -->
   <loc side="top" xoffset="0" yoffset="0">
-   BLK_TL-PLB.glb_netwk_0
+   PLB.glb_netwk_0
 
-   BLK_TL-PLB.i_glb_netwk
-   BLK_TL-PLB.o_glb_netwk
+   PLB.i_glb_netwk
+   PLB.o_glb_netwk
 
-   BLK_TL-PLB.carry_out
+   PLB.carry_out
 
-   BLK_TL-PLB.i_sp4_v_t
-   BLK_TL-PLB.o_sp4_v_t
-   BLK_TL-PLB.i_sp12_v_t
-   BLK_TL-PLB.o_sp12_v_t
+   PLB.i_sp4_v_t
+   PLB.o_sp4_v_t
+   PLB.i_sp12_v_t
+   PLB.o_sp12_v_t
   </loc>
   <!-- ##
-   BLK_TL-PLB.i_sp4_r_v_b    BLK_TL-PLB.o_sp4_r_v_b
-   BLK_TL-PLB.i_neigh_op_rgt BLK_TL-PLB.o_neigh_op_rgt
+   PLB.i_sp4_r_v_b    PLB.o_sp4_r_v_b
+   PLB.i_neigh_op_rgt PLB.o_neigh_op_rgt
        -->
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PLB.i_sp4_h_r
-   BLK_TL-PLB.o_sp4_h_r
-   BLK_TL-PLB.i_sp12_h_r
-   BLK_TL-PLB.o_sp12_h_r
+   PLB.i_sp4_h_r
+   PLB.o_sp4_h_r
+   PLB.i_sp12_h_r
+   PLB.o_sp12_h_r
   </loc>
   <!-- ##
-   BLK_TL-PLB.i_neigh_op_bnr BLK_TL-PLB.o_neigh_op_bnr
-   BLK_TL-PLB.i_neigh_op_bot BLK_TL-PLB.o_neigh_op_bot
-   BLK_TL-PLB.i_neigh_op_bnl BLK_TL-PLB.o_neigh_op_bnl
+   PLB.i_neigh_op_bnr PLB.o_neigh_op_bnr
+   PLB.i_neigh_op_bot PLB.o_neigh_op_bot
+   PLB.i_neigh_op_bnl PLB.o_neigh_op_bnl
        -->
   <loc side="bottom" xoffset="0" yoffset="0">
-   BLK_TL-PLB.carry_in
+   PLB.carry_in
 
-   BLK_TL-PLB.i_sp4_v_b
-   BLK_TL-PLB.o_sp4_v_b
-   BLK_TL-PLB.i_sp12_v_b
-   BLK_TL-PLB.o_sp12_v_b
+   PLB.i_sp4_v_b
+   PLB.o_sp4_v_b
+   PLB.i_sp12_v_b
+   PLB.o_sp12_v_b
   </loc>
   <!-- ##
-   BLK_TL-PLB.i_sp4_l_v_b    BLK_TL-PLB.o_sp4_l_v_b
-   BLK_TL-PLB.o_neigh_op_lft BLK_TL-PLB.i_neigh_op_lft
+   PLB.i_sp4_l_v_b    PLB.o_sp4_l_v_b
+   PLB.o_neigh_op_lft PLB.i_neigh_op_lft
        -->
   <loc side="left" xoffset="0" yoffset="0">
-   BLK_TL-PLB.i_sp4_h_l
-   BLK_TL-PLB.o_sp4_h_l
-   BLK_TL-PLB.i_sp12_h_l
-   BLK_TL-PLB.o_sp12_h_l
+   PLB.i_sp4_h_l
+   PLB.o_sp4_h_l
+   PLB.i_sp12_h_l
+   PLB.o_sp12_h_l
   </loc>
  </pinlocations>
  <switchblock_locations pattern="external_full_internal_straight"/>
@@ -745,5 +765,7 @@
   <fc_override fc_type="frac" fc_val="0.0" port_name="i_neigh_op_tnl" /><fc_override fc_type="frac" fc_val="0.0" port_name="o_neigh_op_tnl" />
        -->
  </fc>
-
+ <metadata>
+  <meta name="type">tile</meta>
+ </metadata>
 </pb_type>

--- a/ice40/devices/tile-routing-virt/tiles/ramb/ramb.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/ramb/ramb.pb_type.xml
@@ -2,7 +2,7 @@
 <!-- A diagram for the iCE40 PLB "Block RAM" is shown in;
       http://www.latticesemi.com/~/media/LatticeSemi/Documents/DataSheets/iCE/iCE40LPHXFamilyDataSheet.pdf
   -->
-<pb_type name="BLK_TL-RAMB" height="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="RAMB" height="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- Read port -->
  <output name="RDATAT" num_pins="8"/>
  <output name="RDATAB" num_pins="8"/>
@@ -23,91 +23,91 @@
  <xi:include href="../../../../primitives/sb_ram/sb_ram.pb_type.xml"/>
 
  <interconnect>
-  <direct name="RDATA00" input="SB_RAM.RDATA[0]"  output="BLK_TL-RAMB.RDATAT[0]"/>
-  <direct name="RDATA01" input="SB_RAM.RDATA[1]"  output="BLK_TL-RAMB.RDATAT[1]"/>
-  <direct name="RDATA02" input="SB_RAM.RDATA[2]"  output="BLK_TL-RAMB.RDATAT[2]"/>
-  <direct name="RDATA03" input="SB_RAM.RDATA[3]"  output="BLK_TL-RAMB.RDATAT[3]"/>
-  <direct name="RDATA04" input="SB_RAM.RDATA[4]"  output="BLK_TL-RAMB.RDATAT[4]"/>
-  <direct name="RDATA05" input="SB_RAM.RDATA[5]"  output="BLK_TL-RAMB.RDATAT[5]"/>
-  <direct name="RDATA06" input="SB_RAM.RDATA[6]"  output="BLK_TL-RAMB.RDATAT[6]"/>
-  <direct name="RDATA07" input="SB_RAM.RDATA[7]"  output="BLK_TL-RAMB.RDATAT[7]"/>
+  <direct name="RDATA00" input="SB_RAM.RDATA[0]"  output="RAMB.RDATAT[0]"/>
+  <direct name="RDATA01" input="SB_RAM.RDATA[1]"  output="RAMB.RDATAT[1]"/>
+  <direct name="RDATA02" input="SB_RAM.RDATA[2]"  output="RAMB.RDATAT[2]"/>
+  <direct name="RDATA03" input="SB_RAM.RDATA[3]"  output="RAMB.RDATAT[3]"/>
+  <direct name="RDATA04" input="SB_RAM.RDATA[4]"  output="RAMB.RDATAT[4]"/>
+  <direct name="RDATA05" input="SB_RAM.RDATA[5]"  output="RAMB.RDATAT[5]"/>
+  <direct name="RDATA06" input="SB_RAM.RDATA[6]"  output="RAMB.RDATAT[6]"/>
+  <direct name="RDATA07" input="SB_RAM.RDATA[7]"  output="RAMB.RDATAT[7]"/>
 
-  <direct name="RDATA08" input="SB_RAM.RDATA[8]"  output="BLK_TL-RAMB.RDATAB[0]"/>
-  <direct name="RDATA09" input="SB_RAM.RDATA[9]"  output="BLK_TL-RAMB.RDATAB[1]"/>
-  <direct name="RDATA10" input="SB_RAM.RDATA[10]" output="BLK_TL-RAMB.RDATAB[2]"/>
-  <direct name="RDATA11" input="SB_RAM.RDATA[11]" output="BLK_TL-RAMB.RDATAB[3]"/>
-  <direct name="RDATA12" input="SB_RAM.RDATA[12]" output="BLK_TL-RAMB.RDATAB[4]"/>
-  <direct name="RDATA13" input="SB_RAM.RDATA[13]" output="BLK_TL-RAMB.RDATAB[5]"/>
-  <direct name="RDATA14" input="SB_RAM.RDATA[14]" output="BLK_TL-RAMB.RDATAB[6]"/>
-  <direct name="RDATA15" input="SB_RAM.RDATA[15]" output="BLK_TL-RAMB.RDATAB[7]"/>
+  <direct name="RDATA08" input="SB_RAM.RDATA[8]"  output="RAMB.RDATAB[0]"/>
+  <direct name="RDATA09" input="SB_RAM.RDATA[9]"  output="RAMB.RDATAB[1]"/>
+  <direct name="RDATA10" input="SB_RAM.RDATA[10]" output="RAMB.RDATAB[2]"/>
+  <direct name="RDATA11" input="SB_RAM.RDATA[11]" output="RAMB.RDATAB[3]"/>
+  <direct name="RDATA12" input="SB_RAM.RDATA[12]" output="RAMB.RDATAB[4]"/>
+  <direct name="RDATA13" input="SB_RAM.RDATA[13]" output="RAMB.RDATAB[5]"/>
+  <direct name="RDATA14" input="SB_RAM.RDATA[14]" output="RAMB.RDATAB[6]"/>
+  <direct name="RDATA15" input="SB_RAM.RDATA[15]" output="RAMB.RDATAB[7]"/>
 
-  <direct name="RADDR00" input="BLK_TL-RAMB.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
-  <direct name="RADDR01" input="BLK_TL-RAMB.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
-  <direct name="RADDR02" input="BLK_TL-RAMB.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
-  <direct name="RADDR03" input="BLK_TL-RAMB.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
-  <direct name="RADDR04" input="BLK_TL-RAMB.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
-  <direct name="RADDR05" input="BLK_TL-RAMB.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
-  <direct name="RADDR06" input="BLK_TL-RAMB.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
-  <direct name="RADDR07" input="BLK_TL-RAMB.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
-  <direct name="RADDR08" input="BLK_TL-RAMB.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
-  <direct name="RADDR09" input="BLK_TL-RAMB.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
-  <direct name="RADDR10" input="BLK_TL-RAMB.RADDR[10]" output="SB_RAM.RADDR[10]"/>
+  <direct name="RADDR00" input="RAMB.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
+  <direct name="RADDR01" input="RAMB.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
+  <direct name="RADDR02" input="RAMB.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
+  <direct name="RADDR03" input="RAMB.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
+  <direct name="RADDR04" input="RAMB.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
+  <direct name="RADDR05" input="RAMB.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
+  <direct name="RADDR06" input="RAMB.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
+  <direct name="RADDR07" input="RAMB.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
+  <direct name="RADDR08" input="RAMB.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
+  <direct name="RADDR09" input="RAMB.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
+  <direct name="RADDR10" input="RAMB.RADDR[10]" output="SB_RAM.RADDR[10]"/>
 
-  <direct name="RE"      input="BLK_TL-RAMB.RE"        output="SB_RAM.RE" />
-  <direct name="RCLKE"   input="BLK_TL-RAMB.RCLKE"     output="SB_RAM.RCLKE" />
-  <direct name="RCLK"    input="BLK_TL-RAMB.RCLK"      output="SB_RAM.RCLK" />
+  <direct name="RE"      input="RAMB.RE"        output="SB_RAM.RE" />
+  <direct name="RCLKE"   input="RAMB.RCLKE"     output="SB_RAM.RCLKE" />
+  <direct name="RCLK"    input="RAMB.RCLK"      output="SB_RAM.RCLK" />
 
-  <direct name="WDATA00" input="BLK_TL-RAMB.WDATAT[0]" output="SB_RAM.WDATA[0]"/>
-  <direct name="WDATA01" input="BLK_TL-RAMB.WDATAT[1]" output="SB_RAM.WDATA[1]"/>
-  <direct name="WDATA02" input="BLK_TL-RAMB.WDATAT[2]" output="SB_RAM.WDATA[2]"/>
-  <direct name="WDATA03" input="BLK_TL-RAMB.WDATAT[3]" output="SB_RAM.WDATA[3]"/>
-  <direct name="WDATA04" input="BLK_TL-RAMB.WDATAT[4]" output="SB_RAM.WDATA[4]"/>
-  <direct name="WDATA05" input="BLK_TL-RAMB.WDATAT[5]" output="SB_RAM.WDATA[5]"/>
-  <direct name="WDATA06" input="BLK_TL-RAMB.WDATAT[6]" output="SB_RAM.WDATA[6]"/>
-  <direct name="WDATA07" input="BLK_TL-RAMB.WDATAT[7]" output="SB_RAM.WDATA[7]"/>
+  <direct name="WDATA00" input="RAMB.WDATAT[0]" output="SB_RAM.WDATA[0]"/>
+  <direct name="WDATA01" input="RAMB.WDATAT[1]" output="SB_RAM.WDATA[1]"/>
+  <direct name="WDATA02" input="RAMB.WDATAT[2]" output="SB_RAM.WDATA[2]"/>
+  <direct name="WDATA03" input="RAMB.WDATAT[3]" output="SB_RAM.WDATA[3]"/>
+  <direct name="WDATA04" input="RAMB.WDATAT[4]" output="SB_RAM.WDATA[4]"/>
+  <direct name="WDATA05" input="RAMB.WDATAT[5]" output="SB_RAM.WDATA[5]"/>
+  <direct name="WDATA06" input="RAMB.WDATAT[6]" output="SB_RAM.WDATA[6]"/>
+  <direct name="WDATA07" input="RAMB.WDATAT[7]" output="SB_RAM.WDATA[7]"/>
 
-  <direct name="WDATA08" input="BLK_TL-RAMB.WDATAB[0]" output="SB_RAM.WDATA[8]"/>
-  <direct name="WDATA09" input="BLK_TL-RAMB.WDATAB[1]" output="SB_RAM.WDATA[9]"/>
-  <direct name="WDATA10" input="BLK_TL-RAMB.WDATAB[2]" output="SB_RAM.WDATA[10]"/>
-  <direct name="WDATA11" input="BLK_TL-RAMB.WDATAB[3]" output="SB_RAM.WDATA[11]"/>
-  <direct name="WDATA12" input="BLK_TL-RAMB.WDATAB[4]" output="SB_RAM.WDATA[12]"/>
-  <direct name="WDATA13" input="BLK_TL-RAMB.WDATAB[5]" output="SB_RAM.WDATA[13]"/>
-  <direct name="WDATA14" input="BLK_TL-RAMB.WDATAB[6]" output="SB_RAM.WDATA[14]"/>
-  <direct name="WDATA15" input="BLK_TL-RAMB.WDATAB[7]" output="SB_RAM.WDATA[15]"/>
+  <direct name="WDATA08" input="RAMB.WDATAB[0]" output="SB_RAM.WDATA[8]"/>
+  <direct name="WDATA09" input="RAMB.WDATAB[1]" output="SB_RAM.WDATA[9]"/>
+  <direct name="WDATA10" input="RAMB.WDATAB[2]" output="SB_RAM.WDATA[10]"/>
+  <direct name="WDATA11" input="RAMB.WDATAB[3]" output="SB_RAM.WDATA[11]"/>
+  <direct name="WDATA12" input="RAMB.WDATAB[4]" output="SB_RAM.WDATA[12]"/>
+  <direct name="WDATA13" input="RAMB.WDATAB[5]" output="SB_RAM.WDATA[13]"/>
+  <direct name="WDATA14" input="RAMB.WDATAB[6]" output="SB_RAM.WDATA[14]"/>
+  <direct name="WDATA15" input="RAMB.WDATAB[7]" output="SB_RAM.WDATA[15]"/>
 
-  <direct name="MASK00" input="BLK_TL-RAMB.MASKT[0]" output="SB_RAM.MASK[0]"/>
-  <direct name="MASK01" input="BLK_TL-RAMB.MASKT[1]" output="SB_RAM.MASK[1]"/>
-  <direct name="MASK02" input="BLK_TL-RAMB.MASKT[2]" output="SB_RAM.MASK[2]"/>
-  <direct name="MASK03" input="BLK_TL-RAMB.MASKT[3]" output="SB_RAM.MASK[3]"/>
-  <direct name="MASK04" input="BLK_TL-RAMB.MASKT[4]" output="SB_RAM.MASK[4]"/>
-  <direct name="MASK05" input="BLK_TL-RAMB.MASKT[5]" output="SB_RAM.MASK[5]"/>
-  <direct name="MASK06" input="BLK_TL-RAMB.MASKT[6]" output="SB_RAM.MASK[6]"/>
-  <direct name="MASK07" input="BLK_TL-RAMB.MASKT[7]" output="SB_RAM.MASK[7]"/>
+  <direct name="MASK00" input="RAMB.MASKT[0]" output="SB_RAM.MASK[0]"/>
+  <direct name="MASK01" input="RAMB.MASKT[1]" output="SB_RAM.MASK[1]"/>
+  <direct name="MASK02" input="RAMB.MASKT[2]" output="SB_RAM.MASK[2]"/>
+  <direct name="MASK03" input="RAMB.MASKT[3]" output="SB_RAM.MASK[3]"/>
+  <direct name="MASK04" input="RAMB.MASKT[4]" output="SB_RAM.MASK[4]"/>
+  <direct name="MASK05" input="RAMB.MASKT[5]" output="SB_RAM.MASK[5]"/>
+  <direct name="MASK06" input="RAMB.MASKT[6]" output="SB_RAM.MASK[6]"/>
+  <direct name="MASK07" input="RAMB.MASKT[7]" output="SB_RAM.MASK[7]"/>
 
-  <direct name="MASK08" input="BLK_TL-RAMB.MASKB[0]" output="SB_RAM.MASK[8]"/>
-  <direct name="MASK09" input="BLK_TL-RAMB.MASKB[1]" output="SB_RAM.MASK[9]"/>
-  <direct name="MASK10" input="BLK_TL-RAMB.MASKB[2]" output="SB_RAM.MASK[10]"/>
-  <direct name="MASK11" input="BLK_TL-RAMB.MASKB[3]" output="SB_RAM.MASK[11]"/>
-  <direct name="MASK12" input="BLK_TL-RAMB.MASKB[4]" output="SB_RAM.MASK[12]"/>
-  <direct name="MASK13" input="BLK_TL-RAMB.MASKB[5]" output="SB_RAM.MASK[13]"/>
-  <direct name="MASK14" input="BLK_TL-RAMB.MASKB[6]" output="SB_RAM.MASK[14]"/>
-  <direct name="MASK15" input="BLK_TL-RAMB.MASKB[7]" output="SB_RAM.MASK[15]"/>
+  <direct name="MASK08" input="RAMB.MASKB[0]" output="SB_RAM.MASK[8]"/>
+  <direct name="MASK09" input="RAMB.MASKB[1]" output="SB_RAM.MASK[9]"/>
+  <direct name="MASK10" input="RAMB.MASKB[2]" output="SB_RAM.MASK[10]"/>
+  <direct name="MASK11" input="RAMB.MASKB[3]" output="SB_RAM.MASK[11]"/>
+  <direct name="MASK12" input="RAMB.MASKB[4]" output="SB_RAM.MASK[12]"/>
+  <direct name="MASK13" input="RAMB.MASKB[5]" output="SB_RAM.MASK[13]"/>
+  <direct name="MASK14" input="RAMB.MASKB[6]" output="SB_RAM.MASK[14]"/>
+  <direct name="MASK15" input="RAMB.MASKB[7]" output="SB_RAM.MASK[15]"/>
 
-  <direct name="WADDR00" input="BLK_TL-RAMB.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
-  <direct name="WADDR01" input="BLK_TL-RAMB.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
-  <direct name="WADDR02" input="BLK_TL-RAMB.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
-  <direct name="WADDR03" input="BLK_TL-RAMB.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
-  <direct name="WADDR04" input="BLK_TL-RAMB.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
-  <direct name="WADDR05" input="BLK_TL-RAMB.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
-  <direct name="WADDR06" input="BLK_TL-RAMB.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
-  <direct name="WADDR07" input="BLK_TL-RAMB.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
-  <direct name="WADDR08" input="BLK_TL-RAMB.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
-  <direct name="WADDR09" input="BLK_TL-RAMB.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
-  <direct name="WADDR10" input="BLK_TL-RAMB.WADDR[10]" output="SB_RAM.WADDR[10]"/>
+  <direct name="WADDR00" input="RAMB.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
+  <direct name="WADDR01" input="RAMB.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
+  <direct name="WADDR02" input="RAMB.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
+  <direct name="WADDR03" input="RAMB.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
+  <direct name="WADDR04" input="RAMB.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
+  <direct name="WADDR05" input="RAMB.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
+  <direct name="WADDR06" input="RAMB.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
+  <direct name="WADDR07" input="RAMB.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
+  <direct name="WADDR08" input="RAMB.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
+  <direct name="WADDR09" input="RAMB.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
+  <direct name="WADDR10" input="RAMB.WADDR[10]" output="SB_RAM.WADDR[10]"/>
 
-  <direct name="WE"    input="BLK_TL-RAMB.WE"          output="SB_RAM.WE" />
-  <direct name="WCLKE" input="BLK_TL-RAMB.WCLKE"       output="SB_RAM.WCLKE" />
-  <direct name="WCLK"  input="BLK_TL-RAMB.WCLK"        output="SB_RAM.WCLK" />
+  <direct name="WE"    input="RAMB.WE"          output="SB_RAM.WE" />
+  <direct name="WCLKE" input="RAMB.WCLKE"       output="SB_RAM.WCLKE" />
+  <direct name="WCLK"  input="RAMB.WCLK"        output="SB_RAM.WCLK" />
  </interconnect>
 
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2">
@@ -130,25 +130,29 @@
  <pinlocations pattern="custom">
   <!-- RAMB Tile -->
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-RAMB.RDATAB
-   BLK_TL-RAMB.WADDR
-   BLK_TL-RAMB.MASKB
-   BLK_TL-RAMB.WDATAB
-   BLK_TL-RAMB.WCLKE
-   BLK_TL-RAMB.WCLK
-   BLK_TL-RAMB.WE
-   BLK_TL-RAMB.RDATAT
-   BLK_TL-RAMB.RADDR
-   BLK_TL-RAMB.MASKT
-   BLK_TL-RAMB.WDATAT
-   BLK_TL-RAMB.RCLKE
-   BLK_TL-RAMB.RCLK
-   BLK_TL-RAMB.RE
+   RAMB.RDATAB
+   RAMB.WADDR
+   RAMB.MASKB
+   RAMB.WDATAB
+   RAMB.WCLKE
+   RAMB.WCLK
+   RAMB.WE
+   RAMB.RDATAT
+   RAMB.RADDR
+   RAMB.MASKT
+   RAMB.WDATAT
+   RAMB.RCLKE
+   RAMB.RCLK
+   RAMB.RE
   </loc>
  </pinlocations>
  <!--
   </loc>
   <loc side="right" xoffset="0" yoffset="1"> -->
  <switchblock_locations pattern="external_full_internal_straight"/>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>
 <!-- End RAMB -->

--- a/ice40/devices/tile-routing-virt/tiles/ramt/ramt.pb_type.xml
+++ b/ice40/devices/tile-routing-virt/tiles/ramt/ramt.pb_type.xml
@@ -2,7 +2,7 @@
 <!-- A diagram for the iCE40 PLB "Block RAM" is shown in;
       http://www.latticesemi.com/~/media/LatticeSemi/Documents/DataSheets/iCE/iCE40LPHXFamilyDataSheet.pdf
   -->
-<pb_type name="BLK_TL-RAMT" height="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="RAMT" height="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- Read port -->
  <output name="RDATAT" num_pins="8"/>
  <output name="RDATAB" num_pins="8"/>
@@ -23,91 +23,91 @@
  <xi:include href="../../../../primitives/sb_ram/sb_ram.pb_type.xml"/>
 
  <interconnect>
-  <direct name="RDATA00" input="SB_RAM.RDATA[0]"  output="BLK_TL-RAMT.RDATAT[0]"/>
-  <direct name="RDATA01" input="SB_RAM.RDATA[1]"  output="BLK_TL-RAMT.RDATAT[1]"/>
-  <direct name="RDATA02" input="SB_RAM.RDATA[2]"  output="BLK_TL-RAMT.RDATAT[2]"/>
-  <direct name="RDATA03" input="SB_RAM.RDATA[3]"  output="BLK_TL-RAMT.RDATAT[3]"/>
-  <direct name="RDATA04" input="SB_RAM.RDATA[4]"  output="BLK_TL-RAMT.RDATAT[4]"/>
-  <direct name="RDATA05" input="SB_RAM.RDATA[5]"  output="BLK_TL-RAMT.RDATAT[5]"/>
-  <direct name="RDATA06" input="SB_RAM.RDATA[6]"  output="BLK_TL-RAMT.RDATAT[6]"/>
-  <direct name="RDATA07" input="SB_RAM.RDATA[7]"  output="BLK_TL-RAMT.RDATAT[7]"/>
+  <direct name="RDATA00" input="SB_RAM.RDATA[0]"  output="RAMT.RDATAT[0]"/>
+  <direct name="RDATA01" input="SB_RAM.RDATA[1]"  output="RAMT.RDATAT[1]"/>
+  <direct name="RDATA02" input="SB_RAM.RDATA[2]"  output="RAMT.RDATAT[2]"/>
+  <direct name="RDATA03" input="SB_RAM.RDATA[3]"  output="RAMT.RDATAT[3]"/>
+  <direct name="RDATA04" input="SB_RAM.RDATA[4]"  output="RAMT.RDATAT[4]"/>
+  <direct name="RDATA05" input="SB_RAM.RDATA[5]"  output="RAMT.RDATAT[5]"/>
+  <direct name="RDATA06" input="SB_RAM.RDATA[6]"  output="RAMT.RDATAT[6]"/>
+  <direct name="RDATA07" input="SB_RAM.RDATA[7]"  output="RAMT.RDATAT[7]"/>
 
-  <direct name="RDATA08" input="SB_RAM.RDATA[8]"  output="BLK_TL-RAMT.RDATAB[0]"/>
-  <direct name="RDATA09" input="SB_RAM.RDATA[9]"  output="BLK_TL-RAMT.RDATAB[1]"/>
-  <direct name="RDATA10" input="SB_RAM.RDATA[10]" output="BLK_TL-RAMT.RDATAB[2]"/>
-  <direct name="RDATA11" input="SB_RAM.RDATA[11]" output="BLK_TL-RAMT.RDATAB[3]"/>
-  <direct name="RDATA12" input="SB_RAM.RDATA[12]" output="BLK_TL-RAMT.RDATAB[4]"/>
-  <direct name="RDATA13" input="SB_RAM.RDATA[13]" output="BLK_TL-RAMT.RDATAB[5]"/>
-  <direct name="RDATA14" input="SB_RAM.RDATA[14]" output="BLK_TL-RAMT.RDATAB[6]"/>
-  <direct name="RDATA15" input="SB_RAM.RDATA[15]" output="BLK_TL-RAMT.RDATAB[7]"/>
+  <direct name="RDATA08" input="SB_RAM.RDATA[8]"  output="RAMT.RDATAB[0]"/>
+  <direct name="RDATA09" input="SB_RAM.RDATA[9]"  output="RAMT.RDATAB[1]"/>
+  <direct name="RDATA10" input="SB_RAM.RDATA[10]" output="RAMT.RDATAB[2]"/>
+  <direct name="RDATA11" input="SB_RAM.RDATA[11]" output="RAMT.RDATAB[3]"/>
+  <direct name="RDATA12" input="SB_RAM.RDATA[12]" output="RAMT.RDATAB[4]"/>
+  <direct name="RDATA13" input="SB_RAM.RDATA[13]" output="RAMT.RDATAB[5]"/>
+  <direct name="RDATA14" input="SB_RAM.RDATA[14]" output="RAMT.RDATAB[6]"/>
+  <direct name="RDATA15" input="SB_RAM.RDATA[15]" output="RAMT.RDATAB[7]"/>
 
-  <direct name="RADDR00" input="BLK_TL-RAMT.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
-  <direct name="RADDR01" input="BLK_TL-RAMT.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
-  <direct name="RADDR02" input="BLK_TL-RAMT.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
-  <direct name="RADDR03" input="BLK_TL-RAMT.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
-  <direct name="RADDR04" input="BLK_TL-RAMT.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
-  <direct name="RADDR05" input="BLK_TL-RAMT.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
-  <direct name="RADDR06" input="BLK_TL-RAMT.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
-  <direct name="RADDR07" input="BLK_TL-RAMT.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
-  <direct name="RADDR08" input="BLK_TL-RAMT.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
-  <direct name="RADDR09" input="BLK_TL-RAMT.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
-  <direct name="RADDR10" input="BLK_TL-RAMT.RADDR[10]" output="SB_RAM.RADDR[10]"/>
+  <direct name="RADDR00" input="RAMT.RADDR[0]"  output="SB_RAM.RADDR[0]"/>
+  <direct name="RADDR01" input="RAMT.RADDR[1]"  output="SB_RAM.RADDR[1]"/>
+  <direct name="RADDR02" input="RAMT.RADDR[2]"  output="SB_RAM.RADDR[2]"/>
+  <direct name="RADDR03" input="RAMT.RADDR[3]"  output="SB_RAM.RADDR[3]"/>
+  <direct name="RADDR04" input="RAMT.RADDR[4]"  output="SB_RAM.RADDR[4]"/>
+  <direct name="RADDR05" input="RAMT.RADDR[5]"  output="SB_RAM.RADDR[5]"/>
+  <direct name="RADDR06" input="RAMT.RADDR[6]"  output="SB_RAM.RADDR[6]"/>
+  <direct name="RADDR07" input="RAMT.RADDR[7]"  output="SB_RAM.RADDR[7]"/>
+  <direct name="RADDR08" input="RAMT.RADDR[8]"  output="SB_RAM.RADDR[8]"/>
+  <direct name="RADDR09" input="RAMT.RADDR[9]"  output="SB_RAM.RADDR[9]"/>
+  <direct name="RADDR10" input="RAMT.RADDR[10]" output="SB_RAM.RADDR[10]"/>
 
-  <direct name="RE"      input="BLK_TL-RAMT.RE"        output="SB_RAM.RE" />
-  <direct name="RCLKE"   input="BLK_TL-RAMT.RCLKE"     output="SB_RAM.RCLKE" />
-  <direct name="RCLK"    input="BLK_TL-RAMT.RCLK"      output="SB_RAM.RCLK" />
+  <direct name="RE"      input="RAMT.RE"        output="SB_RAM.RE" />
+  <direct name="RCLKE"   input="RAMT.RCLKE"     output="SB_RAM.RCLKE" />
+  <direct name="RCLK"    input="RAMT.RCLK"      output="SB_RAM.RCLK" />
 
-  <direct name="WDATA00" input="BLK_TL-RAMT.WDATAT[0]" output="SB_RAM.WDATA[0]"/>
-  <direct name="WDATA01" input="BLK_TL-RAMT.WDATAT[1]" output="SB_RAM.WDATA[1]"/>
-  <direct name="WDATA02" input="BLK_TL-RAMT.WDATAT[2]" output="SB_RAM.WDATA[2]"/>
-  <direct name="WDATA03" input="BLK_TL-RAMT.WDATAT[3]" output="SB_RAM.WDATA[3]"/>
-  <direct name="WDATA04" input="BLK_TL-RAMT.WDATAT[4]" output="SB_RAM.WDATA[4]"/>
-  <direct name="WDATA05" input="BLK_TL-RAMT.WDATAT[5]" output="SB_RAM.WDATA[5]"/>
-  <direct name="WDATA06" input="BLK_TL-RAMT.WDATAT[6]" output="SB_RAM.WDATA[6]"/>
-  <direct name="WDATA07" input="BLK_TL-RAMT.WDATAT[7]" output="SB_RAM.WDATA[7]"/>
+  <direct name="WDATA00" input="RAMT.WDATAT[0]" output="SB_RAM.WDATA[0]"/>
+  <direct name="WDATA01" input="RAMT.WDATAT[1]" output="SB_RAM.WDATA[1]"/>
+  <direct name="WDATA02" input="RAMT.WDATAT[2]" output="SB_RAM.WDATA[2]"/>
+  <direct name="WDATA03" input="RAMT.WDATAT[3]" output="SB_RAM.WDATA[3]"/>
+  <direct name="WDATA04" input="RAMT.WDATAT[4]" output="SB_RAM.WDATA[4]"/>
+  <direct name="WDATA05" input="RAMT.WDATAT[5]" output="SB_RAM.WDATA[5]"/>
+  <direct name="WDATA06" input="RAMT.WDATAT[6]" output="SB_RAM.WDATA[6]"/>
+  <direct name="WDATA07" input="RAMT.WDATAT[7]" output="SB_RAM.WDATA[7]"/>
 
-  <direct name="WDATA08" input="BLK_TL-RAMT.WDATAB[0]" output="SB_RAM.WDATA[8]"/>
-  <direct name="WDATA09" input="BLK_TL-RAMT.WDATAB[1]" output="SB_RAM.WDATA[9]"/>
-  <direct name="WDATA10" input="BLK_TL-RAMT.WDATAB[2]" output="SB_RAM.WDATA[10]"/>
-  <direct name="WDATA11" input="BLK_TL-RAMT.WDATAB[3]" output="SB_RAM.WDATA[11]"/>
-  <direct name="WDATA12" input="BLK_TL-RAMT.WDATAB[4]" output="SB_RAM.WDATA[12]"/>
-  <direct name="WDATA13" input="BLK_TL-RAMT.WDATAB[5]" output="SB_RAM.WDATA[13]"/>
-  <direct name="WDATA14" input="BLK_TL-RAMT.WDATAB[6]" output="SB_RAM.WDATA[14]"/>
-  <direct name="WDATA15" input="BLK_TL-RAMT.WDATAB[7]" output="SB_RAM.WDATA[15]"/>
+  <direct name="WDATA08" input="RAMT.WDATAB[0]" output="SB_RAM.WDATA[8]"/>
+  <direct name="WDATA09" input="RAMT.WDATAB[1]" output="SB_RAM.WDATA[9]"/>
+  <direct name="WDATA10" input="RAMT.WDATAB[2]" output="SB_RAM.WDATA[10]"/>
+  <direct name="WDATA11" input="RAMT.WDATAB[3]" output="SB_RAM.WDATA[11]"/>
+  <direct name="WDATA12" input="RAMT.WDATAB[4]" output="SB_RAM.WDATA[12]"/>
+  <direct name="WDATA13" input="RAMT.WDATAB[5]" output="SB_RAM.WDATA[13]"/>
+  <direct name="WDATA14" input="RAMT.WDATAB[6]" output="SB_RAM.WDATA[14]"/>
+  <direct name="WDATA15" input="RAMT.WDATAB[7]" output="SB_RAM.WDATA[15]"/>
 
-  <direct name="MASK00" input="BLK_TL-RAMT.MASKT[0]" output="SB_RAM.MASK[0]"/>
-  <direct name="MASK01" input="BLK_TL-RAMT.MASKT[1]" output="SB_RAM.MASK[1]"/>
-  <direct name="MASK02" input="BLK_TL-RAMT.MASKT[2]" output="SB_RAM.MASK[2]"/>
-  <direct name="MASK03" input="BLK_TL-RAMT.MASKT[3]" output="SB_RAM.MASK[3]"/>
-  <direct name="MASK04" input="BLK_TL-RAMT.MASKT[4]" output="SB_RAM.MASK[4]"/>
-  <direct name="MASK05" input="BLK_TL-RAMT.MASKT[5]" output="SB_RAM.MASK[5]"/>
-  <direct name="MASK06" input="BLK_TL-RAMT.MASKT[6]" output="SB_RAM.MASK[6]"/>
-  <direct name="MASK07" input="BLK_TL-RAMT.MASKT[7]" output="SB_RAM.MASK[7]"/>
+  <direct name="MASK00" input="RAMT.MASKT[0]" output="SB_RAM.MASK[0]"/>
+  <direct name="MASK01" input="RAMT.MASKT[1]" output="SB_RAM.MASK[1]"/>
+  <direct name="MASK02" input="RAMT.MASKT[2]" output="SB_RAM.MASK[2]"/>
+  <direct name="MASK03" input="RAMT.MASKT[3]" output="SB_RAM.MASK[3]"/>
+  <direct name="MASK04" input="RAMT.MASKT[4]" output="SB_RAM.MASK[4]"/>
+  <direct name="MASK05" input="RAMT.MASKT[5]" output="SB_RAM.MASK[5]"/>
+  <direct name="MASK06" input="RAMT.MASKT[6]" output="SB_RAM.MASK[6]"/>
+  <direct name="MASK07" input="RAMT.MASKT[7]" output="SB_RAM.MASK[7]"/>
 
-  <direct name="MASK08" input="BLK_TL-RAMT.MASKB[0]" output="SB_RAM.MASK[8]"/>
-  <direct name="MASK09" input="BLK_TL-RAMT.MASKB[1]" output="SB_RAM.MASK[9]"/>
-  <direct name="MASK10" input="BLK_TL-RAMT.MASKB[2]" output="SB_RAM.MASK[10]"/>
-  <direct name="MASK11" input="BLK_TL-RAMT.MASKB[3]" output="SB_RAM.MASK[11]"/>
-  <direct name="MASK12" input="BLK_TL-RAMT.MASKB[4]" output="SB_RAM.MASK[12]"/>
-  <direct name="MASK13" input="BLK_TL-RAMT.MASKB[5]" output="SB_RAM.MASK[13]"/>
-  <direct name="MASK14" input="BLK_TL-RAMT.MASKB[6]" output="SB_RAM.MASK[14]"/>
-  <direct name="MASK15" input="BLK_TL-RAMT.MASKB[7]" output="SB_RAM.MASK[15]"/>
+  <direct name="MASK08" input="RAMT.MASKB[0]" output="SB_RAM.MASK[8]"/>
+  <direct name="MASK09" input="RAMT.MASKB[1]" output="SB_RAM.MASK[9]"/>
+  <direct name="MASK10" input="RAMT.MASKB[2]" output="SB_RAM.MASK[10]"/>
+  <direct name="MASK11" input="RAMT.MASKB[3]" output="SB_RAM.MASK[11]"/>
+  <direct name="MASK12" input="RAMT.MASKB[4]" output="SB_RAM.MASK[12]"/>
+  <direct name="MASK13" input="RAMT.MASKB[5]" output="SB_RAM.MASK[13]"/>
+  <direct name="MASK14" input="RAMT.MASKB[6]" output="SB_RAM.MASK[14]"/>
+  <direct name="MASK15" input="RAMT.MASKB[7]" output="SB_RAM.MASK[15]"/>
 
-  <direct name="WADDR00" input="BLK_TL-RAMT.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
-  <direct name="WADDR01" input="BLK_TL-RAMT.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
-  <direct name="WADDR02" input="BLK_TL-RAMT.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
-  <direct name="WADDR03" input="BLK_TL-RAMT.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
-  <direct name="WADDR04" input="BLK_TL-RAMT.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
-  <direct name="WADDR05" input="BLK_TL-RAMT.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
-  <direct name="WADDR06" input="BLK_TL-RAMT.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
-  <direct name="WADDR07" input="BLK_TL-RAMT.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
-  <direct name="WADDR08" input="BLK_TL-RAMT.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
-  <direct name="WADDR09" input="BLK_TL-RAMT.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
-  <direct name="WADDR10" input="BLK_TL-RAMT.WADDR[10]" output="SB_RAM.WADDR[10]"/>
+  <direct name="WADDR00" input="RAMT.WADDR[0]"  output="SB_RAM.WADDR[0]"/>
+  <direct name="WADDR01" input="RAMT.WADDR[1]"  output="SB_RAM.WADDR[1]"/>
+  <direct name="WADDR02" input="RAMT.WADDR[2]"  output="SB_RAM.WADDR[2]"/>
+  <direct name="WADDR03" input="RAMT.WADDR[3]"  output="SB_RAM.WADDR[3]"/>
+  <direct name="WADDR04" input="RAMT.WADDR[4]"  output="SB_RAM.WADDR[4]"/>
+  <direct name="WADDR05" input="RAMT.WADDR[5]"  output="SB_RAM.WADDR[5]"/>
+  <direct name="WADDR06" input="RAMT.WADDR[6]"  output="SB_RAM.WADDR[6]"/>
+  <direct name="WADDR07" input="RAMT.WADDR[7]"  output="SB_RAM.WADDR[7]"/>
+  <direct name="WADDR08" input="RAMT.WADDR[8]"  output="SB_RAM.WADDR[8]"/>
+  <direct name="WADDR09" input="RAMT.WADDR[9]"  output="SB_RAM.WADDR[9]"/>
+  <direct name="WADDR10" input="RAMT.WADDR[10]" output="SB_RAM.WADDR[10]"/>
 
-  <direct name="WE"    input="BLK_TL-RAMT.WE"          output="SB_RAM.WE" />
-  <direct name="WCLKE" input="BLK_TL-RAMT.WCLKE"       output="SB_RAM.WCLKE" />
-  <direct name="WCLK"  input="BLK_TL-RAMT.WCLK"        output="SB_RAM.WCLK" />
+  <direct name="WE"    input="RAMT.WE"          output="SB_RAM.WE" />
+  <direct name="WCLKE" input="RAMT.WCLKE"       output="SB_RAM.WCLKE" />
+  <direct name="WCLK"  input="RAMT.WCLK"        output="SB_RAM.WCLK" />
  </interconnect>
 
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2">
@@ -130,25 +130,29 @@
  <pinlocations pattern="custom">
   <!-- RAMB Tile -->
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-RAMT.RDATAB
-   BLK_TL-RAMT.WADDR
-   BLK_TL-RAMT.MASKB
-   BLK_TL-RAMT.WDATAB
-   BLK_TL-RAMT.WCLKE
-   BLK_TL-RAMT.WCLK
-   BLK_TL-RAMT.WE
-   BLK_TL-RAMT.RDATAT
-   BLK_TL-RAMT.RADDR
-   BLK_TL-RAMT.MASKT
-   BLK_TL-RAMT.WDATAT
-   BLK_TL-RAMT.RCLKE
-   BLK_TL-RAMT.RCLK
-   BLK_TL-RAMT.RE
+   RAMT.RDATAB
+   RAMT.WADDR
+   RAMT.MASKB
+   RAMT.WDATAB
+   RAMT.WCLKE
+   RAMT.WCLK
+   RAMT.WE
+   RAMT.RDATAT
+   RAMT.RADDR
+   RAMT.MASKT
+   RAMT.WDATAT
+   RAMT.RCLKE
+   RAMT.RCLK
+   RAMT.RE
   </loc>
  </pinlocations>
  <!--
   </loc>
   <loc side="right" xoffset="0" yoffset="1"> -->
  <switchblock_locations pattern="external_full_internal_straight"/>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>
 <!-- End RAM -->

--- a/ice40/devices/top-routing-virt/arch.xml
+++ b/ice40/devices/top-routing-virt/arch.xml
@@ -72,7 +72,7 @@
  </layout>
  <directlist>
   <!-- Carry chain from one PLB to the next PLB -->
-  <direct name="CARRYCHAIN" from_pin="BLK_TL-PLB.FCOUT" to_pin="BLK_TL-PLB.FCIN" x_offset="0" y_offset="-1" z_offset="0"/>
+  <direct name="CARRYCHAIN" from_pin="PLB.FCOUT" to_pin="PLB.FCIN" x_offset="0" y_offset="-1" z_offset="0"/>
  </directlist>
 
  <device>

--- a/ice40/devices/top-routing-virt/tiles/dsp/dsp.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/dsp/dsp.pb_type.xml
@@ -1,7 +1,7 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <!-- Place holder for the iCE40 UP DSP Block
      http://www.clifford.at/icestorm/ultraplus.html -->
-<pb_type name="BLK_TL-DSP" height="4" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="DSP" height="4" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- Read port -->
  <input  name="DUMMY_IN"  num_pins="4"/>
  <output name="DUMMY_OUT" num_pins="4"/>
@@ -11,27 +11,25 @@
  <fc in_type="abs" in_val="2" out_type="abs" out_val="2"/>
  <pinlocations pattern="custom">
   <loc side="right" xoffset="0" yoffset="3">
-   BLK_TL-DSP.DUMMY_OUT[3]
-   BLK_TL-DSP.DUMMY_IN[3]
+   DSP.DUMMY_OUT[3]
+   DSP.DUMMY_IN[3]
   </loc>
   <loc side="right" xoffset="0" yoffset="2">
-   BLK_TL-DSP.DUMMY_OUT[2]
-   BLK_TL-DSP.DUMMY_IN[2]
+   DSP.DUMMY_OUT[2]
+   DSP.DUMMY_IN[2]
   </loc>
   <loc side="right" xoffset="0" yoffset="1">
-   BLK_TL-DSP.DUMMY_OUT[1]
-   BLK_TL-DSP.DUMMY_IN[1]
+   DSP.DUMMY_OUT[1]
+   DSP.DUMMY_IN[1]
   </loc>
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-DSP.DUMMY_OUT[0]
-   BLK_TL-DSP.DUMMY_IN[0]
+   DSP.DUMMY_OUT[0]
+   DSP.DUMMY_IN[0]
   </loc>
  </pinlocations>
  <switchblock_locations pattern="external_full_internal_straight"/>
  <metadata>
-  <meta xoffset="0" yoffset="3" name="hlc_tile">dsp3_tile</meta>
-  <meta xoffset="0" yoffset="2" name="hlc_tile">dsp2_tile</meta>
-  <meta xoffset="0" yoffset="1" name="hlc_tile">dsp1_tile</meta>
-  <meta xoffset="0" yoffset="0" name="hlc_tile">dsp0_tile</meta>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
  </metadata>
 </pb_type>

--- a/ice40/devices/top-routing-virt/tiles/pio/pio.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/pio/pio.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_TL-PIO" capacity="2" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PIO" capacity="2" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- SB_IO inputs   -->
  <output name="D_IN" num_pins="2"/>
 
@@ -22,14 +22,17 @@
    <input name="D_OUT" num_pins="2"/>
    <pb_type name="output" blif_model=".output" num_pb="1">
     <input name="outpad" num_pins="1"/>
+    <metadata>
+     <meta name="type">bel</meta>
+     <meta name="subtype">output</meta>
+    </metadata>
    </pb_type>
    <interconnect>
     <mux name="D_OUT" input="PAD.D_OUT[0]" output="output.outpad"/>
    </interconnect>
    <metadata>
-    <meta name="hlc_property">disable_pull_up</meta>
-    <meta name="hlc_property">output_pin_type = simple_output_pin</meta>
-    <meta name="hlc_property">input_pin_type = simple_input_pin</meta>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
    </metadata>
   </pb_type>
 
@@ -40,7 +43,7 @@
      <port type="output" name="D_OUT[0]" from="PAD" />
      <metadata>
        <meta name="fasm_mux">
-	 BLK_TL-PIO.D_OUT[0] = SimpleOutput
+	 PIO.D_OUT[0] = SimpleOutput
        </meta>
      </metadata>
    </direct>
@@ -49,7 +52,7 @@
      <port type="output" name="D_OUT[1]" from="PAD" />
      <metadata>
        <meta name="fasm_mux">
-	 BLK_TL-PIO.D_OUT[1] = SimpleOutput
+	 PIO.D_OUT[1] = SimpleOutput
        </meta>
      </metadata>
    </direct>
@@ -63,15 +66,18 @@
    <output name="PIN"  num_pins="1"/>
    <pb_type name="input" blif_model=".input" num_pb="1">
     <output name="inpad" num_pins="1"/>
+    <metadata>
+     <meta name="type">bel</meta>
+     <meta name="subtype">input</meta>
+    </metadata>
    </pb_type>
    <interconnect>
     <direct><port type="input" name="inpad" from="input" /><port type="output" name="D_IN[0]" from="PAD" /></direct>
     <direct><port type="input" name="inpad" from="input" /><port type="output" name="PIN" from="PAD" /></direct>
    </interconnect>
    <metadata>
-    <meta name="hlc_property">disable_pull_up</meta>
-    <meta name="hlc_property">enable_input</meta>
-    <meta name="hlc_property">input_pin_type = simple_input_pin</meta>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
    </metadata>
   </pb_type>
 
@@ -100,22 +106,21 @@
 
  </mode>
 
- <metadata>
-  <meta name="hlc_cell">io</meta>
-  <meta name="hlc_tile">io_tile</meta>
- </metadata>
-
  <pinlocations pattern="custom">
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PIO.D_IN
-   BLK_TL-PIO.D_OUT
-   BLK_TL-PIO.OUT_ENB
-   BLK_TL-PIO.CEN
-   BLK_TL-PIO.INCLK
-   BLK_TL-PIO.OUTCLK
-   BLK_TL-PIO.LATCH
-   BLK_TL-PIO.PACKAGE_PIN
+   PIO.D_IN
+   PIO.D_OUT
+   PIO.OUT_ENB
+   PIO.CEN
+   PIO.INCLK
+   PIO.OUTCLK
+   PIO.LATCH
+   PIO.PACKAGE_PIN
   </loc>
  </pinlocations>
  <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0" />
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/ice40/devices/top-routing-virt/tiles/plb/plb.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/plb/plb.pb_type.xml
@@ -6,7 +6,7 @@
 
      It is 8 x (SB_CARRY + SB_LUT4 + FF)
   -->
-<pb_type name="BLK_TL-PLB" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="PLB" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- LUT inputs -->
  <input  name="lutff_0/in"       num_pins="4"/>
  <input  name="lutff_1/in"       num_pins="4"/>
@@ -36,77 +36,77 @@
  <input  name="FCIN"   num_pins="1"/>
  <output name="FCOUT"  num_pins="1"/>
 
- <!-- A BLK_IG-PLB contains the same 'cell' repeated 8 times. -->
- <pb_type name="BLK_IG-PLB" num_pb="1">
+ <!-- A PLB contains the same 'cell' repeated 8 times. -->
+ <pb_type name="PLB_CELLS" num_pb="1">
   <xi:include href="../../../../cells/plb/plb.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  </pb_type>
 
  <interconnect>
   <!-- LUT inputs -->
-  <direct><port type="input" name="lutff_0/in"/><port type="output" name="I0" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_1/in"/><port type="output" name="I1" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_2/in"/><port type="output" name="I2" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_3/in"/><port type="output" name="I3" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_4/in"/><port type="output" name="I4" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_5/in"/><port type="output" name="I5" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_6/in"/><port type="output" name="I6" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_7/in"/><port type="output" name="I7" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_0/in"/><port type="output" name="I0" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_1/in"/><port type="output" name="I1" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_2/in"/><port type="output" name="I2" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_3/in"/><port type="output" name="I3" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_4/in"/><port type="output" name="I4" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_5/in"/><port type="output" name="I5" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_6/in"/><port type="output" name="I6" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_7/in"/><port type="output" name="I7" from="PLB_CELLS"/></direct>
 
   <!-- D flip-flop controls -->
-  <direct><port type="input" name="lutff_global/clk"/><port type="output" name="CLK" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_global/s_r"/><port type="output" name="SR" from="BLK_IG-PLB"/></direct>
-  <direct><port type="input" name="lutff_global/cen"/><port type="output" name="EN" from="BLK_IG-PLB"/></direct>
+  <direct><port type="input" name="lutff_global/clk"/><port type="output" name="CLK" from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_global/s_r"/><port type="output" name="SR"  from="PLB_CELLS"/></direct>
+  <direct><port type="input" name="lutff_global/cen"/><port type="output" name="EN"  from="PLB_CELLS"/></direct>
 
   <!-- D flip-flop outputs -->
-  <direct><port type="input" name="O0" from="BLK_IG-PLB" /><port type="output" name="lutff_0/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O1" from="BLK_IG-PLB" /><port type="output" name="lutff_1/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O2" from="BLK_IG-PLB" /><port type="output" name="lutff_2/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O3" from="BLK_IG-PLB" /><port type="output" name="lutff_3/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O4" from="BLK_IG-PLB" /><port type="output" name="lutff_4/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O5" from="BLK_IG-PLB" /><port type="output" name="lutff_5/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O6" from="BLK_IG-PLB" /><port type="output" name="lutff_6/out" from="BLK_TL-PLB"/></direct>
-  <direct><port type="input" name="O7" from="BLK_IG-PLB" /><port type="output" name="lutff_7/out" from="BLK_TL-PLB"/></direct>
+  <direct><port type="input" name="O0" from="PLB_CELLS" /><port type="output" name="lutff_0/out"/></direct>
+  <direct><port type="input" name="O1" from="PLB_CELLS" /><port type="output" name="lutff_1/out"/></direct>
+  <direct><port type="input" name="O2" from="PLB_CELLS" /><port type="output" name="lutff_2/out"/></direct>
+  <direct><port type="input" name="O3" from="PLB_CELLS" /><port type="output" name="lutff_3/out"/></direct>
+  <direct><port type="input" name="O4" from="PLB_CELLS" /><port type="output" name="lutff_4/out"/></direct>
+  <direct><port type="input" name="O5" from="PLB_CELLS" /><port type="output" name="lutff_5/out"/></direct>
+  <direct><port type="input" name="O6" from="PLB_CELLS" /><port type="output" name="lutff_6/out"/></direct>
+  <direct><port type="input" name="O7" from="PLB_CELLS" /><port type="output" name="lutff_7/out"/></direct>
 
   <!-- Fast Carry chain
-  <direct><port type="input" name="FCIN"/><port type="output" name="FCIN" from="BLK_IG-PLB" /></direct>
-  <direct><port type="input" name="FCOUT" from="BLK_IG-PLB" /><port type="output" name="FCOUT"/></direct>
+  <direct><port type="input" name="FCIN"/><port type="output" name="FCIN" from="PLB_CELLS" /></direct>
+  <direct><port type="input" name="FCOUT" from="PLB_CELLS" /><port type="output" name="FCOUT"/></direct>
        -->
   <direct>
-   <port type="input" name="FCIN"/><port type="output" name="FCIN" from="BLK_IG-PLB" />
+   <port type="input" name="FCIN"/><port type="output" name="FCIN" from="PLB_CELLS" />
   </direct>
   <direct>
-   <port type="input" name="FCOUT" from="BLK_IG-PLB" /><port type="output" name="FCOUT"/>
+   <port type="input" name="FCOUT" from="PLB_CELLS" /><port type="output" name="FCOUT"/>
   </direct>
 
  </interconnect>
  <pinlocations pattern="custom">
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-PLB.lutff_0/in
-   BLK_TL-PLB.lutff_1/in
-   BLK_TL-PLB.lutff_2/in
-   BLK_TL-PLB.lutff_3/in
-   BLK_TL-PLB.lutff_4/in
-   BLK_TL-PLB.lutff_5/in
-   BLK_TL-PLB.lutff_6/in
-   BLK_TL-PLB.lutff_7/in
+   PLB.lutff_0/in
+   PLB.lutff_1/in
+   PLB.lutff_2/in
+   PLB.lutff_3/in
+   PLB.lutff_4/in
+   PLB.lutff_5/in
+   PLB.lutff_6/in
+   PLB.lutff_7/in
 
-   BLK_TL-PLB.lutff_global/clk
-   BLK_TL-PLB.lutff_global/cen
-   BLK_TL-PLB.lutff_global/s_r
-   BLK_TL-PLB.lutff_0/out
-   BLK_TL-PLB.lutff_1/out
-   BLK_TL-PLB.lutff_2/out
-   BLK_TL-PLB.lutff_3/out
-   BLK_TL-PLB.lutff_4/out
-   BLK_TL-PLB.lutff_5/out
-   BLK_TL-PLB.lutff_6/out
-   BLK_TL-PLB.lutff_7/out
+   PLB.lutff_global/clk
+   PLB.lutff_global/cen
+   PLB.lutff_global/s_r
+   PLB.lutff_0/out
+   PLB.lutff_1/out
+   PLB.lutff_2/out
+   PLB.lutff_3/out
+   PLB.lutff_4/out
+   PLB.lutff_5/out
+   PLB.lutff_6/out
+   PLB.lutff_7/out
   </loc>
   <loc side="top" xoffset="0" yoffset="0">
-   BLK_TL-PLB.FCIN
+   PLB.FCIN
   </loc>
   <loc side="bottom" xoffset="0" yoffset="0">
-   BLK_TL-PLB.FCOUT
+   PLB.FCOUT
   </loc>
  </pinlocations>
 
@@ -118,6 +118,7 @@
   <fc_override fc_type="frac" fc_val="0.0" port_name="FCIN"  />
  </fc>
  <metadata>
-  <meta name="hlc_tile">logic_tile</meta>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
  </metadata>
 </pb_type>

--- a/ice40/devices/top-routing-virt/tiles/ram/ram.pb_type.xml
+++ b/ice40/devices/top-routing-virt/tiles/ram/ram.pb_type.xml
@@ -2,7 +2,7 @@
 <!-- A diagram for the iCE40 PLB "Block RAM" is shown in;
       http://www.latticesemi.com/~/media/LatticeSemi/Documents/DataSheets/iCE/iCE40LPHXFamilyDataSheet.pdf
   -->
-<pb_type name="BLK_TL-RAM" height="2" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="RAM" height="2" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- Read port -->
  <output name="RDATA" num_pins="16"/>
  <input  name="RADDR"  num_pins="11"/>
@@ -121,29 +121,29 @@
  <pinlocations pattern="custom">
   <!-- RAM Tile -->
    <loc side="right" xoffset="0" yoffset="1">
-   BLK_TL-RAM.RDATA[8:15]
-   BLK_TL-RAM.MASK[8:15]
-   BLK_TL-RAM.WDATA[8:15]
-   BLK_TL-RAM.RADDR
-   BLK_TL-RAM.RCLKE
-   BLK_TL-RAM.RCLK
-   BLK_TL-RAM.RE
+   RAM.RDATA[8:15]
+   RAM.MASK[8:15]
+   RAM.WDATA[8:15]
+   RAM.RADDR
+   RAM.RCLKE
+   RAM.RCLK
+   RAM.RE
   </loc>
   <loc side="right" xoffset="0" yoffset="0">
-   BLK_TL-RAM.RDATA[0:7]
-   BLK_TL-RAM.MASK[0:7]
-   BLK_TL-RAM.WDATA[0:7]
-   BLK_TL-RAM.WADDR
-   BLK_TL-RAM.WCLKE
-   BLK_TL-RAM.WCLK
-   BLK_TL-RAM.WE
+   RAM.RDATA[0:7]
+   RAM.MASK[0:7]
+   RAM.WDATA[0:7]
+   RAM.WADDR
+   RAM.WCLKE
+   RAM.WCLK
+   RAM.WE
   </loc>
  </pinlocations>
 
-  <switchblock_locations pattern="external_full_internal_straight"/>
+ <switchblock_locations pattern="external_full_internal_straight"/>
  <metadata>
-   <meta name="hlc_tile" x_offset="0" y_offset="1">ramt_tile</meta>
-   <meta name="hlc_tile" x_offset="0" y_offset="0">ramb_tile</meta>
+   <meta name="type">block</meta>
+   <meta name="subtype">tile</meta>
  </metadata>
 </pb_type>
 <!-- End RAM -->

--- a/ice40/primitives/sb_ff/sb_ff.pb_type.xml
+++ b/ice40/primitives/sb_ff/sb_ff.pb_type.xml
@@ -1,6 +1,6 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <!-- Flip flop found inside the iCE40 -->
-<pb_type name="BEL_FF-SB_FF" num_pb="1">
+<pb_type name="SB_FF" num_pb="1">
  <clock  name="PCLK"        num_pins="1"/>
  <clock  name="NCLK"        num_pins="1"/>
  <clock  name="PCLK+CEN"    num_pins="1"/>
@@ -31,7 +31,7 @@
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="VPR_FF" name="clk"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="VPR_FF" name="D"/>
-    <pack_pattern name="LUT+FFA" in_port="BEL_FF-SB_FF.D" out_port="VPR_FF.D" />
+    <pack_pattern name="LUT+FFA" in_port="SB_FF.D" out_port="VPR_FF.D" />
    </direct>
    <direct><port type="input" from="VPR_FF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -58,7 +58,7 @@
   <interconnect>
    <direct><port type="input" name="PCLK"/><port type="output" from="SB_DFF" name="C"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFF" name="D"/>
-    <pack_pattern name="LUT+FFB" in_port="BEL_FF-SB_FF.D" out_port="SB_DFF.D" />
+    <pack_pattern name="LUT+FFB" in_port="SB_FF.D" out_port="SB_DFF.D" />
    </direct>
    <direct><port type="input" from="SB_DFF" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -88,7 +88,7 @@
    <direct><port type="input" name="PCLK+CEN"/><port type="output" from="SB_DFFE" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFE" name="E"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFE" name="D"/>
-    <pack_pattern name="LUT+FFC" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFE.D" />
+    <pack_pattern name="LUT+FFC" in_port="SB_FF.D" out_port="SB_DFFE.D" />
    </direct>
    <direct><port type="input" from="SB_DFFE" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -124,7 +124,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFER" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFER" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFER" name="D"/>
-    <pack_pattern name="LUT+FFD" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFER.D" />
+    <pack_pattern name="LUT+FFD" in_port="SB_FF.D" out_port="SB_DFFER.D" />
    </direct>
    <direct><port type="input" from="SB_DFFER" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -161,7 +161,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFES" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFES" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFES" name="D"/>
-    <pack_pattern name="LUT+FFE" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFES.D" />
+    <pack_pattern name="LUT+FFE" in_port="SB_FF.D" out_port="SB_DFFES.D" />
    </direct>
    <direct><port type="input" from="SB_DFFES" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -194,7 +194,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFESR" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFESR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFESR" name="D"/>
-    <pack_pattern name="LUT+FFF" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFESR.D" />
+    <pack_pattern name="LUT+FFF" in_port="SB_FF.D" out_port="SB_DFFESR.D" />
    </direct>
    <direct><port type="input" from="SB_DFFESR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -230,7 +230,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFESS" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFESS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFESS" name="D"/>
-    <pack_pattern name="LUT+FFG" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFESS.D" />
+    <pack_pattern name="LUT+FFG" in_port="SB_FF.D" out_port="SB_DFFESS.D" />
    </direct>
    <direct><port type="input" from="SB_DFFESS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -263,7 +263,7 @@
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFR" name="D"/>
-    <pack_pattern name="LUT+FFH" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFR.D" />
+    <pack_pattern name="LUT+FFH" in_port="SB_FF.D" out_port="SB_DFFR.D" />
    </direct>
    <direct><port type="input" from="SB_DFFR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -297,7 +297,7 @@
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFS" name="D"/>
-    <pack_pattern name="LUT+FFI" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFS.D" />
+    <pack_pattern name="LUT+FFI" in_port="SB_FF.D" out_port="SB_DFFS.D" />
    </direct>
    <direct><port type="input" from="SB_DFFS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -327,7 +327,7 @@
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFSR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFSR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFSR" name="D"/>
-    <pack_pattern name="LUT+FFJ" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFSR.D" />
+    <pack_pattern name="LUT+FFJ" in_port="SB_FF.D" out_port="SB_DFFSR.D" />
    </direct>
    <direct><port type="input" from="SB_DFFSR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -360,7 +360,7 @@
    <direct><port type="input" name="PCLK+SR"/><port type="output" from="SB_DFFSS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFSS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFSS" name="D"/>
-    <pack_pattern name="LUT+FFK" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFSS.D" />
+    <pack_pattern name="LUT+FFK" in_port="SB_FF.D" out_port="SB_DFFSS.D" />
    </direct>
    <direct><port type="input" from="SB_DFFSS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -390,7 +390,7 @@
   <interconnect>
    <direct><port type="input" name="NCLK"/><port type="output" from="SB_DFFN" name="C" /></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFN" name="D" />
-    <pack_pattern name="LUT+FFL" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFN.D" />
+    <pack_pattern name="LUT+FFL" in_port="SB_FF.D" out_port="SB_DFFN.D" />
    </direct>
    <direct><port type="input" from="SB_DFFN" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -423,7 +423,7 @@
    <direct><port type="input" name="NCLK+CEN"/><port type="output" from="SB_DFFNE" name="C"/></direct>
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNE" name="E"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNE" name="D"/>
-    <pack_pattern name="LUT+FFM" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNE.D" />
+    <pack_pattern name="LUT+FFM" in_port="SB_FF.D" out_port="SB_DFFNE.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNE" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -459,7 +459,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNER" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNER" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNER" name="D"/>
-    <pack_pattern name="LUT+FFN" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNER.D" />
+    <pack_pattern name="LUT+FFN" in_port="SB_FF.D" out_port="SB_DFFNER.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNER" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -496,7 +496,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNES" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNES" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNES" name="D"/>
-    <pack_pattern name="LUT+FFO" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNES.D" />
+    <pack_pattern name="LUT+FFO" in_port="SB_FF.D" out_port="SB_DFFNES.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNES" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -532,7 +532,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESR" name="E"/></direct>
    <direct><port type="input" name="R"/><port type="output" from="SB_DFFNESR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESR" name="D"/>
-    <pack_pattern name="LUT+FFP" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNESR.D" />
+    <pack_pattern name="LUT+FFP" in_port="SB_FF.D" out_port="SB_DFFNESR.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNESR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -568,7 +568,7 @@
    <direct><port type="input" name="E"/><port type="output" from="SB_DFFNESS" name="E"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNESS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNESS" name="D"/>
-    <pack_pattern name="LUT+FFQ" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNESS.D" />
+    <pack_pattern name="LUT+FFQ" in_port="SB_FF.D" out_port="SB_DFFNESS.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNESS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -601,7 +601,7 @@
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNR" name="D"/>
-    <pack_pattern name="LUT+FFR" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNR.D" />
+    <pack_pattern name="LUT+FFR" in_port="SB_FF.D" out_port="SB_DFFNR.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -635,7 +635,7 @@
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNS" name="D"/>
-    <pack_pattern name="LUT+FFS" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNS.D" />
+    <pack_pattern name="LUT+FFS" in_port="SB_FF.D" out_port="SB_DFFNS.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -665,7 +665,7 @@
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNSR" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSR" name="R"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSR" name="D"/>
-    <pack_pattern name="LUT+FFT" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNSR.D" />
+    <pack_pattern name="LUT+FFT" in_port="SB_FF.D" out_port="SB_DFFNSR.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNSR" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
@@ -698,10 +698,13 @@
    <direct><port type="input" name="NCLK+SR"/><port type="output" from="SB_DFFNSS" name="C"/></direct>
    <direct><port type="input" name="S"/><port type="output" from="SB_DFFNSS" name="S"/></direct>
    <direct><port type="input" name="D"/><port type="output" from="SB_DFFNSS" name="D"/>
-    <pack_pattern name="LUT+FFU" in_port="BEL_FF-SB_FF.D" out_port="SB_DFFNSS.D" />
+    <pack_pattern name="LUT+FFU" in_port="SB_FF.D" out_port="SB_DFFNSS.D" />
    </direct>
    <direct><port type="input" from="SB_DFFNSS" name="Q" /><port type="output" name="Q"/></direct>
   </interconnect>
  </mode>
-
+ <metadata>
+  <meta name="type">bel</meta>
+  <meta name="subtype">flipflop</meta>
+ </metadata>
 </pb_type>

--- a/ice40/primitives/sb_io/sb_io.pb_type.xml
+++ b/ice40/primitives/sb_io/sb_io.pb_type.xml
@@ -10,43 +10,52 @@
 
  <!-- IO operating as an input -->
  <mode name="PAD_IS_INPUT">
-  <pb_type name="PAD_IN-INPUT" num_pb="1">
+  <pb_type name="INPUT" num_pb="1">
    <output name="D_IN" num_pins="2"/>
    <pb_type name="input" blif_model=".input" num_pb="1">
     <output name="inpad" num_pins="1"/>
    </pb_type>
    <interconnect>
-    <mux><port type="input" from="input" name="inpad"/><port type="output" from="PAD_IN-INPUT" name="D_IN[0]"/></mux>
-    <mux><port type="input" from="input" name="inpad"/><port type="output" from="PAD_IN-INPUT" name="D_IN[1]"/></mux>
+    <mux><port type="input" from="input" name="inpad"/><port type="output" from="INPUT" name="D_IN[0]"/></mux>
+    <mux><port type="input" from="input" name="inpad"/><port type="output" from="INPUT" name="D_IN[1]"/></mux>
    </interconnect>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">input</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" from="PAD_IN-INPUT" name="D_IN"/><port type="output" name="D_IN"/></direct>
+   <direct><port type="input" from="INPUT" name="D_IN"/><port type="output" name="D_IN"/></direct>
   </interconnect>
  </mode>
 
  <!-- IO operating as an output -->
  <mode name="PAD_IS_OUTPUT">
-  <pb_type name="PAD_IN-OUTPUT" num_pb="1">
+  <pb_type name="OUTPUT" num_pb="1">
    <input name="D_OUT" num_pins="2"/>
    <pb_type name="output" blif_model=".output" num_pb="1">
     <input name="outpad" num_pins="1"/>
    </pb_type>
    <interconnect>
     <mux>
-     <port type="input"  from="PAD_IN-OUTPUT" name="D_OUT[0]"/>
-     <port type="input"  from="PAD_IN-OUTPUT" name="D_OUT[1]"/>
+     <port type="input"  from="OUTPUT" name="D_OUT[0]"/>
+     <port type="input"  from="OUTPUT" name="D_OUT[1]"/>
      <port type="output" from="output" name="outpad"/>
     </mux>
    </interconnect>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">output</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="D_OUT"/><port type="output" from="PAD_IN-OUTPUT" name="D_OUT"/></direct>
+   <direct><port type="input" name="D_OUT"/><port type="output" from="OUTPUT" name="D_OUT"/></direct>
   </interconnect>
  </mode>
 
  <metadata>
-  <meta name="hlc_name">io</meta>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
  </metadata>
 
 </pb_type>

--- a/ice40/primitives/sb_lut/sb_lut.pb_type.xml
+++ b/ice40/primitives/sb_lut/sb_lut.pb_type.xml
@@ -1,6 +1,6 @@
 <!-- set: ai sw=1 ts=1 sta et -->
 <!-- 4 input LUT found in the ICE40 -->
-<pb_type name="BEL_LT-LUT" num_pb="1">
+<pb_type name="LUT" num_pb="1">
  <input  name="in" num_pins="4" />
  <output name="out" num_pins="1" />
  <!--
@@ -8,62 +8,74 @@
     through the LUT.
  -->
  <mode name="VPR_LUT4">
-  <pb_type name="BLK_IG-LUT4" num_pb="1" class="lut" blif_model=".names">
+  <pb_type name="LUT4" num_pb="1" class="lut" blif_model=".names">
    <input  name="in"  num_pins="4" port_class="lut_in" />
    <output name="out" num_pins="1" port_class="lut_out" />
-   <delay_matrix type="max" in_port="BLK_IG-LUT4.in" out_port="BLK_IG-LUT4.out">
+   <delay_matrix type="max" in_port="LUT4.in" out_port="LUT4.out">
     10e-12
     10e-12
     10e-12
     10e-12
    </delay_matrix>
+   <metadata>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="in"/><port type="output" from="BLK_IG-LUT4" name="in"/></direct>
-   <direct><port type="input" from="BLK_IG-LUT4" name="out"/><port type="output" name="out"/>
-    <pack_pattern name="LUT+FFA" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFB" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFC" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFD" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFE" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFF" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFG" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFH" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFI" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFJ" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFK" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFL" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFM" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFN" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFO" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFP" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFQ" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFR" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFS" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFT" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
-    <pack_pattern name="LUT+FFU" in_port="BLK_IG-LUT4.out" out_port="BEL_LT-LUT.out"/>
+   <direct><port type="input" name="in"/><port type="output" from="LUT4" name="in"/></direct>
+   <direct><port type="input" from="LUT4" name="out"/><port type="output" name="out"/>
+    <pack_pattern name="LUT+FFA" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFB" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFC" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFD" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFE" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFF" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFG" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFH" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFI" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFJ" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFK" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFL" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFM" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFN" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFO" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFP" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFQ" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFR" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFS" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFT" in_port="LUT4.out" out_port="LUT.out"/>
+    <pack_pattern name="LUT+FFU" in_port="LUT4.out" out_port="LUT.out"/>
    </direct>
   </interconnect>
  </mode>
  <mode name="SB_LUT4">
-  <pb_type name="BLK_IG-SB_LUT4" num_pb="1" blif_model=".subckt SB_LUT4">
+  <pb_type name="SB_LUT4" num_pb="1" blif_model=".subckt SB_LUT4">
    <input  name="I0" num_pins="1" />
    <input  name="I1" num_pins="1" />
    <input  name="I2" num_pins="1" />
    <input  name="I3" num_pins="1" />
    <output name="O"  num_pins="1" />
-   <delay_constant max="10e-12" in_port="BLK_IG-SB_LUT4.I0" out_port="BLK_IG-SB_LUT4.O"/>
-   <delay_constant max="10e-12" in_port="BLK_IG-SB_LUT4.I1" out_port="BLK_IG-SB_LUT4.O"/>
-   <delay_constant max="10e-12" in_port="BLK_IG-SB_LUT4.I2" out_port="BLK_IG-SB_LUT4.O"/>
-   <delay_constant max="10e-12" in_port="BLK_IG-SB_LUT4.I3" out_port="BLK_IG-SB_LUT4.O"/>
+   <delay_constant max="10e-12" in_port="SB_LUT4.I0" out_port="SB_LUT4.O"/>
+   <delay_constant max="10e-12" in_port="SB_LUT4.I1" out_port="SB_LUT4.O"/>
+   <delay_constant max="10e-12" in_port="SB_LUT4.I2" out_port="SB_LUT4.O"/>
+   <delay_constant max="10e-12" in_port="SB_LUT4.I3" out_port="SB_LUT4.O"/>
+   <metadata>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct><port type="input" name="in[0]"/><port type="output" from="BLK_IG-SB_LUT4" name="I0"/></direct>
-   <direct><port type="input" name="in[1]"/><port type="output" from="BLK_IG-SB_LUT4" name="I1"/></direct>
-   <direct><port type="input" name="in[2]"/><port type="output" from="BLK_IG-SB_LUT4" name="I2"/></direct>
-   <direct><port type="input" name="in[3]"/><port type="output" from="BLK_IG-SB_LUT4" name="I3"/></direct>
-   <direct><port type="input" from="BLK_IG-SB_LUT4" name="O"/><port type="output" name="out"/>
+   <direct><port type="input" name="in[0]"/><port type="output" from="SB_LUT4" name="I0"/></direct>
+   <direct><port type="input" name="in[1]"/><port type="output" from="SB_LUT4" name="I1"/></direct>
+   <direct><port type="input" name="in[2]"/><port type="output" from="SB_LUT4" name="I2"/></direct>
+   <direct><port type="input" name="in[3]"/><port type="output" from="SB_LUT4" name="I3"/></direct>
+   <direct><port type="input" from="SB_LUT4" name="O"/><port type="output" name="out"/>
    </direct>
   </interconnect>
  </mode>
+ <metadata>
+  <meta name="type">bel</meta>
+  <meta name="subtype">lut</meta>
+ </metadata>
 </pb_type>

--- a/ice40/utils/ice40_generate_routing.py
+++ b/ice40/utils/ice40_generate_routing.py
@@ -575,9 +575,9 @@ def create_tracks(g, verbose=False):
         print()
         # --------------------------------------------------------
 
-        if tname == "BLK_TL-PLB":
+        if tname == "PLB":
             tracks = plb_tracks
-        elif tname.startswith("BLK_TL-PIO"):
+        elif tname.startswith("PIO"):
             tracks = io_tracks
 
         for d in tracks:

--- a/ice40/utils/ice40_import_layout_from_icebox.py
+++ b/ice40/utils/ice40_import_layout_from_icebox.py
@@ -103,12 +103,12 @@ for name, pins in icebox.pinloc_db.items():
         if (x, y) in get_corner_tiles(ic):
             return None, {}
         if tt == "RAMB":
-            return "BLK_TL-RAM", metadata
+            return "RAM", metadata
         if tt == "RAMT":
             return SKIP, {}
         if tt.startswith("DSP"):
             if tt.endswith("0"):
-                return "BLK_TL-DSP", metadata
+                return "DSP", metadata
             return SKIP, {}
         if tt == "IO":
             padin = ic.padin_pio_db()
@@ -141,9 +141,9 @@ for name, pins in icebox.pinloc_db.items():
                         metadata.get("hlc_latch_io", ""), name
                     )
                 )
-            return "BLK_TL-PIO", metadata
+            return "PIO", metadata
         if tt == "LOGIC":
-            return "BLK_TL-PLB", metadata
+            return "PLB", metadata
         return None, {}
         assert False, tt
 

--- a/ice40/utils/ice40_import_routing_from_icebox.py
+++ b/ice40/utils/ice40_import_routing_from_icebox.py
@@ -375,48 +375,48 @@ def add_pin_aliases(g, ic):
     """Create icebox local names from the architecture pin names."""
     name_rr2local = {}
 
-    # BLK_TL-PLB - http://www.clifford.at/icestorm/logic_tile.html
-    name_rr2local['BLK_TL-PLB.lutff_global/s_r[0]'] = 'lutff_global/s_r'
-    name_rr2local['BLK_TL-PLB.lutff_global/clk[0]'] = 'lutff_global/clk'
-    name_rr2local['BLK_TL-PLB.lutff_global/cen[0]'] = 'lutff_global/cen'
+    # PLB - http://www.clifford.at/icestorm/logic_tile.html
+    name_rr2local['PLB.lutff_global/s_r[0]'] = 'lutff_global/s_r'
+    name_rr2local['PLB.lutff_global/clk[0]'] = 'lutff_global/clk'
+    name_rr2local['PLB.lutff_global/cen[0]'] = 'lutff_global/cen'
     # FIXME: these two are wrong I think, but don't worry about carry for now
-    #name_rr2local['BLK_TL-PLB.FCIN[0]'] = 'lutff_0/cin'
-    #name_rr2local['BLK_TL-PLB.FCOUT[0]'] = 'lutff_7/cout'
-    #name_rr2local['BLK_TL-PLB.lutff_0_cin[0]'] = 'lutff_0/cin'
-    #name_rr2local['BLK_TL-PLB.lutff_7_cout[0]'] = 'lutff_7/cout'
+    #name_rr2local['PLB.FCIN[0]'] = 'lutff_0/cin'
+    #name_rr2local['PLB.FCOUT[0]'] = 'lutff_7/cout'
+    #name_rr2local['PLB.lutff_0_cin[0]'] = 'lutff_0/cin'
+    #name_rr2local['PLB.lutff_7_cout[0]'] = 'lutff_7/cout'
     for luti in range(8):
-        name_rr2local['BLK_TL-PLB.lutff_{}/out[0]'.format(luti)
+        name_rr2local['PLB.lutff_{}/out[0]'.format(luti)
                       ] = 'lutff_{}/out'.format(luti)
         for lut_input in range(4):
-            name_rr2local['BLK_TL-PLB.lutff_{}/in[{}]'.format(luti, lut_input)
+            name_rr2local['PLB.lutff_{}/in[{}]'.format(luti, lut_input)
                           ] = 'lutff_{}/in_{}'.format(luti, lut_input)
 
-    name_rr2local['BLK_TL-PLB.FCOUT[0]'] = 'lutff_0/cout'
+    name_rr2local['PLB.FCOUT[0]'] = 'lutff_0/cout'
 
-    # BLK_TL-PIO - http://www.clifford.at/icestorm/io_tile.html
+    # PIO - http://www.clifford.at/icestorm/io_tile.html
     for blocki in range(2):
-        name_rr2local['BLK_TL-PIO.[{}]LATCH[0]'.format(blocki)
+        name_rr2local['PIO.[{}]LATCH[0]'.format(blocki)
                       ] = 'io_{}/latch'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]OUTCLK[0]'.format(blocki)
+        name_rr2local['PIO.[{}]OUTCLK[0]'.format(blocki)
                       ] = 'io_{}/outclk'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]CEN[0]'.format(blocki)
+        name_rr2local['PIO.[{}]CEN[0]'.format(blocki)
                       ] = 'io_{}/cen'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]INCLK[0]'.format(blocki)
+        name_rr2local['PIO.[{}]INCLK[0]'.format(blocki)
                       ] = 'io_{}/inclk'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]D_IN[0]'.format(blocki)
+        name_rr2local['PIO.[{}]D_IN[0]'.format(blocki)
                       ] = 'io_{}/D_IN_0'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]D_IN[1]'.format(blocki)
+        name_rr2local['PIO.[{}]D_IN[1]'.format(blocki)
                       ] = 'io_{}/D_IN_1'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]D_OUT[0]'.format(blocki)
+        name_rr2local['PIO.[{}]D_OUT[0]'.format(blocki)
                       ] = 'io_{}/D_OUT_0'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]D_OUT[1]'.format(blocki)
+        name_rr2local['PIO.[{}]D_OUT[1]'.format(blocki)
                       ] = 'io_{}/D_OUT_1'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]OUT_ENB[0]'.format(blocki)
+        name_rr2local['PIO.[{}]OUT_ENB[0]'.format(blocki)
                       ] = 'io_{}/OUT_ENB'.format(blocki)
-        name_rr2local['BLK_TL-PIO.[{}]PACKAGE_PIN[0]'.format(blocki)
+        name_rr2local['PIO.[{}]PACKAGE_PIN[0]'.format(blocki)
                       ] = 'io_{}/pin'.format(blocki)
 
-    # BLK_TL-RAM - http://www.clifford.at/icestorm/ram_tile.html
+    # RAM - http://www.clifford.at/icestorm/ram_tile.html
     for top_bottom in 'BT':
         # rdata, wdata, and mask ranges are the same based on Top/Bottom
         if top_bottom == 'T':
@@ -430,10 +430,10 @@ def add_pin_aliases(g, ic):
 
         def add_ram_pin(rw, sig, ind=None):
             if ind is None:
-                name_rr2local['BLK_TL-RAM.{}{}[{}]'.format(rw, sig, 0)
+                name_rr2local['RAM.{}{}[{}]'.format(rw, sig, 0)
                               ] = 'ram/{}{}'.format(rw, sig)
             else:
-                name_rr2local['BLK_TL-RAM.{}{}[{}]'.format(rw, sig, ind)
+                name_rr2local['RAM.{}{}[{}]'.format(rw, sig, ind)
                               ] = 'ram/{}{}_{}'.format(rw, sig, ind)
 
         add_ram_pin(rw, 'CLK')
@@ -448,7 +448,7 @@ def add_pin_aliases(g, ic):
             add_ram_pin('W', 'DATA', ind)
             add_ram_pin('', 'MASK', ind)
 
-    # BLK_TL-RAM
+    # RAM
     for top_bottom in 'BT':
         # rdata, wdata, and mask ranges are the same based on Top/Bottom
         if top_bottom == 'T':
@@ -462,10 +462,10 @@ def add_pin_aliases(g, ic):
 
         def add_ram_pin(rw, sig, ind=None):
             if ind is None:
-                name_rr2local['BLK_TL-RAM.{}{}[{}]'.format(rw, sig, 0)
+                name_rr2local['RAM.{}{}[{}]'.format(rw, sig, 0)
                               ] = 'ram/{}{}'.format(rw, sig)
             else:
-                name_rr2local['BLK_TL-RAM.{}{}[{}]'.format(rw, sig, ind)
+                name_rr2local['RAM.{}{}[{}]'.format(rw, sig, ind)
                               ] = 'ram/{}{}_{}'.format(rw, sig, ind)
 
         add_ram_pin(rw, 'CLK')

--- a/testarch/devices/clutff-bidir-s4/arch.xml
+++ b/testarch/devices/clutff-bidir-s4/arch.xml
@@ -12,7 +12,7 @@
   <xi:include href="../../tiles/clutff/clutff.pb_type.xml"/>
  </complexblocklist>
  <directlist>
-  <direct name="carry" from_pin="BLK_TI-TILE.COUT" to_pin="BLK_TI-TILE.CIN" x_offset="0" y_offset="1" z_offset="0"/>
+  <direct name="carry" from_pin="TILE.COUT" to_pin="TILE.CIN" x_offset="0" y_offset="1" z_offset="0"/>
  </directlist>
 
  <xi:include href="../routing/bidir-s4.xml" xpointer="xpointer(architecture/child::node())" />

--- a/testarch/devices/clutff-unidir-s4/arch.xml
+++ b/testarch/devices/clutff-unidir-s4/arch.xml
@@ -16,7 +16,7 @@
   <xi:include href="../../tiles/const/vcc.pb_type.xml"/>
  </complexblocklist>
  <directlist>
-  <direct name="carry" from_pin="BLK_TI-TILE.COUT" to_pin="BLK_TI-TILE.CIN" x_offset="0" y_offset="1" z_offset="0"/>
+  <direct name="carry" from_pin="TILE.COUT" to_pin="TILE.CIN" x_offset="0" y_offset="1" z_offset="0"/>
  </directlist>
 
  <xi:include href="../routing/unidir-s4.xml" xpointer="xpointer(architecture/child::node())" />

--- a/testarch/devices/ff1/arch.xml
+++ b/testarch/devices/ff1/arch.xml
@@ -8,19 +8,19 @@
  <layout>
   <fixed_layout name="2x4" width="8" height="6">
 
-   <col type="EMPTY"          startx="0" priority="10" />
-   <col type="BLK_BB-VPR_PAD" startx="1" priority="10" />
-   <col type="EMPTY"          startx="2" priority="10" />
+   <col type="EMPTY"   startx="0" priority="10" />
+   <col type="VPR_PAD" startx="1" priority="10" />
+   <col type="EMPTY"   startx="2" priority="10" />
 
-   <col type="BLK_TI-FF1"     startx="3" priority="10" />
-   <col type="BLK_TI-FF1"     startx="4" priority="10" />
+   <col type="FF1"     startx="3" priority="10" />
+   <col type="FF1"     startx="4" priority="10" />
 
-   <col type="EMPTY"          startx="5" priority="10" />
-   <col type="BLK_BB-VPR_PAD" startx="6" priority="10" />
-   <col type="EMPTY"          startx="7" priority="10" />
+   <col type="EMPTY"   startx="5" priority="10" />
+   <col type="VPR_PAD" startx="6" priority="10" />
+   <col type="EMPTY"   startx="7" priority="10" />
 
-   <row type="EMPTY"          starty="0" priority="11" />
-   <row type="EMPTY"          starty="5" priority="11" />
+   <row type="EMPTY"   starty="0" priority="11" />
+   <row type="EMPTY"   starty="5" priority="11" />
 
   </fixed_layout>
  </layout>

--- a/testarch/devices/layouts/10x10.fixed_layout.xml
+++ b/testarch/devices/layouts/10x10.fixed_layout.xml
@@ -20,25 +20,25 @@
     1 ...IIIIIIIIII...
     0 ................
     -->
-    <fill      priority="1" type="BLK_TI-TILE" />
+    <fill      priority="1" type="TILE" />
     <perimeter priority="2" type="EMPTY" />
 
-    <col priority="3" startx="1"  type="BLK_IG-IBUF" />
-    <col priority="3" startx="14" type="BLK_IG-OBUF" />
+    <col priority="3" startx="1"  type="IBUF"  />
+    <col priority="3" startx="14" type="OBUF"  />
 
-    <row priority="4" starty="1"  type="BLK_IG-IBUF" />
-    <row priority="4" starty="14" type="BLK_IG-OBUF" />
+    <row priority="4" starty="1"  type="IBUF"  />
+    <row priority="4" starty="14" type="OBUF"  />
 
-    <col priority="5" startx="2"  type="EMPTY"       />
-    <col priority="5" startx="13" type="EMPTY"       />
+    <col priority="5" startx="2"  type="EMPTY" />
+    <col priority="5" startx="13" type="EMPTY" />
 
-    <row priority="6" starty="2"  type="EMPTY"       />
-    <row priority="6" starty="13" type="EMPTY"       />
+    <row priority="6" starty="2"  type="EMPTY" />
+    <row priority="6" starty="13" type="EMPTY" />
 
     <!-- Corners -->
-    <single priority="7" x="1" y="1"   type="BLK_TI-GND" />
-    <single priority="7" x="1" y="14"  type="BLK_TI-VCC" />
-    <single priority="7" x="14" y="1"  type="EMPTY"  />
-    <single priority="7" x="14" y="14" type="EMPTY"  />
+    <single priority="7" x="1" y="1"   type="GND"   />
+    <single priority="7" x="1" y="14"  type="VCC"   />
+    <single priority="7" x="14" y="1"  type="EMPTY" />
+    <single priority="7" x="14" y="14" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/layouts/1x1.fixed_layout.xml
+++ b/testarch/devices/layouts/1x1.fixed_layout.xml
@@ -7,16 +7,16 @@
     1 .I.X.O.
     0 .......
     -->
-  <col priority="10" startx="0" type="EMPTY"       />
-  <col priority="10" startx="1" type="BLK_IG-IBUF" />
-  <col priority="10" startx="2" type="EMPTY"       />
-  <col priority="10" startx="3" type="BLK_TI-TILE" />
-  <col priority="10" startx="4" type="EMPTY"       />
-  <col priority="10" startx="5" type="BLK_IG-OBUF" />
-  <col priority="10" startx="6" type="EMPTY"       />
+  <col priority="10" startx="0" type="EMPTY" />
+  <col priority="10" startx="1" type="IBUF"  />
+  <col priority="10" startx="2" type="EMPTY" />
+  <col priority="10" startx="3" type="TILE"  />
+  <col priority="10" startx="4" type="EMPTY" />
+  <col priority="10" startx="5" type="OBUF"  />
+  <col priority="10" startx="6" type="EMPTY" />
 
-  <row priority="11" starty="2" type="EMPTY"       />
-  <!--               starty="1"                   -->
-  <row priority="11" starty="0" type="EMPTY"       />
+  <row priority="11" starty="2" type="EMPTY" />
+  <!--               starty="1"             -->
+  <row priority="11" starty="0" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/layouts/1x1.min.fixed_layout.xml
+++ b/testarch/devices/layouts/1x1.min.fixed_layout.xml
@@ -7,13 +7,13 @@
     1 IXO.
     0 ....
     -->
-  <col priority="10" startx="0" type="BLK_IG-IBUF" />
-  <col priority="10" startx="1" type="BLK_TI-TILE" />
-  <col priority="10" startx="2" type="BLK_IG-OBUF" />
-  <col priority="10" startx="3" type="EMPTY"       />
+  <col priority="10" startx="0" type="IBUF"  />
+  <col priority="10" startx="1" type="TILE"  />
+  <col priority="10" startx="2" type="OBUF"  />
+  <col priority="10" startx="3" type="EMPTY" />
 
-  <row priority="11" starty="2" type="EMPTY"       />
-  <!--               starty="1"                   -->
-  <row priority="11" starty="0" type="EMPTY"       />
+  <row priority="11" starty="2" type="EMPTY" />
+  <!--               starty="1"             -->
+  <row priority="11" starty="0" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/layouts/1x2.fixed_layout.xml
+++ b/testarch/devices/layouts/1x2.fixed_layout.xml
@@ -12,17 +12,17 @@
     1 .O.
     0 ...
     -->
-  <col priority="11" startx="0" type="EMPTY"       />
-  <!--               startx="1"                   -->
-  <col priority="11" startx="2" type="EMPTY"       />
+  <col priority="11" startx="0" type="EMPTY" />
+  <!--               startx="1"             -->
+  <col priority="11" startx="2" type="EMPTY" />
 
-  <row priority="10" starty="7" type="EMPTY"       />
-  <row priority="10" starty="6" type="BLK_IG-OBUF" />
-  <row priority="10" starty="5" type="EMPTY"       />
-  <row priority="10" starty="4" type="BLK_TI-TILE" />
-  <row priority="10" starty="3" type="BLK_TI-TILE" />
-  <row priority="10" starty="2" type="EMPTY"       />
-  <row priority="10" starty="1" type="BLK_IG-IBUF" />
-  <row priority="10" starty="0" type="EMPTY"       />
+  <row priority="10" starty="7" type="EMPTY" />
+  <row priority="10" starty="6" type="OBUF"  />
+  <row priority="10" starty="5" type="EMPTY" />
+  <row priority="10" starty="4" type="TILE"  />
+  <row priority="10" starty="3" type="TILE"  />
+  <row priority="10" starty="2" type="EMPTY" />
+  <row priority="10" starty="1" type="IBUF"  />
+  <row priority="10" starty="0" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/layouts/2x1.fixed_layout.xml
+++ b/testarch/devices/layouts/2x1.fixed_layout.xml
@@ -7,17 +7,17 @@
     1 .I.XX.O.
     0 ........
     -->
-  <col priority="10" startx="0" type="EMPTY"       />
-  <col priority="10" startx="1" type="BLK_IG-IBUF" />
-  <col priority="10" startx="2" type="EMPTY"       />
-  <col priority="10" startx="3" type="BLK_TI-TILE" />
-  <col priority="10" startx="4" type="BLK_TI-TILE" />
-  <col priority="10" startx="5" type="EMPTY"       />
-  <col priority="10" startx="6" type="BLK_IG-OBUF" />
-  <col priority="10" startx="7" type="EMPTY"       />
+  <col priority="10" startx="0" type="EMPTY" />
+  <col priority="10" startx="1" type="IBUF"  />
+  <col priority="10" startx="2" type="EMPTY" />
+  <col priority="10" startx="3" type="TILE"  />
+  <col priority="10" startx="4" type="TILE"  />
+  <col priority="10" startx="5" type="EMPTY" />
+  <col priority="10" startx="6" type="OBUF"  />
+  <col priority="10" startx="7" type="EMPTY" />
 
-  <row priority="11" starty="2" type="EMPTY"       />
-  <!--               starty="1"                   -->
-  <row priority="11" starty="0" type="EMPTY"       />
+  <row priority="11" starty="2" type="EMPTY" />
+  <!--               starty="1"             -->
+  <row priority="11" starty="0" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/layouts/2x4.fixed_layout.xml
+++ b/testarch/devices/layouts/2x4.fixed_layout.xml
@@ -10,20 +10,20 @@
     1 .I.XX.O.
     0 ........
     -->
-  <col priority="12" startx="0" type="EMPTY"       />
-  <col priority="10" startx="1" type="BLK_IG-IBUF" />
-  <col priority="10" startx="2" type="EMPTY"       />
-  <col priority="10" startx="3" type="BLK_TI-TILE" />
-  <col priority="10" startx="4" type="BLK_TI-TILE" />
-  <col priority="10" startx="5" type="EMPTY"       />
-  <col priority="10" startx="6" type="BLK_IG-OBUF" />
-  <col priority="12" startx="7" type="EMPTY"       />
+  <col priority="12" startx="0" type="EMPTY" />
+  <col priority="10" startx="1" type="IBUF"  />
+  <col priority="10" startx="2" type="EMPTY" />
+  <col priority="10" startx="3" type="TILE"  />
+  <col priority="10" startx="4" type="TILE"  />
+  <col priority="10" startx="5" type="EMPTY" />
+  <col priority="10" startx="6" type="OBUF"  />
+  <col priority="12" startx="7" type="EMPTY" />
 
-  <row priority="11" starty="5" type="EMPTY"       />
-  <!--               startx="4"                   -->
-  <!--               startx="3"                   -->
-  <!--               startx="2"                   -->
-  <!--               startx="1"                   -->
-  <row priority="11" starty="0" type="EMPTY"       />
+  <row priority="11" starty="5" type="EMPTY" />
+  <!--               startx="4"             -->
+  <!--               startx="3"             -->
+  <!--               startx="2"             -->
+  <!--               startx="1"             -->
+  <row priority="11" starty="0" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/layouts/4x4.fixed_layout.xml
+++ b/testarch/devices/layouts/4x4.fixed_layout.xml
@@ -14,32 +14,32 @@
     1 ...IIII...
     0 ..........
     -->
-  <col priority="12" startx="0" type="EMPTY"       />
-  <col priority="10" startx="1" type="BLK_IG-IBUF" />
-  <col priority="12" startx="2" type="EMPTY"       />
-  <col priority="10" startx="3" type="BLK_TI-TILE" />
-  <col priority="10" startx="4" type="BLK_TI-TILE" />
-  <col priority="10" startx="5" type="BLK_TI-TILE" />
-  <col priority="10" startx="6" type="BLK_TI-TILE" />
-  <col priority="12" startx="7" type="EMPTY"       />
-  <col priority="10" startx="8" type="BLK_IG-OBUF" />
-  <col priority="12" startx="9" type="EMPTY"       />
+  <col priority="12" startx="0" type="EMPTY" />
+  <col priority="10" startx="1" type="IBUF"  />
+  <col priority="12" startx="2" type="EMPTY" />
+  <col priority="10" startx="3" type="TILE"  />
+  <col priority="10" startx="4" type="TILE"  />
+  <col priority="10" startx="5" type="TILE"  />
+  <col priority="10" startx="6" type="TILE"  />
+  <col priority="12" startx="7" type="EMPTY" />
+  <col priority="10" startx="8" type="OBUF"  />
+  <col priority="12" startx="9" type="EMPTY" />
 
-  <row priority="11" starty="9" type="EMPTY"       />
-  <row priority="10" starty="8" type="BLK_IG-OBUF" />
-  <row priority="11" starty="7" type="EMPTY"       />
-  <!--               starty="6"                   -->
-  <!--               starty="5"                   -->
-  <!--               starty="4"                   -->
-  <!--               starty="3"                   -->
-  <row priority="11" starty="2" type="EMPTY"       />
-  <row priority="10" starty="1" type="BLK_IG-IBUF" />
-  <row priority="11" starty="0" type="EMPTY"       />
+  <row priority="11" starty="9" type="EMPTY" />
+  <row priority="10" starty="8" type="OBUF"  />
+  <row priority="11" starty="7" type="EMPTY" />
+  <!--               starty="6"             -->
+  <!--               starty="5"             -->
+  <!--               starty="4"             -->
+  <!--               starty="3"             -->
+  <row priority="11" starty="2" type="EMPTY" />
+  <row priority="10" starty="1" type="IBUF"  />
+  <row priority="11" starty="0" type="EMPTY" />
 
   <!-- Corners -->
-  <single priority="13" x="1" y="1" type="BLK_TI-GND" />
-  <single priority="13" x="1" y="8" type="BLK_TI-VCC" />
-  <single priority="13" x="8" y="8" type="EMPTY"   />
-  <single priority="13" x="8" y="1" type="EMPTY"   />
+  <single priority="13" x="1" y="1" type="GND"   />
+  <single priority="13" x="1" y="8" type="VCC"   />
+  <single priority="13" x="8" y="8" type="EMPTY" />
+  <single priority="13" x="8" y="1" type="EMPTY" />
  </fixed_layout>
 </layout>

--- a/testarch/devices/test2/arch.xml
+++ b/testarch/devices/test2/arch.xml
@@ -8,20 +8,20 @@
  <layout>
   <fixed_layout name="2x4" width="9" height="6">
 
-   <col type="EMPTY"          startx="0" priority="10" />
-   <col type="BLK_BB-VPR_PAD" startx="1" priority="10" />
-   <col type="EMPTY"          startx="2" priority="10" />
+   <col type="EMPTY"   startx="0" priority="10" />
+   <col type="VPR_PAD" startx="1" priority="10" />
+   <col type="EMPTY"   startx="2" priority="10" />
 
-   <col type="BLK_TI-TILE"    startx="3" priority="10" />
-   <col type="BLK_TI-TILE"    startx="4" priority="10" />
-   <col type="BLK_TI-TILE"    startx="5" priority="10" />
+   <col type="TILE"    startx="3" priority="10" />
+   <col type="TILE"    startx="4" priority="10" />
+   <col type="TILE"    startx="5" priority="10" />
 
-   <col type="EMPTY"          startx="6" priority="10" />
-   <col type="BLK_BB-VPR_PAD" startx="7" priority="10" />
-   <col type="EMPTY"          startx="8" priority="10" />
+   <col type="EMPTY"   startx="6" priority="10" />
+   <col type="VPR_PAD" startx="7" priority="10" />
+   <col type="EMPTY"   startx="8" priority="10" />
 
-   <row type="EMPTY"          starty="0" priority="11" />
-   <row type="EMPTY"          starty="5" priority="11" />
+   <row type="EMPTY"   starty="0" priority="11" />
+   <row type="EMPTY"   starty="5" priority="11" />
 
   </fixed_layout>
  </layout>
@@ -56,24 +56,24 @@
 
  <directlist>
   <!-- Top inputs -->
-  <direct name="00" from_pin="BLK_TI-TILE.OUT[3:3]" to_pin="BLK_TI-TILE.IN[2:2]"   x_offset="-1" y_offset="-1" z_offset="0"/>
-  <direct name="01" from_pin="BLK_TI-TILE.OUT[3:3]" to_pin="BLK_TI-TILE.IN[1:1]"   x_offset="0"  y_offset="-1" z_offset="0"/>
-  <direct name="02" from_pin="BLK_TI-TILE.OUT[3:3]" to_pin="BLK_TI-TILE.IN[0:0]"   x_offset="1"  y_offset="-1" z_offset="0"/>
+  <direct name="00" from_pin="TILE.OUT[3:3]" to_pin="TILE.IN[2:2]"   x_offset="-1" y_offset="-1" z_offset="0"/>
+  <direct name="01" from_pin="TILE.OUT[3:3]" to_pin="TILE.IN[1:1]"   x_offset="0"  y_offset="-1" z_offset="0"/>
+  <direct name="02" from_pin="TILE.OUT[3:3]" to_pin="TILE.IN[0:0]"   x_offset="1"  y_offset="-1" z_offset="0"/>
 
   <!-- Right inputs -->
-  <direct name="03" from_pin="BLK_TI-TILE.OUT[1:1]" to_pin="BLK_TI-TILE.IN[8:8]"   x_offset="1"  y_offset="-1" z_offset="0"/>
-  <direct name="04" from_pin="BLK_TI-TILE.OUT[1:1]" to_pin="BLK_TI-TILE.IN[7:7]"   x_offset="1"  y_offset="0"  z_offset="0"/>
-  <direct name="05" from_pin="BLK_TI-TILE.OUT[1:1]" to_pin="BLK_TI-TILE.IN[6:6]"   x_offset="1"  y_offset="1"  z_offset="0"/>
+  <direct name="03" from_pin="TILE.OUT[1:1]" to_pin="TILE.IN[8:8]"   x_offset="1"  y_offset="-1" z_offset="0"/>
+  <direct name="04" from_pin="TILE.OUT[1:1]" to_pin="TILE.IN[7:7]"   x_offset="1"  y_offset="0"  z_offset="0"/>
+  <direct name="05" from_pin="TILE.OUT[1:1]" to_pin="TILE.IN[6:6]"   x_offset="1"  y_offset="1"  z_offset="0"/>
 
   <!-- Bottom inputs -->
-  <direct name="06" from_pin="BLK_TI-TILE.OUT[0:0]" to_pin="BLK_TI-TILE.IN[11:11]" x_offset="-1" y_offset="1"  z_offset="0"/>
-  <direct name="07" from_pin="BLK_TI-TILE.OUT[0:0]" to_pin="BLK_TI-TILE.IN[10:10]" x_offset="0"  y_offset="1"  z_offset="0"/>
-  <direct name="08" from_pin="BLK_TI-TILE.OUT[0:0]" to_pin="BLK_TI-TILE.IN[9:9]"   x_offset="1"  y_offset="1"  z_offset="0"/>
+  <direct name="06" from_pin="TILE.OUT[0:0]" to_pin="TILE.IN[11:11]" x_offset="-1" y_offset="1"  z_offset="0"/>
+  <direct name="07" from_pin="TILE.OUT[0:0]" to_pin="TILE.IN[10:10]" x_offset="0"  y_offset="1"  z_offset="0"/>
+  <direct name="08" from_pin="TILE.OUT[0:0]" to_pin="TILE.IN[9:9]"   x_offset="1"  y_offset="1"  z_offset="0"/>
 
   <!-- Left inputs -->
-  <direct name="09" from_pin="BLK_TI-TILE.OUT[2:2]" to_pin="BLK_TI-TILE.IN[5:5]"   x_offset="-1" y_offset="-1" z_offset="0"/>
-  <direct name="10" from_pin="BLK_TI-TILE.OUT[2:2]" to_pin="BLK_TI-TILE.IN[4:4]"   x_offset="-1" y_offset="0"  z_offset="0"/>
-  <direct name="11" from_pin="BLK_TI-TILE.OUT[2:2]" to_pin="BLK_TI-TILE.IN[3:3]"   x_offset="-1" y_offset="1"  z_offset="0"/>
+  <direct name="09" from_pin="TILE.OUT[2:2]" to_pin="TILE.IN[5:5]"   x_offset="-1" y_offset="-1" z_offset="0"/>
+  <direct name="10" from_pin="TILE.OUT[2:2]" to_pin="TILE.IN[4:4]"   x_offset="-1" y_offset="0"  z_offset="0"/>
+  <direct name="11" from_pin="TILE.OUT[2:2]" to_pin="TILE.IN[3:3]"   x_offset="-1" y_offset="1"  z_offset="0"/>
 
  </directlist>
 </architecture>

--- a/testarch/primitives/const/gnd.pb_type.xml
+++ b/testarch/primitives/const/gnd.pb_type.xml
@@ -1,3 +1,7 @@
-<pb_type blif_model=".subckt GND" name="BLK_IG-GND" num_pb="1">
+<pb_type blif_model=".subckt GND" name="SRC_GND" num_pb="1">
   <output name="GND" num_pins="1"/>
+  <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">blackbox</meta>
+  </metadata>
 </pb_type>

--- a/testarch/primitives/const/vcc.pb_type.xml
+++ b/testarch/primitives/const/vcc.pb_type.xml
@@ -1,3 +1,7 @@
-<pb_type blif_model=".subckt VCC" name="BLK_IG-VCC" num_pb="1">
+<pb_type blif_model=".subckt VCC" name="SRC_VCC" num_pb="1">
   <output name="VCC" num_pins="1"/>
+  <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">blackbox</meta>
+  </metadata>
 </pb_type>

--- a/testarch/primitives/lutff/lutff.pb_type.xml
+++ b/testarch/primitives/lutff/lutff.pb_type.xml
@@ -1,20 +1,24 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_IG-LUTFF" num_pb="1">
-  <clock  name="C"  num_pins="1"/>
-  <input  name="I"  num_pins="4"/>
-  <output name="O"  num_pins="1"/>
-  <output name="LO" num_pins="1"/>
-  <xi:include href="../ff/ff.pb_type.xml"/>
-  <xi:include href="../lut/lut.pb_type.xml"/>
-  <interconnect>
-    <direct name="BEL_FF-FF_D"      input="BEL_LT-LUT.out"    output="BEL_FF-FF.D">
-      <pack_pattern name="LUT2FF" in_port="BEL_LT-LUT.out" out_port="BEL_FF-FF.D"/>
-    </direct>
-    <direct name="BEL_FF-FF_clk"    input="BLK_IG-LUTFF.C"    output="BEL_FF-FF.clk"   />
-    <direct name="BEL_LT-LUT.in[0]" input="BLK_IG-LUTFF.I[0]" output="BEL_LT-LUT.in[0]"/>
-    <direct name="BEL_LT-LUT.in[1]" input="BLK_IG-LUTFF.I[1]" output="BEL_LT-LUT.in[1]"/>
-    <direct name="BEL_LT-LUT.in[2]" input="BLK_IG-LUTFF.I[2]" output="BEL_LT-LUT.in[2]"/>
-    <direct name="BEL_LT-LUT.in[3]" input="BLK_IG-LUTFF.I[3]" output="BEL_LT-LUT.in[3]"/>
-    <mux    name="BLK_IG-LUTFF.O"   input="BEL_LT-LUT.out BEL_FF-FF.Q" output="BLK_IG-LUTFF.O" />
-    <direct name="BLK_IG-LUTFF.LO"  input="BEL_LT-LUT.out"    output="BLK_IG-LUTFF.LO" />
-  </interconnect>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="LUTFF" num_pb="1">
+ <clock  name="C"  num_pins="1"/>
+ <input  name="I"  num_pins="4"/>
+ <output name="O"  num_pins="1"/>
+ <output name="LO" num_pins="1"/>
+ <xi:include href="../ff/ff.pb_type.xml"/>
+ <xi:include href="../lut/lut.pb_type.xml"/>
+ <interconnect>
+  <direct name="FF_D"      input="LUT.out"    output="FF.D">
+   <pack_pattern name="LUT2FF" in_port="LUT.out" out_port="FF.D"/>
+  </direct>
+  <direct name="FF_clk"    input="LUTFF.C"      output="FF.clk"   />
+  <direct name="LUT.in[0]" input="LUTFF.I[0]"   output="LUT.in[0]"/>
+  <direct name="LUT.in[1]" input="LUTFF.I[1]"   output="LUT.in[1]"/>
+  <direct name="LUT.in[2]" input="LUTFF.I[2]"   output="LUT.in[2]"/>
+  <direct name="LUT.in[3]" input="LUTFF.I[3]"   output="LUT.in[3]"/>
+  <mux    name="LUTFF.O"   input="LUT.out FF.Q" output="LUTFF.O"  />
+  <direct name="LUTFF.LO"  input="LUT.out"      output="LUTFF.LO" />
+ </interconnect>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/clutff/clutff.pb_type.xml
+++ b/testarch/tiles/clutff/clutff.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-TILE">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="TILE">
  <!-- Tile Inputs -->
  <clock  name="CLK  " num_pins="2" />
  <input  name="IN   " num_pins="6" />
@@ -8,58 +8,66 @@
  <input  name="CIN  " num_pins="1" />
  <output name="COUT " num_pins="1" />
 
- <pb_type name="BLK_BB-CARRY" num_pb="1" blif_model=".subckt CARRY">
+ <pb_type name="CARRY" num_pb="1" blif_model=".subckt CARRY">
   <input  name="CIN"  num_pins="1"/>
   <input  name="LIN"  num_pins="1"/>
   <output name="COUT" num_pins="1"/>
-  <delay_constant max="0.068e-9" min="0.068e-9" in_port="BLK_BB-CARRY.CIN" out_port="BLK_BB-CARRY.COUT"/>
-  <delay_constant max="0.068e-9" min="0.068e-9" in_port="BLK_BB-CARRY.LIN" out_port="BLK_BB-CARRY.COUT"/>
+  <delay_constant max="0.068e-9" min="0.068e-9" in_port="CARRY.CIN" out_port="CARRY.COUT"/>
+  <delay_constant max="0.068e-9" min="0.068e-9" in_port="CARRY.LIN" out_port="CARRY.COUT"/>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">blackbox</meta>
+  </metadata>
  </pb_type>
 
  <!-- Internal LUTFF -->
- <pb_type name="BLK_SI-LUTFF" num_pb="1">
+ <pb_type name="SLICE" num_pb="1">
   <input  name="I"  num_pins="4"/>
   <clock  name="C"  num_pins="1"/>
   <output name="O"  num_pins="1"/>
   <output name="LO" num_pins="1"/>
   <xi:include href="../../primitives/lutff/lutff.pb_type.xml"/>
   <interconnect>
-   <direct name="BLK_IG-LUTFF.I[0]" input="BLK_SI-LUTFF.I[0]" output="BLK_IG-LUTFF.I[0]" />
-   <direct name="BLK_IG-LUTFF.I[1]" input="BLK_SI-LUTFF.I[1]" output="BLK_IG-LUTFF.I[1]" />
-   <direct name="BLK_IG-LUTFF.I[2]" input="BLK_SI-LUTFF.I[2]" output="BLK_IG-LUTFF.I[2]" />
-   <direct name="BLK_IG-LUTFF.I[3]" input="BLK_SI-LUTFF.I[3]" output="BLK_IG-LUTFF.I[3]" />
-   <direct name="BLK_IG-LUTFF.C"    input="BLK_SI-LUTFF.C"    output="BLK_IG-LUTFF.C"    />
-   <direct name="BLK_SI-LUTFF.O"    input="BLK_IG-LUTFF.O"    output="BLK_SI-LUTFF.O"    />
-   <direct name="BLK_SI-LUTFF.LO"   input="BLK_IG-LUTFF.LO"   output="BLK_SI-LUTFF.LO"   />
+   <direct name="LUTFF.I[0]" input="SLICE.I[0]" output="LUTFF.I[0]" />
+   <direct name="LUTFF.I[1]" input="SLICE.I[1]" output="LUTFF.I[1]" />
+   <direct name="LUTFF.I[2]" input="SLICE.I[2]" output="LUTFF.I[2]" />
+   <direct name="LUTFF.I[3]" input="SLICE.I[3]" output="LUTFF.I[3]" />
+   <direct name="LUTFF.C"    input="SLICE.C"    output="LUTFF.C"    />
+   <direct name="LUTFF.O"    input="LUTFF.O"    output="SLICE.O"    />
+   <direct name="LUTFF.LO"   input="LUTFF.LO"   output="SLICE.LO"   />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
 
  <interconnect>
   <!-- Clock input mux -->
-  <mux name="BEL_RX-CLK0.I[0]" input="BLK_TI-TILE.CLK[0] BLK_TI-TILE.CLK[1]" output="BLK_SI-LUTFF.C" />
+  <mux name="CLK0.I[0]" input="TILE.CLK[0] TILE.CLK[1]" output="SLICE.C" />
 
   <!-- Logic input muxes -->
-  <mux name="BEL_RX-IN0.I[0]" input="BLK_TI-TILE.IN[0] BLK_TI-TILE.IN[1] BLK_TI-TILE.CIN  " output="BLK_SI-LUTFF.I[0]" />
-  <mux name="BEL_RX-IN1.I[1]" input="BLK_TI-TILE.IN[1] BLK_TI-TILE.IN[2] BLK_TI-TILE.IN[3]" output="BLK_SI-LUTFF.I[1]" />
-  <mux name="BEL_RX-IN2.I[2]" input="BLK_TI-TILE.IN[2] BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4]" output="BLK_SI-LUTFF.I[2]" />
-  <mux name="BEL_RX-IN3.I[3]" input="BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4] BLK_TI-TILE.IN[5]" output="BLK_SI-LUTFF.I[3]" />
+  <mux name="IN0.I[0]" input="TILE.IN[0] TILE.IN[1] TILE.CIN  " output="SLICE.I[0]" />
+  <mux name="IN1.I[1]" input="TILE.IN[1] TILE.IN[2] TILE.IN[3]" output="SLICE.I[1]" />
+  <mux name="IN2.I[2]" input="TILE.IN[2] TILE.IN[3] TILE.IN[4]" output="SLICE.I[2]" />
+  <mux name="IN3.I[3]" input="TILE.IN[3] TILE.IN[4] TILE.IN[5]" output="SLICE.I[3]" />
 
   <!-- Output -->
-  <direct name="BLK_TI-TILE.OUT[0]" input="BLK_SI-LUTFF.O"    output="BLK_TI-TILE.OUT[0]" />
-  <direct name="BLK_TI-TILE.OUT[1]" input="BLK_SI-LUTFF.O"    output="BLK_TI-TILE.OUT[1]" />
+  <direct name="TILE.OUT[0]" input="SLICE.O"    output="TILE.OUT[0]" />
+  <direct name="TILE.OUT[1]" input="SLICE.O"    output="TILE.OUT[1]" />
 
-  <direct name="BLK_TI-TILE.CIN"    input="BLK_TI-TILE.CIN"  output="BLK_BB-CARRY.CIN">
-    <pack_pattern name="LUTFF.CARRY" in_port="BLK_TI-TILE.CIN" out_port="BLK_BB-CARRY.CIN"  />
+  <direct name="TILE.CIN"    input="TILE.CIN"  output="CARRY.CIN">
+    <pack_pattern name="SLICE.CARRY" in_port="TILE.CIN" out_port="CARRY.CIN"  />
   </direct>
-  <direct name="BLK_TI-TILE.LIN"    input="BLK_SI-LUTFF.LO"   output="BLK_BB-CARRY.LIN"    />
-  <direct name="BLK_TI-TILE.COUT"   input="BLK_BB-CARRY.COUT" output="BLK_TI-TILE.COUT">
-    <pack_pattern name="LUTFF.CARRY" in_port="BLK_BB-CARRY.COUT" out_port="BLK_TI-TILE.COUT" />
+  <direct name="TILE.LIN"    input="SLICE.LO"   output="CARRY.LIN"    />
+  <direct name="TILE.COUT"   input="CARRY.COUT" output="TILE.COUT">
+    <pack_pattern name="SLICE.CARRY" in_port="CARRY.COUT" out_port="TILE.COUT" />
   </direct>
  </interconnect>
  <pinlocations pattern="custom">
-  <loc side="top">BLK_TI-TILE.COUT</loc>
-  <loc side="right">BLK_TI-TILE.CLK[0] BLK_TI-TILE.CLK[1] BLK_TI-TILE.IN[0] BLK_TI-TILE.IN[1] BLK_TI-TILE.IN[2] BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4] BLK_TI-TILE.IN[5] BLK_TI-TILE.OUT[0] BLK_TI-TILE.OUT[1]</loc>
-  <loc side="bottom">BLK_TI-TILE.CIN</loc>
+  <loc side="top">TILE.COUT</loc>
+  <loc side="right">TILE.CLK[0] TILE.CLK[1] TILE.IN[0] TILE.IN[1] TILE.IN[2] TILE.IN[3] TILE.IN[4] TILE.IN[5] TILE.OUT[0] TILE.OUT[1]</loc>
+  <loc side="bottom">TILE.CIN</loc>
  </pinlocations>
  <fc in_type="abs" in_val="0" out_type="abs" out_val="0">
   <fc_override fc_type="abs" fc_val="2" segment_name="span"  />
@@ -67,4 +75,8 @@
   <fc_override fc_type="abs" fc_val="0" port_name="CIN"  />
   <fc_override fc_type="abs" fc_val="0" port_name="COUT" />
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/const/gnd.pb_type.xml
+++ b/testarch/tiles/const/gnd.pb_type.xml
@@ -1,15 +1,19 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-GND">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="GND">
  <!-- Tile Outputs -->
  <output name="GND" num_pins="1"  />
 
  <xi:include href="../../primitives/const/gnd.pb_type.xml"/>
  <interconnect>
-  <direct name="BLK_TI-GND.GND" input="BLK_IG-GND.GND" output="BLK_TI-GND.GND" />
+  <direct name="GND.GND" input="SRC_GND.GND" output="GND.GND" />
  </interconnect>
 
  <pinlocations pattern="custom">
-  <loc side="right">BLK_TI-GND.GND[0]</loc>
+  <loc side="right">GND.GND[0]</loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0"/>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/const/vcc.pb_type.xml
+++ b/testarch/tiles/const/vcc.pb_type.xml
@@ -1,15 +1,19 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-VCC">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="VCC">
  <!-- Tile Outputs -->
  <output name="VCC" num_pins="1"  />
 
  <xi:include href="../../primitives/const/vcc.pb_type.xml"/>
  <interconnect>
-  <direct name="BLK_TI-VCC.VCC" input="BLK_IG-VCC.VCC" output="BLK_TI-VCC.VCC" />
+  <direct name="VCC.VCC" input="SRC_VCC.VCC" output="VCC.VCC" />
  </interconnect>
 
  <pinlocations pattern="custom">
-  <loc side="right">BLK_TI-VCC.VCC[0]</loc>
+  <loc side="right">VCC.VCC[0]</loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0"/>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/ff-large/ff-large.pb_type.xml
+++ b/testarch/tiles/ff-large/ff-large.pb_type.xml
@@ -1,56 +1,68 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-TILE">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="TILE">
  <!-- Pins -->
  <input name="IN   " num_pins="2" />
  <clock name="CLK  " num_pins="2" />
  <output name="OUT " num_pins="1"  />
 
  <!-- Internal Slices -->
- <pb_type name="BLK_SI-FF_LARGE" num_pb="1">
+ <pb_type name="FF_LARGE" num_pb="1">
   <input  name="I" num_pins="1" equivalent="false"/>
   <clock  name="C" num_pins="1" equivalent="false"/>
   <output name="O" num_pins="1" equivalent="false"/>
   <xi:include href="../../primitives/ff/ff.pb_type.xml"/>
   <interconnect>
-   <direct name="BEL_FF-FF.D"   input="BLK_SI-FF_LARGE.I" output="BEL_FF-FF.D"   />
-   <direct name="BEL_FF-FF.clk" input="BLK_SI-FF_LARGE.C" output="BEL_FF-FF.clk" />
-   <direct name="BLK_SI-FF_LARGE.O"  input="BEL_FF-FF.Q"  output="BLK_SI-FF_LARGE.O"  />
+   <direct name="FF.D"   input="FF_LARGE.I" output="FF.D"   />
+   <direct name="FF.clk" input="FF_LARGE.C" output="FF.clk" />
+   <direct name="FF_LARGE.O"  input="FF.Q"  output="FF_LARGE.O"  />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
 
  <!-- Buffers -->
- <pb_type name="BEL_RX-IN0" num_pb="1">
+ <pb_type name="IN0" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN0.I[0] BEL_RX-IN0.I[1]" name="BEL_RX-IN0.O" output="BEL_RX-IN0.O" />
+   <mux input="IN0.I[0] IN0.I[1]" name="IN0.O" output="IN0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-CLK0" num_pb="1">
+ <pb_type name="CLK0" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-CLK0.I[0] BEL_RX-CLK0.I[1]" name="BEL_RX-CLK0.O" output="BEL_RX-CLK0.O" />
+   <mux input="CLK0.I[0] CLK0.I[1]" name="CLK0.O" output="CLK0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
  <interconnect>
   <!-- Clock input muxes -->
-  <direct input="BLK_TI-FF_LARGE.CLK[0]" name="BEL_RX-CLK0.I[0]" output="BEL_RX-CLK0.I[0]" />
-  <direct input="BLK_TI-FF_LARGE.CLK[1]" name="BEL_RX-CLK0.I[1]" output="BEL_RX-CLK0.I[1]" />
-  <direct input="BEL_RX-CLK0.O"     name="BLK_SI-FF_LARGE.C"     output="BLK_SI-FF_LARGE.C"     />
+  <direct input="FF_LARGE.CLK[0]" name="CLK0.I[0]"     output="CLK0.I[0]"     />
+  <direct input="FF_LARGE.CLK[1]" name="CLK0.I[1]"     output="CLK0.I[1]"     />
+  <direct input="CLK0.O"          name="FF_LARGE.C"    output="FF_LARGE.C"    />
 
   <!-- Logic input muxes -->
-  <direct input="BLK_TI-FF_LARGE.IN[0]"  name="BEL_RX-IN0.I[0]"   output="BEL_RX-IN0.I[0]" />
-  <direct input="BLK_TI-FF_LARGE.IN[1]"  name="BEL_RX-IN0.I[1]"   output="BEL_RX-IN0.I[1]" />
-  <direct input="BEL_RX-IN0.O"      name="BLK_SI-FF_LARGE.I[0]"   output="BLK_SI-FF_LARGE.I[0]" />
+  <direct input="FF_LARGE.IN[0]"  name="IN0.I[0]"      output="IN0.I[0]"      />
+  <direct input="FF_LARGE.IN[1]"  name="IN0.I[1]"      output="IN0.I[1]"      />
+  <direct input="IN0.O"           name="FF_LARGE.I[0]" output="FF_LARGE.I[0]" />
 
   <!-- Output muxes -->
-  <direct input="BLK_SI-FF_LARGE.O"      name="BLK_TI-FF_LARGE.OUT[0]" output="BLK_TI-FF_LARGE.OUT[0]" />
+  <direct input="FF_LARGE.O"      name="FF_LARGE.OUT[0]" output="FF_LARGE.OUT[0]" />
  </interconnect>
 
  <pinlocations pattern="custom">
-  <loc side="top">BLK_TI-FF_LARGE.IN[0] BLK_TI-FF_LARGE.CLK[0] BLK_TI-FF_LARGE.OUT[0]</loc>
-  <loc side="top" xoffset="1">BLK_TI-FF_LARGE.IN[1] BLK_TI-FF_LARGE.CLK[1]</loc>
+  <loc side="top">FF_LARGE.IN[0] FF_LARGE.CLK[0] FF_LARGE.OUT[0]</loc>
+  <loc side="top" xoffset="1">FF_LARGE.IN[1] FF_LARGE.CLK[1]</loc>
   <loc side="right"></loc>
   <loc side="left"></loc>
   <loc side="bottom"></loc>
@@ -58,4 +70,8 @@
  <fc in_type="abs" in_val="1" out_type="abs" out_val="1">
   <fc_override fc_type="frac" fc_val="0.25" port_name="CLK"   />
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/ff1/ff1.pb_type.xml
+++ b/testarch/tiles/ff1/ff1.pb_type.xml
@@ -1,55 +1,67 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-TILE">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="TILE">
  <!-- Pins -->
  <input name="IN   " num_pins="2" />
  <clock name="CLK  " num_pins="2" />
  <output name="OUT " num_pins="1"  />
 
  <!-- Internal Slices -->
- <pb_type name="BLK_SI-FF1" num_pb="1">
+ <pb_type name="FF1" num_pb="1">
   <input  name="I" num_pins="1" equivalent="false"/>
   <clock  name="C" num_pins="1" equivalent="false"/>
   <output name="O" num_pins="1" equivalent="false"/>
   <xi:include href="../../primitives/ff/ff.pb_type.xml"/>
   <interconnect>
-   <direct name="BEL_FF-FF.D"   input="BLK_SI-FF1.I" output="BEL_FF-FF.D"   />
-   <direct name="BEL_FF-FF.clk" input="BLK_SI-FF1.C" output="BEL_FF-FF.clk" />
-   <direct name="BLK_SI-FF1.O"  input="BEL_FF-FF.Q"  output="BLK_SI-FF1.O"  />
+   <direct name="FF.D"   input="FF1.I" output="FF.D"   />
+   <direct name="FF.clk" input="FF1.C" output="FF.clk" />
+   <direct name="FF1.O"  input="FF.Q"  output="FF1.O"  />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
 
  <!-- Buffers -->
- <pb_type name="BEL_RX-IN0" num_pb="1">
+ <pb_type name="IN0" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN0.I[0] BEL_RX-IN0.I[1]" name="BEL_RX-IN0.O" output="BEL_RX-IN0.O" />
+   <mux input="IN0.I[0] IN0.I[1]" name="IN0.O" output="IN0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-CLK0" num_pb="1">
+ <pb_type name="CLK0" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-CLK0.I[0] BEL_RX-CLK0.I[1]" name="BEL_RX-CLK0.O" output="BEL_RX-CLK0.O" />
+   <mux input="CLK0.I[0] CLK0.I[1]" name="CLK0.O" output="CLK0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
  <interconnect>
   <!-- Clock input muxes -->
-  <direct input="BLK_TI-FF1.CLK[0]" name="BEL_RX-CLK0.I[0]" output="BEL_RX-CLK0.I[0]" />
-  <direct input="BLK_TI-FF1.CLK[1]" name="BEL_RX-CLK0.I[1]" output="BEL_RX-CLK0.I[1]" />
-  <direct input="BEL_RX-CLK0.O"     name="BLK_SI-FF1.C"     output="BLK_SI-FF1.C"     />
+  <direct input="FF1.CLK[0]" name="CLK0.I[0]" output="CLK0.I[0]" />
+  <direct input="FF1.CLK[1]" name="CLK0.I[1]" output="CLK0.I[1]" />
+  <direct input="CLK0.O"     name="FF1.C"     output="FF1.C"     />
 
   <!-- Logic input muxes -->
-  <direct input="BLK_TI-FF1.IN[0]"  name="BEL_RX-IN0.I[0]"   output="BEL_RX-IN0.I[0]" />
-  <direct input="BLK_TI-FF1.IN[1]"  name="BEL_RX-IN0.I[1]"   output="BEL_RX-IN0.I[1]" />
-  <direct input="BEL_RX-IN0.O"      name="BLK_SI-FF1.I[0]"   output="BLK_SI-FF1.I[0]" />
+  <direct input="FF1.IN[0]"  name="IN0.I[0]"   output="IN0.I[0]" />
+  <direct input="FF1.IN[1]"  name="IN0.I[1]"   output="IN0.I[1]" />
+  <direct input="IN0.O"      name="FF1.I[0]"   output="FF1.I[0]" />
 
   <!-- Output muxes -->
-  <direct input="BLK_SI-FF1.O"      name="BLK_TI-FF1.OUT[0]" output="BLK_TI-FF1.OUT[0]" />
+  <direct input="FF1.O"      name="FF1.OUT[0]" output="FF1.OUT[0]" />
  </interconnect>
 
  <pinlocations pattern="custom">
-  <loc side="top">BLK_TI-FF1.IN[0] BLK_TI-FF1.IN[1] BLK_TI-FF1.CLK[0] BLK_TI-FF1.CLK[1] BLK_TI-FF1.OUT[0]</loc>
+  <loc side="top">FF1.IN[0] FF1.IN[1] FF1.CLK[0] FF1.CLK[1] FF1.OUT[0]</loc>
   <loc side="right"></loc>
   <loc side="left"></loc>
   <loc side="bottom"></loc>
@@ -57,4 +69,8 @@
  <fc in_type="abs" in_val="1" out_type="abs" out_val="1">
   <fc_override fc_type="frac" fc_val="0.25" port_name="CLK"   />
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/lutff/lutff.pb_type.xml
+++ b/testarch/tiles/lutff/lutff.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-TILE">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="TILE">
  <!-- Tile Inputs -->
  <clock  name="CLK  " num_pins="2" />
  <input  name="IN   " num_pins="6" />
@@ -6,41 +6,49 @@
  <output name="OUT " num_pins="2"  />
 
  <!-- Internal LUTFF -->
- <pb_type name="BLK_SI-LUTFF" num_pb="1">
+ <pb_type name="SLICE" num_pb="1">
   <input  name="I"  num_pins="4" equivalent="false"/>
   <clock  name="C"  num_pins="1" equivalent="false"/>
   <output name="O"  num_pins="1" equivalent="false"/>
   <xi:include href="../../primitives/lutff/lutff.pb_type.xml"/>
   <interconnect>
-   <direct name="BLK_IG-LUTFF.I[0]" input="BLK_SI-LUTFF.I[0]" output="BLK_IG-LUTFF.I[0]" />
-   <direct name="BLK_IG-LUTFF.I[1]" input="BLK_SI-LUTFF.I[1]" output="BLK_IG-LUTFF.I[1]" />
-   <direct name="BLK_IG-LUTFF.I[2]" input="BLK_SI-LUTFF.I[2]" output="BLK_IG-LUTFF.I[2]" />
-   <direct name="BLK_IG-LUTFF.I[3]" input="BLK_SI-LUTFF.I[3]" output="BLK_IG-LUTFF.I[3]" />
-   <direct name="BLK_IG-LUTFF.C"    input="BLK_SI-LUTFF.C"    output="BLK_IG-LUTFF.C"    />
-   <direct name="BLK_SI-LUTFF.O"    input="BLK_IG-LUTFF.O"    output="BLK_SI-LUTFF.O"    />
+   <direct name="LUTFF.I[0]" input="SLICE.I[0]" output="LUTFF.I[0]" />
+   <direct name="LUTFF.I[1]" input="SLICE.I[1]" output="LUTFF.I[1]" />
+   <direct name="LUTFF.I[2]" input="SLICE.I[2]" output="LUTFF.I[2]" />
+   <direct name="LUTFF.I[3]" input="SLICE.I[3]" output="LUTFF.I[3]" />
+   <direct name="LUTFF.C"    input="SLICE.C"    output="LUTFF.C"    />
+   <direct name="LUTFF.O"    input="LUTFF.O"    output="SLICE.O"    />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
 
  <interconnect>
   <!-- Clock input mux -->
-  <mux name="BEL_RX-CLK0.I[0]" input="BLK_TI-TILE.CLK[0] BLK_TI-TILE.CLK[1]" output="BLK_SI-LUTFF.C" />
+  <mux name="CLK0.I[0]" input="TILE.CLK[0] TILE.CLK[1]" output="SLICE.C" />
 
   <!-- Logic input muxes -->
-  <mux name="BEL_RX-IN0.I[0]" input="BLK_TI-TILE.IN[0] BLK_TI-TILE.IN[1] BLK_TI-TILE.IN[2]" output="BLK_SI-LUTFF.I[0]" />
-  <mux name="BEL_RX-IN1.I[1]" input="BLK_TI-TILE.IN[1] BLK_TI-TILE.IN[2] BLK_TI-TILE.IN[3]" output="BLK_SI-LUTFF.I[1]" />
-  <mux name="BEL_RX-IN2.I[2]" input="BLK_TI-TILE.IN[2] BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4]" output="BLK_SI-LUTFF.I[2]" />
-  <mux name="BEL_RX-IN3.I[3]" input="BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4] BLK_TI-TILE.IN[5]" output="BLK_SI-LUTFF.I[3]" />
+  <mux name="IN0.I[0]" input="TILE.IN[0] TILE.IN[1] TILE.IN[2]" output="SLICE.I[0]" />
+  <mux name="IN1.I[1]" input="TILE.IN[1] TILE.IN[2] TILE.IN[3]" output="SLICE.I[1]" />
+  <mux name="IN2.I[2]" input="TILE.IN[2] TILE.IN[3] TILE.IN[4]" output="SLICE.I[2]" />
+  <mux name="IN3.I[3]" input="TILE.IN[3] TILE.IN[4] TILE.IN[5]" output="SLICE.I[3]" />
 
   <!-- Output -->
-  <direct name="BLK_TI-TILE.OUT[0]" input="BLK_SI-LUTFF.O"    output="BLK_TI-TILE.OUT[0]" />
-  <direct name="BLK_TI-TILE.OUT[1]" input="BLK_SI-LUTFF.O"    output="BLK_TI-TILE.OUT[1]" />
+  <direct name="TILE.OUT[0]" input="SLICE.O"    output="TILE.OUT[0]" />
+  <direct name="TILE.OUT[1]" input="SLICE.O"    output="TILE.OUT[1]" />
 
  </interconnect>
  <pinlocations pattern="custom">
-  <loc side="right">BLK_TI-TILE.CLK[0] BLK_TI-TILE.CLK[1] BLK_TI-TILE.IN[0] BLK_TI-TILE.IN[1] BLK_TI-TILE.IN[2] BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4] BLK_TI-TILE.IN[5] BLK_TI-TILE.OUT[0] BLK_TI-TILE.OUT[1]</loc>
+  <loc side="right">TILE.CLK[0] TILE.CLK[1] TILE.IN[0] TILE.IN[1] TILE.IN[2] TILE.IN[3] TILE.IN[4] TILE.IN[5] TILE.OUT[0] TILE.OUT[1]</loc>
  </pinlocations>
  <fc in_type="abs" in_val="0" out_type="abs" out_val="0">
   <fc_override fc_type="abs" fc_val="2" segment_name="span"  />
   <fc_override fc_type="abs" fc_val="2" segment_name="local" />
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/lutff3/lutff3.pb_type.xml
+++ b/testarch/tiles/lutff3/lutff3.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-TILE">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="TILE">
  <input  name="DUMMYI" num_pins="1" />
  <output name="DUMMYO" num_pins="1" />
  <!-- Tile Inputs -->
@@ -7,280 +7,364 @@
  <!-- Tile Outputs -->
  <output name="OUT " num_pins="4"  />
  <!-- Internal Slices -->
- <pb_type name="BLK_SI-LUTFF_A" num_pb="1">
+ <pb_type name="SLICE_A" num_pb="1">
   <input  name="I" num_pins="4" equivalent="false"/>
   <clock  name="C" num_pins="1" equivalent="false"/>
   <output name="O" num_pins="1" equivalent="false"/>
   <xi:include href="../../primitives/lutff/lutff.pb_type.xml"/>
   <interconnect>
-   <direct name="BLK_IG-LUTFF.I"   input="BLK_SI-LUTFF_A.I" output="BLK_IG-LUTFF.I"   />
-   <direct name="BLK_IG-LUTFF.C"   input="BLK_SI-LUTFF_A.C" output="BLK_IG-LUTFF.C"   />
-   <direct name="BLK_SI-LUTFF_A.O" input="BLK_IG-LUTFF.O"   output="BLK_SI-LUTFF_A.O" />
+   <direct name="LUTFF.I"   input="SLICE_A.I" output="LUTFF.I"   />
+   <direct name="LUTFF.C"   input="SLICE_A.C" output="LUTFF.C"   />
+   <direct name="SLICE_A.O" input="LUTFF.O"   output="SLICE_A.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BLK_SI-LUTFF_B" num_pb="1">
+ <pb_type name="SLICE_B" num_pb="1">
   <input  name="I" num_pins="4" equivalent="false"/>
   <clock  name="C" num_pins="1" equivalent="false"/>
   <output name="O" num_pins="1" equivalent="false"/>
   <xi:include href="../../primitives/lutff/lutff.pb_type.xml"/>
   <interconnect>
-   <direct name="BLK_IG-LUTFF.I"   input="BLK_SI-LUTFF_B.I" output="BLK_IG-LUTFF.I"   />
-   <direct name="BLK_IG-LUTFF.C"   input="BLK_SI-LUTFF_B.C" output="BLK_IG-LUTFF.C"   />
-   <direct name="BLK_SI-LUTFF_B.O" input="BLK_IG-LUTFF.O"   output="BLK_SI-LUTFF_B.O" />
+   <direct name="LUTFF.I"   input="SLICE_B.I" output="LUTFF.I"   />
+   <direct name="LUTFF.C"   input="SLICE_B.C" output="LUTFF.C"   />
+   <direct name="SLICE_B.O" input="LUTFF.O"   output="SLICE_B.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BLK_SI-LUTFF_C" num_pb="1">
+ <pb_type name="SLICE_C" num_pb="1">
   <input  name="I" num_pins="4" equivalent="false"/>
   <clock  name="C" num_pins="1" equivalent="false"/>
   <output name="O" num_pins="1" equivalent="false"/>
   <xi:include href="../../primitives/lutff/lutff.pb_type.xml"/>
   <interconnect>
-   <direct name="BLK_IG-LUTFF.I"   input="BLK_SI-LUTFF_C.I" output="BLK_IG-LUTFF.I"   />
-   <direct name="BLK_IG-LUTFF.C"   input="BLK_SI-LUTFF_C.C" output="BLK_IG-LUTFF.C"   />
-   <direct name="BLK_SI-LUTFF_C.O" input="BLK_IG-LUTFF.O"   output="BLK_SI-LUTFF_C.O" />
+   <direct name="LUTFF.I"   input="SLICE_C.I" output="LUTFF.I"   />
+   <direct name="LUTFF.C"   input="SLICE_C.C" output="LUTFF.C"   />
+   <direct name="SLICE_C.O" input="LUTFF.O"   output="SLICE_C.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">slice</meta>
+  </metadata>
  </pb_type>
  <!-- Buffers -->
- <pb_type name="BEL_RX-IN0" num_pb="1">
+ <pb_type name="IN0" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN0.I[0] BEL_RX-IN0.I[1] BEL_RX-IN0.I[2]" name="BEL_RX-IN0.O" output="BEL_RX-IN0.O" />
+   <mux input="IN0.I[0] IN0.I[1] IN0.I[2]" name="IN0.O" output="IN0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN1" num_pb="1">
+ <pb_type name="IN1" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN1.I[0] BEL_RX-IN1.I[1] BEL_RX-IN1.I[2]" name="BEL_RX-IN1.O" output="BEL_RX-IN1.O" />
+   <mux input="IN1.I[0] IN1.I[1] IN1.I[2]" name="IN1.O" output="IN1.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN2" num_pb="1">
+ <pb_type name="IN2" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN2.I[0] BEL_RX-IN2.I[1] BEL_RX-IN2.I[2]" name="BEL_RX-IN2.O" output="BEL_RX-IN2.O" />
+   <mux input="IN2.I[0] IN2.I[1] IN2.I[2]" name="IN2.O" output="IN2.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN3" num_pb="1">
+ <pb_type name="IN3" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN3.I[0] BEL_RX-IN3.I[1] BEL_RX-IN3.I[2]" name="BEL_RX-IN3.O" output="BEL_RX-IN3.O" />
+   <mux input="IN3.I[0] IN3.I[1] IN3.I[2]" name="IN3.O" output="IN3.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN4" num_pb="1">
+ <pb_type name="IN4" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN4.I[0] BEL_RX-IN4.I[1] BEL_RX-IN4.I[2]" name="BEL_RX-IN4.O" output="BEL_RX-IN4.O" />
+   <mux input="IN4.I[0] IN4.I[1] IN4.I[2]" name="IN4.O" output="IN4.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN5" num_pb="1">
+ <pb_type name="IN5" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN5.I[0] BEL_RX-IN5.I[1] BEL_RX-IN5.I[2]" name="BEL_RX-IN5.O" output="BEL_RX-IN5.O" />
+   <mux input="IN5.I[0] IN5.I[1] IN5.I[2]" name="IN5.O" output="IN5.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN6" num_pb="1">
+ <pb_type name="IN6" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN6.I[0] BEL_RX-IN6.I[1] BEL_RX-IN6.I[2]" name="BEL_RX-IN6.O" output="BEL_RX-IN6.O" />
+   <mux input="IN6.I[0] IN6.I[1] IN6.I[2]" name="IN6.O" output="IN6.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN7" num_pb="1">
+ <pb_type name="IN7" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN7.I[0] BEL_RX-IN7.I[1] BEL_RX-IN7.I[2]" name="BEL_RX-IN7.O" output="BEL_RX-IN7.O" />
+   <mux input="IN7.I[0] IN7.I[1] IN7.I[2]" name="IN7.O" output="IN7.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN8" num_pb="1">
+ <pb_type name="IN8" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN8.I[0] BEL_RX-IN8.I[1] BEL_RX-IN8.I[2]" name="BEL_RX-IN8.O" output="BEL_RX-IN8.O" />
+   <mux input="IN8.I[0] IN8.I[1] IN8.I[2]" name="IN8.O" output="IN8.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-IN9" num_pb="1">
+ <pb_type name="IN9" num_pb="1">
   <input  name="I" num_pins="3"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-IN9.I[0] BEL_RX-IN9.I[1] BEL_RX-IN9.I[2]" name="BEL_RX-IN9.O" output="BEL_RX-IN9.O" />
+   <mux input="IN9.I[0] IN9.I[1] IN9.I[2]" name="IN9.O" output="IN9.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
- <pb_type name="BEL_RX-CLK0" num_pb="1">
+ <pb_type name="CLK0" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-CLK0.I[0] BEL_RX-CLK0.I[1]" name="BEL_RX-CLK0.O" output="BEL_RX-CLK0.O" />
+   <mux input="CLK0.I[0] CLK0.I[1]" name="CLK0.O" output="CLK0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-CLK1" num_pb="1">
+ <pb_type name="CLK1" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-CLK1.I[0] BEL_RX-CLK1.I[1]" name="BEL_RX-CLK1.O" output="BEL_RX-CLK1.O" />
+   <mux input="CLK1.I[0] CLK1.I[1]" name="CLK1.O" output="CLK1.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-CLK2" num_pb="1">
+ <pb_type name="CLK2" num_pb="1">
   <input  name="I" num_pins="2"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-CLK2.I[0] BEL_RX-CLK2.I[1]" name="BEL_RX-CLK2.O" output="BEL_RX-CLK2.O" />
+   <mux input="CLK2.I[0] CLK2.I[1]" name="CLK2.O" output="CLK2.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
- <pb_type name="BEL_RX-OUT0" num_pb="1">
+ <pb_type name="OUT0" num_pb="1">
   <input  name="I" num_pins="7"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-OUT0.I[0] BEL_RX-OUT0.I[1] BEL_RX-OUT0.I[2] BEL_RX-OUT0.I[3] BEL_RX-OUT0.I[4] BEL_RX-OUT0.I[5] BEL_RX-OUT0.I[6]" name="BEL_RX-OUT0.O" output="BEL_RX-OUT0.O" />
+   <mux input="OUT0.I[0] OUT0.I[1] OUT0.I[2] OUT0.I[3] OUT0.I[4] OUT0.I[5] OUT0.I[6]" name="OUT0.O" output="OUT0.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-OUT1" num_pb="1">
+ <pb_type name="OUT1" num_pb="1">
   <input  name="I" num_pins="7"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-OUT1.I[0] BEL_RX-OUT1.I[1] BEL_RX-OUT1.I[2] BEL_RX-OUT1.I[3] BEL_RX-OUT1.I[4] BEL_RX-OUT1.I[5] BEL_RX-OUT1.I[6]" name="BEL_RX-OUT1.O" output="BEL_RX-OUT1.O" />
+   <mux input="OUT1.I[0] OUT1.I[1] OUT1.I[2] OUT1.I[3] OUT1.I[4] OUT1.I[5] OUT1.I[6]" name="OUT1.O" output="OUT1.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-OUT2" num_pb="1">
+ <pb_type name="OUT2" num_pb="1">
   <input  name="I" num_pins="7"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-OUT2.I[0] BEL_RX-OUT2.I[1] BEL_RX-OUT2.I[2] BEL_RX-OUT2.I[3] BEL_RX-OUT2.I[4] BEL_RX-OUT2.I[5] BEL_RX-OUT2.I[6]" name="BEL_RX-OUT2.O" output="BEL_RX-OUT2.O" />
+   <mux input="OUT2.I[0] OUT2.I[1] OUT2.I[2] OUT2.I[3] OUT2.I[4] OUT2.I[5] OUT2.I[6]" name="OUT2.O" output="OUT2.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
- <pb_type name="BEL_RX-OUT3" num_pb="1">
+ <pb_type name="OUT3" num_pb="1">
   <input  name="I" num_pins="12"/>
   <output name="O" num_pins="1"/>
   <interconnect>
-   <mux input="BEL_RX-OUT3.I[0] BEL_RX-OUT3.I[1] BEL_RX-OUT3.I[2] BEL_RX-OUT3.I[3] BEL_RX-OUT3.I[4] BEL_RX-OUT3.I[5] BEL_RX-OUT3.I[6] BEL_RX-OUT3.I[7] BEL_RX-OUT3.I[8] BEL_RX-OUT3.I[9] BEL_RX-OUT3.I[10] BEL_RX-OUT3.I[11]" name="BEL_RX-OUT3.O" output="BEL_RX-OUT3.O" />
+   <mux input="OUT3.I[0] OUT3.I[1] OUT3.I[2] OUT3.I[3] OUT3.I[4] OUT3.I[5] OUT3.I[6] OUT3.I[7] OUT3.I[8] OUT3.I[9] OUT3.I[10] OUT3.I[11]" name="OUT3.O" output="OUT3.O" />
   </interconnect>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">routing</meta>
+  </metadata>
  </pb_type>
 
  <interconnect>
   <!-- Clock input muxes -->
-  <direct input="BLK_TI-TILE.CLK[0]" name="BEL_RX-CLK0.I[0]"    output="BEL_RX-CLK0.I[0]" />
-  <direct input="BLK_TI-TILE.CLK[1]" name="BEL_RX-CLK0.I[1]"    output="BEL_RX-CLK0.I[1]" />
-  <direct input="BEL_RX-CLK0.O"      name="BLK_SI-LUTFF_A.C"    output="BLK_SI-LUTFF_A.C" />
+  <direct input="TILE.CLK[0]" name="CLK0.I[0]"    output="CLK0.I[0]" />
+  <direct input="TILE.CLK[1]" name="CLK0.I[1]"    output="CLK0.I[1]" />
+  <direct input="CLK0.O"      name="SLICE_A.C"    output="SLICE_A.C" />
 
-  <direct input="BLK_TI-TILE.CLK[1]" name="BEL_RX-CLK1.I[0]"    output="BEL_RX-CLK1.I[0]" />
-  <direct input="BLK_TI-TILE.CLK[2]" name="BEL_RX-CLK1.I[1]"    output="BEL_RX-CLK1.I[1]" />
-  <direct input="BEL_RX-CLK1.O"      name="BLK_SI-LUTFF_B.C"    output="BLK_SI-LUTFF_B.C" />
+  <direct input="TILE.CLK[1]" name="CLK1.I[0]"    output="CLK1.I[0]" />
+  <direct input="TILE.CLK[2]" name="CLK1.I[1]"    output="CLK1.I[1]" />
+  <direct input="CLK1.O"      name="SLICE_B.C"    output="SLICE_B.C" />
 
-  <direct input="BLK_TI-TILE.CLK[2]" name="BEL_RX-CLK2.I[0]"    output="BEL_RX-CLK2.I[0]" />
-  <direct input="BLK_TI-TILE.CLK[3]" name="BEL_RX-CLK2.I[1]"    output="BEL_RX-CLK2.I[1]" />
-  <direct input="BEL_RX-CLK2.O"      name="BLK_SI-LUTFF_C.C"    output="BLK_SI-LUTFF_C.C" />
+  <direct input="TILE.CLK[2]" name="CLK2.I[0]"    output="CLK2.I[0]" />
+  <direct input="TILE.CLK[3]" name="CLK2.I[1]"    output="CLK2.I[1]" />
+  <direct input="CLK2.O"      name="SLICE_C.C"    output="SLICE_C.C" />
 
   <!-- Logic input muxes -->
-  <direct input="BLK_TI-TILE.IN[0]"  name="BEL_RX-IN0.I[0]"     output="BEL_RX-IN0.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[1]"  name="BEL_RX-IN0.I[1]"     output="BEL_RX-IN0.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[2]"  name="BEL_RX-IN0.I[2]"     output="BEL_RX-IN0.I[2]"     />
-  <direct input="BEL_RX-IN0.O"       name="BLK_SI-LUTFF_A.I[0]" output="BLK_SI-LUTFF_A.I[0]" />
+  <direct input="TILE.IN[0]"  name="IN0.I[0]"     output="IN0.I[0]"     />
+  <direct input="TILE.IN[1]"  name="IN0.I[1]"     output="IN0.I[1]"     />
+  <direct input="TILE.IN[2]"  name="IN0.I[2]"     output="IN0.I[2]"     />
+  <direct input="IN0.O"       name="SLICE_A.I[0]" output="SLICE_A.I[0]" />
 
-  <direct input="BLK_TI-TILE.IN[1]"  name="BEL_RX-IN1.I[0]"     output="BEL_RX-IN1.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[2]"  name="BEL_RX-IN1.I[1]"     output="BEL_RX-IN1.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[3]"  name="BEL_RX-IN1.I[2]"     output="BEL_RX-IN1.I[2]"     />
-  <direct input="BEL_RX-IN1.O"       name="BLK_SI-LUTFF_A.I[1]" output="BLK_SI-LUTFF_A.I[1]" />
+  <direct input="TILE.IN[1]"  name="IN1.I[0]"     output="IN1.I[0]"     />
+  <direct input="TILE.IN[2]"  name="IN1.I[1]"     output="IN1.I[1]"     />
+  <direct input="TILE.IN[3]"  name="IN1.I[2]"     output="IN1.I[2]"     />
+  <direct input="IN1.O"       name="SLICE_A.I[1]" output="SLICE_A.I[1]" />
 
-  <direct input="BLK_TI-TILE.IN[2]"  name="BEL_RX-IN2.I[0]"     output="BEL_RX-IN2.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[3]"  name="BEL_RX-IN2.I[1]"     output="BEL_RX-IN2.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[4]"  name="BEL_RX-IN2.I[2]"     output="BEL_RX-IN2.I[2]"     />
-  <direct input="BEL_RX-IN2.O"       name="BLK_SI-LUTFF_A.I[2]" output="BLK_SI-LUTFF_A.I[2]" />
+  <direct input="TILE.IN[2]"  name="IN2.I[0]"     output="IN2.I[0]"     />
+  <direct input="TILE.IN[3]"  name="IN2.I[1]"     output="IN2.I[1]"     />
+  <direct input="TILE.IN[4]"  name="IN2.I[2]"     output="IN2.I[2]"     />
+  <direct input="IN2.O"       name="SLICE_A.I[2]" output="SLICE_A.I[2]" />
 
-  <direct input="BLK_TI-TILE.IN[3]"  name="BEL_RX-IN3.I[0]"     output="BEL_RX-IN3.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[4]"  name="BEL_RX-IN3.I[1]"     output="BEL_RX-IN3.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[5]"  name="BEL_RX-IN3.I[2]"     output="BEL_RX-IN3.I[2]"     />
-  <direct input="BEL_RX-IN3.O"       name="BLK_SI-LUTFF_A.I[3]" output="BLK_SI-LUTFF_A.I[3]" />
-  <direct input="BEL_RX-IN3.O"       name="BLK_SI-LUTFF_B.I[0]" output="BLK_SI-LUTFF_B.I[0]" />
+  <direct input="TILE.IN[3]"  name="IN3.I[0]"     output="IN3.I[0]"     />
+  <direct input="TILE.IN[4]"  name="IN3.I[1]"     output="IN3.I[1]"     />
+  <direct input="TILE.IN[5]"  name="IN3.I[2]"     output="IN3.I[2]"     />
+  <direct input="IN3.O"       name="SLICE_A.I[3]" output="SLICE_A.I[3]" />
+  <direct input="IN3.O"       name="SLICE_B.I[0]" output="SLICE_B.I[0]" />
 
-  <direct input="BLK_TI-TILE.IN[4]"  name="BEL_RX-IN4.I[0]"     output="BEL_RX-IN4.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[5]"  name="BEL_RX-IN4.I[1]"     output="BEL_RX-IN4.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[6]"  name="BEL_RX-IN4.I[2]"     output="BEL_RX-IN4.I[2]"     />
-  <direct input="BEL_RX-IN4.O"       name="BLK_SI-LUTFF_B.I[1]" output="BLK_SI-LUTFF_B.I[1]" />
+  <direct input="TILE.IN[4]"  name="IN4.I[0]"     output="IN4.I[0]"     />
+  <direct input="TILE.IN[5]"  name="IN4.I[1]"     output="IN4.I[1]"     />
+  <direct input="TILE.IN[6]"  name="IN4.I[2]"     output="IN4.I[2]"     />
+  <direct input="IN4.O"       name="SLICE_B.I[1]" output="SLICE_B.I[1]" />
 
-  <direct input="BLK_TI-TILE.IN[5]"  name="BEL_RX-IN5.I[0]"     output="BEL_RX-IN5.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[6]"  name="BEL_RX-IN5.I[1]"     output="BEL_RX-IN5.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[7]"  name="BEL_RX-IN5.I[2]"     output="BEL_RX-IN5.I[2]"     />
-  <direct input="BEL_RX-IN5.O"       name="BLK_SI-LUTFF_B.I[2]" output="BLK_SI-LUTFF_B.I[2]" />
+  <direct input="TILE.IN[5]"  name="IN5.I[0]"     output="IN5.I[0]"     />
+  <direct input="TILE.IN[6]"  name="IN5.I[1]"     output="IN5.I[1]"     />
+  <direct input="TILE.IN[7]"  name="IN5.I[2]"     output="IN5.I[2]"     />
+  <direct input="IN5.O"       name="SLICE_B.I[2]" output="SLICE_B.I[2]" />
 
-  <direct input="BLK_TI-TILE.IN[6]"  name="BEL_RX-IN6.I[0]"     output="BEL_RX-IN6.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[7]"  name="BEL_RX-IN6.I[1]"     output="BEL_RX-IN6.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[8]"  name="BEL_RX-IN6.I[2]"     output="BEL_RX-IN6.I[2]"     />
-  <direct input="BEL_RX-IN6.O"       name="BLK_SI-LUTFF_B.I[3]" output="BLK_SI-LUTFF_B.I[3]" />
-  <direct input="BEL_RX-IN6.O"       name="BLK_SI-LUTFF_C.I[0]" output="BLK_SI-LUTFF_C.I[0]" />
+  <direct input="TILE.IN[6]"  name="IN6.I[0]"     output="IN6.I[0]"     />
+  <direct input="TILE.IN[7]"  name="IN6.I[1]"     output="IN6.I[1]"     />
+  <direct input="TILE.IN[8]"  name="IN6.I[2]"     output="IN6.I[2]"     />
+  <direct input="IN6.O"       name="SLICE_B.I[3]" output="SLICE_B.I[3]" />
+  <direct input="IN6.O"       name="SLICE_C.I[0]" output="SLICE_C.I[0]" />
 
-  <direct input="BLK_TI-TILE.IN[7]"  name="BEL_RX-IN7.I[0]"     output="BEL_RX-IN7.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[8]"  name="BEL_RX-IN7.I[1]"     output="BEL_RX-IN7.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[9]"  name="BEL_RX-IN7.I[2]"     output="BEL_RX-IN7.I[2]"     />
-  <direct input="BEL_RX-IN7.O"       name="BLK_SI-LUTFF_C.I[1]" output="BLK_SI-LUTFF_C.I[1]" />
+  <direct input="TILE.IN[7]"  name="IN7.I[0]"     output="IN7.I[0]"     />
+  <direct input="TILE.IN[8]"  name="IN7.I[1]"     output="IN7.I[1]"     />
+  <direct input="TILE.IN[9]"  name="IN7.I[2]"     output="IN7.I[2]"     />
+  <direct input="IN7.O"       name="SLICE_C.I[1]" output="SLICE_C.I[1]" />
 
-  <direct input="BLK_TI-TILE.IN[8]"  name="BEL_RX-IN8.I[0]"     output="BEL_RX-IN8.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[9]"  name="BEL_RX-IN8.I[1]"     output="BEL_RX-IN8.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[10]" name="BEL_RX-IN8.I[2]"     output="BEL_RX-IN8.I[2]"     />
-  <direct input="BEL_RX-IN8.O"       name="BLK_SI-LUTFF_C.I[2]" output="BLK_SI-LUTFF_C.I[2]" />
+  <direct input="TILE.IN[8]"  name="IN8.I[0]"     output="IN8.I[0]"     />
+  <direct input="TILE.IN[9]"  name="IN8.I[1]"     output="IN8.I[1]"     />
+  <direct input="TILE.IN[10]" name="IN8.I[2]"     output="IN8.I[2]"     />
+  <direct input="IN8.O"       name="SLICE_C.I[2]" output="SLICE_C.I[2]" />
 
-  <direct input="BLK_TI-TILE.IN[9]"  name="BEL_RX-IN9.I[0]"     output="BEL_RX-IN9.I[0]"     />
-  <direct input="BLK_TI-TILE.IN[10]" name="BEL_RX-IN9.I[1]"     output="BEL_RX-IN9.I[1]"     />
-  <direct input="BLK_TI-TILE.IN[11]" name="BEL_RX-IN9.I[2]"     output="BEL_RX-IN9.I[2]"     />
-  <direct input="BEL_RX-IN9.O"       name="BLK_SI-LUTFF_C.I[3]" output="BLK_SI-LUTFF_C.I[3]" />
+  <direct input="TILE.IN[9]"  name="IN9.I[0]"     output="IN9.I[0]"     />
+  <direct input="TILE.IN[10]" name="IN9.I[1]"     output="IN9.I[1]"     />
+  <direct input="TILE.IN[11]" name="IN9.I[2]"     output="IN9.I[2]"     />
+  <direct input="IN9.O"       name="SLICE_C.I[3]" output="SLICE_C.I[3]" />
 
   <!-- Output muxes -->
-  <direct input="BLK_SI-LUTFF_A.O"   name="BEL_RX-OUT0.I[0]" output="BEL_RX-OUT0.I[0]"   />
-  <direct input="BLK_SI-LUTFF_B.O"   name="BEL_RX-OUT0.I[1]" output="BEL_RX-OUT0.I[1]"   />
-  <direct input="BLK_SI-LUTFF_C.O"   name="BEL_RX-OUT0.I[2]" output="BEL_RX-OUT0.I[2]"   />
-  <direct input="BLK_TI-TILE.IN[0]"  name="BEL_RX-OUT0.I[3]" output="BEL_RX-OUT0.I[3]"   />
-  <direct input="BLK_TI-TILE.IN[1]"  name="BEL_RX-OUT0.I[4]" output="BEL_RX-OUT0.I[4]"   />
-  <direct input="BLK_TI-TILE.IN[2]"  name="BEL_RX-OUT0.I[5]" output="BEL_RX-OUT0.I[5]"   />
-  <direct input="BLK_TI-TILE.IN[3]"  name="BEL_RX-OUT0.I[6]" output="BEL_RX-OUT0.I[6]"   />
-  <direct input="BEL_RX-OUT0.O"      name="BLK_TI-TILE.OUT0" output="BLK_TI-TILE.OUT[0]" />
+  <direct input="SLICE_A.O"   name="OUT0.I[0]" output="OUT0.I[0]"   />
+  <direct input="SLICE_B.O"   name="OUT0.I[1]" output="OUT0.I[1]"   />
+  <direct input="SLICE_C.O"   name="OUT0.I[2]" output="OUT0.I[2]"   />
+  <direct input="TILE.IN[0]"  name="OUT0.I[3]" output="OUT0.I[3]"   />
+  <direct input="TILE.IN[1]"  name="OUT0.I[4]" output="OUT0.I[4]"   />
+  <direct input="TILE.IN[2]"  name="OUT0.I[5]" output="OUT0.I[5]"   />
+  <direct input="TILE.IN[3]"  name="OUT0.I[6]" output="OUT0.I[6]"   />
+  <direct input="OUT0.O"      name="TILE.OUT0" output="TILE.OUT[0]" />
 
-  <direct input="BLK_SI-LUTFF_A.O"   name="BEL_RX-OUT1.I[0]" output="BEL_RX-OUT1.I[0]"   />
-  <direct input="BLK_SI-LUTFF_B.O"   name="BEL_RX-OUT1.I[1]" output="BEL_RX-OUT1.I[1]"   />
-  <direct input="BLK_SI-LUTFF_C.O"   name="BEL_RX-OUT1.I[2]" output="BEL_RX-OUT1.I[2]"   />
-  <direct input="BLK_TI-TILE.IN[4]"  name="BEL_RX-OUT1.I[3]" output="BEL_RX-OUT1.I[3]"   />
-  <direct input="BLK_TI-TILE.IN[5]"  name="BEL_RX-OUT1.I[4]" output="BEL_RX-OUT1.I[4]"   />
-  <direct input="BLK_TI-TILE.IN[6]"  name="BEL_RX-OUT1.I[5]" output="BEL_RX-OUT1.I[5]"   />
-  <direct input="BLK_TI-TILE.IN[7]"  name="BEL_RX-OUT1.I[6]" output="BEL_RX-OUT1.I[6]"   />
-  <direct input="BEL_RX-OUT1.O"      name="BLK_TI-TILE.OUT1" output="BLK_TI-TILE.OUT[1]" />
+  <direct input="SLICE_A.O"   name="OUT1.I[0]" output="OUT1.I[0]"   />
+  <direct input="SLICE_B.O"   name="OUT1.I[1]" output="OUT1.I[1]"   />
+  <direct input="SLICE_C.O"   name="OUT1.I[2]" output="OUT1.I[2]"   />
+  <direct input="TILE.IN[4]"  name="OUT1.I[3]" output="OUT1.I[3]"   />
+  <direct input="TILE.IN[5]"  name="OUT1.I[4]" output="OUT1.I[4]"   />
+  <direct input="TILE.IN[6]"  name="OUT1.I[5]" output="OUT1.I[5]"   />
+  <direct input="TILE.IN[7]"  name="OUT1.I[6]" output="OUT1.I[6]"   />
+  <direct input="OUT1.O"      name="TILE.OUT1" output="TILE.OUT[1]" />
 
-  <direct input="BLK_SI-LUTFF_A.O"   name="BEL_RX-OUT2.I[0]" output="BEL_RX-OUT2.I[0]"   />
-  <direct input="BLK_SI-LUTFF_B.O"   name="BEL_RX-OUT2.I[1]" output="BEL_RX-OUT2.I[1]"   />
-  <direct input="BLK_SI-LUTFF_C.O"   name="BEL_RX-OUT2.I[2]" output="BEL_RX-OUT2.I[2]"   />
-  <direct input="BLK_TI-TILE.IN[8]"  name="BEL_RX-OUT2.I[3]" output="BEL_RX-OUT2.I[3]"   />
-  <direct input="BLK_TI-TILE.IN[9]"  name="BEL_RX-OUT2.I[4]" output="BEL_RX-OUT2.I[4]"   />
-  <direct input="BLK_TI-TILE.IN[10]" name="BEL_RX-OUT2.I[5]" output="BEL_RX-OUT2.I[5]"   />
-  <direct input="BLK_TI-TILE.IN[11]" name="BEL_RX-OUT2.I[6]" output="BEL_RX-OUT2.I[6]"   />
-  <direct input="BEL_RX-OUT2.O"      name="BLK_TI-TILE.OUT2" output="BLK_TI-TILE.OUT[2]" />
+  <direct input="SLICE_A.O"   name="OUT2.I[0]" output="OUT2.I[0]"   />
+  <direct input="SLICE_B.O"   name="OUT2.I[1]" output="OUT2.I[1]"   />
+  <direct input="SLICE_C.O"   name="OUT2.I[2]" output="OUT2.I[2]"   />
+  <direct input="TILE.IN[8]"  name="OUT2.I[3]" output="OUT2.I[3]"   />
+  <direct input="TILE.IN[9]"  name="OUT2.I[4]" output="OUT2.I[4]"   />
+  <direct input="TILE.IN[10]" name="OUT2.I[5]" output="OUT2.I[5]"   />
+  <direct input="TILE.IN[11]" name="OUT2.I[6]" output="OUT2.I[6]"   />
+  <direct input="OUT2.O"      name="TILE.OUT2" output="TILE.OUT[2]" />
 
-  <direct input="BLK_TI-TILE.IN[0]"  name="BEL_RX-OUT3.I[0]"  output="BEL_RX-OUT3.I[0]"  />
-  <direct input="BLK_TI-TILE.IN[1]"  name="BEL_RX-OUT3.I[1]"  output="BEL_RX-OUT3.I[1]"  />
-  <direct input="BLK_TI-TILE.IN[2]"  name="BEL_RX-OUT3.I[2]"  output="BEL_RX-OUT3.I[2]"  />
-  <direct input="BLK_TI-TILE.IN[3]"  name="BEL_RX-OUT3.I[3]"  output="BEL_RX-OUT3.I[3]"  />
-  <direct input="BLK_TI-TILE.IN[4]"  name="BEL_RX-OUT3.I[4]"  output="BEL_RX-OUT3.I[4]"  />
-  <direct input="BLK_TI-TILE.IN[5]"  name="BEL_RX-OUT3.I[5]"  output="BEL_RX-OUT3.I[5]"  />
-  <direct input="BLK_TI-TILE.IN[6]"  name="BEL_RX-OUT3.I[6]"  output="BEL_RX-OUT3.I[6]"  />
-  <direct input="BLK_TI-TILE.IN[7]"  name="BEL_RX-OUT3.I[7]"  output="BEL_RX-OUT3.I[7]"  />
-  <direct input="BLK_TI-TILE.IN[8]"  name="BEL_RX-OUT3.I[8]"  output="BEL_RX-OUT3.I[8]"  />
-  <direct input="BLK_TI-TILE.IN[9]"  name="BEL_RX-OUT3.I[9]"  output="BEL_RX-OUT3.I[9]"  />
-  <direct input="BLK_TI-TILE.IN[10]" name="BEL_RX-OUT3.I[10]" output="BEL_RX-OUT3.I[10]" />
-  <direct input="BLK_TI-TILE.IN[11]" name="BEL_RX-OUT3.I[11]" output="BEL_RX-OUT3.I[11]" />
-  <direct input="BEL_RX-OUT3.O"        name="BLK_TI-TILE.OUT3" output="BLK_TI-TILE.OUT[3]" />
+  <direct input="TILE.IN[0]"  name="OUT3.I[0]"  output="OUT3.I[0]"  />
+  <direct input="TILE.IN[1]"  name="OUT3.I[1]"  output="OUT3.I[1]"  />
+  <direct input="TILE.IN[2]"  name="OUT3.I[2]"  output="OUT3.I[2]"  />
+  <direct input="TILE.IN[3]"  name="OUT3.I[3]"  output="OUT3.I[3]"  />
+  <direct input="TILE.IN[4]"  name="OUT3.I[4]"  output="OUT3.I[4]"  />
+  <direct input="TILE.IN[5]"  name="OUT3.I[5]"  output="OUT3.I[5]"  />
+  <direct input="TILE.IN[6]"  name="OUT3.I[6]"  output="OUT3.I[6]"  />
+  <direct input="TILE.IN[7]"  name="OUT3.I[7]"  output="OUT3.I[7]"  />
+  <direct input="TILE.IN[8]"  name="OUT3.I[8]"  output="OUT3.I[8]"  />
+  <direct input="TILE.IN[9]"  name="OUT3.I[9]"  output="OUT3.I[9]"  />
+  <direct input="TILE.IN[10]" name="OUT3.I[10]" output="OUT3.I[10]" />
+  <direct input="TILE.IN[11]" name="OUT3.I[11]" output="OUT3.I[11]" />
+  <direct input="OUT3.O"        name="TILE.OUT3" output="TILE.OUT[3]" />
  </interconnect>
  <pinlocations pattern="custom">
-  <loc side="top">   BLK_TI-TILE.IN[0] BLK_TI-TILE.IN[1]  BLK_TI-TILE.IN[2]   BLK_TI-TILE.OUT[0] BLK_TI-TILE.CLK[0]</loc>
-  <loc side="right"> BLK_TI-TILE.IN[3] BLK_TI-TILE.IN[4]  BLK_TI-TILE.IN[5]   BLK_TI-TILE.OUT[1] BLK_TI-TILE.CLK[1]</loc>
-  <loc side="left">  BLK_TI-TILE.IN[6] BLK_TI-TILE.IN[7]  BLK_TI-TILE.IN[8]   BLK_TI-TILE.OUT[2] BLK_TI-TILE.CLK[2] BLK_TI-TILE.DUMMYI[0]</loc>
-  <loc side="bottom">BLK_TI-TILE.IN[9] BLK_TI-TILE.IN[10] BLK_TI-TILE.IN[11]  BLK_TI-TILE.OUT[3] BLK_TI-TILE.CLK[3] BLK_TI-TILE.DUMMYO[0]</loc>
+  <loc side="top">   TILE.IN[0] TILE.IN[1]  TILE.IN[2]   TILE.OUT[0] TILE.CLK[0]</loc>
+  <loc side="right"> TILE.IN[3] TILE.IN[4]  TILE.IN[5]   TILE.OUT[1] TILE.CLK[1]</loc>
+  <loc side="left">  TILE.IN[6] TILE.IN[7]  TILE.IN[8]   TILE.OUT[2] TILE.CLK[2] TILE.DUMMYI[0]</loc>
+  <loc side="bottom">TILE.IN[9] TILE.IN[10] TILE.IN[11]  TILE.OUT[3] TILE.CLK[3] TILE.DUMMYO[0]</loc>
  </pinlocations>
  <fc in_type="frac" in_val="0.0" out_type="frac" out_val="0.0">
   <fc_override fc_type="frac" fc_val="1.0" port_name="DUMMYI" />
   <fc_override fc_type="frac" fc_val="1.0" port_name="DUMMYO" />
   <fc_override fc_type="frac" fc_val="1.0" port_name="CLK"   />
  </fc>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/tiles/wire/wire.pb_type.xml
+++ b/testarch/tiles/wire/wire.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLK_TI-TILE">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="TILE">
  <!-- Tile Inputs -->
  <input  name="IN"  num_pins="1" />
  <!-- Tile Outputs -->
@@ -7,13 +7,17 @@
  <xi:include href="../../../vpr/wire/wire.pb_type.xml"/>
 
  <interconnect>
-  <direct name="BLK_TI-TILE.IN"  input="BLK_TI-TILE.IN"  output="BLK_IG-WIRE.in"  />
-  <direct name="BLK_TI-TILE.OUT" input="BLK_IG-WIRE.out" output="BLK_TI-TILE.OUT" />
+  <direct name="TILE.IN"  input="TILE.IN"  output="WIRE.in"  />
+  <direct name="TILE.OUT" input="WIRE.out" output="TILE.OUT" />
  </interconnect>
 
  <pinlocations pattern="custom">
-  <loc side="right">BLK_TI-TILE.IN[0] BLK_TI-TILE.OUT[0]</loc>
+  <loc side="right">TILE.IN[0] TILE.OUT[0]</loc>
  </pinlocations>
 
  <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0"/>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/testarch/utils/testarch_graph.py
+++ b/testarch/utils/testarch_graph.py
@@ -128,8 +128,8 @@ def create_global_constant_tracks(graph, mux, short, grid_width, grid_height):
         "GND", graph, unique_pos, short, grid_width, grid_height
     )
 
-    vcc_pin = graph.create_pin_name_from_tile_type_and_pin('BLK_TI-VCC', 'VCC')
-    gnd_pin = graph.create_pin_name_from_tile_type_and_pin('BLK_TI-GND', 'GND')
+    vcc_pin = graph.create_pin_name_from_tile_type_and_pin('VCC', 'VCC')
+    gnd_pin = graph.create_pin_name_from_tile_type_and_pin('GND', 'GND')
 
     found_vcc = False
     found_gnd = False
@@ -241,12 +241,10 @@ def connect_blocks_to_tracks(
 
     special_pins = set(
         (
-            graph.create_pin_name_from_tile_type_and_pin(
-                'BLK_TI-TILE', 'COUT'
-            ),
-            graph.create_pin_name_from_tile_type_and_pin('BLK_TI-TILE', 'CIN'),
-            graph.create_pin_name_from_tile_type_and_pin('BLK_TI-VCC', 'VCC'),
-            graph.create_pin_name_from_tile_type_and_pin('BLK_TI-GND', 'GND'),
+            graph.create_pin_name_from_tile_type_and_pin('TILE', 'COUT'),
+            graph.create_pin_name_from_tile_type_and_pin('TILE', 'CIN'),
+            graph.create_pin_name_from_tile_type_and_pin('VCC', 'VCC'),
+            graph.create_pin_name_from_tile_type_and_pin('GND', 'GND'),
         )
     )
 

--- a/utils/lib/rr_graph/graph.py
+++ b/utils/lib/rr_graph/graph.py
@@ -94,8 +94,8 @@ def parse_net(
     ('c', 'd', [1])
     >>> parse_net('c.d[40]')
     ('c', 'd', [40])
-    >>> parse_net('BLK_BB-VPR_PAD.outpad[0]')
-    ('BLK_BB-VPR_PAD', 'outpad', [0])
+    >>> parse_net('VPR_PAD.outpad[0]')
+    ('VPR_PAD', 'outpad', [0])
 
     Fully specified with more complex block names
     >>> parse_net('a.b.c[0]')
@@ -116,8 +116,8 @@ def parse_net(
     ('c', 'd', [8, 9, 10, 11])
 
     Net with no pin index.
-    >>> parse_net('BLK_BB-VPR_PAD.outpad')
-    ('BLK_BB-VPR_PAD', 'outpad', None)
+    >>> parse_net('VPR_PAD.outpad')
+    ('VPR_PAD', 'outpad', None)
 
     Net with no block
     >>> parse_net('outpad[10]')
@@ -728,21 +728,21 @@ class BlockType(MostlyReadOnly):
         """
 
         >>> xml_string = '''
-        ... <block_type id="1" name="BLK_BB-VPR_PAD" width="2" height="3">
+        ... <block_type id="1" name="VPR_PAD" width="2" height="3">
         ...   <pin_class type="OUTPUT">
-        ...     <pin ptc="0">BLK_BB-VPR_PAD.outpad[0]</pin>
+        ...     <pin ptc="0">VPR_PAD.outpad[0]</pin>
         ...   </pin_class>
         ...   <pin_class type="OUTPUT">
-        ...     <pin ptc="1">BLK_BB-VPR_PAD.outpad[1]</pin>
+        ...     <pin ptc="1">VPR_PAD.outpad[1]</pin>
         ...   </pin_class>
         ...   <pin_class type="INPUT">
-        ...     <pin ptc="2">BLK_BB-VPR_PAD.inpad[0]</pin>
+        ...     <pin ptc="2">VPR_PAD.inpad[0]</pin>
         ...   </pin_class>
         ... </block_type>
         ... '''
         >>> bt = BlockType.from_xml(None, ET.fromstring(xml_string))
         >>> bt # doctest: +ELLIPSIS
-        BlockType(graph=None, id=1, name='BLK_BB-VPR_PAD', size=Size(w=2, h=3), pin_classes=[...], pins_index={...})
+        BlockType(graph=None, id=1, name='VPR_PAD', size=Size(w=2, h=3), pin_classes=[...], pins_index={...})
         >>> len(bt.pin_classes)
         3
         >>> bt.pin_classes[0].direction
@@ -750,31 +750,31 @@ class BlockType(MostlyReadOnly):
         >>> bt.pin_classes[0] # doctest: +ELLIPSIS
         PinClass(block_type=BlockType(), direction='output', pins=[...])
         >>> bt.pin_classes[0].pins[0]
-        Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=None, block_type_index=0, side=None)
+        Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=None, block_type_index=0, side=None)
         >>> bt.pin_classes[1].direction
         'output'
         >>> bt.pin_classes[1].pins[0]
-        Pin(pin_class=PinClass(), port_name='outpad', port_index=1, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=None, block_type_index=1, side=None)
+        Pin(pin_class=PinClass(), port_name='outpad', port_index=1, block_type_name='VPR_PAD', block_type_subblk=None, block_type_index=1, side=None)
         >>> bt.pin_classes[2].direction
         'input'
         >>> bt.pin_classes[2].pins[0]
-        Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=None, block_type_index=2, side=None)
+        Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=None, block_type_index=2, side=None)
 
         Multiple pins in a single pinclass.
         >>> xml_string = '''
-        ... <block_type id="1" name="BLK_BB-VPR_PAD" width="2" height="3">
+        ... <block_type id="1" name="VPR_PAD" width="2" height="3">
         ...   <pin_class type="OUTPUT">
-        ...     <pin ptc="0">BLK_BB-VPR_PAD.outpad[0]</pin>
-        ...     <pin ptc="1">BLK_BB-VPR_PAD.outpad[1]</pin>
+        ...     <pin ptc="0">VPR_PAD.outpad[0]</pin>
+        ...     <pin ptc="1">VPR_PAD.outpad[1]</pin>
         ...   </pin_class>
         ...   <pin_class type="INPUT">
-        ...     <pin ptc="2">BLK_BB-VPR_PAD.inpad[0]</pin>
+        ...     <pin ptc="2">VPR_PAD.inpad[0]</pin>
         ...   </pin_class>
         ... </block_type>
         ... '''
         >>> bt = BlockType.from_xml(None, ET.fromstring(xml_string))
         >>> bt # doctest: +ELLIPSIS
-        BlockType(graph=None, id=1, name='BLK_BB-VPR_PAD', size=Size(w=2, h=3), pin_classes=[...], pins_index={...}, ports_index={...})
+        BlockType(graph=None, id=1, name='VPR_PAD', size=Size(w=2, h=3), pin_classes=[...], pins_index={...}, ports_index={...})
         >>> bt.pin_classes[0] # doctest: +ELLIPSIS
         PinClass(block_type=BlockType(), direction='output', pins=[...])
         >>> len(bt.pins_index)
@@ -786,33 +786,33 @@ class BlockType(MostlyReadOnly):
         >>> len(bt.pin_classes[1].pins)
         1
         >>> bt.pin_classes[0].pins[0]
-        Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=None, block_type_index=0, side=None)
+        Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=None, block_type_index=0, side=None)
         >>> bt.pin_classes[0].pins[1]
-        Pin(pin_class=PinClass(), port_name='outpad', port_index=1, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=None, block_type_index=1, side=None)
+        Pin(pin_class=PinClass(), port_name='outpad', port_index=1, block_type_name='VPR_PAD', block_type_subblk=None, block_type_index=1, side=None)
         >>> bt.pin_classes[1].pins[0]
-        Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=None, block_type_index=2, side=None)
+        Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=None, block_type_index=2, side=None)
         >>>
 
         Multiple subblocks within a block_type
         >>> xml_string = '''
-        ... <block_type id="1" name="BLK_BB-VPR_PAD" width="2" height="3">
+        ... <block_type id="1" name="VPR_PAD" width="2" height="3">
         ...   <pin_class type="OUTPUT">
-        ...     <pin ptc="0">BLK_BB-VPR_PAD[0].outpad[0]</pin>
+        ...     <pin ptc="0">VPR_PAD[0].outpad[0]</pin>
         ...   </pin_class>
         ...   <pin_class type="INPUT">
-        ...     <pin ptc="1">BLK_BB-VPR_PAD[0].inpad[0]</pin>
+        ...     <pin ptc="1">VPR_PAD[0].inpad[0]</pin>
         ...   </pin_class>
         ...   <pin_class type="OUTPUT">
-        ...     <pin ptc="2">BLK_BB-VPR_PAD[1].outpad[0]</pin>
+        ...     <pin ptc="2">VPR_PAD[1].outpad[0]</pin>
         ...   </pin_class>
         ...   <pin_class type="INPUT">
-        ...     <pin ptc="3">BLK_BB-VPR_PAD[1].inpad[0]</pin>
+        ...     <pin ptc="3">VPR_PAD[1].inpad[0]</pin>
         ...   </pin_class>
         ... </block_type>
         ... '''
         >>> bt = BlockType.from_xml(None, ET.fromstring(xml_string))
         >>> bt # doctest: +ELLIPSIS
-        BlockType(graph=None, id=1, name='BLK_BB-VPR_PAD', size=Size(w=2, h=3), pin_classes=[...], pins_index={...}, ports_index={...})
+        BlockType(graph=None, id=1, name='VPR_PAD', size=Size(w=2, h=3), pin_classes=[...], pins_index={...}, ports_index={...})
         >>> bt.pin_classes[0] # doctest: +ELLIPSIS
         PinClass(block_type=BlockType(), direction='output', pins=[...])
         >>> len(bt.pins_index)
@@ -821,13 +821,13 @@ class BlockType(MostlyReadOnly):
         4
         >>> # All the pin classes should only have one pin
         >>> bt.pin_classes[0].pins
-        (Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=0, block_type_index=0, side=None),)
+        (Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=0, block_type_index=0, side=None),)
         >>> bt.pin_classes[1].pins
-        (Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=0, block_type_index=1, side=None),)
+        (Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=0, block_type_index=1, side=None),)
         >>> bt.pin_classes[2].pins
-        (Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=1, block_type_index=2, side=None),)
+        (Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=1, block_type_index=2, side=None),)
         >>> bt.pin_classes[3].pins
-        (Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='BLK_BB-VPR_PAD', block_type_subblk=1, block_type_index=3, side=None),)
+        (Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=1, block_type_index=3, side=None),)
         """
         assert block_type_node.tag == "block_type", block_type_node
         block_type_id = int(block_type_node.attrib['id'])
@@ -2575,21 +2575,21 @@ class Graph:
         Traceback (most recent call last):
             ...
         KeyError: P(x=4, y=4)
-        >>> g.block_grid.block_types["BLK_IG-IBUF"]
-        BlockType(graph=..., id=1, name='BLK_IG-IBUF', size=Size(w=1, h=1), ...)
+        >>> g.block_grid.block_types["IBUF"]
+        BlockType(graph=..., id=1, name='IBUF', size=Size(w=1, h=1), ...)
         >>> g.block_grid.block_types[2]
-        BlockType(graph=..., id=2, name='BLK_IG-OBUF', size=Size(w=1, h=1), ...)
+        BlockType(graph=..., id=2, name='OBUF', size=Size(w=1, h=1), ...)
         >>> for block in g.block_grid.blocks_for(row=1):
         ...     print(block.position, block.block_type.name)
-        P(x=0, y=1) BLK_IG-IBUF
-        P(x=1, y=1) BLK_TI-TILE
-        P(x=2, y=1) BLK_IG-OBUF
+        P(x=0, y=1) IBUF
+        P(x=1, y=1) TILE
+        P(x=2, y=1) OBUF
         P(x=3, y=1) EMPTY
         >>> for bt in g.block_grid.block_types_for(row=1):
         ...     print(bt.name)
-        BLK_IG-IBUF
-        BLK_TI-TILE
-        BLK_IG-OBUF
+        IBUF
+        TILE
+        OBUF
         EMPTY
 
         """
@@ -3209,22 +3209,22 @@ def simple_test_graph(**kwargs):
     <block_types>
         <block_type id="0" name="EMPTY" width="1" height="1">
         </block_type>
-        <block_type id="1" name="BLK_IG-IBUF" width="1" height="1">
+        <block_type id="1" name="IBUF" width="1" height="1">
             <pin_class type="OUTPUT">
-                <pin ptc="0">BLK_IG-IBUF.I[0]</pin>
+                <pin ptc="0">IBUF.I[0]</pin>
             </pin_class>
         </block_type>
-        <block_type id="2" name="BLK_IG-OBUF" width="1" height="1">
+        <block_type id="2" name="OBUF" width="1" height="1">
             <pin_class type="INPUT">
-                <pin ptc="0">BLK_IG-OBUF.O[0]</pin>
+                <pin ptc="0">OBUF.O[0]</pin>
             </pin_class>
         </block_type>
-        <block_type id="3" name="BLK_TI-TILE" width="1" height="1">
+        <block_type id="3" name="TILE" width="1" height="1">
             <pin_class type="INPUT">
-                <pin ptc="0">BLK_TI-TILE.IN[0]</pin>
+                <pin ptc="0">TILE.IN[0]</pin>
             </pin_class>
             <pin_class type="OUTPUT">
-                <pin ptc="1">BLK_TI-TILE.OUT[0]</pin>
+                <pin ptc="1">TILE.OUT[0]</pin>
             </pin_class>
         </block_type>
     </block_types>

--- a/utils/lib/rr_graph/tests/test_graph.py
+++ b/utils/lib/rr_graph/tests/test_graph.py
@@ -18,8 +18,7 @@ class TestGraph(unittest.TestCase):
         self.assertEqual(('c', 'd', [1]), graph.parse_net('c.d[1]'))
         self.assertEqual(('c', 'd', [40]), graph.parse_net('c.d[40]'))
         self.assertEqual(
-            ('BLK_BB-VPR_PAD', 'outpad', [0]),
-            graph.parse_net('BLK_BB-VPR_PAD.outpad[0]')
+            ('VPR_PAD', 'outpad', [0]), graph.parse_net('VPR_PAD.outpad[0]')
         )
         # Complex block names
         self.assertEqual(('a.b', 'c', [0]), graph.parse_net('a.b.c[0]'))
@@ -118,15 +117,15 @@ class TestGraph(unittest.TestCase):
 
     def test_blocktype_from_xml(self):
         xml_string = '''
-        <block_type id="1" name="BLK_BB-VPR_PAD" width="2" height="3">
+        <block_type id="1" name="VPR_PAD" width="2" height="3">
             <pin_class type="OUTPUT">
-                <pin ptc="0">BLK_BB-VPR_PAD.outpad[0]</pin>
+                <pin ptc="0">VPR_PAD.outpad[0]</pin>
             </pin_class>
             <pin_class type="OUTPUT">
-                <pin ptc="1">BLK_BB-VPR_PAD.outpad[1]</pin>
+                <pin ptc="1">VPR_PAD.outpad[1]</pin>
             </pin_class>
             <pin_class type="INPUT">
-                <pin ptc="2">BLK_BB-VPR_PAD.inpad[0]</pin>
+                <pin ptc="2">VPR_PAD.inpad[0]</pin>
             </pin_class>
         </block_type>
         '''
@@ -137,13 +136,13 @@ class TestGraph(unittest.TestCase):
 
         # Multiple pins in a single pinclass
         xml_string = '''
-        <block_type id="1" name="BLK_BB-VPR_PAD" width="2" height="3">
+        <block_type id="1" name="VPR_PAD" width="2" height="3">
             <pin_class type="OUTPUT">
-                <pin ptc="0">BLK_BB-VPR_PAD.outpad[0]</pin>
-                <pin ptc="1">BLK_BB-VPR_PAD.outpad[1]</pin>
+                <pin ptc="0">VPR_PAD.outpad[0]</pin>
+                <pin ptc="1">VPR_PAD.outpad[1]</pin>
             </pin_class>
             <pin_class type="INPUT">
-                <pin ptc="2">BLK_BB-VPR_PAD.inpad[0]</pin>
+                <pin ptc="2">VPR_PAD.inpad[0]</pin>
             </pin_class>
         </block_type>
         '''
@@ -154,18 +153,18 @@ class TestGraph(unittest.TestCase):
 
         # Multiple subblocks within a block_type
         xml_string = '''
-        <block_type id="1" name="BLK_BB-VPR_PAD" width="2" height="3">
+        <block_type id="1" name="VPR_PAD" width="2" height="3">
             <pin_class type="OUTPUT">
-                <pin ptc="0">BLK_BB-VPR_PAD[0].outpad[0]</pin>
+                <pin ptc="0">VPR_PAD[0].outpad[0]</pin>
             </pin_class>
             <pin_class type="INPUT">
-                <pin ptc="1">BLK_BB-VPR_PAD[0].inpad[0]</pin>
+                <pin ptc="1">VPR_PAD[0].inpad[0]</pin>
             </pin_class>
             <pin_class type="OUTPUT">
-                <pin ptc="2">BLK_BB-VPR_PAD[1].outpad[0]</pin>
+                <pin ptc="2">VPR_PAD[1].outpad[0]</pin>
             </pin_class>
             <pin_class type="INPUT">
-                <pin ptc="3">BLK_BB-VPR_PAD[1].inpad[0]</pin>
+                <pin ptc="3">VPR_PAD[1].inpad[0]</pin>
             </pin_class>
         </block_type>
         '''
@@ -570,8 +569,8 @@ class TestGraph(unittest.TestCase):
         with self.assertRaises(KeyError):
             g.block_grid[P(4, 4)]
 
-        self.assertEqual(1, g.block_grid.block_types["BLK_IG-IBUF"].id)
-        self.assertEqual('BLK_IG-OBUF', g.block_grid.block_types[2].name)
+        self.assertEqual(1, g.block_grid.block_types["IBUF"].id)
+        self.assertEqual('OBUF', g.block_grid.block_types[2].name)
 
 
 if __name__ == "__main__":

--- a/utils/vlog/vlog_to_pbtype.py
+++ b/utils/vlog/vlog_to_pbtype.py
@@ -125,18 +125,18 @@ def mod_pb_name(mod):
     # Process type and class of module
     mod_cls = mod.CLASS
     if mod_cls == "routing":
-        return "BEL_RX-" + mod.name
+        return mod.name
     elif mod_cls == "mux":
-        return "BEL_MX-" + mod.name
+        return mod.name
     elif mod_cls == "flipflop":
-        return "BEL_FF-" + mod.name
+        return mod.name
     elif mod_cls == "lut":
-        return "BEL_LT-" + mod.name
+        return mod.name
     elif is_blackbox and not has_modes:
-        return "BEL_BB-" + mod.name
+        return mod.name
     else:
         #TODO: other types
-        return "BLK_IG-" + mod.name
+        return mod.name
 
 
 def strip_name(name):

--- a/vpr/const/const.pb_type.xml
+++ b/vpr/const/const.pb_type.xml
@@ -1,5 +1,9 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".names" class="lut" name="BEL_01-CONST" num_pb="1">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".names" class="lut" name="CONST" num_pb="1">
   <input name="in" num_pins="0" port_class="lut_in"/>
   <output name="out" num_pins="1" port_class="lut_out"/>
-  <delay_matrix in_port="BEL_01-CONST.in" out_port="BEL_01-CONST.out" type="max">0</delay_matrix>
+  <delay_matrix in_port="CONST.in" out_port="CONST.out" type="max">0</delay_matrix>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">constant</meta>
+  </metadata>
 </pb_type>

--- a/vpr/dual-pad/dual-pad.pb_type.xml
+++ b/vpr/dual-pad/dual-pad.pb_type.xml
@@ -1,8 +1,8 @@
 <pb_types xmlns:xi="http://www.w3.org/2001/XInclude">
- <pb_type name="BLK_IG-OBUF" capacity="2">
+ <pb_type name="OBUF" capacity="2">
   <xi:include href="../pad/pad.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  </pb_type>
- <pb_type name="BLK_IG-IBUF" capacity="2">
+ <pb_type name="IBUF" capacity="2">
   <xi:include href="../pad/pad.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
  </pb_type>
 </pb_types>

--- a/vpr/dual-pad/ibuf.pb_type.xml
+++ b/vpr/dual-pad/ibuf.pb_type.xml
@@ -1,28 +1,36 @@
 <!-- An IO pin found on an FPGA -->
-<pb_type name="BLK_IG-IBUF" capacity="2">
+<pb_type name="IBUF" capacity="2">
  <input name="outpad" num_pins="1"/>
  <output name="inpad" num_pins="1"/>
 
  <!-- IO operating as an input -->
  <mode name="PAD_IS_INPUT">
-   <pb_type name="PAD_IN-INPUT" blif_model=".input" num_pb="1">
-    <output name="inpad" num_pins="1"/>
-   </pb_type>
-   <interconnect>
-    <direct name="INPUT" input="PAD_IN-INPUT.inpad" output="BLK_IG-IBUF.inpad">
-     <delay_constant max="4.243e-11" in_port="PAD_IN-INPUT.inpad" out_port="BLK_IG-IBUF.inpad"/>
-    </direct>
-   </interconnect>
+  <pb_type name="INPUT" blif_model=".input" num_pb="1">
+   <output name="inpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">input</meta>
+   </metadata>
+  </pb_type>
+  <interconnect>
+   <direct name="INPUT" input="INPUT.inpad" output="IBUF.inpad">
+    <delay_constant max="4.243e-11" in_port="INPUT.inpad" out_port="IBUF.inpad"/>
+   </direct>
+  </interconnect>
  </mode>
 
  <!-- IO operating as an output -->
  <mode name="PAD_IS_OUTPUT">
-  <pb_type name="PAD_OT-OUTPUT" blif_model=".output" num_pb="1">
+  <pb_type name="OUTPUT" blif_model=".output" num_pb="1">
    <input name="outpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">output</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct name="OUTPUT" input="BLK_IG-IBUF.outpad" output="PAD_OT-OUTPUT.outpad">
-    <delay_constant max="1.394e-11" in_port="BLK_IG-IBUF.outpad" out_port="PAD_OT-OUTPUT.outpad"/>
+   <direct name="OUTPUT" input="IBUF.outpad" output="OUTPUT.outpad">
+    <delay_constant max="1.394e-11" in_port="IBUF.outpad" out_port="OUTPUT.outpad"/>
    </direct>
   </interconnect>
  </mode>
@@ -42,6 +50,10 @@
   different pin definitions (one for each side of the FPGA).
  -->
  <pinlocations pattern="custom">
-  <loc side="right">BLK_IG-IBUF.outpad BLK_IG-IBUF.inpad</loc>
+  <loc side="right">IBUF.outpad IBUF.inpad</loc>
  </pinlocations>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/vpr/dual-pad/obuf.pb_type.xml
+++ b/vpr/dual-pad/obuf.pb_type.xml
@@ -1,28 +1,36 @@
 <!-- An IO pin found on an FPGA -->
-<pb_type name="BLK_IG-OBUF" capacity="2">
+<pb_type name="OBUF" capacity="2">
  <input name="outpad" num_pins="1"/>
  <output name="inpad" num_pins="1"/>
 
  <!-- IO operating as an input -->
  <mode name="PAD_IS_INPUT">
-   <pb_type name="PAD_IN-INPUT" blif_model=".input" num_pb="1">
-    <output name="inpad" num_pins="1"/>
-   </pb_type>
-   <interconnect>
-    <direct name="INPUT" input="PAD_IN-INPUT.inpad" output="BLK_IG-OBUF.inpad">
-     <delay_constant max="4.243e-11" in_port="PAD_IN-INPUT.inpad" out_port="BLK_IG-OBUF.inpad"/>
-    </direct>
-   </interconnect>
+  <pb_type name="INPUT" blif_model=".input" num_pb="1">
+   <output name="inpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">input</meta>
+   </metadata>
+  </pb_type>
+  <interconnect>
+   <direct name="INPUT" input="INPUT.inpad" output="OBUF.inpad">
+    <delay_constant max="4.243e-11" in_port="INPUT.inpad" out_port="OBUF.inpad"/>
+   </direct>
+  </interconnect>
  </mode>
 
  <!-- IO operating as an output -->
  <mode name="PAD_IS_OUTPUT">
-  <pb_type name="PAD_OT-OUTPUT" blif_model=".output" num_pb="1">
+  <pb_type name="OUTPUT" blif_model=".output" num_pb="1">
    <input name="outpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">output</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct name="OUTPUT" input="BLK_IG-OBUF.outpad" output="PAD_OT-OUTPUT.outpad">
-    <delay_constant max="1.394e-11" in_port="BLK_IG-OBUF.outpad" out_port="PAD_OT-OUTPUT.outpad"/>
+   <direct name="OUTPUT" input="OBUF.outpad" output="OUTPUT.outpad">
+    <delay_constant max="1.394e-11" in_port="OBUF.outpad" out_port="OUTPUT.outpad"/>
    </direct>
   </interconnect>
  </mode>
@@ -42,6 +50,10 @@
   different pin definitions (one for each side of the FPGA).
  -->
  <pinlocations pattern="custom">
-  <loc side="right">BLK_IG-OBUF.outpad BLK_IG-OBUF.inpad</loc>
+  <loc side="right">OBUF.outpad OBUF.inpad</loc>
  </pinlocations>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/vpr/ibuf/ibuf.pb_type.xml
+++ b/vpr/ibuf/ibuf.pb_type.xml
@@ -1,14 +1,22 @@
 <!-- An IO pin found on an FPGA -->
-<pb_type name="BLK_IG-IBUF" capacity="1">
+<pb_type name="IBUF" capacity="1">
  <output name="I" num_pins="1"/>
- <pb_type name="BLK_BB-IBUF" blif_model=".input" num_pb="1">
+ <pb_type name="PAD" blif_model=".input" num_pb="1">
   <output name="inpad" num_pins="1"/>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">input</meta>
+  </metadata>
  </pb_type>
  <interconnect>
-  <direct name="IBUF" input="BLK_BB-IBUF.inpad" output="BLK_IG-IBUF.I" />
+  <direct name="IBUF" input="PAD.inpad" output="IBUF.I" />
  </interconnect>
  <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0" />
  <pinlocations pattern="custom">
-  <loc side="right">BLK_IG-IBUF.I</loc>
+  <loc side="right">IBUF.I</loc>
  </pinlocations>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/vpr/obuf/obuf.pb_type.xml
+++ b/vpr/obuf/obuf.pb_type.xml
@@ -1,14 +1,22 @@
 <!-- An IO pin found on an FPGA -->
-<pb_type name="BLK_IG-OBUF" capacity="1">
+<pb_type name="OBUF" capacity="1">
  <input name="O" num_pins="1"/>
- <pb_type name="BLK_BB-OBUF" blif_model=".output" num_pb="1">
+ <pb_type name="PAD" blif_model=".output" num_pb="1">
   <input name="outpad" num_pins="1"/>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">output</meta>
+  </metadata>
  </pb_type>
  <interconnect>
-  <direct name="OBUF" input="BLK_IG-OBUF.O" output="BLK_BB-OBUF.outpad" />
+  <direct name="OBUF" input="OBUF.O" output="PAD.outpad" />
  </interconnect>
  <fc in_type="frac" in_val="1.0" out_type="frac" out_val="1.0" />
  <pinlocations pattern="custom">
-  <loc side="right">BLK_IG-OBUF.O</loc>
+  <loc side="right">OBUF.O</loc>
  </pinlocations>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/vpr/pad/pad.pb_type.xml
+++ b/vpr/pad/pad.pb_type.xml
@@ -1,28 +1,36 @@
 <!-- An IO pin found on an FPGA -->
-<pb_type name="BLK_BB-VPR_PAD" capacity="1">
+<pb_type name="VPR_PAD" capacity="1">
  <input name="outpad" num_pins="1"/>
  <output name="inpad" num_pins="1"/>
 
  <!-- IO operating as an input -->
  <mode name="PAD_IS_INPUT">
-   <pb_type name="PAD_IN-INPUT" blif_model=".input" num_pb="1">
-    <output name="inpad" num_pins="1"/>
-   </pb_type>
-   <interconnect>
-    <direct name="INPUT" input="PAD_IN-INPUT.inpad" output="BLK_BB-VPR_PAD.inpad">
-     <delay_constant max="4.243e-11" in_port="PAD_IN-INPUT.inpad" out_port="BLK_BB-VPR_PAD.inpad"/>
-    </direct>
-   </interconnect>
+  <pb_type name="INPUT" blif_model=".input" num_pb="1">
+   <output name="inpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">input</meta>
+   </metadata>
+  </pb_type>
+  <interconnect>
+   <direct name="INPUT" input="INPUT.inpad" output="VPR_PAD.inpad">
+    <delay_constant max="4.243e-11" in_port="INPUT.inpad" out_port="VPR_PAD.inpad"/>
+   </direct>
+  </interconnect>
  </mode>
 
  <!-- IO operating as an output -->
  <mode name="PAD_IS_OUTPUT">
-  <pb_type name="PAD_OT-OUTPUT" blif_model=".output" num_pb="1">
+  <pb_type name="OUTPUT" blif_model=".output" num_pb="1">
    <input name="outpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">output</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-   <direct name="OUTPUT" input="BLK_BB-VPR_PAD.outpad" output="PAD_OT-OUTPUT.outpad">
-    <delay_constant max="1.394e-11" in_port="BLK_BB-VPR_PAD.outpad" out_port="PAD_OT-OUTPUT.outpad"/>
+   <direct name="OUTPUT" input="VPR_PAD.outpad" output="OUTPUT.outpad">
+    <delay_constant max="1.394e-11" in_port="VPR_PAD.outpad" out_port="OUTPUT.outpad"/>
    </direct>
   </interconnect>
  </mode>
@@ -42,6 +50,10 @@
   different pin definitions (one for each side of the FPGA).
  -->
  <pinlocations pattern="custom">
-  <loc side="right">BLK_BB-VPR_PAD.outpad BLK_BB-VPR_PAD.inpad</loc>
+  <loc side="right">VPR_PAD.outpad VPR_PAD.inpad</loc>
  </pinlocations>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">tile</meta>
+ </metadata>
 </pb_type>

--- a/vpr/wire/wire.pb_type.xml
+++ b/vpr/wire/wire.pb_type.xml
@@ -1,5 +1,9 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".names" class="lut" name="BLK_IG-WIRE" num_pb="1">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".names" class="lut" name="WIRE" num_pb="1">
   <input name="in" num_pins="1" port_class="lut_in"/>
   <output name="out" num_pins="1" port_class="lut_out"/>
-  <delay_matrix in_port="BLK_IG-WIRE.in" out_port="BLK_IG-WIRE.out" type="max">0</delay_matrix>
+  <delay_matrix in_port="WIRE.in" out_port="WIRE.out" type="max">0</delay_matrix>
+  <metadata>
+   <meta name="type">bel</meta>
+   <meta name="subtype">wire</meta>
+  </metadata>
 </pb_type>

--- a/xc7/fasm2bels/net_map.py
+++ b/xc7/fasm2bels/net_map.py
@@ -17,8 +17,8 @@ class Net(namedtuple('Net', 'name wire_pkey tile site_pin')):
     pass
 
 
-# BLK_TI-CLBLL_L.CLBLL_LL_A1[0] -> (CLBLL_L, CLBLL_LL_A1)
-PIN_NAME_TO_PARTS = re.compile(r'^BLK_TI-([^\.]+)\.([^\]]+)\[0\]$')
+# CLBLL_L.CLBLL_LL_A1[0] -> (CLBLL_L, CLBLL_LL_A1)
+PIN_NAME_TO_PARTS = re.compile(r'^([^\.]+)\.([^\]]+)\[0\]$')
 
 
 def create_net_list(conn, graph, route_file):
@@ -37,7 +37,7 @@ def create_net_list(conn, graph, route_file):
         pin_name = graph.pin_ptc_to_name_map[(gridloc.block_type_id, node.ptc)]
 
         # Do not add synthetic nets to map.
-        if pin_name.startswith('BLK_SY-'):
+        if pin_name.startswith('SYN-'):
             continue
 
         m = PIN_NAME_TO_PARTS.match(pin_name)

--- a/xc7/primitives/bram/bram.pb_type.xml
+++ b/xc7/primitives/bram/bram.pb_type.xml
@@ -12,7 +12,7 @@ affected by the BRAM mode, each site cannot be handled independendly.  For this
 reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
 
   -->
-<pb_type name="BLK_IG-BRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="BRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- RAMBFIFO36E1 site pins -->
  <input  name="RAMB36_Y0_WEBWEU"         num_pins="8"  />
  <input  name="RAMB36_Y0_WEBWEL"         num_pins="8"  />
@@ -185,97 +185,97 @@ reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
  <mode name="BRAM36">
   <xi:include href="rambfifo36e1.pb_type.xml" />
   <interconnect>
-   <direct name="RAMB36_X0Y0_WEBWEU"            input="BLK_IG-BRAM.RAMB36_Y0_WEBWEU"             output="BLK_IG-RAMBFIFO36E1.WEBWEU" />
-   <direct name="RAMB36_X0Y0_WEBWEL"            input="BLK_IG-BRAM.RAMB36_Y0_WEBWEL"             output="BLK_IG-RAMBFIFO36E1.WEBWEL" />
-   <direct name="RAMB36_X0Y0_WEAU"              input="BLK_IG-BRAM.RAMB36_Y0_WEAU"               output="BLK_IG-RAMBFIFO36E1.WEAU" />
-   <direct name="RAMB36_X0Y0_WEAL"              input="BLK_IG-BRAM.RAMB36_Y0_WEAL"               output="BLK_IG-RAMBFIFO36E1.WEAL" />
+   <direct name="RAMB36_X0Y0_WEBWEU"            input="BRAM.RAMB36_Y0_WEBWEU"             output="RAMBFIFO36E1.WEBWEU" />
+   <direct name="RAMB36_X0Y0_WEBWEL"            input="BRAM.RAMB36_Y0_WEBWEL"             output="RAMBFIFO36E1.WEBWEL" />
+   <direct name="RAMB36_X0Y0_WEAU"              input="BRAM.RAMB36_Y0_WEAU"               output="RAMBFIFO36E1.WEAU" />
+   <direct name="RAMB36_X0Y0_WEAL"              input="BRAM.RAMB36_Y0_WEAL"               output="RAMBFIFO36E1.WEAL" />
 
-   <direct name="RAMB36_X0Y0_TSTWROS"           input="BLK_IG-BRAM.RAMB36_Y0_TSTWROS"            output="BLK_IG-RAMBFIFO36E1.TSTWROS" />
-   <direct name="RAMB36_X0Y0_TSTWRCNTOFF"       input="BLK_IG-BRAM.RAMB36_Y0_TSTWRCNTOFF"        output="BLK_IG-RAMBFIFO36E1.TSTWRCNTOFF" />
-   <direct name="RAMB36_X0Y0_TSTRDOS"           input="BLK_IG-BRAM.RAMB36_Y0_TSTRDOS"            output="BLK_IG-RAMBFIFO36E1.TSTRDOS" />
-   <direct name="RAMB36_X0Y0_TSTRDCNTOFF"       input="BLK_IG-BRAM.RAMB36_Y0_TSTRDCNTOFF"        output="BLK_IG-RAMBFIFO36E1.TSTRDCNTOFF" />
-   <direct name="RAMB36_X0Y0_TSTOFF"            input="BLK_IG-BRAM.RAMB36_Y0_TSTOFF"             output="BLK_IG-RAMBFIFO36E1.TSTOFF" />
-   <direct name="RAMB36_X0Y0_TSTIN"             input="BLK_IG-BRAM.RAMB36_Y0_TSTIN"              output="BLK_IG-RAMBFIFO36E1.TSTIN" />
-   <direct name="RAMB36_X0Y0_TSTFLAGIN"         input="BLK_IG-BRAM.RAMB36_Y0_TSTFLAGIN"          output="BLK_IG-RAMBFIFO36E1.TSTFLAGIN" />
-   <direct name="RAMB36_X0Y0_TSTCNT"            input="BLK_IG-BRAM.RAMB36_Y0_TSTCNT"             output="BLK_IG-RAMBFIFO36E1.TSTCNT" />
-   <direct name="RAMB36_X0Y0_TSTBRAMRST"        input="BLK_IG-BRAM.RAMB36_Y0_TSTBRAMRST"         output="BLK_IG-RAMBFIFO36E1.TSTBRAMRST" />
+   <direct name="RAMB36_X0Y0_TSTWROS"           input="BRAM.RAMB36_Y0_TSTWROS"            output="RAMBFIFO36E1.TSTWROS" />
+   <direct name="RAMB36_X0Y0_TSTWRCNTOFF"       input="BRAM.RAMB36_Y0_TSTWRCNTOFF"        output="RAMBFIFO36E1.TSTWRCNTOFF" />
+   <direct name="RAMB36_X0Y0_TSTRDOS"           input="BRAM.RAMB36_Y0_TSTRDOS"            output="RAMBFIFO36E1.TSTRDOS" />
+   <direct name="RAMB36_X0Y0_TSTRDCNTOFF"       input="BRAM.RAMB36_Y0_TSTRDCNTOFF"        output="RAMBFIFO36E1.TSTRDCNTOFF" />
+   <direct name="RAMB36_X0Y0_TSTOFF"            input="BRAM.RAMB36_Y0_TSTOFF"             output="RAMBFIFO36E1.TSTOFF" />
+   <direct name="RAMB36_X0Y0_TSTIN"             input="BRAM.RAMB36_Y0_TSTIN"              output="RAMBFIFO36E1.TSTIN" />
+   <direct name="RAMB36_X0Y0_TSTFLAGIN"         input="BRAM.RAMB36_Y0_TSTFLAGIN"          output="RAMBFIFO36E1.TSTFLAGIN" />
+   <direct name="RAMB36_X0Y0_TSTCNT"            input="BRAM.RAMB36_Y0_TSTCNT"             output="RAMBFIFO36E1.TSTCNT" />
+   <direct name="RAMB36_X0Y0_TSTBRAMRST"        input="BRAM.RAMB36_Y0_TSTBRAMRST"         output="RAMBFIFO36E1.TSTBRAMRST" />
 
-   <direct name="RAMB36_X0Y0_RSTREGBU"          input="BLK_IG-BRAM.RAMB36_Y0_RSTREGBU"           output="BLK_IG-RAMBFIFO36E1.RSTREGBU" />
-   <direct name="RAMB36_X0Y0_RSTREGBL"          input="BLK_IG-BRAM.RAMB36_Y0_RSTREGBL"           output="BLK_IG-RAMBFIFO36E1.RSTREGBL" />
-   <direct name="RAMB36_X0Y0_RSTREGARSTREGU"    input="BLK_IG-BRAM.RAMB36_Y0_RSTREGARSTREGU"     output="BLK_IG-RAMBFIFO36E1.RSTREGARSTREGU" />
-   <direct name="RAMB36_X0Y0_RSTREGARSTREGL"    input="BLK_IG-BRAM.RAMB36_Y0_RSTREGARSTREGL"     output="BLK_IG-RAMBFIFO36E1.RSTREGARSTREGL" />
-   <direct name="RAMB36_X0Y0_RSTRAMBU"          input="BLK_IG-BRAM.RAMB36_Y0_RSTRAMBU"           output="BLK_IG-RAMBFIFO36E1.RSTRAMBU" />
-   <direct name="RAMB36_X0Y0_RSTRAMBL"          input="BLK_IG-BRAM.RAMB36_Y0_RSTRAMBL"           output="BLK_IG-RAMBFIFO36E1.RSTRAMBL" />
-   <direct name="RAMB36_X0Y0_RSTRAMARSTRAMU"    input="BLK_IG-BRAM.RAMB36_Y0_RSTRAMARSTRAMU"     output="BLK_IG-RAMBFIFO36E1.RSTRAMARSTRAMU" />
-   <direct name="RAMB36_X0Y0_RSTRAMARSTRAMLRST" input="BLK_IG-BRAM.RAMB36_Y0_RSTRAMARSTRAMLRST"  output="BLK_IG-RAMBFIFO36E1.RSTRAMARSTRAMLRST" />
+   <direct name="RAMB36_X0Y0_RSTREGBU"          input="BRAM.RAMB36_Y0_RSTREGBU"           output="RAMBFIFO36E1.RSTREGBU" />
+   <direct name="RAMB36_X0Y0_RSTREGBL"          input="BRAM.RAMB36_Y0_RSTREGBL"           output="RAMBFIFO36E1.RSTREGBL" />
+   <direct name="RAMB36_X0Y0_RSTREGARSTREGU"    input="BRAM.RAMB36_Y0_RSTREGARSTREGU"     output="RAMBFIFO36E1.RSTREGARSTREGU" />
+   <direct name="RAMB36_X0Y0_RSTREGARSTREGL"    input="BRAM.RAMB36_Y0_RSTREGARSTREGL"     output="RAMBFIFO36E1.RSTREGARSTREGL" />
+   <direct name="RAMB36_X0Y0_RSTRAMBU"          input="BRAM.RAMB36_Y0_RSTRAMBU"           output="RAMBFIFO36E1.RSTRAMBU" />
+   <direct name="RAMB36_X0Y0_RSTRAMBL"          input="BRAM.RAMB36_Y0_RSTRAMBL"           output="RAMBFIFO36E1.RSTRAMBL" />
+   <direct name="RAMB36_X0Y0_RSTRAMARSTRAMU"    input="BRAM.RAMB36_Y0_RSTRAMARSTRAMU"     output="RAMBFIFO36E1.RSTRAMARSTRAMU" />
+   <direct name="RAMB36_X0Y0_RSTRAMARSTRAMLRST" input="BRAM.RAMB36_Y0_RSTRAMARSTRAMLRST"  output="RAMBFIFO36E1.RSTRAMARSTRAMLRST" />
 
-   <direct name="RAMB36_X0Y0_REGCLKBU"          input="BLK_IG-BRAM.RAMB36_Y0_REGCLKBU"           output="BLK_IG-RAMBFIFO36E1.REGCLKBU" />
-   <direct name="RAMB36_X0Y0_REGCLKBL"          input="BLK_IG-BRAM.RAMB36_Y0_REGCLKBL"           output="BLK_IG-RAMBFIFO36E1.REGCLKBL" />
-   <direct name="RAMB36_X0Y0_REGCLKARDRCLKU"    input="BLK_IG-BRAM.RAMB36_Y0_REGCLKARDRCLKU"     output="BLK_IG-RAMBFIFO36E1.REGCLKARDRCLKU" />
-   <direct name="RAMB36_X0Y0_REGCLKARDRCLKL"    input="BLK_IG-BRAM.RAMB36_Y0_REGCLKARDRCLKL"     output="BLK_IG-RAMBFIFO36E1.REGCLKARDRCLKL" />
-   <direct name="RAMB36_X0Y0_REGCEBU"           input="BLK_IG-BRAM.RAMB36_Y0_REGCEBU"            output="BLK_IG-RAMBFIFO36E1.REGCEBU" />
-   <direct name="RAMB36_X0Y0_REGCEBL"           input="BLK_IG-BRAM.RAMB36_Y0_REGCEBL"            output="BLK_IG-RAMBFIFO36E1.REGCEBL" />
-   <direct name="RAMB36_X0Y0_REGCEAREGCEU"      input="BLK_IG-BRAM.RAMB36_Y0_REGCEAREGCEU"       output="BLK_IG-RAMBFIFO36E1.REGCEAREGCEU" />
-   <direct name="RAMB36_X0Y0_REGCEAREGCEL"      input="BLK_IG-BRAM.RAMB36_Y0_REGCEAREGCEL"       output="BLK_IG-RAMBFIFO36E1.REGCEAREGCEL" />
+   <direct name="RAMB36_X0Y0_REGCLKBU"          input="BRAM.RAMB36_Y0_REGCLKBU"           output="RAMBFIFO36E1.REGCLKBU" />
+   <direct name="RAMB36_X0Y0_REGCLKBL"          input="BRAM.RAMB36_Y0_REGCLKBL"           output="RAMBFIFO36E1.REGCLKBL" />
+   <direct name="RAMB36_X0Y0_REGCLKARDRCLKU"    input="BRAM.RAMB36_Y0_REGCLKARDRCLKU"     output="RAMBFIFO36E1.REGCLKARDRCLKU" />
+   <direct name="RAMB36_X0Y0_REGCLKARDRCLKL"    input="BRAM.RAMB36_Y0_REGCLKARDRCLKL"     output="RAMBFIFO36E1.REGCLKARDRCLKL" />
+   <direct name="RAMB36_X0Y0_REGCEBU"           input="BRAM.RAMB36_Y0_REGCEBU"            output="RAMBFIFO36E1.REGCEBU" />
+   <direct name="RAMB36_X0Y0_REGCEBL"           input="BRAM.RAMB36_Y0_REGCEBL"            output="RAMBFIFO36E1.REGCEBL" />
+   <direct name="RAMB36_X0Y0_REGCEAREGCEU"      input="BRAM.RAMB36_Y0_REGCEAREGCEU"       output="RAMBFIFO36E1.REGCEAREGCEU" />
+   <direct name="RAMB36_X0Y0_REGCEAREGCEL"      input="BRAM.RAMB36_Y0_REGCEAREGCEL"       output="RAMBFIFO36E1.REGCEAREGCEL" />
 
-   <direct name="RAMB36_X0Y0_INJECTDBITERR"     input="BLK_IG-BRAM.RAMB36_Y0_INJECTDBITERR"      output="BLK_IG-RAMBFIFO36E1.INJECTDBITERR" />
-   <direct name="RAMB36_X0Y0_INJECTSBITERR"     input="BLK_IG-BRAM.RAMB36_Y0_INJECTSBITERR"      output="BLK_IG-RAMBFIFO36E1.INJECTSBITERR" />
+   <direct name="RAMB36_X0Y0_INJECTDBITERR"     input="BRAM.RAMB36_Y0_INJECTDBITERR"      output="RAMBFIFO36E1.INJECTDBITERR" />
+   <direct name="RAMB36_X0Y0_INJECTSBITERR"     input="BRAM.RAMB36_Y0_INJECTSBITERR"      output="RAMBFIFO36E1.INJECTSBITERR" />
 
-   <direct name="RAMB36_X0Y0_ENBWRENU"          input="BLK_IG-BRAM.RAMB36_Y0_ENBWRENU"           output="BLK_IG-RAMBFIFO36E1.ENBWRENU" />
-   <direct name="RAMB36_X0Y0_ENBWRENL"          input="BLK_IG-BRAM.RAMB36_Y0_ENBWRENL"           output="BLK_IG-RAMBFIFO36E1.ENBWRENL" />
-   <direct name="RAMB36_X0Y0_ENARDENU"          input="BLK_IG-BRAM.RAMB36_Y0_ENARDENU"           output="BLK_IG-RAMBFIFO36E1.ENARDENU" />
-   <direct name="RAMB36_X0Y0_ENARDENL"          input="BLK_IG-BRAM.RAMB36_Y0_ENARDENL"           output="BLK_IG-RAMBFIFO36E1.ENARDENL" />
-   <direct name="RAMB36_X0Y0_DIPBDIP"           input="BLK_IG-BRAM.RAMB36_Y0_DIPBDIP"            output="BLK_IG-RAMBFIFO36E1.DIPBDIP" />
-   <direct name="RAMB36_X0Y0_DIPADIP"           input="BLK_IG-BRAM.RAMB36_Y0_DIPADIP"            output="BLK_IG-RAMBFIFO36E1.DIPADIP" />
-   <direct name="RAMB36_X0Y0_DIBDI"             input="BLK_IG-BRAM.RAMB36_Y0_DIBDI"              output="BLK_IG-RAMBFIFO36E1.DIBDI" />
-   <direct name="RAMB36_X0Y0_DIADI"             input="BLK_IG-BRAM.RAMB36_Y0_DIADI"              output="BLK_IG-RAMBFIFO36E1.DIADI" />
+   <direct name="RAMB36_X0Y0_ENBWRENU"          input="BRAM.RAMB36_Y0_ENBWRENU"           output="RAMBFIFO36E1.ENBWRENU" />
+   <direct name="RAMB36_X0Y0_ENBWRENL"          input="BRAM.RAMB36_Y0_ENBWRENL"           output="RAMBFIFO36E1.ENBWRENL" />
+   <direct name="RAMB36_X0Y0_ENARDENU"          input="BRAM.RAMB36_Y0_ENARDENU"           output="RAMBFIFO36E1.ENARDENU" />
+   <direct name="RAMB36_X0Y0_ENARDENL"          input="BRAM.RAMB36_Y0_ENARDENL"           output="RAMBFIFO36E1.ENARDENL" />
+   <direct name="RAMB36_X0Y0_DIPBDIP"           input="BRAM.RAMB36_Y0_DIPBDIP"            output="RAMBFIFO36E1.DIPBDIP" />
+   <direct name="RAMB36_X0Y0_DIPADIP"           input="BRAM.RAMB36_Y0_DIPADIP"            output="RAMBFIFO36E1.DIPADIP" />
+   <direct name="RAMB36_X0Y0_DIBDI"             input="BRAM.RAMB36_Y0_DIBDI"              output="RAMBFIFO36E1.DIBDI" />
+   <direct name="RAMB36_X0Y0_DIADI"             input="BRAM.RAMB36_Y0_DIADI"              output="RAMBFIFO36E1.DIADI" />
 
-   <direct name="RAMB36_X0Y0_CLKBWRCLKU"        input="BLK_IG-BRAM.RAMB36_Y0_CLKBWRCLKU"         output="BLK_IG-RAMBFIFO36E1.CLKBWRCLKU" />
-   <direct name="RAMB36_X0Y0_CLKBWRCLKL"        input="BLK_IG-BRAM.RAMB36_Y0_CLKBWRCLKL"         output="BLK_IG-RAMBFIFO36E1.CLKBWRCLKL" />
-   <direct name="RAMB36_X0Y0_CLKARDCLKU"        input="BLK_IG-BRAM.RAMB36_Y0_CLKARDCLKU"         output="BLK_IG-RAMBFIFO36E1.CLKARDCLKU" />
-   <direct name="RAMB36_X0Y0_CLKARDCLKL"        input="BLK_IG-BRAM.RAMB36_Y0_CLKARDCLKL"         output="BLK_IG-RAMBFIFO36E1.CLKARDCLKL" />
+   <direct name="RAMB36_X0Y0_CLKBWRCLKU"        input="BRAM.RAMB36_Y0_CLKBWRCLKU"         output="RAMBFIFO36E1.CLKBWRCLKU" />
+   <direct name="RAMB36_X0Y0_CLKBWRCLKL"        input="BRAM.RAMB36_Y0_CLKBWRCLKL"         output="RAMBFIFO36E1.CLKBWRCLKL" />
+   <direct name="RAMB36_X0Y0_CLKARDCLKU"        input="BRAM.RAMB36_Y0_CLKARDCLKU"         output="RAMBFIFO36E1.CLKARDCLKU" />
+   <direct name="RAMB36_X0Y0_CLKARDCLKL"        input="BRAM.RAMB36_Y0_CLKARDCLKL"         output="RAMBFIFO36E1.CLKARDCLKL" />
 
-   <direct name="RAMB36_X0Y0_CASCADEINA"        input="BLK_IG-BRAM.RAMB36_Y0_CASCADEINA"         output="BLK_IG-RAMBFIFO36E1.CASCADEINA" />
-   <direct name="RAMB36_X0Y0_CASCADEINB"        input="BLK_IG-BRAM.RAMB36_Y0_CASCADEINB"         output="BLK_IG-RAMBFIFO36E1.CASCADEINB" />
+   <direct name="RAMB36_X0Y0_CASCADEINA"        input="BRAM.RAMB36_Y0_CASCADEINA"         output="RAMBFIFO36E1.CASCADEINA" />
+   <direct name="RAMB36_X0Y0_CASCADEINB"        input="BRAM.RAMB36_Y0_CASCADEINB"         output="RAMBFIFO36E1.CASCADEINB" />
 
-   <direct name="RAMB36_X0Y0_ADDRBWRADDRU"      input="BLK_IG-BRAM.RAMB36_Y0_ADDRBWRADDRU"       output="BLK_IG-RAMBFIFO36E1.ADDRBWRADDRU" />
-   <direct name="RAMB36_X0Y0_ADDRBWRADDRL"      input="BLK_IG-BRAM.RAMB36_Y0_ADDRBWRADDRL"       output="BLK_IG-RAMBFIFO36E1.ADDRBWRADDRL" />
+   <direct name="RAMB36_X0Y0_ADDRBWRADDRU"      input="BRAM.RAMB36_Y0_ADDRBWRADDRU"       output="RAMBFIFO36E1.ADDRBWRADDRU" />
+   <direct name="RAMB36_X0Y0_ADDRBWRADDRL"      input="BRAM.RAMB36_Y0_ADDRBWRADDRL"       output="RAMBFIFO36E1.ADDRBWRADDRL" />
 
-   <direct name="RAMB36_X0Y0_ADDRARDADDRU"      input="BLK_IG-BRAM.RAMB36_Y0_ADDRARDADDRU"       output="BLK_IG-RAMBFIFO36E1.ADDRARDADDRU" />
-   <direct name="RAMB36_X0Y0_ADDRARDADDRL"      input="BLK_IG-BRAM.RAMB36_Y0_ADDRARDADDRL"       output="BLK_IG-RAMBFIFO36E1.ADDRARDADDRL" />
+   <direct name="RAMB36_X0Y0_ADDRARDADDRU"      input="BRAM.RAMB36_Y0_ADDRARDADDRU"       output="RAMBFIFO36E1.ADDRARDADDRU" />
+   <direct name="RAMB36_X0Y0_ADDRARDADDRL"      input="BRAM.RAMB36_Y0_ADDRARDADDRL"       output="RAMBFIFO36E1.ADDRARDADDRL" />
 
-   <direct name="RAMB36_X0Y0_WRERR"             input="BLK_IG-RAMBFIFO36E1.WRERR"                  output="BLK_IG-BRAM.RAMB36_Y0_WRERR" />
-   <direct name="RAMB36_X0Y0_WRCOUNT"           input="BLK_IG-RAMBFIFO36E1.WRCOUNT"                output="BLK_IG-BRAM.RAMB36_Y0_WRCOUNT" />
+   <direct name="RAMB36_X0Y0_WRERR"             input="RAMBFIFO36E1.WRERR"                output="BRAM.RAMB36_Y0_WRERR" />
+   <direct name="RAMB36_X0Y0_WRCOUNT"           input="RAMBFIFO36E1.WRCOUNT"              output="BRAM.RAMB36_Y0_WRCOUNT" />
 
-   <direct name="RAMB36_X0Y0_TSTOUT"            input="BLK_IG-RAMBFIFO36E1.TSTOUT"                 output="BLK_IG-BRAM.RAMB36_Y0_TSTOUT" />
+   <direct name="RAMB36_X0Y0_TSTOUT"            input="RAMBFIFO36E1.TSTOUT"               output="BRAM.RAMB36_Y0_TSTOUT" />
 
-   <direct name="RAMB36_X0Y0_SBITERR"           input="BLK_IG-RAMBFIFO36E1.SBITERR"                output="BLK_IG-BRAM.RAMB36_Y0_SBITERR" />
+   <direct name="RAMB36_X0Y0_SBITERR"           input="RAMBFIFO36E1.SBITERR"              output="BRAM.RAMB36_Y0_SBITERR" />
 
-   <direct name="RAMB36_X0Y0_RDERR"             input="BLK_IG-RAMBFIFO36E1.RDERR"                  output="BLK_IG-BRAM.RAMB36_Y0_RDERR" />
-   <direct name="RAMB36_X0Y0_RDCOUNT"           input="BLK_IG-RAMBFIFO36E1.RDCOUNT"                output="BLK_IG-BRAM.RAMB36_Y0_RDCOUNT" />
+   <direct name="RAMB36_X0Y0_RDERR"             input="RAMBFIFO36E1.RDERR"                output="BRAM.RAMB36_Y0_RDERR" />
+   <direct name="RAMB36_X0Y0_RDCOUNT"           input="RAMBFIFO36E1.RDCOUNT"              output="BRAM.RAMB36_Y0_RDCOUNT" />
 
-   <direct name="RAMB36_X0Y0_FULL"              input="BLK_IG-RAMBFIFO36E1.FULL"                   output="BLK_IG-BRAM.RAMB36_Y0_FULL" />
-   <direct name="RAMB36_X0Y0_EMPTY"             input="BLK_IG-RAMBFIFO36E1.EMPTY"                  output="BLK_IG-BRAM.RAMB36_Y0_EMPTY" />
+   <direct name="RAMB36_X0Y0_FULL"              input="RAMBFIFO36E1.FULL"                 output="BRAM.RAMB36_Y0_FULL" />
+   <direct name="RAMB36_X0Y0_EMPTY"             input="RAMBFIFO36E1.EMPTY"                output="BRAM.RAMB36_Y0_EMPTY" />
 
-   <direct name="RAMB36_X0Y0_ECCPARITY"         input="BLK_IG-RAMBFIFO36E1.ECCPARITY"              output="BLK_IG-BRAM.RAMB36_Y0_ECCPARITY" />
+   <direct name="RAMB36_X0Y0_ECCPARITY"         input="RAMBFIFO36E1.ECCPARITY"            output="BRAM.RAMB36_Y0_ECCPARITY" />
 
-   <direct name="RAMB36_X0Y0_DOPBDOP"           input="BLK_IG-RAMBFIFO36E1.DOPBDOP"                output="BLK_IG-BRAM.RAMB36_Y0_DOPBDOP" />
-   <direct name="RAMB36_X0Y0_DOPADOP"           input="BLK_IG-RAMBFIFO36E1.DOPADOP"                output="BLK_IG-BRAM.RAMB36_Y0_DOPADOP" />
+   <direct name="RAMB36_X0Y0_DOPBDOP"           input="RAMBFIFO36E1.DOPBDOP"              output="BRAM.RAMB36_Y0_DOPBDOP" />
+   <direct name="RAMB36_X0Y0_DOPADOP"           input="RAMBFIFO36E1.DOPADOP"              output="BRAM.RAMB36_Y0_DOPADOP" />
 
-   <direct name="RAMB36_X0Y0_DOBDO"             input="BLK_IG-RAMBFIFO36E1.DOBDO"                  output="BLK_IG-BRAM.RAMB36_Y0_DOBDO" />
-   <direct name="RAMB36_X0Y0_DOADO"             input="BLK_IG-RAMBFIFO36E1.DOADO"                  output="BLK_IG-BRAM.RAMB36_Y0_DOADO" />
+   <direct name="RAMB36_X0Y0_DOBDO"             input="RAMBFIFO36E1.DOBDO"                output="BRAM.RAMB36_Y0_DOBDO" />
+   <direct name="RAMB36_X0Y0_DOADO"             input="RAMBFIFO36E1.DOADO"                output="BRAM.RAMB36_Y0_DOADO" />
 
-   <direct name="RAMB36_X0Y0_DBITERR"           input="BLK_IG-RAMBFIFO36E1.DBITERR"                output="BLK_IG-BRAM.RAMB36_Y0_DBITERR" />
+   <direct name="RAMB36_X0Y0_DBITERR"           input="RAMBFIFO36E1.DBITERR"              output="BRAM.RAMB36_Y0_DBITERR" />
 
-   <direct name="RAMB36_X0Y0_CASCADEOUTA"       input="BLK_IG-RAMBFIFO36E1.CASCADEOUTA"            output="BLK_IG-BRAM.RAMB36_Y0_CASCADEOUTA" />
-   <direct name="RAMB36_X0Y0_CASCADEOUTB"       input="BLK_IG-RAMBFIFO36E1.CASCADEOUTB"            output="BLK_IG-BRAM.RAMB36_Y0_CASCADEOUTB" />
+   <direct name="RAMB36_X0Y0_CASCADEOUTA"       input="RAMBFIFO36E1.CASCADEOUTA"          output="BRAM.RAMB36_Y0_CASCADEOUTA" />
+   <direct name="RAMB36_X0Y0_CASCADEOUTB"       input="RAMBFIFO36E1.CASCADEOUTB"          output="BRAM.RAMB36_Y0_CASCADEOUTB" />
 
-   <direct name="RAMB36_X0Y0_ALMOSTFULL"        input="BLK_IG-RAMBFIFO36E1.ALMOSTFULL"             output="BLK_IG-BRAM.RAMB36_Y0_ALMOSTFULL" />
-   <direct name="RAMB36_X0Y0_ALMOSTEMPTY"       input="BLK_IG-RAMBFIFO36E1.ALMOSTEMPTY"            output="BLK_IG-BRAM.RAMB36_Y0_ALMOSTEMPTY" />
+   <direct name="RAMB36_X0Y0_ALMOSTFULL"        input="RAMBFIFO36E1.ALMOSTFULL"           output="BRAM.RAMB36_Y0_ALMOSTFULL" />
+   <direct name="RAMB36_X0Y0_ALMOSTEMPTY"       input="RAMBFIFO36E1.ALMOSTEMPTY"          output="BRAM.RAMB36_Y0_ALMOSTEMPTY" />
   </interconnect>
  </mode>
  <mode name="2xBRAM18">
-  <pb_type name="BLK_IG-RAMB18E1" num_pb="2" blif_model=".subckt RAMB18E1_VPR">
+  <pb_type name="RAMB18E1" num_pb="2" blif_model=".subckt RAMB18E1_VPR">
    <xi:include href="ramb18e1.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])" />
    <metadata>
      <xi:include href="ramb18e1.pb_type.xml" xpointer="xpointer(pb_type/metadata/child::node())" />
@@ -284,69 +284,73 @@ reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
   </pb_type>
   <interconnect>
    <!-- Y0 should point to a rambfifo18e1 model, not ramb18e1 model. -->
-   <direct name="RAMB18_X0Y0_WREN"             input="BLK_IG-BRAM.RAMB18_Y0_WREN"              output="BLK_IG-RAMB18E1[0].ENBWREN" />
-   <direct name="RAMB18_X0Y0_WRCLK"            input="BLK_IG-BRAM.RAMB18_Y0_WRCLK"             output="BLK_IG-RAMB18E1[0].CLKBWRCLK" />
-   <direct name="RAMB18_X0Y0_WEBWE"            input="BLK_IG-BRAM.RAMB18_Y0_WEBWE"             output="BLK_IG-RAMB18E1[0].WEBWE" />
-   <direct name="RAMB18_X0Y0_WEA"              input="BLK_IG-BRAM.RAMB18_Y0_WEA"               output="BLK_IG-RAMB18E1[0].WEA" />
+   <direct name="RAMB18_X0Y0_WREN"             input="BRAM.RAMB18_Y0_WREN"              output="RAMB18E1[0].ENBWREN" />
+   <direct name="RAMB18_X0Y0_WRCLK"            input="BRAM.RAMB18_Y0_WRCLK"             output="RAMB18E1[0].CLKBWRCLK" />
+   <direct name="RAMB18_X0Y0_WEBWE"            input="BRAM.RAMB18_Y0_WEBWE"             output="RAMB18E1[0].WEBWE" />
+   <direct name="RAMB18_X0Y0_WEA"              input="BRAM.RAMB18_Y0_WEA"               output="RAMB18E1[0].WEA" />
 
-   <direct name="RAMB18_X0Y0_RSTREGB"          input="BLK_IG-BRAM.RAMB18_Y0_RSTREGB"           output="BLK_IG-RAMB18E1[0].RSTREGB" />
-   <direct name="RAMB18_X0Y0_RSTREG"           input="BLK_IG-BRAM.RAMB18_Y0_RSTREG"            output="BLK_IG-RAMB18E1[0].RSTREGARSTREG" />
-   <direct name="RAMB18_X0Y0_RSTRAMB"          input="BLK_IG-BRAM.RAMB18_Y0_RSTRAMB"           output="BLK_IG-RAMB18E1[0].RSTRAMB" />
-   <direct name="RAMB18_X0Y0_RST"              input="BLK_IG-BRAM.RAMB18_Y0_RST"               output="BLK_IG-RAMB18E1[0].RSTRAMARSTRAM" />
+   <direct name="RAMB18_X0Y0_RSTREGB"          input="BRAM.RAMB18_Y0_RSTREGB"           output="RAMB18E1[0].RSTREGB" />
+   <direct name="RAMB18_X0Y0_RSTREG"           input="BRAM.RAMB18_Y0_RSTREG"            output="RAMB18E1[0].RSTREGARSTREG" />
+   <direct name="RAMB18_X0Y0_RSTRAMB"          input="BRAM.RAMB18_Y0_RSTRAMB"           output="RAMB18E1[0].RSTRAMB" />
+   <direct name="RAMB18_X0Y0_RST"              input="BRAM.RAMB18_Y0_RST"               output="RAMB18E1[0].RSTRAMARSTRAM" />
 
-   <direct name="RAMB18_X0Y0_REGCLKB"          input="BLK_IG-BRAM.RAMB18_Y0_REGCLKB"           output="BLK_IG-RAMB18E1[0].REGCLKB" />
-   <direct name="RAMB18_X0Y0_REGCEB"           input="BLK_IG-BRAM.RAMB18_Y0_REGCEB"            output="BLK_IG-RAMB18E1[0].REGCEB" />
-   <direct name="RAMB18_X0Y0_REGCE"            input="BLK_IG-BRAM.RAMB18_Y0_REGCE"             output="BLK_IG-RAMB18E1[0].REGCEAREGCE" />
-   <direct name="RAMB18_X0Y0_RDRCLK"           input="BLK_IG-BRAM.RAMB18_Y0_RDRCLK"            output="BLK_IG-RAMB18E1[0].REGCLKARDRCLK" />
-   <direct name="RAMB18_X0Y0_RDEN"             input="BLK_IG-BRAM.RAMB18_Y0_RDEN"              output="BLK_IG-RAMB18E1[0].ENARDEN" />
-   <direct name="RAMB18_X0Y0_RDCLK"            input="BLK_IG-BRAM.RAMB18_Y0_RDCLK"             output="BLK_IG-RAMB18E1[0].CLKARDCLK" />
+   <direct name="RAMB18_X0Y0_REGCLKB"          input="BRAM.RAMB18_Y0_REGCLKB"           output="RAMB18E1[0].REGCLKB" />
+   <direct name="RAMB18_X0Y0_REGCEB"           input="BRAM.RAMB18_Y0_REGCEB"            output="RAMB18E1[0].REGCEB" />
+   <direct name="RAMB18_X0Y0_REGCE"            input="BRAM.RAMB18_Y0_REGCE"             output="RAMB18E1[0].REGCEAREGCE" />
+   <direct name="RAMB18_X0Y0_RDRCLK"           input="BRAM.RAMB18_Y0_RDRCLK"            output="RAMB18E1[0].REGCLKARDRCLK" />
+   <direct name="RAMB18_X0Y0_RDEN"             input="BRAM.RAMB18_Y0_RDEN"              output="RAMB18E1[0].ENARDEN" />
+   <direct name="RAMB18_X0Y0_RDCLK"            input="BRAM.RAMB18_Y0_RDCLK"             output="RAMB18E1[0].CLKARDCLK" />
 
-   <direct name="RAMB18_X0Y0_DIPBDIP"          input="BLK_IG-BRAM.RAMB18_Y0_DIPBDIP"           output="BLK_IG-RAMB18E1[0].DIPBDIP" />
-   <direct name="RAMB18_X0Y0_DIPADIP"          input="BLK_IG-BRAM.RAMB18_Y0_DIPADIP"           output="BLK_IG-RAMB18E1[0].DIPADIP" />
-   <direct name="RAMB18_X0Y0_DIBDI"            input="BLK_IG-BRAM.RAMB18_Y0_DIBDI"             output="BLK_IG-RAMB18E1[0].DIBDI" />
-   <direct name="RAMB18_X0Y0_DIADI"            input="BLK_IG-BRAM.RAMB18_Y0_DIADI"             output="BLK_IG-RAMB18E1[0].DIADI" />
+   <direct name="RAMB18_X0Y0_DIPBDIP"          input="BRAM.RAMB18_Y0_DIPBDIP"           output="RAMB18E1[0].DIPBDIP" />
+   <direct name="RAMB18_X0Y0_DIPADIP"          input="BRAM.RAMB18_Y0_DIPADIP"           output="RAMB18E1[0].DIPADIP" />
+   <direct name="RAMB18_X0Y0_DIBDI"            input="BRAM.RAMB18_Y0_DIBDI"             output="RAMB18E1[0].DIBDI" />
+   <direct name="RAMB18_X0Y0_DIADI"            input="BRAM.RAMB18_Y0_DIADI"             output="RAMB18E1[0].DIADI" />
 
-   <direct name="RAMB18_X0Y0_ADDRATIEHIGH"     input="BLK_IG-BRAM.RAMB18_Y0_ADDRATIEHIGH"      output="BLK_IG-RAMB18E1[0].ADDRATIEHIGH" />
-   <direct name="RAMB18_X0Y0_ADDRARDADDR"      input="BLK_IG-BRAM.RAMB18_Y0_ADDRARDADDR"       output="BLK_IG-RAMB18E1[0].ADDRARDADDR" />
-   <direct name="RAMB18_X0Y0_ADDRBTIEHIGH"     input="BLK_IG-BRAM.RAMB18_Y0_ADDRBTIEHIGH"      output="BLK_IG-RAMB18E1[0].ADDRBTIEHIGH" />
-   <direct name="RAMB18_X0Y0_ADDRBWRADDR"      input="BLK_IG-BRAM.RAMB18_Y0_ADDRBWRADDR"       output="BLK_IG-RAMB18E1[0].ADDRBWRADDR" />
+   <direct name="RAMB18_X0Y0_ADDRATIEHIGH"     input="BRAM.RAMB18_Y0_ADDRATIEHIGH"      output="RAMB18E1[0].ADDRATIEHIGH" />
+   <direct name="RAMB18_X0Y0_ADDRARDADDR"      input="BRAM.RAMB18_Y0_ADDRARDADDR"       output="RAMB18E1[0].ADDRARDADDR" />
+   <direct name="RAMB18_X0Y0_ADDRBTIEHIGH"     input="BRAM.RAMB18_Y0_ADDRBTIEHIGH"      output="RAMB18E1[0].ADDRBTIEHIGH" />
+   <direct name="RAMB18_X0Y0_ADDRBWRADDR"      input="BRAM.RAMB18_Y0_ADDRBWRADDR"       output="RAMB18E1[0].ADDRBWRADDR" />
 
-   <direct name="RAMB18_X0Y0_DOBDOP"           input="BLK_IG-RAMB18E1[0].DOPBDOP"              output="BLK_IG-BRAM.RAMB18_Y0_DOP[3:2]" />
-   <direct name="RAMB18_X0Y0_DOADOP"           input="BLK_IG-RAMB18E1[0].DOPADOP"              output="BLK_IG-BRAM.RAMB18_Y0_DOP[1:0]" />
-   <direct name="RAMB18_X0Y0_DOBDO"            input="BLK_IG-RAMB18E1[0].DOBDO"                output="BLK_IG-BRAM.RAMB18_Y0_DO[31:16]" />
-   <direct name="RAMB18_X0Y0_DOADO"            input="BLK_IG-RAMB18E1[0].DOADO"                output="BLK_IG-BRAM.RAMB18_Y0_DO[15:0]" />
+   <direct name="RAMB18_X0Y0_DOBDOP"           input="RAMB18E1[0].DOPBDOP"              output="BRAM.RAMB18_Y0_DOP[3:2]" />
+   <direct name="RAMB18_X0Y0_DOADOP"           input="RAMB18E1[0].DOPADOP"              output="BRAM.RAMB18_Y0_DOP[1:0]" />
+   <direct name="RAMB18_X0Y0_DOBDO"            input="RAMB18E1[0].DOBDO"                output="BRAM.RAMB18_Y0_DO[31:16]" />
+   <direct name="RAMB18_X0Y0_DOADO"            input="RAMB18E1[0].DOADO"                output="BRAM.RAMB18_Y0_DO[15:0]" />
 
-   <direct name="RAMB18_X0Y1_ENBWREN"          input="BLK_IG-BRAM.RAMB18_Y1_ENBWREN"           output="BLK_IG-RAMB18E1[1].ENBWREN" />
-   <direct name="RAMB18_X0Y1_CLKBWRCLK"        input="BLK_IG-BRAM.RAMB18_Y1_CLKBWRCLK"         output="BLK_IG-RAMB18E1[1].CLKBWRCLK" />
-   <direct name="RAMB18_X0Y1_WEBWE"            input="BLK_IG-BRAM.RAMB18_Y1_WEBWE"             output="BLK_IG-RAMB18E1[1].WEBWE" />
-   <direct name="RAMB18_X0Y1_WEA"              input="BLK_IG-BRAM.RAMB18_Y1_WEA"               output="BLK_IG-RAMB18E1[1].WEA" />
+   <direct name="RAMB18_X0Y1_ENBWREN"          input="BRAM.RAMB18_Y1_ENBWREN"           output="RAMB18E1[1].ENBWREN" />
+   <direct name="RAMB18_X0Y1_CLKBWRCLK"        input="BRAM.RAMB18_Y1_CLKBWRCLK"         output="RAMB18E1[1].CLKBWRCLK" />
+   <direct name="RAMB18_X0Y1_WEBWE"            input="BRAM.RAMB18_Y1_WEBWE"             output="RAMB18E1[1].WEBWE" />
+   <direct name="RAMB18_X0Y1_WEA"              input="BRAM.RAMB18_Y1_WEA"               output="RAMB18E1[1].WEA" />
 
-   <direct name="RAMB18_X0Y1_RSTREGB"          input="BLK_IG-BRAM.RAMB18_Y1_RSTREGB"           output="BLK_IG-RAMB18E1[1].RSTREGB" />
-   <direct name="RAMB18_X0Y1_RSTREGARSTREG"    input="BLK_IG-BRAM.RAMB18_Y1_RSTREGARSTREG"     output="BLK_IG-RAMB18E1[1].RSTREGARSTREG" />
-   <direct name="RAMB18_X0Y1_RSTRAMB"          input="BLK_IG-BRAM.RAMB18_Y1_RSTRAMB"           output="BLK_IG-RAMB18E1[1].RSTRAMB" />
-   <direct name="RAMB18_X0Y1_RSTRAMARSTRAM"    input="BLK_IG-BRAM.RAMB18_Y1_RSTRAMARSTRAM"     output="BLK_IG-RAMB18E1[1].RSTRAMARSTRAM" />
+   <direct name="RAMB18_X0Y1_RSTREGB"          input="BRAM.RAMB18_Y1_RSTREGB"           output="RAMB18E1[1].RSTREGB" />
+   <direct name="RAMB18_X0Y1_RSTREGARSTREG"    input="BRAM.RAMB18_Y1_RSTREGARSTREG"     output="RAMB18E1[1].RSTREGARSTREG" />
+   <direct name="RAMB18_X0Y1_RSTRAMB"          input="BRAM.RAMB18_Y1_RSTRAMB"           output="RAMB18E1[1].RSTRAMB" />
+   <direct name="RAMB18_X0Y1_RSTRAMARSTRAM"    input="BRAM.RAMB18_Y1_RSTRAMARSTRAM"     output="RAMB18E1[1].RSTRAMARSTRAM" />
 
-   <direct name="RAMB18_X0Y1_REGCLKB"          input="BLK_IG-BRAM.RAMB18_Y1_REGCLKB"           output="BLK_IG-RAMB18E1[1].REGCLKB" />
-   <direct name="RAMB18_X0Y1_REGCEB"           input="BLK_IG-BRAM.RAMB18_Y1_REGCEB"            output="BLK_IG-RAMB18E1[1].REGCEB" />
-   <direct name="RAMB18_X0Y1_REGCEAREGCE"      input="BLK_IG-BRAM.RAMB18_Y1_REGCEAREGCE"       output="BLK_IG-RAMB18E1[1].REGCEAREGCE" />
-   <direct name="RAMB18_X0Y1_REGCLKARDRCLK"    input="BLK_IG-BRAM.RAMB18_Y1_REGCLKARDRCLK"     output="BLK_IG-RAMB18E1[1].REGCLKARDRCLK" />
-   <direct name="RAMB18_X0Y1_ENARDEN"          input="BLK_IG-BRAM.RAMB18_Y1_ENARDEN"           output="BLK_IG-RAMB18E1[1].ENARDEN" />
-   <direct name="RAMB18_X0Y1_CLKARDCLK"        input="BLK_IG-BRAM.RAMB18_Y1_CLKARDCLK"         output="BLK_IG-RAMB18E1[1].CLKARDCLK" />
+   <direct name="RAMB18_X0Y1_REGCLKB"          input="BRAM.RAMB18_Y1_REGCLKB"           output="RAMB18E1[1].REGCLKB" />
+   <direct name="RAMB18_X0Y1_REGCEB"           input="BRAM.RAMB18_Y1_REGCEB"            output="RAMB18E1[1].REGCEB" />
+   <direct name="RAMB18_X0Y1_REGCEAREGCE"      input="BRAM.RAMB18_Y1_REGCEAREGCE"       output="RAMB18E1[1].REGCEAREGCE" />
+   <direct name="RAMB18_X0Y1_REGCLKARDRCLK"    input="BRAM.RAMB18_Y1_REGCLKARDRCLK"     output="RAMB18E1[1].REGCLKARDRCLK" />
+   <direct name="RAMB18_X0Y1_ENARDEN"          input="BRAM.RAMB18_Y1_ENARDEN"           output="RAMB18E1[1].ENARDEN" />
+   <direct name="RAMB18_X0Y1_CLKARDCLK"        input="BRAM.RAMB18_Y1_CLKARDCLK"         output="RAMB18E1[1].CLKARDCLK" />
 
-   <direct name="RAMB18_X0Y1_DIPBDIP"          input="BLK_IG-BRAM.RAMB18_Y1_DIPBDIP"           output="BLK_IG-RAMB18E1[1].DIPBDIP" />
-   <direct name="RAMB18_X0Y1_DIPADIP"          input="BLK_IG-BRAM.RAMB18_Y1_DIPADIP"           output="BLK_IG-RAMB18E1[1].DIPADIP" />
-   <direct name="RAMB18_X0Y1_DIBDI"            input="BLK_IG-BRAM.RAMB18_Y1_DIBDI"             output="BLK_IG-RAMB18E1[1].DIBDI" />
-   <direct name="RAMB18_X0Y1_DIADI"            input="BLK_IG-BRAM.RAMB18_Y1_DIADI"             output="BLK_IG-RAMB18E1[1].DIADI" />
+   <direct name="RAMB18_X0Y1_DIPBDIP"          input="BRAM.RAMB18_Y1_DIPBDIP"           output="RAMB18E1[1].DIPBDIP" />
+   <direct name="RAMB18_X0Y1_DIPADIP"          input="BRAM.RAMB18_Y1_DIPADIP"           output="RAMB18E1[1].DIPADIP" />
+   <direct name="RAMB18_X0Y1_DIBDI"            input="BRAM.RAMB18_Y1_DIBDI"             output="RAMB18E1[1].DIBDI" />
+   <direct name="RAMB18_X0Y1_DIADI"            input="BRAM.RAMB18_Y1_DIADI"             output="RAMB18E1[1].DIADI" />
 
-   <direct name="RAMB18_X0Y1_ADDRATIEHIGH"     input="BLK_IG-BRAM.RAMB18_Y1_ADDRATIEHIGH"      output="BLK_IG-RAMB18E1[1].ADDRATIEHIGH" />
-   <direct name="RAMB18_X0Y1_ADDRARDADDR"      input="BLK_IG-BRAM.RAMB18_Y1_ADDRARDADDR"       output="BLK_IG-RAMB18E1[1].ADDRARDADDR" />
-   <direct name="RAMB18_X0Y1_ADDRBTIEHIGH"     input="BLK_IG-BRAM.RAMB18_Y1_ADDRBTIEHIGH"      output="BLK_IG-RAMB18E1[1].ADDRBTIEHIGH" />
-   <direct name="RAMB18_X0Y1_ADDRBWRADDR"      input="BLK_IG-BRAM.RAMB18_Y1_ADDRBWRADDR"       output="BLK_IG-RAMB18E1[1].ADDRBWRADDR" />
+   <direct name="RAMB18_X0Y1_ADDRATIEHIGH"     input="BRAM.RAMB18_Y1_ADDRATIEHIGH"      output="RAMB18E1[1].ADDRATIEHIGH" />
+   <direct name="RAMB18_X0Y1_ADDRARDADDR"      input="BRAM.RAMB18_Y1_ADDRARDADDR"       output="RAMB18E1[1].ADDRARDADDR" />
+   <direct name="RAMB18_X0Y1_ADDRBTIEHIGH"     input="BRAM.RAMB18_Y1_ADDRBTIEHIGH"      output="RAMB18E1[1].ADDRBTIEHIGH" />
+   <direct name="RAMB18_X0Y1_ADDRBWRADDR"      input="BRAM.RAMB18_Y1_ADDRBWRADDR"       output="RAMB18E1[1].ADDRBWRADDR" />
 
-   <direct name="RAMB18_X0Y1_DOPADOP"          input="BLK_IG-RAMB18E1[1].DOPADOP"                output="BLK_IG-BRAM.RAMB18_Y1_DOPADOP" />
-   <direct name="RAMB18_X0Y1_DOPBDOP"          input="BLK_IG-RAMB18E1[1].DOPBDOP"                output="BLK_IG-BRAM.RAMB18_Y1_DOPBDOP" />
-   <direct name="RAMB18_X0Y1_DOADO"            input="BLK_IG-RAMB18E1[1].DOADO"                  output="BLK_IG-BRAM.RAMB18_Y1_DOADO" />
-   <direct name="RAMB18_X0Y1_DOBDO"            input="BLK_IG-RAMB18E1[1].DOBDO"                  output="BLK_IG-BRAM.RAMB18_Y1_DOBDO" />
+   <direct name="RAMB18_X0Y1_DOPADOP"          input="RAMB18E1[1].DOPADOP"              output="BRAM.RAMB18_Y1_DOPADOP" />
+   <direct name="RAMB18_X0Y1_DOPBDOP"          input="RAMB18E1[1].DOPBDOP"              output="BRAM.RAMB18_Y1_DOPBDOP" />
+   <direct name="RAMB18_X0Y1_DOADO"            input="RAMB18E1[1].DOADO"                output="BRAM.RAMB18_Y1_DOADO" />
+   <direct name="RAMB18_X0Y1_DOBDO"            input="RAMB18E1[1].DOBDO"                output="BRAM.RAMB18_Y1_DOBDO" />
   </interconnect>
  </mode>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/xc7/primitives/bram/ramb18e1.pb_type.xml
+++ b/xc7/primitives/bram/ramb18e1.pb_type.xml
@@ -8,7 +8,7 @@ There are both Latches (first) and Registers (second) on the output (why!?)
 The RAM has extra bits that can be used for parity (DIP / DOP).
 
   -->
-<pb_type name="BLK_IG-RAMB18E1" num_pb="1" blif_model=".subckt RAMB18E1_VPR">
+<pb_type name="RAMB18E1" num_pb="1" blif_model=".subckt RAMB18E1_VPR">
  <!-- Port A - 16bit wide -->
  <clock  name="CLKARDCLK"     num_pins="1"  />
  <input  name="REGCEAREGCE"   num_pins="1"  />
@@ -24,17 +24,17 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
  <output name="DOADO"         num_pins="16" />
  <output name="DOPADOP"       num_pins="2"  />
 
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.REGCEAREGCE"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.REGCLKARDRCLK"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.ENARDEN"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.RSTRAMARSTRAM"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.RSTREGARSTREG"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.ADDRARDADDR"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.DIADI"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.DIPADIP"  clock="CLKARDCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.WEA"  clock="CLKARDCLK" />
- <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB18E1.DOADO"  clock="CLKARDCLK" />
- <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB18E1.DOPADOP"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.REGCEAREGCE"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.REGCLKARDRCLK"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.ENARDEN"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.RSTRAMARSTRAM"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.RSTREGARSTREG"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.ADDRARDADDR"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.DIADI"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.DIPADIP"  clock="CLKARDCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.WEA"  clock="CLKARDCLK" />
+ <T_clock_to_Q max="10e-12" port="RAMB18E1.DOADO"  clock="CLKARDCLK" />
+ <T_clock_to_Q max="10e-12" port="RAMB18E1.DOPADOP"  clock="CLKARDCLK" />
 
  <!-- Port B - 16bit wide -->
  <clock  name="CLKBWRCLK"     num_pins="1"  />
@@ -51,17 +51,17 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
  <output name="DOBDO"         num_pins="16" />
  <output name="DOPBDOP"       num_pins="2"  />
 
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.ENBWREN"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.REGCEB"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.REGCLKB"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.RSTRAMB"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.RSTREGB"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.ADDRBWRADDR"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.DIBDI"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.DIPBDIP"  clock="CLKBWRCLK" />
- <T_setup value="10e-12" port="BLK_IG-RAMB18E1.WEBWE"  clock="CLKBWRCLK" />
- <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB18E1.DOBDO"  clock="CLKBWRCLK" />
- <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB18E1.DOPBDOP"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.ENBWREN"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.REGCEB"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.REGCLKB"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.RSTRAMB"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.RSTREGB"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.ADDRBWRADDR"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.DIBDI"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.DIPBDIP"  clock="CLKBWRCLK" />
+ <T_setup value="10e-12" port="RAMB18E1.WEBWE"  clock="CLKBWRCLK" />
+ <T_clock_to_Q max="10e-12" port="RAMB18E1.DOBDO"  clock="CLKBWRCLK" />
+ <T_clock_to_Q max="10e-12" port="RAMB18E1.DOPBDOP"  clock="CLKBWRCLK" />
 
  <metadata>
    <meta name="fasm_params">
@@ -193,5 +193,7 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
      WRITE_MODE_B_NO_CHANGE = WRITE_MODE_B_NO_CHANGE
      WRITE_MODE_B_READ_FIRST = WRITE_MODE_B_READ_FIRST
    </meta>
+   <meta name="type">bel</meta>
+   <meta name="subtype">memory</meta>
  </metadata>
 </pb_type>

--- a/xc7/primitives/bram/rambfifo36e1.pb_type.xml
+++ b/xc7/primitives/bram/rambfifo36e1.pb_type.xml
@@ -8,7 +8,7 @@ There are both Latches (first) and Registers (second) on the output (why!?)
 The RAM has extra bits that can be used for parity (DIP / DOP).
 
   -->
-<pb_type name="BLK_IG-RAMBFIFO36E1" num_pb="1">
+<pb_type name="RAMBFIFO36E1" num_pb="1">
  <input  name="WEBWEU"         num_pins="8"  />
  <input  name="WEBWEL"         num_pins="8"  />
  <input  name="WEAU"           num_pins="4"  />
@@ -99,7 +99,7 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
 
  <!-- Missing FIFO36E1 -->
  <mode name="BRAM">
-  <pb_type name="BLK_IG-RAMB36E1" num_pb="1" blif_model=".subckt RAMB36E1_PRIM">
+  <pb_type name="RAMB36E1" num_pb="1" blif_model=".subckt RAMB36E1_PRIM">
    <!-- Port A - 32bit wide -->
    <clock  name="CLKARDCLKU"        num_pins="1"  />
    <clock  name="CLKARDCLKL"        num_pins="1"  />
@@ -120,22 +120,22 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
    <output name="DOADO"             num_pins="32" />
    <output name="DOPADOP"           num_pins="4"  />
 
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.REGCEAREGCEU"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.REGCEAREGCEL"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ENARDENU"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ENARDENL"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTRAMARSTRAMU"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTRAMARSTRAMLRST"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTREGARSTREGU"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTREGARSTREGL"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ADDRARDADDRU"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ADDRARDADDRL"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.DIADI"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.DIPADIP"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.WEAU"  clock="CLKARDCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.WEAL"  clock="CLKARDCLKL" />
-   <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB36E1.DOADO"  clock="CLKARDCLKL" />
-   <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB36E1.DOPADOP"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.REGCEAREGCEU"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.REGCEAREGCEL"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ENARDENU"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ENARDENL"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTRAMARSTRAMU"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTRAMARSTRAMLRST"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTREGARSTREGU"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTREGARSTREGL"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ADDRARDADDRU"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ADDRARDADDRL"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.DIADI"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.DIPADIP"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.WEAU"  clock="CLKARDCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.WEAL"  clock="CLKARDCLKL" />
+   <T_clock_to_Q max="10e-12" port="RAMB36E1.DOADO"  clock="CLKARDCLKL" />
+   <T_clock_to_Q max="10e-12" port="RAMB36E1.DOPADOP"  clock="CLKARDCLKL" />
 
    <!-- Port B - 32bit wide -->
    <clock  name="CLKBWRCLKU"     num_pins="1"  />
@@ -157,22 +157,22 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
    <output name="DOBDO"          num_pins="32" />
    <output name="DOPBDOP"        num_pins="4"  />
 
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ENBWRENU"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ENBWRENL"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.REGCEBU"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.REGCEBL"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTRAMBU"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTRAMBL"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTREGBU"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.RSTREGBL"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ADDRBWRADDRU"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.ADDRBWRADDRL"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.DIBDI"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.DIPBDIP"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.WEBWEU"  clock="CLKBWRCLKL" />
-   <T_setup value="10e-12" port="BLK_IG-RAMB36E1.WEBWEL"  clock="CLKBWRCLKL" />
-   <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB36E1.DOBDO"  clock="CLKBWRCLKL" />
-   <T_clock_to_Q max="10e-12" port="BLK_IG-RAMB36E1.DOPBDOP"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ENBWRENU"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ENBWRENL"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.REGCEBU"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.REGCEBL"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTRAMBU"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTRAMBL"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTREGBU"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.RSTREGBL"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ADDRBWRADDRU"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.ADDRBWRADDRL"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.DIBDI"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.DIPBDIP"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.WEBWEU"  clock="CLKBWRCLKL" />
+   <T_setup value="10e-12" port="RAMB36E1.WEBWEL"  clock="CLKBWRCLKL" />
+   <T_clock_to_Q max="10e-12" port="RAMB36E1.DOBDO"  clock="CLKBWRCLKL" />
+   <T_clock_to_Q max="10e-12" port="RAMB36E1.DOPBDOP"  clock="CLKBWRCLKL" />
 
    <input  name="CASCADEINA"    num_pins="1"  />
    <input  name="CASCADEINB"    num_pins="1"  />
@@ -181,55 +181,59 @@ The RAM has extra bits that can be used for parity (DIP / DOP).
   </pb_type>
   <interconnect>
    <!-- Port A inputs -->
-   <direct name="CLKARDCLKU"        input="BLK_IG-RAMBFIFO36E1.CLKARDCLKU"        output="BLK_IG-RAMB36E1.CLKARDCLKU"     />
-   <direct name="CLKARDCLKL"        input="BLK_IG-RAMBFIFO36E1.CLKARDCLKL"        output="BLK_IG-RAMB36E1.CLKARDCLKL"     />
-   <direct name="REGCEAREGCEU"      input="BLK_IG-RAMBFIFO36E1.REGCEAREGCEU"      output="BLK_IG-RAMB36E1.REGCEAREGCEU"   />
-   <direct name="REGCEAREGCEL"      input="BLK_IG-RAMBFIFO36E1.REGCEAREGCEL"      output="BLK_IG-RAMB36E1.REGCEAREGCEL"   />
-   <direct name="ENARDENU"          input="BLK_IG-RAMBFIFO36E1.ENARDENU"          output="BLK_IG-RAMB36E1.ENARDENU"       />
-   <direct name="ENARDENL"          input="BLK_IG-RAMBFIFO36E1.ENARDENL"          output="BLK_IG-RAMB36E1.ENARDENL"       />
-   <direct name="RSTRAMARSTRAMU"    input="BLK_IG-RAMBFIFO36E1.RSTRAMARSTRAMU"    output="BLK_IG-RAMB36E1.RSTRAMARSTRAMU" />
-   <direct name="RSTRAMARSTRAMLRST" input="BLK_IG-RAMBFIFO36E1.RSTRAMARSTRAMLRST" output="BLK_IG-RAMB36E1.RSTRAMARSTRAMLRST" />
-   <direct name="RSTREGARSTREGU"    input="BLK_IG-RAMBFIFO36E1.RSTREGARSTREGU"    output="BLK_IG-RAMB36E1.RSTREGARSTREGU" />
-   <direct name="RSTREGARSTREGL"    input="BLK_IG-RAMBFIFO36E1.RSTREGARSTREGL"    output="BLK_IG-RAMB36E1.RSTREGARSTREGL" />
-   <direct name="ADDRARDADDRU"      input="BLK_IG-RAMBFIFO36E1.ADDRARDADDRU"      output="BLK_IG-RAMB36E1.ADDRARDADDRU"   />
-   <direct name="ADDRARDADDRL"      input="BLK_IG-RAMBFIFO36E1.ADDRARDADDRL"      output="BLK_IG-RAMB36E1.ADDRARDADDRL"   />
-   <direct name="DIADI"             input="BLK_IG-RAMBFIFO36E1.DIADI"             output="BLK_IG-RAMB36E1.DIADI"         />
-   <direct name="DIPADIP"           input="BLK_IG-RAMBFIFO36E1.DIPADIP"           output="BLK_IG-RAMB36E1.DIPADIP"       />
-   <direct name="WEAU"              input="BLK_IG-RAMBFIFO36E1.WEAU"              output="BLK_IG-RAMB36E1.WEAU"           />
-   <direct name="WEAL"              input="BLK_IG-RAMBFIFO36E1.WEAL"              output="BLK_IG-RAMB36E1.WEAL"           />
+   <direct name="CLKARDCLKU"        input="RAMBFIFO36E1.CLKARDCLKU"        output="RAMB36E1.CLKARDCLKU"     />
+   <direct name="CLKARDCLKL"        input="RAMBFIFO36E1.CLKARDCLKL"        output="RAMB36E1.CLKARDCLKL"     />
+   <direct name="REGCEAREGCEU"      input="RAMBFIFO36E1.REGCEAREGCEU"      output="RAMB36E1.REGCEAREGCEU"   />
+   <direct name="REGCEAREGCEL"      input="RAMBFIFO36E1.REGCEAREGCEL"      output="RAMB36E1.REGCEAREGCEL"   />
+   <direct name="ENARDENU"          input="RAMBFIFO36E1.ENARDENU"          output="RAMB36E1.ENARDENU"       />
+   <direct name="ENARDENL"          input="RAMBFIFO36E1.ENARDENL"          output="RAMB36E1.ENARDENL"       />
+   <direct name="RSTRAMARSTRAMU"    input="RAMBFIFO36E1.RSTRAMARSTRAMU"    output="RAMB36E1.RSTRAMARSTRAMU" />
+   <direct name="RSTRAMARSTRAMLRST" input="RAMBFIFO36E1.RSTRAMARSTRAMLRST" output="RAMB36E1.RSTRAMARSTRAMLRST" />
+   <direct name="RSTREGARSTREGU"    input="RAMBFIFO36E1.RSTREGARSTREGU"    output="RAMB36E1.RSTREGARSTREGU" />
+   <direct name="RSTREGARSTREGL"    input="RAMBFIFO36E1.RSTREGARSTREGL"    output="RAMB36E1.RSTREGARSTREGL" />
+   <direct name="ADDRARDADDRU"      input="RAMBFIFO36E1.ADDRARDADDRU"      output="RAMB36E1.ADDRARDADDRU"   />
+   <direct name="ADDRARDADDRL"      input="RAMBFIFO36E1.ADDRARDADDRL"      output="RAMB36E1.ADDRARDADDRL"   />
+   <direct name="DIADI"             input="RAMBFIFO36E1.DIADI"             output="RAMB36E1.DIADI"         />
+   <direct name="DIPADIP"           input="RAMBFIFO36E1.DIPADIP"           output="RAMB36E1.DIPADIP"       />
+   <direct name="WEAU"              input="RAMBFIFO36E1.WEAU"              output="RAMB36E1.WEAU"           />
+   <direct name="WEAL"              input="RAMBFIFO36E1.WEAL"              output="RAMB36E1.WEAL"           />
 
    <!-- Port A outputs -->
-   <direct name="DOADO"             input="BLK_IG-RAMB36E1.DOADO"                 output="BLK_IG-RAMBFIFO36E1.DOADO"     />
-   <direct name="DOPADOP"           input="BLK_IG-RAMB36E1.DOPADOP"               output="BLK_IG-RAMBFIFO36E1.DOPADOP"   />
+   <direct name="DOADO"             input="RAMB36E1.DOADO"                 output="RAMBFIFO36E1.DOADO"     />
+   <direct name="DOPADOP"           input="RAMB36E1.DOPADOP"               output="RAMBFIFO36E1.DOPADOP"   />
 
    <!-- Port B inputs -->
-   <direct name="CLKBWRCLKU"        input="BLK_IG-RAMBFIFO36E1.CLKBWRCLKU"        output="BLK_IG-RAMB36E1.CLKBWRCLKU"     />
-   <direct name="CLKBWRCLKL"        input="BLK_IG-RAMBFIFO36E1.CLKBWRCLKL"        output="BLK_IG-RAMB36E1.CLKBWRCLKL"     />
-   <direct name="ENBWRENU"          input="BLK_IG-RAMBFIFO36E1.ENBWRENU"          output="BLK_IG-RAMB36E1.ENBWRENU"       />
-   <direct name="ENBWRENL"          input="BLK_IG-RAMBFIFO36E1.ENBWRENL"          output="BLK_IG-RAMB36E1.ENBWRENL"       />
-   <direct name="REGCEBU"           input="BLK_IG-RAMBFIFO36E1.REGCEBU"           output="BLK_IG-RAMB36E1.REGCEBU"        />
-   <direct name="REGCEBL"           input="BLK_IG-RAMBFIFO36E1.REGCEBL"           output="BLK_IG-RAMB36E1.REGCEBL"        />
-   <direct name="RSTRAMBU"          input="BLK_IG-RAMBFIFO36E1.RSTRAMBU"          output="BLK_IG-RAMB36E1.RSTRAMBU"       />
-   <direct name="RSTRAMBL"          input="BLK_IG-RAMBFIFO36E1.RSTRAMBL"          output="BLK_IG-RAMB36E1.RSTRAMBL"       />
-   <direct name="RSTREGBU"          input="BLK_IG-RAMBFIFO36E1.RSTREGBU"          output="BLK_IG-RAMB36E1.RSTREGBU"       />
-   <direct name="RSTREGBL"          input="BLK_IG-RAMBFIFO36E1.RSTREGBL"          output="BLK_IG-RAMB36E1.RSTREGBL"       />
-   <direct name="ADDRBWRADDRU"      input="BLK_IG-RAMBFIFO36E1.ADDRBWRADDRU"      output="BLK_IG-RAMB36E1.ADDRBWRADDRU"   />
-   <direct name="ADDRBWRADDRL"      input="BLK_IG-RAMBFIFO36E1.ADDRBWRADDRL"      output="BLK_IG-RAMB36E1.ADDRBWRADDRL"   />
-   <direct name="DIBDI"             input="BLK_IG-RAMBFIFO36E1.DIBDI"             output="BLK_IG-RAMB36E1.DIBDI"         />
-   <direct name="DIPBDIP"           input="BLK_IG-RAMBFIFO36E1.DIPBDIP"           output="BLK_IG-RAMB36E1.DIPBDIP"       />
-   <direct name="WEBWEU"            input="BLK_IG-RAMBFIFO36E1.WEBWEU"            output="BLK_IG-RAMB36E1.WEBWEU"         />
-   <direct name="WEBWEL"            input="BLK_IG-RAMBFIFO36E1.WEBWEL"            output="BLK_IG-RAMB36E1.WEBWEL"         />
+   <direct name="CLKBWRCLKU"        input="RAMBFIFO36E1.CLKBWRCLKU"        output="RAMB36E1.CLKBWRCLKU"     />
+   <direct name="CLKBWRCLKL"        input="RAMBFIFO36E1.CLKBWRCLKL"        output="RAMB36E1.CLKBWRCLKL"     />
+   <direct name="ENBWRENU"          input="RAMBFIFO36E1.ENBWRENU"          output="RAMB36E1.ENBWRENU"       />
+   <direct name="ENBWRENL"          input="RAMBFIFO36E1.ENBWRENL"          output="RAMB36E1.ENBWRENL"       />
+   <direct name="REGCEBU"           input="RAMBFIFO36E1.REGCEBU"           output="RAMB36E1.REGCEBU"        />
+   <direct name="REGCEBL"           input="RAMBFIFO36E1.REGCEBL"           output="RAMB36E1.REGCEBL"        />
+   <direct name="RSTRAMBU"          input="RAMBFIFO36E1.RSTRAMBU"          output="RAMB36E1.RSTRAMBU"       />
+   <direct name="RSTRAMBL"          input="RAMBFIFO36E1.RSTRAMBL"          output="RAMB36E1.RSTRAMBL"       />
+   <direct name="RSTREGBU"          input="RAMBFIFO36E1.RSTREGBU"          output="RAMB36E1.RSTREGBU"       />
+   <direct name="RSTREGBL"          input="RAMBFIFO36E1.RSTREGBL"          output="RAMB36E1.RSTREGBL"       />
+   <direct name="ADDRBWRADDRU"      input="RAMBFIFO36E1.ADDRBWRADDRU"      output="RAMB36E1.ADDRBWRADDRU"   />
+   <direct name="ADDRBWRADDRL"      input="RAMBFIFO36E1.ADDRBWRADDRL"      output="RAMB36E1.ADDRBWRADDRL"   />
+   <direct name="DIBDI"             input="RAMBFIFO36E1.DIBDI"             output="RAMB36E1.DIBDI"         />
+   <direct name="DIPBDIP"           input="RAMBFIFO36E1.DIPBDIP"           output="RAMB36E1.DIPBDIP"       />
+   <direct name="WEBWEU"            input="RAMBFIFO36E1.WEBWEU"            output="RAMB36E1.WEBWEU"         />
+   <direct name="WEBWEL"            input="RAMBFIFO36E1.WEBWEL"            output="RAMB36E1.WEBWEL"         />
 
    <!-- Port B outputs -->
-   <direct name="DOBDO"             input="BLK_IG-RAMB36E1.DOBDO"                 output="BLK_IG-RAMBFIFO36E1.DOBDO"     />
-   <direct name="DOPBDOP"           input="BLK_IG-RAMB36E1.DOPBDOP"               output="BLK_IG-RAMBFIFO36E1.DOPBDOP"   />
+   <direct name="DOBDO"             input="RAMB36E1.DOBDO"                 output="RAMBFIFO36E1.DOBDO"     />
+   <direct name="DOPBDOP"           input="RAMB36E1.DOPBDOP"               output="RAMBFIFO36E1.DOPBDOP"   />
 
    <!-- Other pins -->
-   <direct name="CASCADEINA"        input="BLK_IG-RAMBFIFO36E1.CASCADEINA"        output="BLK_IG-RAMB36E1.CASCADEINA"    />
-   <direct name="CASCADEINB"        input="BLK_IG-RAMBFIFO36E1.CASCADEINB"        output="BLK_IG-RAMB36E1.CASCADEINB"    />
-   <direct name="CASCADEOUTA"       input="BLK_IG-RAMB36E1.CASCADEOUTA"           output="BLK_IG-RAMBFIFO36E1.CASCADEOUTA" />
-   <direct name="CASCADEOUTB"       input="BLK_IG-RAMB36E1.CASCADEOUTB"           output="BLK_IG-RAMBFIFO36E1.CASCADEOUTB" />
+   <direct name="CASCADEINA"        input="RAMBFIFO36E1.CASCADEINA"        output="RAMB36E1.CASCADEINA"    />
+   <direct name="CASCADEINB"        input="RAMBFIFO36E1.CASCADEINB"        output="RAMB36E1.CASCADEINB"    />
+   <direct name="CASCADEOUTA"       input="RAMB36E1.CASCADEOUTA"           output="RAMBFIFO36E1.CASCADEOUTA" />
+   <direct name="CASCADEOUTB"       input="RAMB36E1.CASCADEOUTB"           output="RAMBFIFO36E1.CASCADEOUTB" />
 
   </interconnect>
  </mode>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/xc7/primitives/bram_l/bram_l.pb_type.xml
+++ b/xc7/primitives/bram_l/bram_l.pb_type.xml
@@ -12,7 +12,7 @@ affected by the BRAM mode, each site cannot be handled independendly.  For this
 reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
 
   -->
-<pb_type name="BLK_IG-BRAM_L" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="BRAM_X0" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- RAMBFIFO36E1 site pins -->
  <input  name="RAMB36_X0Y0_WEBWEU"         num_pins="8"  />
  <input  name="RAMB36_X0Y0_WEBWEL"         num_pins="8"  />
@@ -185,170 +185,174 @@ reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
  <xi:include href="../bram/bram.pb_type.xml"/>
 
  <interconnect>
-  <direct name="RAMB36_X0Y0_WEBWEU"            input="BLK_IG-BRAM_L.RAMB36_X0Y0_WEBWEU"             output="BLK_IG-BRAM.RAMB36_Y0_WEBWEU" />
-  <direct name="RAMB36_X0Y0_WEBWEL"            input="BLK_IG-BRAM_L.RAMB36_X0Y0_WEBWEL"             output="BLK_IG-BRAM.RAMB36_Y0_WEBWEL" />
-  <direct name="RAMB36_X0Y0_WEAU"              input="BLK_IG-BRAM_L.RAMB36_X0Y0_WEAU"               output="BLK_IG-BRAM.RAMB36_Y0_WEAU" />
-  <direct name="RAMB36_X0Y0_WEAL"              input="BLK_IG-BRAM_L.RAMB36_X0Y0_WEAL"               output="BLK_IG-BRAM.RAMB36_Y0_WEAL" />
+  <direct name="RAMB36_X0Y0_WEBWEU"            input="BRAM_X0.RAMB36_X0Y0_WEBWEU"             output="BRAM.RAMB36_Y0_WEBWEU" />
+  <direct name="RAMB36_X0Y0_WEBWEL"            input="BRAM_X0.RAMB36_X0Y0_WEBWEL"             output="BRAM.RAMB36_Y0_WEBWEL" />
+  <direct name="RAMB36_X0Y0_WEAU"              input="BRAM_X0.RAMB36_X0Y0_WEAU"               output="BRAM.RAMB36_Y0_WEAU" />
+  <direct name="RAMB36_X0Y0_WEAL"              input="BRAM_X0.RAMB36_X0Y0_WEAL"               output="BRAM.RAMB36_Y0_WEAL" />
 
-  <direct name="RAMB36_X0Y0_TSTWROS"           input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTWROS"            output="BLK_IG-BRAM.RAMB36_Y0_TSTWROS" />
-  <direct name="RAMB36_X0Y0_TSTWRCNTOFF"       input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTWRCNTOFF"        output="BLK_IG-BRAM.RAMB36_Y0_TSTWRCNTOFF" />
-  <direct name="RAMB36_X0Y0_TSTRDOS"           input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTRDOS"            output="BLK_IG-BRAM.RAMB36_Y0_TSTRDOS" />
-  <direct name="RAMB36_X0Y0_TSTRDCNTOFF"       input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTRDCNTOFF"        output="BLK_IG-BRAM.RAMB36_Y0_TSTRDCNTOFF" />
-  <direct name="RAMB36_X0Y0_TSTOFF"            input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTOFF"             output="BLK_IG-BRAM.RAMB36_Y0_TSTOFF" />
-  <direct name="RAMB36_X0Y0_TSTIN"             input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTIN"              output="BLK_IG-BRAM.RAMB36_Y0_TSTIN" />
-  <direct name="RAMB36_X0Y0_TSTFLAGIN"         input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTFLAGIN"          output="BLK_IG-BRAM.RAMB36_Y0_TSTFLAGIN" />
-  <direct name="RAMB36_X0Y0_TSTCNT"            input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTCNT"             output="BLK_IG-BRAM.RAMB36_Y0_TSTCNT" />
-  <direct name="RAMB36_X0Y0_TSTBRAMRST"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTBRAMRST"         output="BLK_IG-BRAM.RAMB36_Y0_TSTBRAMRST" />
+  <direct name="RAMB36_X0Y0_TSTWROS"           input="BRAM_X0.RAMB36_X0Y0_TSTWROS"            output="BRAM.RAMB36_Y0_TSTWROS" />
+  <direct name="RAMB36_X0Y0_TSTWRCNTOFF"       input="BRAM_X0.RAMB36_X0Y0_TSTWRCNTOFF"        output="BRAM.RAMB36_Y0_TSTWRCNTOFF" />
+  <direct name="RAMB36_X0Y0_TSTRDOS"           input="BRAM_X0.RAMB36_X0Y0_TSTRDOS"            output="BRAM.RAMB36_Y0_TSTRDOS" />
+  <direct name="RAMB36_X0Y0_TSTRDCNTOFF"       input="BRAM_X0.RAMB36_X0Y0_TSTRDCNTOFF"        output="BRAM.RAMB36_Y0_TSTRDCNTOFF" />
+  <direct name="RAMB36_X0Y0_TSTOFF"            input="BRAM_X0.RAMB36_X0Y0_TSTOFF"             output="BRAM.RAMB36_Y0_TSTOFF" />
+  <direct name="RAMB36_X0Y0_TSTIN"             input="BRAM_X0.RAMB36_X0Y0_TSTIN"              output="BRAM.RAMB36_Y0_TSTIN" />
+  <direct name="RAMB36_X0Y0_TSTFLAGIN"         input="BRAM_X0.RAMB36_X0Y0_TSTFLAGIN"          output="BRAM.RAMB36_Y0_TSTFLAGIN" />
+  <direct name="RAMB36_X0Y0_TSTCNT"            input="BRAM_X0.RAMB36_X0Y0_TSTCNT"             output="BRAM.RAMB36_Y0_TSTCNT" />
+  <direct name="RAMB36_X0Y0_TSTBRAMRST"        input="BRAM_X0.RAMB36_X0Y0_TSTBRAMRST"         output="BRAM.RAMB36_Y0_TSTBRAMRST" />
 
-  <direct name="RAMB36_X0Y0_RSTREGBU"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTREGBU"           output="BLK_IG-BRAM.RAMB36_Y0_RSTREGBU" />
-  <direct name="RAMB36_X0Y0_RSTREGBL"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTREGBL"           output="BLK_IG-BRAM.RAMB36_Y0_RSTREGBL" />
-  <direct name="RAMB36_X0Y0_RSTREGARSTREGU"    input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTREGARSTREGU"     output="BLK_IG-BRAM.RAMB36_Y0_RSTREGARSTREGU" />
-  <direct name="RAMB36_X0Y0_RSTREGARSTREGL"    input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTREGARSTREGL"     output="BLK_IG-BRAM.RAMB36_Y0_RSTREGARSTREGL" />
-  <direct name="RAMB36_X0Y0_RSTRAMBU"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTRAMBU"           output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMBU" />
-  <direct name="RAMB36_X0Y0_RSTRAMBL"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTRAMBL"           output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMBL" />
-  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMU"    input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTRAMARSTRAMU"     output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMARSTRAMU" />
-  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMLRST" input="BLK_IG-BRAM_L.RAMB36_X0Y0_RSTRAMARSTRAMLRST"  output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMARSTRAMLRST" />
+  <direct name="RAMB36_X0Y0_RSTREGBU"          input="BRAM_X0.RAMB36_X0Y0_RSTREGBU"           output="BRAM.RAMB36_Y0_RSTREGBU" />
+  <direct name="RAMB36_X0Y0_RSTREGBL"          input="BRAM_X0.RAMB36_X0Y0_RSTREGBL"           output="BRAM.RAMB36_Y0_RSTREGBL" />
+  <direct name="RAMB36_X0Y0_RSTREGARSTREGU"    input="BRAM_X0.RAMB36_X0Y0_RSTREGARSTREGU"     output="BRAM.RAMB36_Y0_RSTREGARSTREGU" />
+  <direct name="RAMB36_X0Y0_RSTREGARSTREGL"    input="BRAM_X0.RAMB36_X0Y0_RSTREGARSTREGL"     output="BRAM.RAMB36_Y0_RSTREGARSTREGL" />
+  <direct name="RAMB36_X0Y0_RSTRAMBU"          input="BRAM_X0.RAMB36_X0Y0_RSTRAMBU"           output="BRAM.RAMB36_Y0_RSTRAMBU" />
+  <direct name="RAMB36_X0Y0_RSTRAMBL"          input="BRAM_X0.RAMB36_X0Y0_RSTRAMBL"           output="BRAM.RAMB36_Y0_RSTRAMBL" />
+  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMU"    input="BRAM_X0.RAMB36_X0Y0_RSTRAMARSTRAMU"     output="BRAM.RAMB36_Y0_RSTRAMARSTRAMU" />
+  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMLRST" input="BRAM_X0.RAMB36_X0Y0_RSTRAMARSTRAMLRST"  output="BRAM.RAMB36_Y0_RSTRAMARSTRAMLRST" />
 
-  <direct name="RAMB36_X0Y0_REGCLKBU"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCLKBU"           output="BLK_IG-BRAM.RAMB36_Y0_REGCLKBU" />
-  <direct name="RAMB36_X0Y0_REGCLKBL"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCLKBL"           output="BLK_IG-BRAM.RAMB36_Y0_REGCLKBL" />
-  <direct name="RAMB36_X0Y0_REGCLKARDRCLKU"    input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCLKARDRCLKU"     output="BLK_IG-BRAM.RAMB36_Y0_REGCLKARDRCLKU" />
-  <direct name="RAMB36_X0Y0_REGCLKARDRCLKL"    input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCLKARDRCLKL"     output="BLK_IG-BRAM.RAMB36_Y0_REGCLKARDRCLKL" />
-  <direct name="RAMB36_X0Y0_REGCEBU"           input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCEBU"            output="BLK_IG-BRAM.RAMB36_Y0_REGCEBU" />
-  <direct name="RAMB36_X0Y0_REGCEBL"           input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCEBL"            output="BLK_IG-BRAM.RAMB36_Y0_REGCEBL" />
-  <direct name="RAMB36_X0Y0_REGCEAREGCEU"      input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCEAREGCEU"       output="BLK_IG-BRAM.RAMB36_Y0_REGCEAREGCEU" />
-  <direct name="RAMB36_X0Y0_REGCEAREGCEL"      input="BLK_IG-BRAM_L.RAMB36_X0Y0_REGCEAREGCEL"       output="BLK_IG-BRAM.RAMB36_Y0_REGCEAREGCEL" />
+  <direct name="RAMB36_X0Y0_REGCLKBU"          input="BRAM_X0.RAMB36_X0Y0_REGCLKBU"           output="BRAM.RAMB36_Y0_REGCLKBU" />
+  <direct name="RAMB36_X0Y0_REGCLKBL"          input="BRAM_X0.RAMB36_X0Y0_REGCLKBL"           output="BRAM.RAMB36_Y0_REGCLKBL" />
+  <direct name="RAMB36_X0Y0_REGCLKARDRCLKU"    input="BRAM_X0.RAMB36_X0Y0_REGCLKARDRCLKU"     output="BRAM.RAMB36_Y0_REGCLKARDRCLKU" />
+  <direct name="RAMB36_X0Y0_REGCLKARDRCLKL"    input="BRAM_X0.RAMB36_X0Y0_REGCLKARDRCLKL"     output="BRAM.RAMB36_Y0_REGCLKARDRCLKL" />
+  <direct name="RAMB36_X0Y0_REGCEBU"           input="BRAM_X0.RAMB36_X0Y0_REGCEBU"            output="BRAM.RAMB36_Y0_REGCEBU" />
+  <direct name="RAMB36_X0Y0_REGCEBL"           input="BRAM_X0.RAMB36_X0Y0_REGCEBL"            output="BRAM.RAMB36_Y0_REGCEBL" />
+  <direct name="RAMB36_X0Y0_REGCEAREGCEU"      input="BRAM_X0.RAMB36_X0Y0_REGCEAREGCEU"       output="BRAM.RAMB36_Y0_REGCEAREGCEU" />
+  <direct name="RAMB36_X0Y0_REGCEAREGCEL"      input="BRAM_X0.RAMB36_X0Y0_REGCEAREGCEL"       output="BRAM.RAMB36_Y0_REGCEAREGCEL" />
 
-  <direct name="RAMB36_X0Y0_INJECTDBITERR"     input="BLK_IG-BRAM_L.RAMB36_X0Y0_INJECTDBITERR"      output="BLK_IG-BRAM.RAMB36_Y0_INJECTDBITERR" />
-  <direct name="RAMB36_X0Y0_INJECTSBITERR"     input="BLK_IG-BRAM_L.RAMB36_X0Y0_INJECTSBITERR"      output="BLK_IG-BRAM.RAMB36_Y0_INJECTSBITERR" />
+  <direct name="RAMB36_X0Y0_INJECTDBITERR"     input="BRAM_X0.RAMB36_X0Y0_INJECTDBITERR"      output="BRAM.RAMB36_Y0_INJECTDBITERR" />
+  <direct name="RAMB36_X0Y0_INJECTSBITERR"     input="BRAM_X0.RAMB36_X0Y0_INJECTSBITERR"      output="BRAM.RAMB36_Y0_INJECTSBITERR" />
 
-  <direct name="RAMB36_X0Y0_ENBWRENU"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_ENBWRENU"           output="BLK_IG-BRAM.RAMB36_Y0_ENBWRENU" />
-  <direct name="RAMB36_X0Y0_ENBWRENL"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_ENBWRENL"           output="BLK_IG-BRAM.RAMB36_Y0_ENBWRENL" />
-  <direct name="RAMB36_X0Y0_ENARDENU"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_ENARDENU"           output="BLK_IG-BRAM.RAMB36_Y0_ENARDENU" />
-  <direct name="RAMB36_X0Y0_ENARDENL"          input="BLK_IG-BRAM_L.RAMB36_X0Y0_ENARDENL"           output="BLK_IG-BRAM.RAMB36_Y0_ENARDENL" />
-  <direct name="RAMB36_X0Y0_DIPBDIP"           input="BLK_IG-BRAM_L.RAMB36_X0Y0_DIPBDIP"            output="BLK_IG-BRAM.RAMB36_Y0_DIPBDIP" />
-  <direct name="RAMB36_X0Y0_DIPADIP"           input="BLK_IG-BRAM_L.RAMB36_X0Y0_DIPADIP"            output="BLK_IG-BRAM.RAMB36_Y0_DIPADIP" />
-  <direct name="RAMB36_X0Y0_DIBDI"             input="BLK_IG-BRAM_L.RAMB36_X0Y0_DIBDI"              output="BLK_IG-BRAM.RAMB36_Y0_DIBDI" />
-  <direct name="RAMB36_X0Y0_DIADI"             input="BLK_IG-BRAM_L.RAMB36_X0Y0_DIADI"              output="BLK_IG-BRAM.RAMB36_Y0_DIADI" />
+  <direct name="RAMB36_X0Y0_ENBWRENU"          input="BRAM_X0.RAMB36_X0Y0_ENBWRENU"           output="BRAM.RAMB36_Y0_ENBWRENU" />
+  <direct name="RAMB36_X0Y0_ENBWRENL"          input="BRAM_X0.RAMB36_X0Y0_ENBWRENL"           output="BRAM.RAMB36_Y0_ENBWRENL" />
+  <direct name="RAMB36_X0Y0_ENARDENU"          input="BRAM_X0.RAMB36_X0Y0_ENARDENU"           output="BRAM.RAMB36_Y0_ENARDENU" />
+  <direct name="RAMB36_X0Y0_ENARDENL"          input="BRAM_X0.RAMB36_X0Y0_ENARDENL"           output="BRAM.RAMB36_Y0_ENARDENL" />
+  <direct name="RAMB36_X0Y0_DIPBDIP"           input="BRAM_X0.RAMB36_X0Y0_DIPBDIP"            output="BRAM.RAMB36_Y0_DIPBDIP" />
+  <direct name="RAMB36_X0Y0_DIPADIP"           input="BRAM_X0.RAMB36_X0Y0_DIPADIP"            output="BRAM.RAMB36_Y0_DIPADIP" />
+  <direct name="RAMB36_X0Y0_DIBDI"             input="BRAM_X0.RAMB36_X0Y0_DIBDI"              output="BRAM.RAMB36_Y0_DIBDI" />
+  <direct name="RAMB36_X0Y0_DIADI"             input="BRAM_X0.RAMB36_X0Y0_DIADI"              output="BRAM.RAMB36_Y0_DIADI" />
 
-  <direct name="RAMB36_X0Y0_CLKBWRCLKU"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_CLKBWRCLKU"         output="BLK_IG-BRAM.RAMB36_Y0_CLKBWRCLKU" />
-  <direct name="RAMB36_X0Y0_CLKBWRCLKL"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_CLKBWRCLKL"         output="BLK_IG-BRAM.RAMB36_Y0_CLKBWRCLKL" />
-  <direct name="RAMB36_X0Y0_CLKARDCLKU"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_CLKARDCLKU"         output="BLK_IG-BRAM.RAMB36_Y0_CLKARDCLKU" />
-  <direct name="RAMB36_X0Y0_CLKARDCLKL"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_CLKARDCLKL"         output="BLK_IG-BRAM.RAMB36_Y0_CLKARDCLKL" />
+  <direct name="RAMB36_X0Y0_CLKBWRCLKU"        input="BRAM_X0.RAMB36_X0Y0_CLKBWRCLKU"         output="BRAM.RAMB36_Y0_CLKBWRCLKU" />
+  <direct name="RAMB36_X0Y0_CLKBWRCLKL"        input="BRAM_X0.RAMB36_X0Y0_CLKBWRCLKL"         output="BRAM.RAMB36_Y0_CLKBWRCLKL" />
+  <direct name="RAMB36_X0Y0_CLKARDCLKU"        input="BRAM_X0.RAMB36_X0Y0_CLKARDCLKU"         output="BRAM.RAMB36_Y0_CLKARDCLKU" />
+  <direct name="RAMB36_X0Y0_CLKARDCLKL"        input="BRAM_X0.RAMB36_X0Y0_CLKARDCLKL"         output="BRAM.RAMB36_Y0_CLKARDCLKL" />
 
-  <direct name="RAMB36_X0Y0_CASCADEINA"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_CASCADEINA"         output="BLK_IG-BRAM.RAMB36_Y0_CASCADEINA" />
-  <direct name="RAMB36_X0Y0_CASCADEINB"        input="BLK_IG-BRAM_L.RAMB36_X0Y0_CASCADEINB"         output="BLK_IG-BRAM.RAMB36_Y0_CASCADEINB" />
+  <direct name="RAMB36_X0Y0_CASCADEINA"        input="BRAM_X0.RAMB36_X0Y0_CASCADEINA"         output="BRAM.RAMB36_Y0_CASCADEINA" />
+  <direct name="RAMB36_X0Y0_CASCADEINB"        input="BRAM_X0.RAMB36_X0Y0_CASCADEINB"         output="BRAM.RAMB36_Y0_CASCADEINB" />
 
-  <direct name="RAMB36_X0Y0_ADDRBWRADDRU"      input="BLK_IG-BRAM_L.RAMB36_X0Y0_ADDRBWRADDRU"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRBWRADDRU" />
-  <direct name="RAMB36_X0Y0_ADDRBWRADDRL"      input="BLK_IG-BRAM_L.RAMB36_X0Y0_ADDRBWRADDRL"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRBWRADDRL" />
+  <direct name="RAMB36_X0Y0_ADDRBWRADDRU"      input="BRAM_X0.RAMB36_X0Y0_ADDRBWRADDRU"       output="BRAM.RAMB36_Y0_ADDRBWRADDRU" />
+  <direct name="RAMB36_X0Y0_ADDRBWRADDRL"      input="BRAM_X0.RAMB36_X0Y0_ADDRBWRADDRL"       output="BRAM.RAMB36_Y0_ADDRBWRADDRL" />
 
-  <direct name="RAMB36_X0Y0_ADDRARDADDRU"      input="BLK_IG-BRAM_L.RAMB36_X0Y0_ADDRARDADDRU"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRARDADDRU" />
-  <direct name="RAMB36_X0Y0_ADDRARDADDRL"      input="BLK_IG-BRAM_L.RAMB36_X0Y0_ADDRARDADDRL"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRARDADDRL" />
+  <direct name="RAMB36_X0Y0_ADDRARDADDRU"      input="BRAM_X0.RAMB36_X0Y0_ADDRARDADDRU"       output="BRAM.RAMB36_Y0_ADDRARDADDRU" />
+  <direct name="RAMB36_X0Y0_ADDRARDADDRL"      input="BRAM_X0.RAMB36_X0Y0_ADDRARDADDRL"       output="BRAM.RAMB36_Y0_ADDRARDADDRL" />
 
-  <direct name="RAMB36_X0Y0_WRERR"             input="BLK_IG-BRAM.RAMB36_Y0_WRERR"                  output="BLK_IG-BRAM_L.RAMB36_X0Y0_WRERR" />
-  <direct name="RAMB36_X0Y0_WRCOUNT"           input="BLK_IG-BRAM.RAMB36_Y0_WRCOUNT"                output="BLK_IG-BRAM_L.RAMB36_X0Y0_WRCOUNT" />
+  <direct name="RAMB36_X0Y0_WRERR"             input="BRAM.RAMB36_Y0_WRERR"                  output="BRAM_X0.RAMB36_X0Y0_WRERR" />
+  <direct name="RAMB36_X0Y0_WRCOUNT"           input="BRAM.RAMB36_Y0_WRCOUNT"                output="BRAM_X0.RAMB36_X0Y0_WRCOUNT" />
 
-  <direct name="RAMB36_X0Y0_TSTOUT"            input="BLK_IG-BRAM.RAMB36_Y0_TSTOUT"                 output="BLK_IG-BRAM_L.RAMB36_X0Y0_TSTOUT" />
+  <direct name="RAMB36_X0Y0_TSTOUT"            input="BRAM.RAMB36_Y0_TSTOUT"                 output="BRAM_X0.RAMB36_X0Y0_TSTOUT" />
 
-  <direct name="RAMB36_X0Y0_SBITERR"           input="BLK_IG-BRAM.RAMB36_Y0_SBITERR"                output="BLK_IG-BRAM_L.RAMB36_X0Y0_SBITERR" />
+  <direct name="RAMB36_X0Y0_SBITERR"           input="BRAM.RAMB36_Y0_SBITERR"                output="BRAM_X0.RAMB36_X0Y0_SBITERR" />
 
-  <direct name="RAMB36_X0Y0_RDERR"             input="BLK_IG-BRAM.RAMB36_Y0_RDERR"                  output="BLK_IG-BRAM_L.RAMB36_X0Y0_RDERR" />
-  <direct name="RAMB36_X0Y0_RDCOUNT"           input="BLK_IG-BRAM.RAMB36_Y0_RDCOUNT"                output="BLK_IG-BRAM_L.RAMB36_X0Y0_RDCOUNT" />
+  <direct name="RAMB36_X0Y0_RDERR"             input="BRAM.RAMB36_Y0_RDERR"                  output="BRAM_X0.RAMB36_X0Y0_RDERR" />
+  <direct name="RAMB36_X0Y0_RDCOUNT"           input="BRAM.RAMB36_Y0_RDCOUNT"                output="BRAM_X0.RAMB36_X0Y0_RDCOUNT" />
 
-  <direct name="RAMB36_X0Y0_FULL"              input="BLK_IG-BRAM.RAMB36_Y0_FULL"                   output="BLK_IG-BRAM_L.RAMB36_X0Y0_FULL" />
-  <direct name="RAMB36_X0Y0_EMPTY"             input="BLK_IG-BRAM.RAMB36_Y0_EMPTY"                  output="BLK_IG-BRAM_L.RAMB36_X0Y0_EMPTY" />
+  <direct name="RAMB36_X0Y0_FULL"              input="BRAM.RAMB36_Y0_FULL"                   output="BRAM_X0.RAMB36_X0Y0_FULL" />
+  <direct name="RAMB36_X0Y0_EMPTY"             input="BRAM.RAMB36_Y0_EMPTY"                  output="BRAM_X0.RAMB36_X0Y0_EMPTY" />
 
-  <direct name="RAMB36_X0Y0_ECCPARITY"         input="BLK_IG-BRAM.RAMB36_Y0_ECCPARITY"              output="BLK_IG-BRAM_L.RAMB36_X0Y0_ECCPARITY" />
+  <direct name="RAMB36_X0Y0_ECCPARITY"         input="BRAM.RAMB36_Y0_ECCPARITY"              output="BRAM_X0.RAMB36_X0Y0_ECCPARITY" />
 
-  <direct name="RAMB36_X0Y0_DOPBDOP"           input="BLK_IG-BRAM.RAMB36_Y0_DOPBDOP"                output="BLK_IG-BRAM_L.RAMB36_X0Y0_DOPBDOP" />
-  <direct name="RAMB36_X0Y0_DOPADOP"           input="BLK_IG-BRAM.RAMB36_Y0_DOPADOP"                output="BLK_IG-BRAM_L.RAMB36_X0Y0_DOPADOP" />
+  <direct name="RAMB36_X0Y0_DOPBDOP"           input="BRAM.RAMB36_Y0_DOPBDOP"                output="BRAM_X0.RAMB36_X0Y0_DOPBDOP" />
+  <direct name="RAMB36_X0Y0_DOPADOP"           input="BRAM.RAMB36_Y0_DOPADOP"                output="BRAM_X0.RAMB36_X0Y0_DOPADOP" />
 
-  <direct name="RAMB36_X0Y0_DOBDO"             input="BLK_IG-BRAM.RAMB36_Y0_DOBDO"                  output="BLK_IG-BRAM_L.RAMB36_X0Y0_DOBDO" />
-  <direct name="RAMB36_X0Y0_DOADO"             input="BLK_IG-BRAM.RAMB36_Y0_DOADO"                  output="BLK_IG-BRAM_L.RAMB36_X0Y0_DOADO" />
+  <direct name="RAMB36_X0Y0_DOBDO"             input="BRAM.RAMB36_Y0_DOBDO"                  output="BRAM_X0.RAMB36_X0Y0_DOBDO" />
+  <direct name="RAMB36_X0Y0_DOADO"             input="BRAM.RAMB36_Y0_DOADO"                  output="BRAM_X0.RAMB36_X0Y0_DOADO" />
 
-  <direct name="RAMB36_X0Y0_DBITERR"           input="BLK_IG-BRAM.RAMB36_Y0_DBITERR"                output="BLK_IG-BRAM_L.RAMB36_X0Y0_DBITERR" />
+  <direct name="RAMB36_X0Y0_DBITERR"           input="BRAM.RAMB36_Y0_DBITERR"                output="BRAM_X0.RAMB36_X0Y0_DBITERR" />
 
-  <direct name="RAMB36_X0Y0_CASCADEOUTA"       input="BLK_IG-BRAM.RAMB36_Y0_CASCADEOUTA"            output="BLK_IG-BRAM_L.RAMB36_X0Y0_CASCADEOUTA" />
-  <direct name="RAMB36_X0Y0_CASCADEOUTB"       input="BLK_IG-BRAM.RAMB36_Y0_CASCADEOUTB"            output="BLK_IG-BRAM_L.RAMB36_X0Y0_CASCADEOUTB" />
+  <direct name="RAMB36_X0Y0_CASCADEOUTA"       input="BRAM.RAMB36_Y0_CASCADEOUTA"            output="BRAM_X0.RAMB36_X0Y0_CASCADEOUTA" />
+  <direct name="RAMB36_X0Y0_CASCADEOUTB"       input="BRAM.RAMB36_Y0_CASCADEOUTB"            output="BRAM_X0.RAMB36_X0Y0_CASCADEOUTB" />
 
-  <direct name="RAMB36_X0Y0_ALMOSTFULL"        input="BLK_IG-BRAM.RAMB36_Y0_ALMOSTFULL"             output="BLK_IG-BRAM_L.RAMB36_X0Y0_ALMOSTFULL" />
-  <direct name="RAMB36_X0Y0_ALMOSTEMPTY"       input="BLK_IG-BRAM.RAMB36_Y0_ALMOSTEMPTY"            output="BLK_IG-BRAM_L.RAMB36_X0Y0_ALMOSTEMPTY" />
+  <direct name="RAMB36_X0Y0_ALMOSTFULL"        input="BRAM.RAMB36_Y0_ALMOSTFULL"             output="BRAM_X0.RAMB36_X0Y0_ALMOSTFULL" />
+  <direct name="RAMB36_X0Y0_ALMOSTEMPTY"       input="BRAM.RAMB36_Y0_ALMOSTEMPTY"            output="BRAM_X0.RAMB36_X0Y0_ALMOSTEMPTY" />
 
-  <direct name="RAMB18_X0Y0_WREN"             input="BLK_IG-BRAM_L.RAMB18_X0Y0_WREN"                output="BLK_IG-BRAM.RAMB18_Y0_WREN" />
-  <direct name="RAMB18_X0Y0_WRCLK"            input="BLK_IG-BRAM_L.RAMB18_X0Y0_WRCLK"               output="BLK_IG-BRAM.RAMB18_Y0_WRCLK" />
-  <direct name="RAMB18_X0Y0_WEBWE"            input="BLK_IG-BRAM_L.RAMB18_X0Y0_WEBWE"               output="BLK_IG-BRAM.RAMB18_Y0_WEBWE" />
-  <direct name="RAMB18_X0Y0_WEA"              input="BLK_IG-BRAM_L.RAMB18_X0Y0_WEA"                 output="BLK_IG-BRAM.RAMB18_Y0_WEA" />
+  <direct name="RAMB18_X0Y0_WREN"              input="BRAM_X0.RAMB18_X0Y0_WREN"              output="BRAM.RAMB18_Y0_WREN" />
+  <direct name="RAMB18_X0Y0_WRCLK"             input="BRAM_X0.RAMB18_X0Y0_WRCLK"             output="BRAM.RAMB18_Y0_WRCLK" />
+  <direct name="RAMB18_X0Y0_WEBWE"             input="BRAM_X0.RAMB18_X0Y0_WEBWE"             output="BRAM.RAMB18_Y0_WEBWE" />
+  <direct name="RAMB18_X0Y0_WEA"               input="BRAM_X0.RAMB18_X0Y0_WEA"               output="BRAM.RAMB18_Y0_WEA" />
 
-  <direct name="RAMB18_X0Y0_RSTREGB"          input="BLK_IG-BRAM_L.RAMB18_X0Y0_RSTREGB"             output="BLK_IG-BRAM.RAMB18_Y0_RSTREGB" />
-  <direct name="RAMB18_X0Y0_RSTREG"           input="BLK_IG-BRAM_L.RAMB18_X0Y0_RSTREG"              output="BLK_IG-BRAM.RAMB18_Y0_RSTREG" />
-  <direct name="RAMB18_X0Y0_RSTRAMB"          input="BLK_IG-BRAM_L.RAMB18_X0Y0_RSTRAMB"             output="BLK_IG-BRAM.RAMB18_Y0_RSTRAMB" />
-  <direct name="RAMB18_X0Y0_RST"              input="BLK_IG-BRAM_L.RAMB18_X0Y0_RST"                 output="BLK_IG-BRAM.RAMB18_Y0_RST" />
+  <direct name="RAMB18_X0Y0_RSTREGB"           input="BRAM_X0.RAMB18_X0Y0_RSTREGB"           output="BRAM.RAMB18_Y0_RSTREGB" />
+  <direct name="RAMB18_X0Y0_RSTREG"            input="BRAM_X0.RAMB18_X0Y0_RSTREG"            output="BRAM.RAMB18_Y0_RSTREG" />
+  <direct name="RAMB18_X0Y0_RSTRAMB"           input="BRAM_X0.RAMB18_X0Y0_RSTRAMB"           output="BRAM.RAMB18_Y0_RSTRAMB" />
+  <direct name="RAMB18_X0Y0_RST"               input="BRAM_X0.RAMB18_X0Y0_RST"               output="BRAM.RAMB18_Y0_RST" />
 
-  <direct name="RAMB18_X0Y0_REGCLKB"          input="BLK_IG-BRAM_L.RAMB18_X0Y0_REGCLKB"             output="BLK_IG-BRAM.RAMB18_Y0_REGCLKB" />
-  <direct name="RAMB18_X0Y0_REGCEB"           input="BLK_IG-BRAM_L.RAMB18_X0Y0_REGCEB"              output="BLK_IG-BRAM.RAMB18_Y0_REGCEB" />
-  <direct name="RAMB18_X0Y0_REGCE"            input="BLK_IG-BRAM_L.RAMB18_X0Y0_REGCE"               output="BLK_IG-BRAM.RAMB18_Y0_REGCE" />
-  <direct name="RAMB18_X0Y0_RDRCLK"           input="BLK_IG-BRAM_L.RAMB18_X0Y0_RDRCLK"              output="BLK_IG-BRAM.RAMB18_Y0_RDRCLK" />
-  <direct name="RAMB18_X0Y0_RDEN"             input="BLK_IG-BRAM_L.RAMB18_X0Y0_RDEN"                output="BLK_IG-BRAM.RAMB18_Y0_RDEN" />
-  <direct name="RAMB18_X0Y0_RDCLK"            input="BLK_IG-BRAM_L.RAMB18_X0Y0_RDCLK"               output="BLK_IG-BRAM.RAMB18_Y0_RDCLK" />
+  <direct name="RAMB18_X0Y0_REGCLKB"           input="BRAM_X0.RAMB18_X0Y0_REGCLKB"           output="BRAM.RAMB18_Y0_REGCLKB" />
+  <direct name="RAMB18_X0Y0_REGCEB"            input="BRAM_X0.RAMB18_X0Y0_REGCEB"            output="BRAM.RAMB18_Y0_REGCEB" />
+  <direct name="RAMB18_X0Y0_REGCE"             input="BRAM_X0.RAMB18_X0Y0_REGCE"             output="BRAM.RAMB18_Y0_REGCE" />
+  <direct name="RAMB18_X0Y0_RDRCLK"            input="BRAM_X0.RAMB18_X0Y0_RDRCLK"            output="BRAM.RAMB18_Y0_RDRCLK" />
+  <direct name="RAMB18_X0Y0_RDEN"              input="BRAM_X0.RAMB18_X0Y0_RDEN"              output="BRAM.RAMB18_Y0_RDEN" />
+  <direct name="RAMB18_X0Y0_RDCLK"             input="BRAM_X0.RAMB18_X0Y0_RDCLK"             output="BRAM.RAMB18_Y0_RDCLK" />
 
-  <direct name="RAMB18_X0Y0_DIPBDIP"          input="BLK_IG-BRAM_L.RAMB18_X0Y0_DIPBDIP"             output="BLK_IG-BRAM.RAMB18_Y0_DIPBDIP" />
-  <direct name="RAMB18_X0Y0_DIPADIP"          input="BLK_IG-BRAM_L.RAMB18_X0Y0_DIPADIP"             output="BLK_IG-BRAM.RAMB18_Y0_DIPADIP" />
-  <direct name="RAMB18_X0Y0_DIBDI"            input="BLK_IG-BRAM_L.RAMB18_X0Y0_DIBDI"               output="BLK_IG-BRAM.RAMB18_Y0_DIBDI" />
-  <direct name="RAMB18_X0Y0_DIADI"            input="BLK_IG-BRAM_L.RAMB18_X0Y0_DIADI"               output="BLK_IG-BRAM.RAMB18_Y0_DIADI" />
+  <direct name="RAMB18_X0Y0_DIPBDIP"           input="BRAM_X0.RAMB18_X0Y0_DIPBDIP"           output="BRAM.RAMB18_Y0_DIPBDIP" />
+  <direct name="RAMB18_X0Y0_DIPADIP"           input="BRAM_X0.RAMB18_X0Y0_DIPADIP"           output="BRAM.RAMB18_Y0_DIPADIP" />
+  <direct name="RAMB18_X0Y0_DIBDI"             input="BRAM_X0.RAMB18_X0Y0_DIBDI"             output="BRAM.RAMB18_Y0_DIBDI" />
+  <direct name="RAMB18_X0Y0_DIADI"             input="BRAM_X0.RAMB18_X0Y0_DIADI"             output="BRAM.RAMB18_Y0_DIADI" />
 
-  <direct name="RAMB18_X0Y0_ADDRARDADDR"      input="BLK_IG-BRAM_L.RAMB18_X0Y0_ADDRARDADDR"         output="BLK_IG-BRAM.RAMB18_Y0_ADDRARDADDR" />
-  <direct name="RAMB18_X0Y0_ADDRBWRADDR"      input="BLK_IG-BRAM_L.RAMB18_X0Y0_ADDRBWRADDR"         output="BLK_IG-BRAM.RAMB18_Y0_ADDRBWRADDR" />
-  <direct name="RAMB18_X0Y0_ADDRATIEHIGH"     input="BLK_IG-BRAM_L.RAMB18_X0Y0_ADDRATIEHIGH"        output="BLK_IG-BRAM.RAMB18_Y0_ADDRATIEHIGH" />
-  <direct name="RAMB18_X0Y0_ADDRBTIEHIGH"     input="BLK_IG-BRAM_L.RAMB18_X0Y0_ADDRBTIEHIGH"        output="BLK_IG-BRAM.RAMB18_Y0_ADDRBTIEHIGH" />
+  <direct name="RAMB18_X0Y0_ADDRARDADDR"       input="BRAM_X0.RAMB18_X0Y0_ADDRARDADDR"       output="BRAM.RAMB18_Y0_ADDRARDADDR" />
+  <direct name="RAMB18_X0Y0_ADDRBWRADDR"       input="BRAM_X0.RAMB18_X0Y0_ADDRBWRADDR"       output="BRAM.RAMB18_Y0_ADDRBWRADDR" />
+  <direct name="RAMB18_X0Y0_ADDRATIEHIGH"      input="BRAM_X0.RAMB18_X0Y0_ADDRATIEHIGH"      output="BRAM.RAMB18_Y0_ADDRATIEHIGH" />
+  <direct name="RAMB18_X0Y0_ADDRBTIEHIGH"      input="BRAM_X0.RAMB18_X0Y0_ADDRBTIEHIGH"      output="BRAM.RAMB18_Y0_ADDRBTIEHIGH" />
 
-  <direct name="RAMB18_X0Y0_WRERR"            input="BLK_IG-BRAM.RAMB18_Y0_WRERR"                   output="BLK_IG-BRAM_L.RAMB18_X0Y0_WRERR" />
-  <direct name="RAMB18_X0Y0_WRCOUNT"          input="BLK_IG-BRAM.RAMB18_Y0_WRCOUNT"                 output="BLK_IG-BRAM_L.RAMB18_X0Y0_WRCOUNT" />
-  <direct name="RAMB18_X0Y0_RDERR"            input="BLK_IG-BRAM.RAMB18_Y0_RDERR"                   output="BLK_IG-BRAM_L.RAMB18_X0Y0_RDERR" />
-  <direct name="RAMB18_X0Y0_RDCOUNT"          input="BLK_IG-BRAM.RAMB18_Y0_RDCOUNT"                 output="BLK_IG-BRAM_L.RAMB18_X0Y0_RDCOUNT" />
-  <direct name="RAMB18_X0Y0_FULL"             input="BLK_IG-BRAM.RAMB18_Y0_FULL"                    output="BLK_IG-BRAM_L.RAMB18_X0Y0_FULL" />
-  <direct name="RAMB18_X0Y0_EMPTY"            input="BLK_IG-BRAM.RAMB18_Y0_EMPTY"                   output="BLK_IG-BRAM_L.RAMB18_X0Y0_EMPTY" />
-  <direct name="RAMB18_X0Y0_DOP"              input="BLK_IG-BRAM.RAMB18_Y0_DOP"                     output="BLK_IG-BRAM_L.RAMB18_X0Y0_DOP" />
-  <direct name="RAMB18_X0Y0_DO"               input="BLK_IG-BRAM.RAMB18_Y0_DO"                      output="BLK_IG-BRAM_L.RAMB18_X0Y0_DO" />
-  <direct name="RAMB18_X0Y0_ALMOSTFULL"       input="BLK_IG-BRAM.RAMB18_Y0_ALMOSTFULL"              output="BLK_IG-BRAM_L.RAMB18_X0Y0_ALMOSTFULL" />
-  <direct name="RAMB18_X0Y0_ALMOSTEMPTY"      input="BLK_IG-BRAM.RAMB18_Y0_ALMOSTEMPTY"             output="BLK_IG-BRAM_L.RAMB18_X0Y0_ALMOSTEMPTY" />
+  <direct name="RAMB18_X0Y0_WRERR"             input="BRAM.RAMB18_Y0_WRERR"                  output="BRAM_X0.RAMB18_X0Y0_WRERR" />
+  <direct name="RAMB18_X0Y0_WRCOUNT"           input="BRAM.RAMB18_Y0_WRCOUNT"                output="BRAM_X0.RAMB18_X0Y0_WRCOUNT" />
+  <direct name="RAMB18_X0Y0_RDERR"             input="BRAM.RAMB18_Y0_RDERR"                  output="BRAM_X0.RAMB18_X0Y0_RDERR" />
+  <direct name="RAMB18_X0Y0_RDCOUNT"           input="BRAM.RAMB18_Y0_RDCOUNT"                output="BRAM_X0.RAMB18_X0Y0_RDCOUNT" />
+  <direct name="RAMB18_X0Y0_FULL"              input="BRAM.RAMB18_Y0_FULL"                   output="BRAM_X0.RAMB18_X0Y0_FULL" />
+  <direct name="RAMB18_X0Y0_EMPTY"             input="BRAM.RAMB18_Y0_EMPTY"                  output="BRAM_X0.RAMB18_X0Y0_EMPTY" />
+  <direct name="RAMB18_X0Y0_DOP"               input="BRAM.RAMB18_Y0_DOP"                    output="BRAM_X0.RAMB18_X0Y0_DOP" />
+  <direct name="RAMB18_X0Y0_DO"                input="BRAM.RAMB18_Y0_DO"                     output="BRAM_X0.RAMB18_X0Y0_DO" />
+  <direct name="RAMB18_X0Y0_ALMOSTFULL"        input="BRAM.RAMB18_Y0_ALMOSTFULL"             output="BRAM_X0.RAMB18_X0Y0_ALMOSTFULL" />
+  <direct name="RAMB18_X0Y0_ALMOSTEMPTY"       input="BRAM.RAMB18_Y0_ALMOSTEMPTY"            output="BRAM_X0.RAMB18_X0Y0_ALMOSTEMPTY" />
 
-  <direct name="RAMB18_X0Y1_ENBWREN"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_ENBWREN"             output="BLK_IG-BRAM.RAMB18_Y1_ENBWREN" />
-  <direct name="RAMB18_X0Y1_CLKBWRCLK"        input="BLK_IG-BRAM_L.RAMB18_X0Y1_CLKBWRCLK"           output="BLK_IG-BRAM.RAMB18_Y1_CLKBWRCLK" />
-  <direct name="RAMB18_X0Y1_WEBWE"            input="BLK_IG-BRAM_L.RAMB18_X0Y1_WEBWE"               output="BLK_IG-BRAM.RAMB18_Y1_WEBWE" />
-  <direct name="RAMB18_X0Y1_WEA"              input="BLK_IG-BRAM_L.RAMB18_X0Y1_WEA"                 output="BLK_IG-BRAM.RAMB18_Y1_WEA" />
+  <direct name="RAMB18_X0Y1_ENBWREN"           input="BRAM_X0.RAMB18_X0Y1_ENBWREN"           output="BRAM.RAMB18_Y1_ENBWREN" />
+  <direct name="RAMB18_X0Y1_CLKBWRCLK"         input="BRAM_X0.RAMB18_X0Y1_CLKBWRCLK"         output="BRAM.RAMB18_Y1_CLKBWRCLK" />
+  <direct name="RAMB18_X0Y1_WEBWE"             input="BRAM_X0.RAMB18_X0Y1_WEBWE"             output="BRAM.RAMB18_Y1_WEBWE" />
+  <direct name="RAMB18_X0Y1_WEA"               input="BRAM_X0.RAMB18_X0Y1_WEA"               output="BRAM.RAMB18_Y1_WEA" />
 
-  <direct name="RAMB18_X0Y1_RSTREGB"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_RSTREGB"             output="BLK_IG-BRAM.RAMB18_Y1_RSTREGB" />
-  <direct name="RAMB18_X0Y1_RSTREGARSTREG"    input="BLK_IG-BRAM_L.RAMB18_X0Y1_RSTREGARSTREG"       output="BLK_IG-BRAM.RAMB18_Y1_RSTREGARSTREG" />
-  <direct name="RAMB18_X0Y1_RSTRAMB"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_RSTRAMB"             output="BLK_IG-BRAM.RAMB18_Y1_RSTRAMB" />
-  <direct name="RAMB18_X0Y1_RSTRAMARSTRAM"    input="BLK_IG-BRAM_L.RAMB18_X0Y1_RSTRAMARSTRAM"       output="BLK_IG-BRAM.RAMB18_Y1_RSTRAMARSTRAM" />
+  <direct name="RAMB18_X0Y1_RSTREGB"           input="BRAM_X0.RAMB18_X0Y1_RSTREGB"           output="BRAM.RAMB18_Y1_RSTREGB" />
+  <direct name="RAMB18_X0Y1_RSTREGARSTREG"     input="BRAM_X0.RAMB18_X0Y1_RSTREGARSTREG"     output="BRAM.RAMB18_Y1_RSTREGARSTREG" />
+  <direct name="RAMB18_X0Y1_RSTRAMB"           input="BRAM_X0.RAMB18_X0Y1_RSTRAMB"           output="BRAM.RAMB18_Y1_RSTRAMB" />
+  <direct name="RAMB18_X0Y1_RSTRAMARSTRAM"     input="BRAM_X0.RAMB18_X0Y1_RSTRAMARSTRAM"     output="BRAM.RAMB18_Y1_RSTRAMARSTRAM" />
 
-  <direct name="RAMB18_X0Y1_REGCLKB"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_REGCLKB"             output="BLK_IG-BRAM.RAMB18_Y1_REGCLKB" />
-  <direct name="RAMB18_X0Y1_REGCEB"           input="BLK_IG-BRAM_L.RAMB18_X0Y1_REGCEB"              output="BLK_IG-BRAM.RAMB18_Y1_REGCEB" />
-  <direct name="RAMB18_X0Y1_REGCEAREGCE"      input="BLK_IG-BRAM_L.RAMB18_X0Y1_REGCEAREGCE"         output="BLK_IG-BRAM.RAMB18_Y1_REGCEAREGCE" />
-  <direct name="RAMB18_X0Y1_REGCLKARDRCLK"    input="BLK_IG-BRAM_L.RAMB18_X0Y1_REGCLKARDRCLK"       output="BLK_IG-BRAM.RAMB18_Y1_REGCLKARDRCLK" />
-  <direct name="RAMB18_X0Y1_ENARDEN"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_ENARDEN"             output="BLK_IG-BRAM.RAMB18_Y1_ENARDEN" />
-  <direct name="RAMB18_X0Y1_CLKARDCLK"        input="BLK_IG-BRAM_L.RAMB18_X0Y1_CLKARDCLK"           output="BLK_IG-BRAM.RAMB18_Y1_CLKARDCLK" />
+  <direct name="RAMB18_X0Y1_REGCLKB"           input="BRAM_X0.RAMB18_X0Y1_REGCLKB"           output="BRAM.RAMB18_Y1_REGCLKB" />
+  <direct name="RAMB18_X0Y1_REGCEB"            input="BRAM_X0.RAMB18_X0Y1_REGCEB"            output="BRAM.RAMB18_Y1_REGCEB" />
+  <direct name="RAMB18_X0Y1_REGCEAREGCE"       input="BRAM_X0.RAMB18_X0Y1_REGCEAREGCE"       output="BRAM.RAMB18_Y1_REGCEAREGCE" />
+  <direct name="RAMB18_X0Y1_REGCLKARDRCLK"     input="BRAM_X0.RAMB18_X0Y1_REGCLKARDRCLK"     output="BRAM.RAMB18_Y1_REGCLKARDRCLK" />
+  <direct name="RAMB18_X0Y1_ENARDEN"           input="BRAM_X0.RAMB18_X0Y1_ENARDEN"           output="BRAM.RAMB18_Y1_ENARDEN" />
+  <direct name="RAMB18_X0Y1_CLKARDCLK"         input="BRAM_X0.RAMB18_X0Y1_CLKARDCLK"         output="BRAM.RAMB18_Y1_CLKARDCLK" />
 
-  <direct name="RAMB18_X0Y1_DIPBDIP"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_DIPBDIP"             output="BLK_IG-BRAM.RAMB18_Y1_DIPBDIP" />
-  <direct name="RAMB18_X0Y1_DIPADIP"          input="BLK_IG-BRAM_L.RAMB18_X0Y1_DIPADIP"             output="BLK_IG-BRAM.RAMB18_Y1_DIPADIP" />
-  <direct name="RAMB18_X0Y1_DIBDI"            input="BLK_IG-BRAM_L.RAMB18_X0Y1_DIBDI"               output="BLK_IG-BRAM.RAMB18_Y1_DIBDI" />
-  <direct name="RAMB18_X0Y1_DIADI"            input="BLK_IG-BRAM_L.RAMB18_X0Y1_DIADI"               output="BLK_IG-BRAM.RAMB18_Y1_DIADI" />
+  <direct name="RAMB18_X0Y1_DIPBDIP"           input="BRAM_X0.RAMB18_X0Y1_DIPBDIP"           output="BRAM.RAMB18_Y1_DIPBDIP" />
+  <direct name="RAMB18_X0Y1_DIPADIP"           input="BRAM_X0.RAMB18_X0Y1_DIPADIP"           output="BRAM.RAMB18_Y1_DIPADIP" />
+  <direct name="RAMB18_X0Y1_DIBDI"             input="BRAM_X0.RAMB18_X0Y1_DIBDI"             output="BRAM.RAMB18_Y1_DIBDI" />
+  <direct name="RAMB18_X0Y1_DIADI"             input="BRAM_X0.RAMB18_X0Y1_DIADI"             output="BRAM.RAMB18_Y1_DIADI" />
 
-  <direct name="RAMB18_X0Y1_ADDRARDADDR"      input="BLK_IG-BRAM_L.RAMB18_X0Y1_ADDRARDADDR"         output="BLK_IG-BRAM.RAMB18_Y1_ADDRARDADDR" />
-  <direct name="RAMB18_X0Y1_ADDRBWRADDR"      input="BLK_IG-BRAM_L.RAMB18_X0Y1_ADDRBWRADDR"         output="BLK_IG-BRAM.RAMB18_Y1_ADDRBWRADDR" />
-  <direct name="RAMB18_X0Y1_ADDRATIEHIGH"     input="BLK_IG-BRAM_L.RAMB18_X0Y1_ADDRATIEHIGH"        output="BLK_IG-BRAM.RAMB18_Y1_ADDRATIEHIGH" />
-  <direct name="RAMB18_X0Y1_ADDRBTIEHIGH"     input="BLK_IG-BRAM_L.RAMB18_X0Y1_ADDRBTIEHIGH"        output="BLK_IG-BRAM.RAMB18_Y1_ADDRBTIEHIGH" />
+  <direct name="RAMB18_X0Y1_ADDRARDADDR"       input="BRAM_X0.RAMB18_X0Y1_ADDRARDADDR"       output="BRAM.RAMB18_Y1_ADDRARDADDR" />
+  <direct name="RAMB18_X0Y1_ADDRBWRADDR"       input="BRAM_X0.RAMB18_X0Y1_ADDRBWRADDR"       output="BRAM.RAMB18_Y1_ADDRBWRADDR" />
+  <direct name="RAMB18_X0Y1_ADDRATIEHIGH"      input="BRAM_X0.RAMB18_X0Y1_ADDRATIEHIGH"      output="BRAM.RAMB18_Y1_ADDRATIEHIGH" />
+  <direct name="RAMB18_X0Y1_ADDRBTIEHIGH"      input="BRAM_X0.RAMB18_X0Y1_ADDRBTIEHIGH"      output="BRAM.RAMB18_Y1_ADDRBTIEHIGH" />
 
-  <direct name="RAMB18_X0Y1_WRERR"            input="BLK_IG-BRAM.RAMB18_Y1_WRERR"                   output="BLK_IG-BRAM_L.RAMB18_X0Y1_WRERR" />
-  <direct name="RAMB18_X0Y1_WRCOUNT"          input="BLK_IG-BRAM.RAMB18_Y1_WRCOUNT"                 output="BLK_IG-BRAM_L.RAMB18_X0Y1_WRCOUNT" />
-  <direct name="RAMB18_X0Y1_RDERR"            input="BLK_IG-BRAM.RAMB18_Y1_RDERR"                   output="BLK_IG-BRAM_L.RAMB18_X0Y1_RDERR" />
-  <direct name="RAMB18_X0Y1_RDCOUNT"          input="BLK_IG-BRAM.RAMB18_Y1_RDCOUNT"                 output="BLK_IG-BRAM_L.RAMB18_X0Y1_RDCOUNT" />
-  <direct name="RAMB18_X0Y1_FULL"             input="BLK_IG-BRAM.RAMB18_Y1_FULL"                    output="BLK_IG-BRAM_L.RAMB18_X0Y1_FULL" />
-  <direct name="RAMB18_X0Y1_EMPTY"            input="BLK_IG-BRAM.RAMB18_Y1_EMPTY"                   output="BLK_IG-BRAM_L.RAMB18_X0Y1_EMPTY" />
-  <direct name="RAMB18_X0Y1_DOPADOP"          input="BLK_IG-BRAM.RAMB18_Y1_DOPADOP"                 output="BLK_IG-BRAM_L.RAMB18_X0Y1_DOPADOP" />
-  <direct name="RAMB18_X0Y1_DOPBDOP"          input="BLK_IG-BRAM.RAMB18_Y1_DOPBDOP"                 output="BLK_IG-BRAM_L.RAMB18_X0Y1_DOPBDOP" />
-  <direct name="RAMB18_X0Y1_DOADO"            input="BLK_IG-BRAM.RAMB18_Y1_DOADO"                   output="BLK_IG-BRAM_L.RAMB18_X0Y1_DOADO" />
-  <direct name="RAMB18_X0Y1_DOBDO"            input="BLK_IG-BRAM.RAMB18_Y1_DOBDO"                   output="BLK_IG-BRAM_L.RAMB18_X0Y1_DOBDO" />
-  <direct name="RAMB18_X0Y1_ALMOSTFULL"       input="BLK_IG-BRAM.RAMB18_Y1_ALMOSTFULL"              output="BLK_IG-BRAM_L.RAMB18_X0Y1_ALMOSTFULL" />
-  <direct name="RAMB18_X0Y1_ALMOSTEMPTY"      input="BLK_IG-BRAM.RAMB18_Y1_ALMOSTEMPTY"             output="BLK_IG-BRAM_L.RAMB18_X0Y1_ALMOSTEMPTY" />
+  <direct name="RAMB18_X0Y1_WRERR"             input="BRAM.RAMB18_Y1_WRERR"                  output="BRAM_X0.RAMB18_X0Y1_WRERR" />
+  <direct name="RAMB18_X0Y1_WRCOUNT"           input="BRAM.RAMB18_Y1_WRCOUNT"                output="BRAM_X0.RAMB18_X0Y1_WRCOUNT" />
+  <direct name="RAMB18_X0Y1_RDERR"             input="BRAM.RAMB18_Y1_RDERR"                  output="BRAM_X0.RAMB18_X0Y1_RDERR" />
+  <direct name="RAMB18_X0Y1_RDCOUNT"           input="BRAM.RAMB18_Y1_RDCOUNT"                output="BRAM_X0.RAMB18_X0Y1_RDCOUNT" />
+  <direct name="RAMB18_X0Y1_FULL"              input="BRAM.RAMB18_Y1_FULL"                   output="BRAM_X0.RAMB18_X0Y1_FULL" />
+  <direct name="RAMB18_X0Y1_EMPTY"             input="BRAM.RAMB18_Y1_EMPTY"                  output="BRAM_X0.RAMB18_X0Y1_EMPTY" />
+  <direct name="RAMB18_X0Y1_DOPADOP"           input="BRAM.RAMB18_Y1_DOPADOP"                output="BRAM_X0.RAMB18_X0Y1_DOPADOP" />
+  <direct name="RAMB18_X0Y1_DOPBDOP"           input="BRAM.RAMB18_Y1_DOPBDOP"                output="BRAM_X0.RAMB18_X0Y1_DOPBDOP" />
+  <direct name="RAMB18_X0Y1_DOADO"             input="BRAM.RAMB18_Y1_DOADO"                  output="BRAM_X0.RAMB18_X0Y1_DOADO" />
+  <direct name="RAMB18_X0Y1_DOBDO"             input="BRAM.RAMB18_Y1_DOBDO"                  output="BRAM_X0.RAMB18_X0Y1_DOBDO" />
+  <direct name="RAMB18_X0Y1_ALMOSTFULL"        input="BRAM.RAMB18_Y1_ALMOSTFULL"             output="BRAM_X0.RAMB18_X0Y1_ALMOSTFULL" />
+  <direct name="RAMB18_X0Y1_ALMOSTEMPTY"       input="BRAM.RAMB18_Y1_ALMOSTEMPTY"            output="BRAM_X0.RAMB18_X0Y1_ALMOSTEMPTY" />
  </interconnect>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/xc7/primitives/bram_r/bram_r.pb_type.xml
+++ b/xc7/primitives/bram_r/bram_r.pb_type.xml
@@ -12,7 +12,7 @@ affected by the BRAM mode, each site cannot be handled independendly.  For this
 reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
 
   -->
-<pb_type name="BLK_IG-BRAM_R" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="BRAM_X0" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <!-- RAMBFIFO36E1 site pins -->
  <input  name="RAMB36_X0Y0_WEBWEU"         num_pins="8"  />
  <input  name="RAMB36_X0Y0_WEBWEL"         num_pins="8"  />
@@ -127,8 +127,8 @@ reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
 
  <input  name="RAMB18_X0Y0_ADDRARDADDR"   num_pins="14" />
  <input  name="RAMB18_X0Y0_ADDRBWRADDR"   num_pins="14" />
- <input  name="RAMB18_X0Y0_ADDRATIEHIGH"  num_pins="2" />
- <input  name="RAMB18_X0Y0_ADDRBTIEHIGH"  num_pins="2" />
+ <input  name="RAMB18_X0Y0_ADDRATIEHIGH"  num_pins="2"  />
+ <input  name="RAMB18_X0Y0_ADDRBTIEHIGH"  num_pins="2"  />
 
  <output name="RAMB18_X0Y0_WRERR"         num_pins="1"  />
  <output name="RAMB18_X0Y0_WRCOUNT"       num_pins="12" />
@@ -166,8 +166,8 @@ reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
 
  <input  name="RAMB18_X0Y1_ADDRARDADDR"   num_pins="14" />
  <input  name="RAMB18_X0Y1_ADDRBWRADDR"   num_pins="14" />
- <input  name="RAMB18_X0Y1_ADDRATIEHIGH"  num_pins="2" />
- <input  name="RAMB18_X0Y1_ADDRBTIEHIGH"  num_pins="2" />
+ <input  name="RAMB18_X0Y1_ADDRATIEHIGH"  num_pins="2"  />
+ <input  name="RAMB18_X0Y1_ADDRBTIEHIGH"  num_pins="2"  />
 
  <output name="RAMB18_X0Y1_WRERR"         num_pins="1"  />
  <output name="RAMB18_X0Y1_WRCOUNT"       num_pins="12" />
@@ -185,171 +185,174 @@ reason, BRAM tiles use a "fused sites" mode to accomidate the cross site logic.
  <xi:include href="../bram/bram.pb_type.xml"/>
 
  <interconnect>
-  <direct name="RAMB36_X0Y0_WEBWEU"            input="BLK_IG-BRAM_R.RAMB36_X0Y0_WEBWEU"             output="BLK_IG-BRAM.RAMB36_Y0_WEBWEU" />
-  <direct name="RAMB36_X0Y0_WEBWEL"            input="BLK_IG-BRAM_R.RAMB36_X0Y0_WEBWEL"             output="BLK_IG-BRAM.RAMB36_Y0_WEBWEL" />
-  <direct name="RAMB36_X0Y0_WEAU"              input="BLK_IG-BRAM_R.RAMB36_X0Y0_WEAU"               output="BLK_IG-BRAM.RAMB36_Y0_WEAU" />
-  <direct name="RAMB36_X0Y0_WEAL"              input="BLK_IG-BRAM_R.RAMB36_X0Y0_WEAL"               output="BLK_IG-BRAM.RAMB36_Y0_WEAL" />
+  <direct name="RAMB36_X0Y0_WEBWEU"            input="BRAM_X0.RAMB36_X0Y0_WEBWEU"             output="BRAM.RAMB36_Y0_WEBWEU" />
+  <direct name="RAMB36_X0Y0_WEBWEL"            input="BRAM_X0.RAMB36_X0Y0_WEBWEL"             output="BRAM.RAMB36_Y0_WEBWEL" />
+  <direct name="RAMB36_X0Y0_WEAU"              input="BRAM_X0.RAMB36_X0Y0_WEAU"               output="BRAM.RAMB36_Y0_WEAU" />
+  <direct name="RAMB36_X0Y0_WEAL"              input="BRAM_X0.RAMB36_X0Y0_WEAL"               output="BRAM.RAMB36_Y0_WEAL" />
 
-  <direct name="RAMB36_X0Y0_TSTWROS"           input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTWROS"            output="BLK_IG-BRAM.RAMB36_Y0_TSTWROS" />
-  <direct name="RAMB36_X0Y0_TSTWRCNTOFF"       input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTWRCNTOFF"        output="BLK_IG-BRAM.RAMB36_Y0_TSTWRCNTOFF" />
-  <direct name="RAMB36_X0Y0_TSTRDOS"           input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTRDOS"            output="BLK_IG-BRAM.RAMB36_Y0_TSTRDOS" />
-  <direct name="RAMB36_X0Y0_TSTRDCNTOFF"       input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTRDCNTOFF"        output="BLK_IG-BRAM.RAMB36_Y0_TSTRDCNTOFF" />
-  <direct name="RAMB36_X0Y0_TSTOFF"            input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTOFF"             output="BLK_IG-BRAM.RAMB36_Y0_TSTOFF" />
-  <direct name="RAMB36_X0Y0_TSTIN"             input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTIN"              output="BLK_IG-BRAM.RAMB36_Y0_TSTIN" />
-  <direct name="RAMB36_X0Y0_TSTFLAGIN"         input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTFLAGIN"          output="BLK_IG-BRAM.RAMB36_Y0_TSTFLAGIN" />
-  <direct name="RAMB36_X0Y0_TSTCNT"            input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTCNT"             output="BLK_IG-BRAM.RAMB36_Y0_TSTCNT" />
-  <direct name="RAMB36_X0Y0_TSTBRAMRST"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTBRAMRST"         output="BLK_IG-BRAM.RAMB36_Y0_TSTBRAMRST" />
+  <direct name="RAMB36_X0Y0_TSTWROS"           input="BRAM_X0.RAMB36_X0Y0_TSTWROS"            output="BRAM.RAMB36_Y0_TSTWROS" />
+  <direct name="RAMB36_X0Y0_TSTWRCNTOFF"       input="BRAM_X0.RAMB36_X0Y0_TSTWRCNTOFF"        output="BRAM.RAMB36_Y0_TSTWRCNTOFF" />
+  <direct name="RAMB36_X0Y0_TSTRDOS"           input="BRAM_X0.RAMB36_X0Y0_TSTRDOS"            output="BRAM.RAMB36_Y0_TSTRDOS" />
+  <direct name="RAMB36_X0Y0_TSTRDCNTOFF"       input="BRAM_X0.RAMB36_X0Y0_TSTRDCNTOFF"        output="BRAM.RAMB36_Y0_TSTRDCNTOFF" />
+  <direct name="RAMB36_X0Y0_TSTOFF"            input="BRAM_X0.RAMB36_X0Y0_TSTOFF"             output="BRAM.RAMB36_Y0_TSTOFF" />
+  <direct name="RAMB36_X0Y0_TSTIN"             input="BRAM_X0.RAMB36_X0Y0_TSTIN"              output="BRAM.RAMB36_Y0_TSTIN" />
+  <direct name="RAMB36_X0Y0_TSTFLAGIN"         input="BRAM_X0.RAMB36_X0Y0_TSTFLAGIN"          output="BRAM.RAMB36_Y0_TSTFLAGIN" />
+  <direct name="RAMB36_X0Y0_TSTCNT"            input="BRAM_X0.RAMB36_X0Y0_TSTCNT"             output="BRAM.RAMB36_Y0_TSTCNT" />
+  <direct name="RAMB36_X0Y0_TSTBRAMRST"        input="BRAM_X0.RAMB36_X0Y0_TSTBRAMRST"         output="BRAM.RAMB36_Y0_TSTBRAMRST" />
 
-  <direct name="RAMB36_X0Y0_RSTREGBU"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTREGBU"           output="BLK_IG-BRAM.RAMB36_Y0_RSTREGBU" />
-  <direct name="RAMB36_X0Y0_RSTREGBL"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTREGBL"           output="BLK_IG-BRAM.RAMB36_Y0_RSTREGBL" />
-  <direct name="RAMB36_X0Y0_RSTREGARSTREGU"    input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTREGARSTREGU"     output="BLK_IG-BRAM.RAMB36_Y0_RSTREGARSTREGU" />
-  <direct name="RAMB36_X0Y0_RSTREGARSTREGL"    input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTREGARSTREGL"     output="BLK_IG-BRAM.RAMB36_Y0_RSTREGARSTREGL" />
-  <direct name="RAMB36_X0Y0_RSTRAMBU"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTRAMBU"           output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMBU" />
-  <direct name="RAMB36_X0Y0_RSTRAMBL"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTRAMBL"           output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMBL" />
-  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMU"    input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTRAMARSTRAMU"     output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMARSTRAMU" />
-  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMLRST" input="BLK_IG-BRAM_R.RAMB36_X0Y0_RSTRAMARSTRAMLRST"  output="BLK_IG-BRAM.RAMB36_Y0_RSTRAMARSTRAMLRST" />
+  <direct name="RAMB36_X0Y0_RSTREGBU"          input="BRAM_X0.RAMB36_X0Y0_RSTREGBU"           output="BRAM.RAMB36_Y0_RSTREGBU" />
+  <direct name="RAMB36_X0Y0_RSTREGBL"          input="BRAM_X0.RAMB36_X0Y0_RSTREGBL"           output="BRAM.RAMB36_Y0_RSTREGBL" />
+  <direct name="RAMB36_X0Y0_RSTREGARSTREGU"    input="BRAM_X0.RAMB36_X0Y0_RSTREGARSTREGU"     output="BRAM.RAMB36_Y0_RSTREGARSTREGU" />
+  <direct name="RAMB36_X0Y0_RSTREGARSTREGL"    input="BRAM_X0.RAMB36_X0Y0_RSTREGARSTREGL"     output="BRAM.RAMB36_Y0_RSTREGARSTREGL" />
+  <direct name="RAMB36_X0Y0_RSTRAMBU"          input="BRAM_X0.RAMB36_X0Y0_RSTRAMBU"           output="BRAM.RAMB36_Y0_RSTRAMBU" />
+  <direct name="RAMB36_X0Y0_RSTRAMBL"          input="BRAM_X0.RAMB36_X0Y0_RSTRAMBL"           output="BRAM.RAMB36_Y0_RSTRAMBL" />
+  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMU"    input="BRAM_X0.RAMB36_X0Y0_RSTRAMARSTRAMU"     output="BRAM.RAMB36_Y0_RSTRAMARSTRAMU" />
+  <direct name="RAMB36_X0Y0_RSTRAMARSTRAMLRST" input="BRAM_X0.RAMB36_X0Y0_RSTRAMARSTRAMLRST"  output="BRAM.RAMB36_Y0_RSTRAMARSTRAMLRST" />
 
-  <direct name="RAMB36_X0Y0_REGCLKBU"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCLKBU"           output="BLK_IG-BRAM.RAMB36_Y0_REGCLKBU" />
-  <direct name="RAMB36_X0Y0_REGCLKBL"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCLKBL"           output="BLK_IG-BRAM.RAMB36_Y0_REGCLKBL" />
-  <direct name="RAMB36_X0Y0_REGCLKARDRCLKU"    input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCLKARDRCLKU"     output="BLK_IG-BRAM.RAMB36_Y0_REGCLKARDRCLKU" />
-  <direct name="RAMB36_X0Y0_REGCLKARDRCLKL"    input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCLKARDRCLKL"     output="BLK_IG-BRAM.RAMB36_Y0_REGCLKARDRCLKL" />
-  <direct name="RAMB36_X0Y0_REGCEBU"           input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCEBU"            output="BLK_IG-BRAM.RAMB36_Y0_REGCEBU" />
-  <direct name="RAMB36_X0Y0_REGCEBL"           input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCEBL"            output="BLK_IG-BRAM.RAMB36_Y0_REGCEBL" />
-  <direct name="RAMB36_X0Y0_REGCEAREGCEU"      input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCEAREGCEU"       output="BLK_IG-BRAM.RAMB36_Y0_REGCEAREGCEU" />
-  <direct name="RAMB36_X0Y0_REGCEAREGCEL"      input="BLK_IG-BRAM_R.RAMB36_X0Y0_REGCEAREGCEL"       output="BLK_IG-BRAM.RAMB36_Y0_REGCEAREGCEL" />
+  <direct name="RAMB36_X0Y0_REGCLKBU"          input="BRAM_X0.RAMB36_X0Y0_REGCLKBU"           output="BRAM.RAMB36_Y0_REGCLKBU" />
+  <direct name="RAMB36_X0Y0_REGCLKBL"          input="BRAM_X0.RAMB36_X0Y0_REGCLKBL"           output="BRAM.RAMB36_Y0_REGCLKBL" />
+  <direct name="RAMB36_X0Y0_REGCLKARDRCLKU"    input="BRAM_X0.RAMB36_X0Y0_REGCLKARDRCLKU"     output="BRAM.RAMB36_Y0_REGCLKARDRCLKU" />
+  <direct name="RAMB36_X0Y0_REGCLKARDRCLKL"    input="BRAM_X0.RAMB36_X0Y0_REGCLKARDRCLKL"     output="BRAM.RAMB36_Y0_REGCLKARDRCLKL" />
+  <direct name="RAMB36_X0Y0_REGCEBU"           input="BRAM_X0.RAMB36_X0Y0_REGCEBU"            output="BRAM.RAMB36_Y0_REGCEBU" />
+  <direct name="RAMB36_X0Y0_REGCEBL"           input="BRAM_X0.RAMB36_X0Y0_REGCEBL"            output="BRAM.RAMB36_Y0_REGCEBL" />
+  <direct name="RAMB36_X0Y0_REGCEAREGCEU"      input="BRAM_X0.RAMB36_X0Y0_REGCEAREGCEU"       output="BRAM.RAMB36_Y0_REGCEAREGCEU" />
+  <direct name="RAMB36_X0Y0_REGCEAREGCEL"      input="BRAM_X0.RAMB36_X0Y0_REGCEAREGCEL"       output="BRAM.RAMB36_Y0_REGCEAREGCEL" />
 
-  <direct name="RAMB36_X0Y0_INJECTDBITERR"     input="BLK_IG-BRAM_R.RAMB36_X0Y0_INJECTDBITERR"      output="BLK_IG-BRAM.RAMB36_Y0_INJECTDBITERR" />
-  <direct name="RAMB36_X0Y0_INJECTSBITERR"     input="BLK_IG-BRAM_R.RAMB36_X0Y0_INJECTSBITERR"      output="BLK_IG-BRAM.RAMB36_Y0_INJECTSBITERR" />
+  <direct name="RAMB36_X0Y0_INJECTDBITERR"     input="BRAM_X0.RAMB36_X0Y0_INJECTDBITERR"      output="BRAM.RAMB36_Y0_INJECTDBITERR" />
+  <direct name="RAMB36_X0Y0_INJECTSBITERR"     input="BRAM_X0.RAMB36_X0Y0_INJECTSBITERR"      output="BRAM.RAMB36_Y0_INJECTSBITERR" />
 
-  <direct name="RAMB36_X0Y0_ENBWRENU"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_ENBWRENU"           output="BLK_IG-BRAM.RAMB36_Y0_ENBWRENU" />
-  <direct name="RAMB36_X0Y0_ENBWRENL"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_ENBWRENL"           output="BLK_IG-BRAM.RAMB36_Y0_ENBWRENL" />
-  <direct name="RAMB36_X0Y0_ENARDENU"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_ENARDENU"           output="BLK_IG-BRAM.RAMB36_Y0_ENARDENU" />
-  <direct name="RAMB36_X0Y0_ENARDENL"          input="BLK_IG-BRAM_R.RAMB36_X0Y0_ENARDENL"           output="BLK_IG-BRAM.RAMB36_Y0_ENARDENL" />
-  <direct name="RAMB36_X0Y0_DIPBDIP"           input="BLK_IG-BRAM_R.RAMB36_X0Y0_DIPBDIP"            output="BLK_IG-BRAM.RAMB36_Y0_DIPBDIP" />
-  <direct name="RAMB36_X0Y0_DIPADIP"           input="BLK_IG-BRAM_R.RAMB36_X0Y0_DIPADIP"            output="BLK_IG-BRAM.RAMB36_Y0_DIPADIP" />
-  <direct name="RAMB36_X0Y0_DIBDI"             input="BLK_IG-BRAM_R.RAMB36_X0Y0_DIBDI"              output="BLK_IG-BRAM.RAMB36_Y0_DIBDI" />
-  <direct name="RAMB36_X0Y0_DIADI"             input="BLK_IG-BRAM_R.RAMB36_X0Y0_DIADI"              output="BLK_IG-BRAM.RAMB36_Y0_DIADI" />
+  <direct name="RAMB36_X0Y0_ENBWRENU"          input="BRAM_X0.RAMB36_X0Y0_ENBWRENU"           output="BRAM.RAMB36_Y0_ENBWRENU" />
+  <direct name="RAMB36_X0Y0_ENBWRENL"          input="BRAM_X0.RAMB36_X0Y0_ENBWRENL"           output="BRAM.RAMB36_Y0_ENBWRENL" />
+  <direct name="RAMB36_X0Y0_ENARDENU"          input="BRAM_X0.RAMB36_X0Y0_ENARDENU"           output="BRAM.RAMB36_Y0_ENARDENU" />
+  <direct name="RAMB36_X0Y0_ENARDENL"          input="BRAM_X0.RAMB36_X0Y0_ENARDENL"           output="BRAM.RAMB36_Y0_ENARDENL" />
+  <direct name="RAMB36_X0Y0_DIPBDIP"           input="BRAM_X0.RAMB36_X0Y0_DIPBDIP"            output="BRAM.RAMB36_Y0_DIPBDIP" />
+  <direct name="RAMB36_X0Y0_DIPADIP"           input="BRAM_X0.RAMB36_X0Y0_DIPADIP"            output="BRAM.RAMB36_Y0_DIPADIP" />
+  <direct name="RAMB36_X0Y0_DIBDI"             input="BRAM_X0.RAMB36_X0Y0_DIBDI"              output="BRAM.RAMB36_Y0_DIBDI" />
+  <direct name="RAMB36_X0Y0_DIADI"             input="BRAM_X0.RAMB36_X0Y0_DIADI"              output="BRAM.RAMB36_Y0_DIADI" />
 
-  <direct name="RAMB36_X0Y0_CLKBWRCLKU"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_CLKBWRCLKU"         output="BLK_IG-BRAM.RAMB36_Y0_CLKBWRCLKU" />
-  <direct name="RAMB36_X0Y0_CLKBWRCLKL"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_CLKBWRCLKL"         output="BLK_IG-BRAM.RAMB36_Y0_CLKBWRCLKL" />
-  <direct name="RAMB36_X0Y0_CLKARDCLKU"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_CLKARDCLKU"         output="BLK_IG-BRAM.RAMB36_Y0_CLKARDCLKU" />
-  <direct name="RAMB36_X0Y0_CLKARDCLKL"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_CLKARDCLKL"         output="BLK_IG-BRAM.RAMB36_Y0_CLKARDCLKL" />
+  <direct name="RAMB36_X0Y0_CLKBWRCLKU"        input="BRAM_X0.RAMB36_X0Y0_CLKBWRCLKU"         output="BRAM.RAMB36_Y0_CLKBWRCLKU" />
+  <direct name="RAMB36_X0Y0_CLKBWRCLKL"        input="BRAM_X0.RAMB36_X0Y0_CLKBWRCLKL"         output="BRAM.RAMB36_Y0_CLKBWRCLKL" />
+  <direct name="RAMB36_X0Y0_CLKARDCLKU"        input="BRAM_X0.RAMB36_X0Y0_CLKARDCLKU"         output="BRAM.RAMB36_Y0_CLKARDCLKU" />
+  <direct name="RAMB36_X0Y0_CLKARDCLKL"        input="BRAM_X0.RAMB36_X0Y0_CLKARDCLKL"         output="BRAM.RAMB36_Y0_CLKARDCLKL" />
 
-  <direct name="RAMB36_X0Y0_CASCADEINA"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_CASCADEINA"         output="BLK_IG-BRAM.RAMB36_Y0_CASCADEINA" />
-  <direct name="RAMB36_X0Y0_CASCADEINB"        input="BLK_IG-BRAM_R.RAMB36_X0Y0_CASCADEINB"         output="BLK_IG-BRAM.RAMB36_Y0_CASCADEINB" />
+  <direct name="RAMB36_X0Y0_CASCADEINA"        input="BRAM_X0.RAMB36_X0Y0_CASCADEINA"         output="BRAM.RAMB36_Y0_CASCADEINA" />
+  <direct name="RAMB36_X0Y0_CASCADEINB"        input="BRAM_X0.RAMB36_X0Y0_CASCADEINB"         output="BRAM.RAMB36_Y0_CASCADEINB" />
 
-  <direct name="RAMB36_X0Y0_ADDRBWRADDRU"      input="BLK_IG-BRAM_R.RAMB36_X0Y0_ADDRBWRADDRU"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRBWRADDRU" />
-  <direct name="RAMB36_X0Y0_ADDRBWRADDRL"      input="BLK_IG-BRAM_R.RAMB36_X0Y0_ADDRBWRADDRL"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRBWRADDRL" />
+  <direct name="RAMB36_X0Y0_ADDRBWRADDRU"      input="BRAM_X0.RAMB36_X0Y0_ADDRBWRADDRU"       output="BRAM.RAMB36_Y0_ADDRBWRADDRU" />
+  <direct name="RAMB36_X0Y0_ADDRBWRADDRL"      input="BRAM_X0.RAMB36_X0Y0_ADDRBWRADDRL"       output="BRAM.RAMB36_Y0_ADDRBWRADDRL" />
 
-  <direct name="RAMB36_X0Y0_ADDRARDADDRU"      input="BLK_IG-BRAM_R.RAMB36_X0Y0_ADDRARDADDRU"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRARDADDRU" />
-  <direct name="RAMB36_X0Y0_ADDRARDADDRL"      input="BLK_IG-BRAM_R.RAMB36_X0Y0_ADDRARDADDRL"       output="BLK_IG-BRAM.RAMB36_Y0_ADDRARDADDRL" />
+  <direct name="RAMB36_X0Y0_ADDRARDADDRU"      input="BRAM_X0.RAMB36_X0Y0_ADDRARDADDRU"       output="BRAM.RAMB36_Y0_ADDRARDADDRU" />
+  <direct name="RAMB36_X0Y0_ADDRARDADDRL"      input="BRAM_X0.RAMB36_X0Y0_ADDRARDADDRL"       output="BRAM.RAMB36_Y0_ADDRARDADDRL" />
 
-  <direct name="RAMB36_X0Y0_WRERR"             input="BLK_IG-BRAM.RAMB36_Y0_WRERR"                  output="BLK_IG-BRAM_R.RAMB36_X0Y0_WRERR" />
-  <direct name="RAMB36_X0Y0_WRCOUNT"           input="BLK_IG-BRAM.RAMB36_Y0_WRCOUNT"                output="BLK_IG-BRAM_R.RAMB36_X0Y0_WRCOUNT" />
+  <direct name="RAMB36_X0Y0_WRERR"             input="BRAM.RAMB36_Y0_WRERR"                  output="BRAM_X0.RAMB36_X0Y0_WRERR" />
+  <direct name="RAMB36_X0Y0_WRCOUNT"           input="BRAM.RAMB36_Y0_WRCOUNT"                output="BRAM_X0.RAMB36_X0Y0_WRCOUNT" />
 
-  <direct name="RAMB36_X0Y0_TSTOUT"            input="BLK_IG-BRAM.RAMB36_Y0_TSTOUT"                 output="BLK_IG-BRAM_R.RAMB36_X0Y0_TSTOUT" />
+  <direct name="RAMB36_X0Y0_TSTOUT"            input="BRAM.RAMB36_Y0_TSTOUT"                 output="BRAM_X0.RAMB36_X0Y0_TSTOUT" />
 
-  <direct name="RAMB36_X0Y0_SBITERR"           input="BLK_IG-BRAM.RAMB36_Y0_SBITERR"                output="BLK_IG-BRAM_R.RAMB36_X0Y0_SBITERR" />
+  <direct name="RAMB36_X0Y0_SBITERR"           input="BRAM.RAMB36_Y0_SBITERR"                output="BRAM_X0.RAMB36_X0Y0_SBITERR" />
 
-  <direct name="RAMB36_X0Y0_RDERR"             input="BLK_IG-BRAM.RAMB36_Y0_RDERR"                  output="BLK_IG-BRAM_R.RAMB36_X0Y0_RDERR" />
-  <direct name="RAMB36_X0Y0_RDCOUNT"           input="BLK_IG-BRAM.RAMB36_Y0_RDCOUNT"                output="BLK_IG-BRAM_R.RAMB36_X0Y0_RDCOUNT" />
+  <direct name="RAMB36_X0Y0_RDERR"             input="BRAM.RAMB36_Y0_RDERR"                  output="BRAM_X0.RAMB36_X0Y0_RDERR" />
+  <direct name="RAMB36_X0Y0_RDCOUNT"           input="BRAM.RAMB36_Y0_RDCOUNT"                output="BRAM_X0.RAMB36_X0Y0_RDCOUNT" />
 
-  <direct name="RAMB36_X0Y0_FULL"              input="BLK_IG-BRAM.RAMB36_Y0_FULL"                   output="BLK_IG-BRAM_R.RAMB36_X0Y0_FULL" />
-  <direct name="RAMB36_X0Y0_EMPTY"             input="BLK_IG-BRAM.RAMB36_Y0_EMPTY"                  output="BLK_IG-BRAM_R.RAMB36_X0Y0_EMPTY" />
+  <direct name="RAMB36_X0Y0_FULL"              input="BRAM.RAMB36_Y0_FULL"                   output="BRAM_X0.RAMB36_X0Y0_FULL" />
+  <direct name="RAMB36_X0Y0_EMPTY"             input="BRAM.RAMB36_Y0_EMPTY"                  output="BRAM_X0.RAMB36_X0Y0_EMPTY" />
 
-  <direct name="RAMB36_X0Y0_ECCPARITY"         input="BLK_IG-BRAM.RAMB36_Y0_ECCPARITY"              output="BLK_IG-BRAM_R.RAMB36_X0Y0_ECCPARITY" />
+  <direct name="RAMB36_X0Y0_ECCPARITY"         input="BRAM.RAMB36_Y0_ECCPARITY"              output="BRAM_X0.RAMB36_X0Y0_ECCPARITY" />
 
-  <direct name="RAMB36_X0Y0_DOPBDOP"           input="BLK_IG-BRAM.RAMB36_Y0_DOPBDOP"                output="BLK_IG-BRAM_R.RAMB36_X0Y0_DOPBDOP" />
-  <direct name="RAMB36_X0Y0_DOPADOP"           input="BLK_IG-BRAM.RAMB36_Y0_DOPADOP"                output="BLK_IG-BRAM_R.RAMB36_X0Y0_DOPADOP" />
+  <direct name="RAMB36_X0Y0_DOPBDOP"           input="BRAM.RAMB36_Y0_DOPBDOP"                output="BRAM_X0.RAMB36_X0Y0_DOPBDOP" />
+  <direct name="RAMB36_X0Y0_DOPADOP"           input="BRAM.RAMB36_Y0_DOPADOP"                output="BRAM_X0.RAMB36_X0Y0_DOPADOP" />
 
-  <direct name="RAMB36_X0Y0_DOBDO"             input="BLK_IG-BRAM.RAMB36_Y0_DOBDO"                  output="BLK_IG-BRAM_R.RAMB36_X0Y0_DOBDO" />
-  <direct name="RAMB36_X0Y0_DOADO"             input="BLK_IG-BRAM.RAMB36_Y0_DOADO"                  output="BLK_IG-BRAM_R.RAMB36_X0Y0_DOADO" />
+  <direct name="RAMB36_X0Y0_DOBDO"             input="BRAM.RAMB36_Y0_DOBDO"                  output="BRAM_X0.RAMB36_X0Y0_DOBDO" />
+  <direct name="RAMB36_X0Y0_DOADO"             input="BRAM.RAMB36_Y0_DOADO"                  output="BRAM_X0.RAMB36_X0Y0_DOADO" />
 
-  <direct name="RAMB36_X0Y0_DBITERR"           input="BLK_IG-BRAM.RAMB36_Y0_DBITERR"                output="BLK_IG-BRAM_R.RAMB36_X0Y0_DBITERR" />
+  <direct name="RAMB36_X0Y0_DBITERR"           input="BRAM.RAMB36_Y0_DBITERR"                output="BRAM_X0.RAMB36_X0Y0_DBITERR" />
 
-  <direct name="RAMB36_X0Y0_CASCADEOUTA"       input="BLK_IG-BRAM.RAMB36_Y0_CASCADEOUTA"            output="BLK_IG-BRAM_R.RAMB36_X0Y0_CASCADEOUTA" />
-  <direct name="RAMB36_X0Y0_CASCADEOUTB"       input="BLK_IG-BRAM.RAMB36_Y0_CASCADEOUTB"            output="BLK_IG-BRAM_R.RAMB36_X0Y0_CASCADEOUTB" />
+  <direct name="RAMB36_X0Y0_CASCADEOUTA"       input="BRAM.RAMB36_Y0_CASCADEOUTA"            output="BRAM_X0.RAMB36_X0Y0_CASCADEOUTA" />
+  <direct name="RAMB36_X0Y0_CASCADEOUTB"       input="BRAM.RAMB36_Y0_CASCADEOUTB"            output="BRAM_X0.RAMB36_X0Y0_CASCADEOUTB" />
 
-  <direct name="RAMB36_X0Y0_ALMOSTFULL"        input="BLK_IG-BRAM.RAMB36_Y0_ALMOSTFULL"             output="BLK_IG-BRAM_R.RAMB36_X0Y0_ALMOSTFULL" />
-  <direct name="RAMB36_X0Y0_ALMOSTEMPTY"       input="BLK_IG-BRAM.RAMB36_Y0_ALMOSTEMPTY"            output="BLK_IG-BRAM_R.RAMB36_X0Y0_ALMOSTEMPTY" />
+  <direct name="RAMB36_X0Y0_ALMOSTFULL"        input="BRAM.RAMB36_Y0_ALMOSTFULL"             output="BRAM_X0.RAMB36_X0Y0_ALMOSTFULL" />
+  <direct name="RAMB36_X0Y0_ALMOSTEMPTY"       input="BRAM.RAMB36_Y0_ALMOSTEMPTY"            output="BRAM_X0.RAMB36_X0Y0_ALMOSTEMPTY" />
 
-  <direct name="RAMB18_X0Y0_WREN"             input="BLK_IG-BRAM_R.RAMB18_X0Y0_WREN"              output="BLK_IG-BRAM.RAMB18_Y0_WREN" />
-  <direct name="RAMB18_X0Y0_WRCLK"            input="BLK_IG-BRAM_R.RAMB18_X0Y0_WRCLK"             output="BLK_IG-BRAM.RAMB18_Y0_WRCLK" />
-  <direct name="RAMB18_X0Y0_WEBWE"            input="BLK_IG-BRAM_R.RAMB18_X0Y0_WEBWE"             output="BLK_IG-BRAM.RAMB18_Y0_WEBWE" />
-  <direct name="RAMB18_X0Y0_WEA"              input="BLK_IG-BRAM_R.RAMB18_X0Y0_WEA"               output="BLK_IG-BRAM.RAMB18_Y0_WEA" />
+  <direct name="RAMB18_X0Y0_WREN"              input="BRAM_X0.RAMB18_X0Y0_WREN"              output="BRAM.RAMB18_Y0_WREN" />
+  <direct name="RAMB18_X0Y0_WRCLK"             input="BRAM_X0.RAMB18_X0Y0_WRCLK"             output="BRAM.RAMB18_Y0_WRCLK" />
+  <direct name="RAMB18_X0Y0_WEBWE"             input="BRAM_X0.RAMB18_X0Y0_WEBWE"             output="BRAM.RAMB18_Y0_WEBWE" />
+  <direct name="RAMB18_X0Y0_WEA"               input="BRAM_X0.RAMB18_X0Y0_WEA"               output="BRAM.RAMB18_Y0_WEA" />
 
-  <direct name="RAMB18_X0Y0_RSTREGB"          input="BLK_IG-BRAM_R.RAMB18_X0Y0_RSTREGB"           output="BLK_IG-BRAM.RAMB18_Y0_RSTREGB" />
-  <direct name="RAMB18_X0Y0_RSTREG"           input="BLK_IG-BRAM_R.RAMB18_X0Y0_RSTREG"            output="BLK_IG-BRAM.RAMB18_Y0_RSTREG" />
-  <direct name="RAMB18_X0Y0_RSTRAMB"          input="BLK_IG-BRAM_R.RAMB18_X0Y0_RSTRAMB"           output="BLK_IG-BRAM.RAMB18_Y0_RSTRAMB" />
-  <direct name="RAMB18_X0Y0_RST"              input="BLK_IG-BRAM_R.RAMB18_X0Y0_RST"               output="BLK_IG-BRAM.RAMB18_Y0_RST" />
+  <direct name="RAMB18_X0Y0_RSTREGB"           input="BRAM_X0.RAMB18_X0Y0_RSTREGB"           output="BRAM.RAMB18_Y0_RSTREGB" />
+  <direct name="RAMB18_X0Y0_RSTREG"            input="BRAM_X0.RAMB18_X0Y0_RSTREG"            output="BRAM.RAMB18_Y0_RSTREG" />
+  <direct name="RAMB18_X0Y0_RSTRAMB"           input="BRAM_X0.RAMB18_X0Y0_RSTRAMB"           output="BRAM.RAMB18_Y0_RSTRAMB" />
+  <direct name="RAMB18_X0Y0_RST"               input="BRAM_X0.RAMB18_X0Y0_RST"               output="BRAM.RAMB18_Y0_RST" />
 
-  <direct name="RAMB18_X0Y0_REGCLKB"          input="BLK_IG-BRAM_R.RAMB18_X0Y0_REGCLKB"           output="BLK_IG-BRAM.RAMB18_Y0_REGCLKB" />
-  <direct name="RAMB18_X0Y0_REGCEB"           input="BLK_IG-BRAM_R.RAMB18_X0Y0_REGCEB"            output="BLK_IG-BRAM.RAMB18_Y0_REGCEB" />
-  <direct name="RAMB18_X0Y0_REGCE"            input="BLK_IG-BRAM_R.RAMB18_X0Y0_REGCE"             output="BLK_IG-BRAM.RAMB18_Y0_REGCE" />
-  <direct name="RAMB18_X0Y0_RDRCLK"           input="BLK_IG-BRAM_R.RAMB18_X0Y0_RDRCLK"            output="BLK_IG-BRAM.RAMB18_Y0_RDRCLK" />
-  <direct name="RAMB18_X0Y0_RDEN"             input="BLK_IG-BRAM_R.RAMB18_X0Y0_RDEN"              output="BLK_IG-BRAM.RAMB18_Y0_RDEN" />
-  <direct name="RAMB18_X0Y0_RDCLK"            input="BLK_IG-BRAM_R.RAMB18_X0Y0_RDCLK"             output="BLK_IG-BRAM.RAMB18_Y0_RDCLK" />
+  <direct name="RAMB18_X0Y0_REGCLKB"           input="BRAM_X0.RAMB18_X0Y0_REGCLKB"           output="BRAM.RAMB18_Y0_REGCLKB" />
+  <direct name="RAMB18_X0Y0_REGCEB"            input="BRAM_X0.RAMB18_X0Y0_REGCEB"            output="BRAM.RAMB18_Y0_REGCEB" />
+  <direct name="RAMB18_X0Y0_REGCE"             input="BRAM_X0.RAMB18_X0Y0_REGCE"             output="BRAM.RAMB18_Y0_REGCE" />
+  <direct name="RAMB18_X0Y0_RDRCLK"            input="BRAM_X0.RAMB18_X0Y0_RDRCLK"            output="BRAM.RAMB18_Y0_RDRCLK" />
+  <direct name="RAMB18_X0Y0_RDEN"              input="BRAM_X0.RAMB18_X0Y0_RDEN"              output="BRAM.RAMB18_Y0_RDEN" />
+  <direct name="RAMB18_X0Y0_RDCLK"             input="BRAM_X0.RAMB18_X0Y0_RDCLK"             output="BRAM.RAMB18_Y0_RDCLK" />
 
-  <direct name="RAMB18_X0Y0_DIPBDIP"          input="BLK_IG-BRAM_R.RAMB18_X0Y0_DIPBDIP"           output="BLK_IG-BRAM.RAMB18_Y0_DIPBDIP" />
-  <direct name="RAMB18_X0Y0_DIPADIP"          input="BLK_IG-BRAM_R.RAMB18_X0Y0_DIPADIP"           output="BLK_IG-BRAM.RAMB18_Y0_DIPADIP" />
-  <direct name="RAMB18_X0Y0_DIBDI"            input="BLK_IG-BRAM_R.RAMB18_X0Y0_DIBDI"             output="BLK_IG-BRAM.RAMB18_Y0_DIBDI" />
-  <direct name="RAMB18_X0Y0_DIADI"            input="BLK_IG-BRAM_R.RAMB18_X0Y0_DIADI"             output="BLK_IG-BRAM.RAMB18_Y0_DIADI" />
+  <direct name="RAMB18_X0Y0_DIPBDIP"           input="BRAM_X0.RAMB18_X0Y0_DIPBDIP"           output="BRAM.RAMB18_Y0_DIPBDIP" />
+  <direct name="RAMB18_X0Y0_DIPADIP"           input="BRAM_X0.RAMB18_X0Y0_DIPADIP"           output="BRAM.RAMB18_Y0_DIPADIP" />
+  <direct name="RAMB18_X0Y0_DIBDI"             input="BRAM_X0.RAMB18_X0Y0_DIBDI"             output="BRAM.RAMB18_Y0_DIBDI" />
+  <direct name="RAMB18_X0Y0_DIADI"             input="BRAM_X0.RAMB18_X0Y0_DIADI"             output="BRAM.RAMB18_Y0_DIADI" />
 
-  <direct name="RAMB18_X0Y0_ADDRARDADDR"      input="BLK_IG-BRAM_R.RAMB18_X0Y0_ADDRARDADDR"       output="BLK_IG-BRAM.RAMB18_Y0_ADDRARDADDR" />
-  <direct name="RAMB18_X0Y0_ADDRBWRADDR"      input="BLK_IG-BRAM_R.RAMB18_X0Y0_ADDRBWRADDR"       output="BLK_IG-BRAM.RAMB18_Y0_ADDRBWRADDR" />
-  <direct name="RAMB18_X0Y0_ADDRATIEHIGH"     input="BLK_IG-BRAM_R.RAMB18_X0Y0_ADDRATIEHIGH"      output="BLK_IG-BRAM.RAMB18_Y0_ADDRATIEHIGH" />
-  <direct name="RAMB18_X0Y0_ADDRBTIEHIGH"     input="BLK_IG-BRAM_R.RAMB18_X0Y0_ADDRBTIEHIGH"      output="BLK_IG-BRAM.RAMB18_Y0_ADDRBTIEHIGH" />
+  <direct name="RAMB18_X0Y0_ADDRARDADDR"       input="BRAM_X0.RAMB18_X0Y0_ADDRARDADDR"       output="BRAM.RAMB18_Y0_ADDRARDADDR" />
+  <direct name="RAMB18_X0Y0_ADDRBWRADDR"       input="BRAM_X0.RAMB18_X0Y0_ADDRBWRADDR"       output="BRAM.RAMB18_Y0_ADDRBWRADDR" />
+  <direct name="RAMB18_X0Y0_ADDRATIEHIGH"      input="BRAM_X0.RAMB18_X0Y0_ADDRATIEHIGH"      output="BRAM.RAMB18_Y0_ADDRATIEHIGH" />
+  <direct name="RAMB18_X0Y0_ADDRBTIEHIGH"      input="BRAM_X0.RAMB18_X0Y0_ADDRBTIEHIGH"      output="BRAM.RAMB18_Y0_ADDRBTIEHIGH" />
 
-  <direct name="RAMB18_X0Y0_WRERR"            input="BLK_IG-BRAM.RAMB18_Y0_WRERR"                  output="BLK_IG-BRAM_R.RAMB18_X0Y0_WRERR" />
-  <direct name="RAMB18_X0Y0_WRCOUNT"          input="BLK_IG-BRAM.RAMB18_Y0_WRCOUNT"                output="BLK_IG-BRAM_R.RAMB18_X0Y0_WRCOUNT" />
-  <direct name="RAMB18_X0Y0_RDERR"            input="BLK_IG-BRAM.RAMB18_Y0_RDERR"                  output="BLK_IG-BRAM_R.RAMB18_X0Y0_RDERR" />
-  <direct name="RAMB18_X0Y0_RDCOUNT"          input="BLK_IG-BRAM.RAMB18_Y0_RDCOUNT"                output="BLK_IG-BRAM_R.RAMB18_X0Y0_RDCOUNT" />
-  <direct name="RAMB18_X0Y0_FULL"             input="BLK_IG-BRAM.RAMB18_Y0_FULL"                   output="BLK_IG-BRAM_R.RAMB18_X0Y0_FULL" />
-  <direct name="RAMB18_X0Y0_EMPTY"            input="BLK_IG-BRAM.RAMB18_Y0_EMPTY"                  output="BLK_IG-BRAM_R.RAMB18_X0Y0_EMPTY" />
-  <direct name="RAMB18_X0Y0_DOP"              input="BLK_IG-BRAM.RAMB18_Y0_DOP"                    output="BLK_IG-BRAM_R.RAMB18_X0Y0_DOP" />
-  <direct name="RAMB18_X0Y0_DO"               input="BLK_IG-BRAM.RAMB18_Y0_DO"                     output="BLK_IG-BRAM_R.RAMB18_X0Y0_DO" />
-  <direct name="RAMB18_X0Y0_ALMOSTFULL"       input="BLK_IG-BRAM.RAMB18_Y0_ALMOSTFULL"             output="BLK_IG-BRAM_R.RAMB18_X0Y0_ALMOSTFULL" />
-  <direct name="RAMB18_X0Y0_ALMOSTEMPTY"      input="BLK_IG-BRAM.RAMB18_Y0_ALMOSTEMPTY"            output="BLK_IG-BRAM_R.RAMB18_X0Y0_ALMOSTEMPTY" />
+  <direct name="RAMB18_X0Y0_WRERR"             input="BRAM.RAMB18_Y0_WRERR"                  output="BRAM_X0.RAMB18_X0Y0_WRERR" />
+  <direct name="RAMB18_X0Y0_WRCOUNT"           input="BRAM.RAMB18_Y0_WRCOUNT"                output="BRAM_X0.RAMB18_X0Y0_WRCOUNT" />
+  <direct name="RAMB18_X0Y0_RDERR"             input="BRAM.RAMB18_Y0_RDERR"                  output="BRAM_X0.RAMB18_X0Y0_RDERR" />
+  <direct name="RAMB18_X0Y0_RDCOUNT"           input="BRAM.RAMB18_Y0_RDCOUNT"                output="BRAM_X0.RAMB18_X0Y0_RDCOUNT" />
+  <direct name="RAMB18_X0Y0_FULL"              input="BRAM.RAMB18_Y0_FULL"                   output="BRAM_X0.RAMB18_X0Y0_FULL" />
+  <direct name="RAMB18_X0Y0_EMPTY"             input="BRAM.RAMB18_Y0_EMPTY"                  output="BRAM_X0.RAMB18_X0Y0_EMPTY" />
+  <direct name="RAMB18_X0Y0_DOP"               input="BRAM.RAMB18_Y0_DOP"                    output="BRAM_X0.RAMB18_X0Y0_DOP" />
+  <direct name="RAMB18_X0Y0_DO"                input="BRAM.RAMB18_Y0_DO"                     output="BRAM_X0.RAMB18_X0Y0_DO" />
+  <direct name="RAMB18_X0Y0_ALMOSTFULL"        input="BRAM.RAMB18_Y0_ALMOSTFULL"             output="BRAM_X0.RAMB18_X0Y0_ALMOSTFULL" />
+  <direct name="RAMB18_X0Y0_ALMOSTEMPTY"       input="BRAM.RAMB18_Y0_ALMOSTEMPTY"            output="BRAM_X0.RAMB18_X0Y0_ALMOSTEMPTY" />
 
-  <direct name="RAMB18_X0Y1_ENBWREN"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_ENBWREN"           output="BLK_IG-BRAM.RAMB18_Y1_ENBWREN" />
-  <direct name="RAMB18_X0Y1_CLKBWRCLK"        input="BLK_IG-BRAM_R.RAMB18_X0Y1_CLKBWRCLK"         output="BLK_IG-BRAM.RAMB18_Y1_CLKBWRCLK" />
-  <direct name="RAMB18_X0Y1_WEBWE"            input="BLK_IG-BRAM_R.RAMB18_X0Y1_WEBWE"             output="BLK_IG-BRAM.RAMB18_Y1_WEBWE" />
-  <direct name="RAMB18_X0Y1_WEA"              input="BLK_IG-BRAM_R.RAMB18_X0Y1_WEA"               output="BLK_IG-BRAM.RAMB18_Y1_WEA" />
+  <direct name="RAMB18_X0Y1_ENBWREN"           input="BRAM_X0.RAMB18_X0Y1_ENBWREN"           output="BRAM.RAMB18_Y1_ENBWREN" />
+  <direct name="RAMB18_X0Y1_CLKBWRCLK"         input="BRAM_X0.RAMB18_X0Y1_CLKBWRCLK"         output="BRAM.RAMB18_Y1_CLKBWRCLK" />
+  <direct name="RAMB18_X0Y1_WEBWE"             input="BRAM_X0.RAMB18_X0Y1_WEBWE"             output="BRAM.RAMB18_Y1_WEBWE" />
+  <direct name="RAMB18_X0Y1_WEA"               input="BRAM_X0.RAMB18_X0Y1_WEA"               output="BRAM.RAMB18_Y1_WEA" />
 
-  <direct name="RAMB18_X0Y1_RSTREGB"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_RSTREGB"           output="BLK_IG-BRAM.RAMB18_Y1_RSTREGB" />
-  <direct name="RAMB18_X0Y1_RSTREGARSTREG"    input="BLK_IG-BRAM_R.RAMB18_X0Y1_RSTREGARSTREG"     output="BLK_IG-BRAM.RAMB18_Y1_RSTREGARSTREG" />
-  <direct name="RAMB18_X0Y1_RSTRAMB"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_RSTRAMB"           output="BLK_IG-BRAM.RAMB18_Y1_RSTRAMB" />
-  <direct name="RAMB18_X0Y1_RSTRAMARSTRAM"    input="BLK_IG-BRAM_R.RAMB18_X0Y1_RSTRAMARSTRAM"     output="BLK_IG-BRAM.RAMB18_Y1_RSTRAMARSTRAM" />
+  <direct name="RAMB18_X0Y1_RSTREGB"           input="BRAM_X0.RAMB18_X0Y1_RSTREGB"           output="BRAM.RAMB18_Y1_RSTREGB" />
+  <direct name="RAMB18_X0Y1_RSTREGARSTREG"     input="BRAM_X0.RAMB18_X0Y1_RSTREGARSTREG"     output="BRAM.RAMB18_Y1_RSTREGARSTREG" />
+  <direct name="RAMB18_X0Y1_RSTRAMB"           input="BRAM_X0.RAMB18_X0Y1_RSTRAMB"           output="BRAM.RAMB18_Y1_RSTRAMB" />
+  <direct name="RAMB18_X0Y1_RSTRAMARSTRAM"     input="BRAM_X0.RAMB18_X0Y1_RSTRAMARSTRAM"     output="BRAM.RAMB18_Y1_RSTRAMARSTRAM" />
 
-  <direct name="RAMB18_X0Y1_REGCLKB"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_REGCLKB"           output="BLK_IG-BRAM.RAMB18_Y1_REGCLKB" />
-  <direct name="RAMB18_X0Y1_REGCEB"           input="BLK_IG-BRAM_R.RAMB18_X0Y1_REGCEB"            output="BLK_IG-BRAM.RAMB18_Y1_REGCEB" />
-  <direct name="RAMB18_X0Y1_REGCEAREGCE"      input="BLK_IG-BRAM_R.RAMB18_X0Y1_REGCEAREGCE"       output="BLK_IG-BRAM.RAMB18_Y1_REGCEAREGCE" />
-  <direct name="RAMB18_X0Y1_REGCLKARDRCLK"    input="BLK_IG-BRAM_R.RAMB18_X0Y1_REGCLKARDRCLK"     output="BLK_IG-BRAM.RAMB18_Y1_REGCLKARDRCLK" />
-  <direct name="RAMB18_X0Y1_ENARDEN"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_ENARDEN"           output="BLK_IG-BRAM.RAMB18_Y1_ENARDEN" />
-  <direct name="RAMB18_X0Y1_CLKARDCLK"        input="BLK_IG-BRAM_R.RAMB18_X0Y1_CLKARDCLK"         output="BLK_IG-BRAM.RAMB18_Y1_CLKARDCLK" />
+  <direct name="RAMB18_X0Y1_REGCLKB"           input="BRAM_X0.RAMB18_X0Y1_REGCLKB"           output="BRAM.RAMB18_Y1_REGCLKB" />
+  <direct name="RAMB18_X0Y1_REGCEB"            input="BRAM_X0.RAMB18_X0Y1_REGCEB"            output="BRAM.RAMB18_Y1_REGCEB" />
+  <direct name="RAMB18_X0Y1_REGCEAREGCE"       input="BRAM_X0.RAMB18_X0Y1_REGCEAREGCE"       output="BRAM.RAMB18_Y1_REGCEAREGCE" />
+  <direct name="RAMB18_X0Y1_REGCLKARDRCLK"     input="BRAM_X0.RAMB18_X0Y1_REGCLKARDRCLK"     output="BRAM.RAMB18_Y1_REGCLKARDRCLK" />
+  <direct name="RAMB18_X0Y1_ENARDEN"           input="BRAM_X0.RAMB18_X0Y1_ENARDEN"           output="BRAM.RAMB18_Y1_ENARDEN" />
+  <direct name="RAMB18_X0Y1_CLKARDCLK"         input="BRAM_X0.RAMB18_X0Y1_CLKARDCLK"         output="BRAM.RAMB18_Y1_CLKARDCLK" />
 
-  <direct name="RAMB18_X0Y1_DIPBDIP"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_DIPBDIP"           output="BLK_IG-BRAM.RAMB18_Y1_DIPBDIP" />
-  <direct name="RAMB18_X0Y1_DIPADIP"          input="BLK_IG-BRAM_R.RAMB18_X0Y1_DIPADIP"           output="BLK_IG-BRAM.RAMB18_Y1_DIPADIP" />
-  <direct name="RAMB18_X0Y1_DIBDI"            input="BLK_IG-BRAM_R.RAMB18_X0Y1_DIBDI"             output="BLK_IG-BRAM.RAMB18_Y1_DIBDI" />
-  <direct name="RAMB18_X0Y1_DIADI"            input="BLK_IG-BRAM_R.RAMB18_X0Y1_DIADI"             output="BLK_IG-BRAM.RAMB18_Y1_DIADI" />
+  <direct name="RAMB18_X0Y1_DIPBDIP"           input="BRAM_X0.RAMB18_X0Y1_DIPBDIP"           output="BRAM.RAMB18_Y1_DIPBDIP" />
+  <direct name="RAMB18_X0Y1_DIPADIP"           input="BRAM_X0.RAMB18_X0Y1_DIPADIP"           output="BRAM.RAMB18_Y1_DIPADIP" />
+  <direct name="RAMB18_X0Y1_DIBDI"             input="BRAM_X0.RAMB18_X0Y1_DIBDI"             output="BRAM.RAMB18_Y1_DIBDI" />
+  <direct name="RAMB18_X0Y1_DIADI"             input="BRAM_X0.RAMB18_X0Y1_DIADI"             output="BRAM.RAMB18_Y1_DIADI" />
 
-  <direct name="RAMB18_X0Y1_ADDRARDADDR"      input="BLK_IG-BRAM_R.RAMB18_X0Y1_ADDRARDADDR"       output="BLK_IG-BRAM.RAMB18_Y1_ADDRARDADDR" />
-  <direct name="RAMB18_X0Y1_ADDRBWRADDR"      input="BLK_IG-BRAM_R.RAMB18_X0Y1_ADDRBWRADDR"       output="BLK_IG-BRAM.RAMB18_Y1_ADDRBWRADDR" />
-  <direct name="RAMB18_X0Y1_ADDRATIEHIGH"     input="BLK_IG-BRAM_R.RAMB18_X0Y1_ADDRATIEHIGH"      output="BLK_IG-BRAM.RAMB18_Y1_ADDRATIEHIGH" />
-  <direct name="RAMB18_X0Y1_ADDRBTIEHIGH"     input="BLK_IG-BRAM_R.RAMB18_X0Y1_ADDRBTIEHIGH"      output="BLK_IG-BRAM.RAMB18_Y1_ADDRBTIEHIGH" />
+  <direct name="RAMB18_X0Y1_ADDRARDADDR"       input="BRAM_X0.RAMB18_X0Y1_ADDRARDADDR"       output="BRAM.RAMB18_Y1_ADDRARDADDR" />
+  <direct name="RAMB18_X0Y1_ADDRBWRADDR"       input="BRAM_X0.RAMB18_X0Y1_ADDRBWRADDR"       output="BRAM.RAMB18_Y1_ADDRBWRADDR" />
+  <direct name="RAMB18_X0Y1_ADDRATIEHIGH"      input="BRAM_X0.RAMB18_X0Y1_ADDRATIEHIGH"      output="BRAM.RAMB18_Y1_ADDRATIEHIGH" />
+  <direct name="RAMB18_X0Y1_ADDRBTIEHIGH"      input="BRAM_X0.RAMB18_X0Y1_ADDRBTIEHIGH"      output="BRAM.RAMB18_Y1_ADDRBTIEHIGH" />
 
-  <direct name="RAMB18_X0Y1_WRERR"            input="BLK_IG-BRAM.RAMB18_Y1_WRERR"                  output="BLK_IG-BRAM_R.RAMB18_X0Y1_WRERR" />
-  <direct name="RAMB18_X0Y1_WRCOUNT"          input="BLK_IG-BRAM.RAMB18_Y1_WRCOUNT"                output="BLK_IG-BRAM_R.RAMB18_X0Y1_WRCOUNT" />
-  <direct name="RAMB18_X0Y1_RDERR"            input="BLK_IG-BRAM.RAMB18_Y1_RDERR"                  output="BLK_IG-BRAM_R.RAMB18_X0Y1_RDERR" />
-  <direct name="RAMB18_X0Y1_RDCOUNT"          input="BLK_IG-BRAM.RAMB18_Y1_RDCOUNT"                output="BLK_IG-BRAM_R.RAMB18_X0Y1_RDCOUNT" />
-  <direct name="RAMB18_X0Y1_FULL"             input="BLK_IG-BRAM.RAMB18_Y1_FULL"                   output="BLK_IG-BRAM_R.RAMB18_X0Y1_FULL" />
-  <direct name="RAMB18_X0Y1_EMPTY"            input="BLK_IG-BRAM.RAMB18_Y1_EMPTY"                  output="BLK_IG-BRAM_R.RAMB18_X0Y1_EMPTY" />
-  <direct name="RAMB18_X0Y1_DOPADOP"          input="BLK_IG-BRAM.RAMB18_Y1_DOPADOP"                output="BLK_IG-BRAM_R.RAMB18_X0Y1_DOPADOP" />
-  <direct name="RAMB18_X0Y1_DOPBDOP"          input="BLK_IG-BRAM.RAMB18_Y1_DOPBDOP"                output="BLK_IG-BRAM_R.RAMB18_X0Y1_DOPBDOP" />
-  <direct name="RAMB18_X0Y1_DOADO"            input="BLK_IG-BRAM.RAMB18_Y1_DOADO"                  output="BLK_IG-BRAM_R.RAMB18_X0Y1_DOADO" />
-  <direct name="RAMB18_X0Y1_DOBDO"            input="BLK_IG-BRAM.RAMB18_Y1_DOBDO"                  output="BLK_IG-BRAM_R.RAMB18_X0Y1_DOBDO" />
-  <direct name="RAMB18_X0Y1_ALMOSTFULL"       input="BLK_IG-BRAM.RAMB18_Y1_ALMOSTFULL"             output="BLK_IG-BRAM_R.RAMB18_X0Y1_ALMOSTFULL" />
-  <direct name="RAMB18_X0Y1_ALMOSTEMPTY"      input="BLK_IG-BRAM.RAMB18_Y1_ALMOSTEMPTY"            output="BLK_IG-BRAM_R.RAMB18_X0Y1_ALMOSTEMPTY" />
+  <direct name="RAMB18_X0Y1_WRERR"             input="BRAM.RAMB18_Y1_WRERR"                  output="BRAM_X0.RAMB18_X0Y1_WRERR" />
+  <direct name="RAMB18_X0Y1_WRCOUNT"           input="BRAM.RAMB18_Y1_WRCOUNT"                output="BRAM_X0.RAMB18_X0Y1_WRCOUNT" />
+  <direct name="RAMB18_X0Y1_RDERR"             input="BRAM.RAMB18_Y1_RDERR"                  output="BRAM_X0.RAMB18_X0Y1_RDERR" />
+  <direct name="RAMB18_X0Y1_RDCOUNT"           input="BRAM.RAMB18_Y1_RDCOUNT"                output="BRAM_X0.RAMB18_X0Y1_RDCOUNT" />
+  <direct name="RAMB18_X0Y1_FULL"              input="BRAM.RAMB18_Y1_FULL"                   output="BRAM_X0.RAMB18_X0Y1_FULL" />
+  <direct name="RAMB18_X0Y1_EMPTY"             input="BRAM.RAMB18_Y1_EMPTY"                  output="BRAM_X0.RAMB18_X0Y1_EMPTY" />
+  <direct name="RAMB18_X0Y1_DOPADOP"           input="BRAM.RAMB18_Y1_DOPADOP"                output="BRAM_X0.RAMB18_X0Y1_DOPADOP" />
+  <direct name="RAMB18_X0Y1_DOPBDOP"           input="BRAM.RAMB18_Y1_DOPBDOP"                output="BRAM_X0.RAMB18_X0Y1_DOPBDOP" />
+  <direct name="RAMB18_X0Y1_DOADO"             input="BRAM.RAMB18_Y1_DOADO"                  output="BRAM_X0.RAMB18_X0Y1_DOADO" />
+  <direct name="RAMB18_X0Y1_DOBDO"             input="BRAM.RAMB18_Y1_DOBDO"                  output="BRAM_X0.RAMB18_X0Y1_DOBDO" />
+  <direct name="RAMB18_X0Y1_ALMOSTFULL"        input="BRAM.RAMB18_Y1_ALMOSTFULL"             output="BRAM_X0.RAMB18_X0Y1_ALMOSTFULL" />
+  <direct name="RAMB18_X0Y1_ALMOSTEMPTY"       input="BRAM.RAMB18_Y1_ALMOSTEMPTY"            output="BRAM_X0.RAMB18_X0Y1_ALMOSTEMPTY" />
  </interconnect>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>
-

--- a/xc7/primitives/common_slice/Nlut/ntemplate.Nlut.pb_type.xml
+++ b/xc7/primitives/common_slice/Nlut/ntemplate.Nlut.pb_type.xml
@@ -5,7 +5,7 @@
       - 2 * 5 input, 1 output LUT
       - 1 * 6 input, 1 output LUT
   -->
-<pb_type name="BLK_IG-{N}LUT" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="{N}LUT" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
  <input  name="A1" num_pins="1"/>
  <input  name="A2" num_pins="1"/>
  <input  name="A3" num_pins="1"/>
@@ -16,65 +16,73 @@
  <output name="O6" num_pins="1"/>
 
  <!-- LUT5+LUT5+F6MUX with two outputs -->
- <mode name="BLK_IG-{N}LUT-LUT5_MUX">
-   <pb_type name="BEL_LT-{N}5LUT" num_pb="2" class="lut" blif_model=".names">
+ <mode name="{N}LUT-LUT5_MUX">
+   <pb_type name="{N}5LUT" num_pb="2" class="lut" blif_model=".names">
      <input  name="in"  num_pins="5" port_class="lut_in" />
      <output name="out" num_pins="1" port_class="lut_out" />
-     <delay_matrix type="max" in_port="BEL_LT-{N}5LUT.in" out_port="BEL_LT-{N}5LUT.out">
+     <delay_matrix type="max" in_port="{N}5LUT.in" out_port="{N}5LUT.out">
       0.068e-9
       0.068e-9
       0.068e-9
       0.068e-9
       0.068e-9
      </delay_matrix>
+     <metadata>
+       <meta name="type">bel</meta>
+       <meta name="subtype">lut</meta>
+     </metadata>
    </pb_type>
    <xi:include href="../muxes/f6mux/f6mux.pb_type.xml" />
    <interconnect>
      <!-- LUT5 (upper) -> O6 -->
-     <direct name="{N}LUT_A5_0" input="BLK_IG-{N}LUT.A5" output="BEL_LT-{N}5LUT[0].in[4]"/>
-     <direct name="{N}LUT_A4_0" input="BLK_IG-{N}LUT.A4" output="BEL_LT-{N}5LUT[0].in[3]"/>
-     <direct name="{N}LUT_A3_0" input="BLK_IG-{N}LUT.A3" output="BEL_LT-{N}5LUT[0].in[2]"/>
-     <direct name="{N}LUT_A2_0" input="BLK_IG-{N}LUT.A2" output="BEL_LT-{N}5LUT[0].in[1]"/>
-     <direct name="{N}LUT_A1_0" input="BLK_IG-{N}LUT.A1" output="BEL_LT-{N}5LUT[0].in[0]"/>
+     <direct name="{N}LUT_A5_0" input="{N}LUT.A5" output="{N}5LUT[0].in[4]"/>
+     <direct name="{N}LUT_A4_0" input="{N}LUT.A4" output="{N}5LUT[0].in[3]"/>
+     <direct name="{N}LUT_A3_0" input="{N}LUT.A3" output="{N}5LUT[0].in[2]"/>
+     <direct name="{N}LUT_A2_0" input="{N}LUT.A2" output="{N}5LUT[0].in[1]"/>
+     <direct name="{N}LUT_A1_0" input="{N}LUT.A1" output="{N}5LUT[0].in[0]"/>
 
      <!-- LUT5 (lower) -> O5 -->
-     <direct name="{N}LUT_A5_1" input="BLK_IG-{N}LUT.A5" output="BEL_LT-{N}5LUT[1].in[4]"/>
-     <direct name="{N}LUT_A4_1" input="BLK_IG-{N}LUT.A4" output="BEL_LT-{N}5LUT[1].in[3]"/>
-     <direct name="{N}LUT_A3_1" input="BLK_IG-{N}LUT.A3" output="BEL_LT-{N}5LUT[1].in[2]"/>
-     <direct name="{N}LUT_A2_1" input="BLK_IG-{N}LUT.A2" output="BEL_LT-{N}5LUT[1].in[1]"/>
-     <direct name="{N}LUT_A1_1" input="BLK_IG-{N}LUT.A1" output="BEL_LT-{N}5LUT[1].in[0]"/>
+     <direct name="{N}LUT_A5_1" input="{N}LUT.A5" output="{N}5LUT[1].in[4]"/>
+     <direct name="{N}LUT_A4_1" input="{N}LUT.A4" output="{N}5LUT[1].in[3]"/>
+     <direct name="{N}LUT_A3_1" input="{N}LUT.A3" output="{N}5LUT[1].in[2]"/>
+     <direct name="{N}LUT_A2_1" input="{N}LUT.A2" output="{N}5LUT[1].in[1]"/>
+     <direct name="{N}LUT_A1_1" input="{N}LUT.A1" output="{N}5LUT[1].in[0]"/>
 
      <!-- MUX used for LUT6 -->
-     <direct name="F6MUX_I0" input="BEL_LT-{N}5LUT[0].out" output="BEL_MX-F6MUX.I0">
-      <pack_pattern in_port="BEL_LT-{N}5LUT[0].out" name="LUT5toLUT6" out_port="BEL_MX-F6MUX.I0"/>
-      <pack_pattern in_port="BEL_LT-{N}5LUT[0].out" name="LUT5toLUT7" out_port="BEL_MX-F6MUX.I0"/>
-      <pack_pattern in_port="BEL_LT-{N}5LUT[0].out" name="LUT5toLUT8" out_port="BEL_MX-F6MUX.I0"/>
+     <direct name="F6MUX_I0" input="{N}5LUT[0].out" output="F6MUX.I0">
+      <pack_pattern in_port="{N}5LUT[0].out" name="LUT5toLUT6" out_port="F6MUX.I0"/>
+      <pack_pattern in_port="{N}5LUT[0].out" name="LUT5toLUT7" out_port="F6MUX.I0"/>
+      <pack_pattern in_port="{N}5LUT[0].out" name="LUT5toLUT8" out_port="F6MUX.I0"/>
      </direct>
-     <direct name="F6MUX_I1" input="BEL_LT-{N}5LUT[1].out" output="BEL_MX-F6MUX.I1">
-      <pack_pattern in_port="BEL_LT-{N}5LUT[1].out" name="LUT5toLUT6" out_port="BEL_MX-F6MUX.I1"/>
-      <pack_pattern in_port="BEL_LT-{N}5LUT[1].out" name="LUT5toLUT7" out_port="BEL_MX-F6MUX.I1"/>
-      <pack_pattern in_port="BEL_LT-{N}5LUT[1].out" name="LUT5toLUT8" out_port="BEL_MX-F6MUX.I1"/>
+     <direct name="F6MUX_I1" input="{N}5LUT[1].out" output="F6MUX.I1">
+      <pack_pattern in_port="{N}5LUT[1].out" name="LUT5toLUT6" out_port="F6MUX.I1"/>
+      <pack_pattern in_port="{N}5LUT[1].out" name="LUT5toLUT7" out_port="F6MUX.I1"/>
+      <pack_pattern in_port="{N}5LUT[1].out" name="LUT5toLUT8" out_port="F6MUX.I1"/>
      </direct>
-     <direct name="F6MUX_S"  input="BLK_IG-{N}LUT.A6" output="BEL_MX-F6MUX.S">
+     <direct name="F6MUX_S"  input="{N}LUT.A6" output="F6MUX.S">
      </direct>
 
      <!-- LUT outputs -->
-     <direct name="O5" input="BEL_LT-{N}5LUT[0].out"                output="BLK_IG-{N}LUT.O5">
-      <pack_pattern in_port="BEL_LT-{N}5LUT[0].out" name="LUT5x2"     out_port="BLK_IG-{N}LUT.O5"/>
+     <direct name="O5" input="{N}5LUT[0].out"                output="{N}LUT.O5">
+      <pack_pattern in_port="{N}5LUT[0].out" name="LUT5x2"     out_port="{N}LUT.O5"/>
      </direct>
-     <mux    name="O6" input="BEL_LT-{N}5LUT[1].out BEL_MX-F6MUX.O" output="BLK_IG-{N}LUT.O6">
-      <pack_pattern in_port="BEL_MX-F6MUX.O"        name="LUT5toLUT6" out_port="BLK_IG-{N}LUT.O6"/>
-      <pack_pattern in_port="BEL_MX-F6MUX.O"        name="LUT5toLUT7" out_port="BLK_IG-{N}LUT.O6"/>
-      <pack_pattern in_port="BEL_MX-F6MUX.O"        name="LUT5toLUT8" out_port="BLK_IG-{N}LUT.O6"/>
-      <pack_pattern in_port="BEL_LT-{N}5LUT[1].out" name="LUT5x2"     out_port="BLK_IG-{N}LUT.O6"/>
+     <mux    name="O6" input="{N}5LUT[1].out F6MUX.O" output="{N}LUT.O6">
+      <pack_pattern in_port="F6MUX.O"        name="LUT5toLUT6" out_port="{N}LUT.O6"/>
+      <pack_pattern in_port="F6MUX.O"        name="LUT5toLUT7" out_port="{N}LUT.O6"/>
+      <pack_pattern in_port="F6MUX.O"        name="LUT5toLUT8" out_port="{N}LUT.O6"/>
+      <pack_pattern in_port="{N}5LUT[1].out" name="LUT5x2"     out_port="{N}LUT.O6"/>
      </mux>
    </interconnect>
    <metadata>
      <meta name="fasm_type">SPLIT_LUT</meta>
      <meta name="fasm_lut">
-       {N}LUT.INIT[31:0] = BEL_LT-{N}5LUT[0]
-       {N}LUT.INIT[63:32] = BEL_LT-{N}5LUT[1]
+       {N}LUT.INIT[31:0] = {N}5LUT[0]
+       {N}LUT.INIT[63:32] = {N}5LUT[1]
      </meta>
    </metadata>
  </mode>
+ <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/xc7/primitives/common_slice/carry/carry0.pb_type.xml
+++ b/xc7/primitives/common_slice/carry/carry0.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".subckt CARRY0_CONST" name="BEL_BB-CARRY0" num_pb="1">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".subckt CARRY0_CONST" name="CARRY0" num_pb="1">
   <input name="CI" num_pins="1"/>
   <input name="CI_INIT" num_pins="1"/>
   <output name="CO_CHAIN" num_pins="1"/>
@@ -6,21 +6,23 @@
   <input name="DI" num_pins="1"/>
   <output name="O" num_pins="1"/>
   <input name="S" num_pins="1"/>
-  <delay_constant in_port="BEL_BB-CARRY0.CI" max="10e-12" out_port="BEL_BB-CARRY0.CO_CHAIN"/>
-  <delay_constant in_port="BEL_BB-CARRY0.CI_INIT" max="10e-12" out_port="BEL_BB-CARRY0.CO_CHAIN"/>
-  <delay_constant in_port="BEL_BB-CARRY0.DI" max="10e-12" out_port="BEL_BB-CARRY0.CO_CHAIN"/>
-  <delay_constant in_port="BEL_BB-CARRY0.S" max="10e-12" out_port="BEL_BB-CARRY0.CO_CHAIN"/>
-  <delay_constant in_port="BEL_BB-CARRY0.CI" max="10e-12" out_port="BEL_BB-CARRY0.CO_FABRIC"/>
-  <delay_constant in_port="BEL_BB-CARRY0.CI_INIT" max="10e-12" out_port="BEL_BB-CARRY0.CO_FABRIC"/>
-  <delay_constant in_port="BEL_BB-CARRY0.DI" max="10e-12" out_port="BEL_BB-CARRY0.CO_FABRIC"/>
-  <delay_constant in_port="BEL_BB-CARRY0.S" max="10e-12" out_port="BEL_BB-CARRY0.CO_FABRIC"/>
-  <delay_constant in_port="BEL_BB-CARRY0.CI" max="10e-12" out_port="BEL_BB-CARRY0.O"/>
-  <delay_constant in_port="BEL_BB-CARRY0.CI_INIT" max="10e-12" out_port="BEL_BB-CARRY0.O"/>
-  <delay_constant in_port="BEL_BB-CARRY0.S" max="10e-12" out_port="BEL_BB-CARRY0.O"/>
+  <delay_constant in_port="CARRY0.CI" max="10e-12" out_port="CARRY0.CO_CHAIN"/>
+  <delay_constant in_port="CARRY0.CI_INIT" max="10e-12" out_port="CARRY0.CO_CHAIN"/>
+  <delay_constant in_port="CARRY0.DI" max="10e-12" out_port="CARRY0.CO_CHAIN"/>
+  <delay_constant in_port="CARRY0.S" max="10e-12" out_port="CARRY0.CO_CHAIN"/>
+  <delay_constant in_port="CARRY0.CI" max="10e-12" out_port="CARRY0.CO_FABRIC"/>
+  <delay_constant in_port="CARRY0.CI_INIT" max="10e-12" out_port="CARRY0.CO_FABRIC"/>
+  <delay_constant in_port="CARRY0.DI" max="10e-12" out_port="CARRY0.CO_FABRIC"/>
+  <delay_constant in_port="CARRY0.S" max="10e-12" out_port="CARRY0.CO_FABRIC"/>
+  <delay_constant in_port="CARRY0.CI" max="10e-12" out_port="CARRY0.O"/>
+  <delay_constant in_port="CARRY0.CI_INIT" max="10e-12" out_port="CARRY0.O"/>
+  <delay_constant in_port="CARRY0.S" max="10e-12" out_port="CARRY0.O"/>
   <metadata>
     <meta name="fasm_params">
       PRECYINIT.C0 = CYINIT_C0
       PRECYINIT.C1 = CYINIT_C1
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">blackbox</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/common_slice/common_lut_and_f78mux.pb_type.xml
+++ b/xc7/primitives/common_slice/common_lut_and_f78mux.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_IG-COMMON_LUT_AND_F78MUX" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="COMMON_LUT_AND_F78MUX" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <input name="D1" num_pins="1"/>
   <input name="D2" num_pins="1"/>
   <input name="D3" num_pins="1"/>
@@ -42,7 +42,7 @@
 
   <output name="F7AMUX_O" num_pins="1"/>
   <output name="F7BMUX_O" num_pins="1"/>
-  <output name="F8MUX_O" num_pins="1"/>
+  <output name="F8MUX_O"  num_pins="1"/>
 
   <xi:include href="Nlut/alut.pb_type.xml"/>
   <xi:include href="Nlut/blut.pb_type.xml"/>
@@ -54,77 +54,81 @@
 
   <interconnect>
     <!-- LUT input pins -->
-    <direct name="D1" input="BLK_IG-COMMON_LUT_AND_F78MUX.D1" output="BLK_IG-DLUT.A1" />
-    <direct name="D2" input="BLK_IG-COMMON_LUT_AND_F78MUX.D2" output="BLK_IG-DLUT.A2" />
-    <direct name="D3" input="BLK_IG-COMMON_LUT_AND_F78MUX.D3" output="BLK_IG-DLUT.A3" />
-    <direct name="D4" input="BLK_IG-COMMON_LUT_AND_F78MUX.D4" output="BLK_IG-DLUT.A4" />
-    <direct name="D5" input="BLK_IG-COMMON_LUT_AND_F78MUX.D5" output="BLK_IG-DLUT.A5" />
-    <direct name="D6" input="BLK_IG-COMMON_LUT_AND_F78MUX.D6" output="BLK_IG-DLUT.A6" />
+    <direct name="D1" input="COMMON_LUT_AND_F78MUX.D1" output="DLUT.A1" />
+    <direct name="D2" input="COMMON_LUT_AND_F78MUX.D2" output="DLUT.A2" />
+    <direct name="D3" input="COMMON_LUT_AND_F78MUX.D3" output="DLUT.A3" />
+    <direct name="D4" input="COMMON_LUT_AND_F78MUX.D4" output="DLUT.A4" />
+    <direct name="D5" input="COMMON_LUT_AND_F78MUX.D5" output="DLUT.A5" />
+    <direct name="D6" input="COMMON_LUT_AND_F78MUX.D6" output="DLUT.A6" />
 
-    <direct name="C1" input="BLK_IG-COMMON_LUT_AND_F78MUX.C1" output="BLK_IG-CLUT.A1" />
-    <direct name="C2" input="BLK_IG-COMMON_LUT_AND_F78MUX.C2" output="BLK_IG-CLUT.A2" />
-    <direct name="C3" input="BLK_IG-COMMON_LUT_AND_F78MUX.C3" output="BLK_IG-CLUT.A3" />
-    <direct name="C4" input="BLK_IG-COMMON_LUT_AND_F78MUX.C4" output="BLK_IG-CLUT.A4" />
-    <direct name="C5" input="BLK_IG-COMMON_LUT_AND_F78MUX.C5" output="BLK_IG-CLUT.A5" />
-    <direct name="C6" input="BLK_IG-COMMON_LUT_AND_F78MUX.C6" output="BLK_IG-CLUT.A6" />
+    <direct name="C1" input="COMMON_LUT_AND_F78MUX.C1" output="CLUT.A1" />
+    <direct name="C2" input="COMMON_LUT_AND_F78MUX.C2" output="CLUT.A2" />
+    <direct name="C3" input="COMMON_LUT_AND_F78MUX.C3" output="CLUT.A3" />
+    <direct name="C4" input="COMMON_LUT_AND_F78MUX.C4" output="CLUT.A4" />
+    <direct name="C5" input="COMMON_LUT_AND_F78MUX.C5" output="CLUT.A5" />
+    <direct name="C6" input="COMMON_LUT_AND_F78MUX.C6" output="CLUT.A6" />
 
-    <direct name="B1" input="BLK_IG-COMMON_LUT_AND_F78MUX.B1" output="BLK_IG-BLUT.A1" />
-    <direct name="B2" input="BLK_IG-COMMON_LUT_AND_F78MUX.B2" output="BLK_IG-BLUT.A2" />
-    <direct name="B3" input="BLK_IG-COMMON_LUT_AND_F78MUX.B3" output="BLK_IG-BLUT.A3" />
-    <direct name="B4" input="BLK_IG-COMMON_LUT_AND_F78MUX.B4" output="BLK_IG-BLUT.A4" />
-    <direct name="B5" input="BLK_IG-COMMON_LUT_AND_F78MUX.B5" output="BLK_IG-BLUT.A5" />
-    <direct name="B6" input="BLK_IG-COMMON_LUT_AND_F78MUX.B6" output="BLK_IG-BLUT.A6" />
+    <direct name="B1" input="COMMON_LUT_AND_F78MUX.B1" output="BLUT.A1" />
+    <direct name="B2" input="COMMON_LUT_AND_F78MUX.B2" output="BLUT.A2" />
+    <direct name="B3" input="COMMON_LUT_AND_F78MUX.B3" output="BLUT.A3" />
+    <direct name="B4" input="COMMON_LUT_AND_F78MUX.B4" output="BLUT.A4" />
+    <direct name="B5" input="COMMON_LUT_AND_F78MUX.B5" output="BLUT.A5" />
+    <direct name="B6" input="COMMON_LUT_AND_F78MUX.B6" output="BLUT.A6" />
 
-    <direct name="A1" input="BLK_IG-COMMON_LUT_AND_F78MUX.A1" output="BLK_IG-ALUT.A1" />
-    <direct name="A2" input="BLK_IG-COMMON_LUT_AND_F78MUX.A2" output="BLK_IG-ALUT.A2" />
-    <direct name="A3" input="BLK_IG-COMMON_LUT_AND_F78MUX.A3" output="BLK_IG-ALUT.A3" />
-    <direct name="A4" input="BLK_IG-COMMON_LUT_AND_F78MUX.A4" output="BLK_IG-ALUT.A4" />
-    <direct name="A5" input="BLK_IG-COMMON_LUT_AND_F78MUX.A5" output="BLK_IG-ALUT.A5" />
-    <direct name="A6" input="BLK_IG-COMMON_LUT_AND_F78MUX.A6" output="BLK_IG-ALUT.A6" />
+    <direct name="A1" input="COMMON_LUT_AND_F78MUX.A1" output="ALUT.A1" />
+    <direct name="A2" input="COMMON_LUT_AND_F78MUX.A2" output="ALUT.A2" />
+    <direct name="A3" input="COMMON_LUT_AND_F78MUX.A3" output="ALUT.A3" />
+    <direct name="A4" input="COMMON_LUT_AND_F78MUX.A4" output="ALUT.A4" />
+    <direct name="A5" input="COMMON_LUT_AND_F78MUX.A5" output="ALUT.A5" />
+    <direct name="A6" input="COMMON_LUT_AND_F78MUX.A6" output="ALUT.A6" />
 
-    <direct name="DO6" input="BLK_IG-DLUT.O6" output="BLK_IG-COMMON_LUT_AND_F78MUX.DO6" />
-    <direct name="DO5" input="BLK_IG-DLUT.O5" output="BLK_IG-COMMON_LUT_AND_F78MUX.DO5" />
+    <direct name="DO6" input="DLUT.O6" output="COMMON_LUT_AND_F78MUX.DO6" />
+    <direct name="DO5" input="DLUT.O5" output="COMMON_LUT_AND_F78MUX.DO5" />
 
-    <direct name="CO6" input="BLK_IG-CLUT.O6" output="BLK_IG-COMMON_LUT_AND_F78MUX.CO6" />
-    <direct name="CO5" input="BLK_IG-CLUT.O5" output="BLK_IG-COMMON_LUT_AND_F78MUX.CO5" />
+    <direct name="CO6" input="CLUT.O6" output="COMMON_LUT_AND_F78MUX.CO6" />
+    <direct name="CO5" input="CLUT.O5" output="COMMON_LUT_AND_F78MUX.CO5" />
 
-    <direct name="BO6" input="BLK_IG-BLUT.O6" output="BLK_IG-COMMON_LUT_AND_F78MUX.BO6" />
-    <direct name="BO5" input="BLK_IG-BLUT.O5" output="BLK_IG-COMMON_LUT_AND_F78MUX.BO5" />
+    <direct name="BO6" input="BLUT.O6" output="COMMON_LUT_AND_F78MUX.BO6" />
+    <direct name="BO5" input="BLUT.O5" output="COMMON_LUT_AND_F78MUX.BO5" />
 
-    <direct name="AO6" input="BLK_IG-ALUT.O6" output="BLK_IG-COMMON_LUT_AND_F78MUX.AO6" />
-    <direct name="AO5" input="BLK_IG-ALUT.O5" output="BLK_IG-COMMON_LUT_AND_F78MUX.AO5" />
+    <direct name="AO6" input="ALUT.O6" output="COMMON_LUT_AND_F78MUX.AO6" />
+    <direct name="AO5" input="ALUT.O5" output="COMMON_LUT_AND_F78MUX.AO5" />
 
     <!-- F7AMUX inputs -->
-    <direct name="F7AMUX_I0" input="BLK_IG-BLUT.O6"   output="BEL_MX-F7AMUX.I0">
-     <pack_pattern in_port="BLK_IG-BLUT.O6" name="LUT5toLUT7" out_port="BEL_MX-F7AMUX.I0"/>
-     <pack_pattern in_port="BLK_IG-BLUT.O6" name="LUT5toLUT8" out_port="BEL_MX-F7AMUX.I0"/>
+    <direct name="F7AMUX_I0" input="BLUT.O6"   output="F7AMUX.I0">
+     <pack_pattern in_port="BLUT.O6" name="LUT5toLUT7" out_port="F7AMUX.I0"/>
+     <pack_pattern in_port="BLUT.O6" name="LUT5toLUT8" out_port="F7AMUX.I0"/>
     </direct>
-    <direct name="F7AMUX_I1" input="BLK_IG-ALUT.O6"   output="BEL_MX-F7AMUX.I1">
-     <pack_pattern in_port="BLK_IG-ALUT.O6" name="LUT5toLUT7" out_port="BEL_MX-F7AMUX.I1"/>
-     <pack_pattern in_port="BLK_IG-ALUT.O6" name="LUT5toLUT8" out_port="BEL_MX-F7AMUX.I1"/>
+    <direct name="F7AMUX_I1" input="ALUT.O6"   output="F7AMUX.I1">
+     <pack_pattern in_port="ALUT.O6" name="LUT5toLUT7" out_port="F7AMUX.I1"/>
+     <pack_pattern in_port="ALUT.O6" name="LUT5toLUT8" out_port="F7AMUX.I1"/>
     </direct>
-    <direct name="F7AMUX_S"  input="BLK_IG-COMMON_LUT_AND_F78MUX.AX" output="BEL_MX-F7AMUX.S" />
+    <direct name="F7AMUX_S"  input="COMMON_LUT_AND_F78MUX.AX" output="F7AMUX.S" />
     <!-- F7BMUX inputs -->
-    <direct name="F7BMUX_I0" input="BLK_IG-DLUT.O6"   output="BEL_MX-F7BMUX.I0">
-     <pack_pattern in_port="BLK_IG-DLUT.O6" name="LUT5toLUT7" out_port="BEL_MX-F7BMUX.I0"/>
-     <pack_pattern in_port="BLK_IG-DLUT.O6" name="LUT5toLUT8" out_port="BEL_MX-F7BMUX.I0"/>
+    <direct name="F7BMUX_I0" input="DLUT.O6"   output="F7BMUX.I0">
+     <pack_pattern in_port="DLUT.O6" name="LUT5toLUT7" out_port="F7BMUX.I0"/>
+     <pack_pattern in_port="DLUT.O6" name="LUT5toLUT8" out_port="F7BMUX.I0"/>
     </direct>
-    <direct name="F7BMUX_I1" input="BLK_IG-CLUT.O6"   output="BEL_MX-F7BMUX.I1">
-     <pack_pattern in_port="BLK_IG-CLUT.O6" name="LUT5toLUT7" out_port="BEL_MX-F7BMUX.I1"/>
-     <pack_pattern in_port="BLK_IG-CLUT.O6" name="LUT5toLUT8" out_port="BEL_MX-F7BMUX.I1"/>
+    <direct name="F7BMUX_I1" input="CLUT.O6"   output="F7BMUX.I1">
+     <pack_pattern in_port="CLUT.O6" name="LUT5toLUT7" out_port="F7BMUX.I1"/>
+     <pack_pattern in_port="CLUT.O6" name="LUT5toLUT8" out_port="F7BMUX.I1"/>
     </direct>
-    <direct name="F7BMUX_S"  input="BLK_IG-COMMON_LUT_AND_F78MUX.CX" output="BEL_MX-F7BMUX.S" />
+    <direct name="F7BMUX_S"  input="COMMON_LUT_AND_F78MUX.CX" output="F7BMUX.S" />
     <!-- F8MUX inputs -->
-    <direct name="F8MUX_I0"  input="BEL_MX-F7BMUX.O"  output="BEL_MX-F8MUX.I0">
-     <pack_pattern in_port="BEL_MX-F7BMUX.O" name="LUT5toLUT8" out_port="BEL_MX-F8MUX.I0"/>
+    <direct name="F8MUX_I0"  input="F7BMUX.O"  output="F8MUX.I0">
+     <pack_pattern in_port="F7BMUX.O" name="LUT5toLUT8" out_port="F8MUX.I0"/>
     </direct>
-    <direct name="F8MUX_I1"  input="BEL_MX-F7AMUX.O"  output="BEL_MX-F8MUX.I1">
-     <pack_pattern in_port="BEL_MX-F7AMUX.O" name="LUT5toLUT8" out_port="BEL_MX-F8MUX.I1"/>
+    <direct name="F8MUX_I1"  input="F7AMUX.O"  output="F8MUX.I1">
+     <pack_pattern in_port="F7AMUX.O" name="LUT5toLUT8" out_port="F8MUX.I1"/>
     </direct>
-    <direct name="F8MUX_S"   input="BLK_IG-COMMON_LUT_AND_F78MUX.BX" output="BEL_MX-F8MUX.S" />
+    <direct name="F8MUX_S"   input="COMMON_LUT_AND_F78MUX.BX" output="F8MUX.S" />
 
-    <direct name="F7AMUX_O"   input="BEL_MX-F7AMUX.O" output="BLK_IG-COMMON_LUT_AND_F78MUX.F7AMUX_O" />
-    <direct name="F7BMUX_O"   input="BEL_MX-F7BMUX.O" output="BLK_IG-COMMON_LUT_AND_F78MUX.F7BMUX_O" />
-    <direct name="F8MUX_O"   input="BEL_MX-F8MUX.O" output="BLK_IG-COMMON_LUT_AND_F78MUX.F8MUX_O" />
+    <direct name="F7AMUX_O"  input="F7AMUX.O" output="COMMON_LUT_AND_F78MUX.F7AMUX_O" />
+    <direct name="F7BMUX_O"  input="F7BMUX.O" output="COMMON_LUT_AND_F78MUX.F7BMUX_O" />
+    <direct name="F8MUX_O"   input="F8MUX.O" output="COMMON_LUT_AND_F78MUX.F8MUX_O" />
   </interconnect>
+  <metadata>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
+  </metadata>
 </pb_type>

--- a/xc7/primitives/common_slice/common_slice.pb_type.xml
+++ b/xc7/primitives/common_slice/common_slice.pb_type.xml
@@ -6,7 +6,7 @@
 
     Note: For SLICEL, the AMC31 input is left unconnected.
   -->
-<pb_type name="BLK_IG-COMMON_SLICE" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="COMMON_SLICE" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <input name="DX" num_pins="1"/>
   <input name="CX" num_pins="1"/>
@@ -257,276 +257,280 @@
     </mode>
   </pb_type>
 
-  <pb_type name="BEL_BB-CARRY" blif_model=".subckt CARRY" num_pb="3">
+  <pb_type name="CARRY" blif_model=".subckt CARRY" num_pb="3">
     <xi:include href="carry/carry.pb_type.xml"
                 xpointer="xpointer(pb_type/child::node())" />
   </pb_type>
   <interconnect>
     <!-- 5FF MUXs -->
-    <mux name="D5FFMUX" input="BLK_IG-COMMON_SLICE.DX BLK_IG-COMMON_SLICE.DO5" output="BLK_BB-SLICE_FF.D5[3]" >
+    <mux name="D5FFMUX" input="COMMON_SLICE.DX COMMON_SLICE.DO5" output="SLICE_FF.D5[3]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.DO5 = D5FFMUX.IN_A
-          BLK_IG-COMMON_SLICE.DX = D5FFMUX.IN_B
+          COMMON_SLICE.DO5 = D5FFMUX.IN_A
+          COMMON_SLICE.DX = D5FFMUX.IN_B
         </meta>
       </metadata>
     </mux>
-    <mux name="C5FFMUX" input="BLK_IG-COMMON_SLICE.CX BLK_IG-COMMON_SLICE.CO5" output="BLK_BB-SLICE_FF.D5[2]" >
+    <mux name="C5FFMUX" input="COMMON_SLICE.CX COMMON_SLICE.CO5" output="SLICE_FF.D5[2]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.CO5 = C5FFMUX.IN_A
-          BLK_IG-COMMON_SLICE.CX = C5FFMUX.IN_B
+          COMMON_SLICE.CO5 = C5FFMUX.IN_A
+          COMMON_SLICE.CX = C5FFMUX.IN_B
         </meta>
       </metadata>
     </mux>
-    <mux name="B5FFMUX" input="BLK_IG-COMMON_SLICE.BX BLK_IG-COMMON_SLICE.BO5" output="BLK_BB-SLICE_FF.D5[1]" >
+    <mux name="B5FFMUX" input="COMMON_SLICE.BX COMMON_SLICE.BO5" output="SLICE_FF.D5[1]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.BO5 = B5FFMUX.IN_A
-          BLK_IG-COMMON_SLICE.BX = B5FFMUX.IN_B
+          COMMON_SLICE.BO5 = B5FFMUX.IN_A
+          COMMON_SLICE.BX = B5FFMUX.IN_B
         </meta>
       </metadata>
     </mux>
-    <mux name="A5FFMUX" input="BLK_IG-COMMON_SLICE.AX BLK_IG-COMMON_SLICE.AO5" output="BLK_BB-SLICE_FF.D5[0]" >
+    <mux name="A5FFMUX" input="COMMON_SLICE.AX COMMON_SLICE.AO5" output="SLICE_FF.D5[0]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.AO5 = A5FFMUX.IN_A
-          BLK_IG-COMMON_SLICE.AX = A5FFMUX.IN_B
+          COMMON_SLICE.AO5 = A5FFMUX.IN_A
+          COMMON_SLICE.AX = A5FFMUX.IN_B
         </meta>
       </metadata>
     </mux>
 
     <!-- [A-D]MUX -->
     <mux name="DMUX"
-      input="BLK_IG-COMMON_SLICE.AMC31 BLK_BB-SLICE_FF.Q5[3] BEL_BB-CARRY[2].O BEL_BB-CARRY[2].CO_FABRIC BLK_IG-COMMON_SLICE.DO6 BLK_IG-COMMON_SLICE.DO5"
-      output="BLK_IG-COMMON_SLICE.DMUX">
+      input="COMMON_SLICE.AMC31 SLICE_FF.Q5[3] CARRY[2].O CARRY[2].CO_FABRIC COMMON_SLICE.DO6 COMMON_SLICE.DO5"
+      output="COMMON_SLICE.DMUX">
       <metadata>
         <meta name="fasm_mux">
           <!-- TODO: Test that this mux defaults to AMC31 -->
-          BLK_IG-COMMON_SLICE.AMC31 = NONE
-          BLK_BB-SLICE_FF.Q5[3] = DOUTMUX.D5Q
-          BLK_IG-COMMON_SLICE.DO5 = DOUTMUX.O5
-          BLK_IG-COMMON_SLICE.DO6 = DOUTMUX.O6
-          BEL_BB-CARRY[2].CO_FABRIC = DOUTMUX.CY
-          BEL_BB-CARRY[2].O = DOUTMUX.XOR
+          COMMON_SLICE.AMC31 = NONE
+          SLICE_FF.Q5[3] = DOUTMUX.D5Q
+          COMMON_SLICE.DO5 = DOUTMUX.O5
+          COMMON_SLICE.DO6 = DOUTMUX.O6
+          CARRY[2].CO_FABRIC = DOUTMUX.CY
+          CARRY[2].O = DOUTMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="CMUX"
-      input="BLK_BB-SLICE_FF.Q5[2] BEL_BB-CARRY[1].O BEL_BB-CARRY[1].CO_FABRIC BLK_IG-COMMON_SLICE.CO6 BLK_IG-COMMON_SLICE.CO5 BLK_IG-COMMON_SLICE.F7BMUX_O"
-      output="BLK_IG-COMMON_SLICE.CMUX" >
+      input="SLICE_FF.Q5[2] CARRY[1].O CARRY[1].CO_FABRIC COMMON_SLICE.CO6 COMMON_SLICE.CO5 COMMON_SLICE.F7BMUX_O"
+      output="COMMON_SLICE.CMUX" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_BB-SLICE_FF.Q5[2] = COUTMUX.C5Q
-          BLK_IG-COMMON_SLICE.F7BMUX_O = COUTMUX.F7
-          BLK_IG-COMMON_SLICE.CO5 = COUTMUX.O5
-          BLK_IG-COMMON_SLICE.CO6 = COUTMUX.O6
-          BEL_BB-CARRY[1].CO_FABRIC = COUTMUX.CY
-          BEL_BB-CARRY[1].O = COUTMUX.XOR
+          SLICE_FF.Q5[2] = COUTMUX.C5Q
+          COMMON_SLICE.F7BMUX_O = COUTMUX.F7
+          COMMON_SLICE.CO5 = COUTMUX.O5
+          COMMON_SLICE.CO6 = COUTMUX.O6
+          CARRY[1].CO_FABRIC = COUTMUX.CY
+          CARRY[1].O = COUTMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="BMUX"
-      input="BLK_BB-SLICE_FF.Q5[1] BEL_BB-CARRY[0].O BEL_BB-CARRY[0].CO_FABRIC BLK_IG-COMMON_SLICE.BO6 BLK_IG-COMMON_SLICE.BO5 BLK_IG-COMMON_SLICE.F8MUX_O"
-      output="BLK_IG-COMMON_SLICE.BMUX" >
+      input="SLICE_FF.Q5[1] CARRY[0].O CARRY[0].CO_FABRIC COMMON_SLICE.BO6 COMMON_SLICE.BO5 COMMON_SLICE.F8MUX_O"
+      output="COMMON_SLICE.BMUX" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_BB-SLICE_FF.Q5[1] = BOUTMUX.B5Q
-          BLK_IG-COMMON_SLICE.F8MUX_O = BOUTMUX.F8
-          BLK_IG-COMMON_SLICE.BO5 = BOUTMUX.O5
-          BLK_IG-COMMON_SLICE.BO6 = BOUTMUX.O6
-          BEL_BB-CARRY[0].CO_FABRIC = BOUTMUX.CY
-          BEL_BB-CARRY[0].O = BOUTMUX.XOR
+          SLICE_FF.Q5[1] = BOUTMUX.B5Q
+          COMMON_SLICE.F8MUX_O = BOUTMUX.F8
+          COMMON_SLICE.BO5 = BOUTMUX.O5
+          COMMON_SLICE.BO6 = BOUTMUX.O6
+          CARRY[0].CO_FABRIC = BOUTMUX.CY
+          CARRY[0].O = BOUTMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="AMUX"
-      input="BLK_BB-SLICE_FF.Q5[0] BEL_BB-CARRY0.O BEL_BB-CARRY0.CO_FABRIC BLK_IG-COMMON_SLICE.AO6 BLK_IG-COMMON_SLICE.AO5 BLK_IG-COMMON_SLICE.F7AMUX_O"
-      output="BLK_IG-COMMON_SLICE.AMUX" >
+      input="SLICE_FF.Q5[0] CARRY0.O CARRY0.CO_FABRIC COMMON_SLICE.AO6 COMMON_SLICE.AO5 COMMON_SLICE.F7AMUX_O"
+      output="COMMON_SLICE.AMUX" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_BB-SLICE_FF.Q5[0] = AOUTMUX.A5Q
-          BLK_IG-COMMON_SLICE.F7AMUX_O = AOUTMUX.F7
-          BLK_IG-COMMON_SLICE.AO5 = AOUTMUX.O5
-          BLK_IG-COMMON_SLICE.AO6 = AOUTMUX.O6
-          BEL_BB-CARRY0.CO_FABRIC = AOUTMUX.CY
-          BEL_BB-CARRY0.O = AOUTMUX.XOR
+          SLICE_FF.Q5[0] = AOUTMUX.A5Q
+          COMMON_SLICE.F7AMUX_O = AOUTMUX.F7
+          COMMON_SLICE.AO5 = AOUTMUX.O5
+          COMMON_SLICE.AO6 = AOUTMUX.O6
+          CARRY0.CO_FABRIC = AOUTMUX.CY
+          CARRY0.O = AOUTMUX.XOR
         </meta>
       </metadata>
     </mux>
 
     <!-- [A-D]FFMUX -->
     <mux name="DFFMUX"
-      input="BEL_BB-CARRY[2].O BEL_BB-CARRY[2].CO_FABRIC BLK_IG-COMMON_SLICE.DO6 BLK_IG-COMMON_SLICE.DO5 BLK_IG-COMMON_SLICE.DX"
-      output="BLK_BB-SLICE_FF.D[3]" >
+      input="CARRY[2].O CARRY[2].CO_FABRIC COMMON_SLICE.DO6 COMMON_SLICE.DO5 COMMON_SLICE.DX"
+      output="SLICE_FF.D[3]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.DX = DFFMUX.DX
-          BLK_IG-COMMON_SLICE.DO5 = DFFMUX.O5
-          BLK_IG-COMMON_SLICE.DO6 = DFFMUX.O6
-          BEL_BB-CARRY[2].CO_FABRIC = DFFMUX.CY
-          BEL_BB-CARRY[2].O = DFFMUX.XOR
+          COMMON_SLICE.DX = DFFMUX.DX
+          COMMON_SLICE.DO5 = DFFMUX.O5
+          COMMON_SLICE.DO6 = DFFMUX.O6
+          CARRY[2].CO_FABRIC = DFFMUX.CY
+          CARRY[2].O = DFFMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="CFFMUX"
-      input="BEL_BB-CARRY[1].O BEL_BB-CARRY[1].CO_FABRIC BLK_IG-COMMON_SLICE.CO6 BLK_IG-COMMON_SLICE.CO5 BLK_IG-COMMON_SLICE.CX BLK_IG-COMMON_SLICE.F7BMUX_O"
-      output="BLK_BB-SLICE_FF.D[2]" >
+      input="CARRY[1].O CARRY[1].CO_FABRIC COMMON_SLICE.CO6 COMMON_SLICE.CO5 COMMON_SLICE.CX COMMON_SLICE.F7BMUX_O"
+      output="SLICE_FF.D[2]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.CX = CFFMUX.CX
-          BLK_IG-COMMON_SLICE.F7BMUX_O = CFFMUX.F7
-          BLK_IG-COMMON_SLICE.CO5 = CFFMUX.O5
-          BLK_IG-COMMON_SLICE.CO6 = CFFMUX.O6
-          BEL_BB-CARRY[1].CO_FABRIC = CFFMUX.CY
-          BEL_BB-CARRY[1].O = CFFMUX.XOR
+          COMMON_SLICE.CX = CFFMUX.CX
+          COMMON_SLICE.F7BMUX_O = CFFMUX.F7
+          COMMON_SLICE.CO5 = CFFMUX.O5
+          COMMON_SLICE.CO6 = CFFMUX.O6
+          CARRY[1].CO_FABRIC = CFFMUX.CY
+          CARRY[1].O = CFFMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="BFFMUX"
-      input="BEL_BB-CARRY[0].O BEL_BB-CARRY[0].CO_FABRIC BLK_IG-COMMON_SLICE.BO6 BLK_IG-COMMON_SLICE.BO5 BLK_IG-COMMON_SLICE.BX BLK_IG-COMMON_SLICE.F8MUX_O"
-      output="BLK_BB-SLICE_FF.D[1]" >
+      input="CARRY[0].O CARRY[0].CO_FABRIC COMMON_SLICE.BO6 COMMON_SLICE.BO5 COMMON_SLICE.BX COMMON_SLICE.F8MUX_O"
+      output="SLICE_FF.D[1]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.BX = BFFMUX.BX
-          BLK_IG-COMMON_SLICE.F8MUX_O = BFFMUX.F8
-          BLK_IG-COMMON_SLICE.BO5 = BFFMUX.O5
-          BLK_IG-COMMON_SLICE.BO6 = BFFMUX.O6
-          BEL_BB-CARRY[0].CO_FABRIC = BFFMUX.CY
-          BEL_BB-CARRY[0].O = BFFMUX.XOR
+          COMMON_SLICE.BX = BFFMUX.BX
+          COMMON_SLICE.F8MUX_O = BFFMUX.F8
+          COMMON_SLICE.BO5 = BFFMUX.O5
+          COMMON_SLICE.BO6 = BFFMUX.O6
+          CARRY[0].CO_FABRIC = BFFMUX.CY
+          CARRY[0].O = BFFMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="AFFMUX"
-      input="BEL_BB-CARRY0.O BEL_BB-CARRY0.CO_FABRIC BLK_IG-COMMON_SLICE.AO6 BLK_IG-COMMON_SLICE.AO5 BLK_IG-COMMON_SLICE.AX BLK_IG-COMMON_SLICE.F7AMUX_O"
-      output="BLK_BB-SLICE_FF.D[0]" >
+      input="CARRY0.O CARRY0.CO_FABRIC COMMON_SLICE.AO6 COMMON_SLICE.AO5 COMMON_SLICE.AX COMMON_SLICE.F7AMUX_O"
+      output="SLICE_FF.D[0]" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.AX = AFFMUX.AX
-          BLK_IG-COMMON_SLICE.F7AMUX_O = AFFMUX.F7
-          BLK_IG-COMMON_SLICE.AO5 = AFFMUX.O5
-          BLK_IG-COMMON_SLICE.AO6 = AFFMUX.O6
-          BEL_BB-CARRY0.CO_FABRIC = AFFMUX.CY
-          BEL_BB-CARRY0.O = AFFMUX.XOR
+          COMMON_SLICE.AX = AFFMUX.AX
+          COMMON_SLICE.F7AMUX_O = AFFMUX.F7
+          COMMON_SLICE.AO5 = AFFMUX.O5
+          COMMON_SLICE.AO6 = AFFMUX.O6
+          CARRY0.CO_FABRIC = AFFMUX.CY
+          CARRY0.O = AFFMUX.XOR
         </meta>
       </metadata>
     </mux>
 
     <!-- [A-F]Q outputs -->
-    <direct name="AFF" input="BLK_BB-SLICE_FF.Q[0]" output="BLK_IG-COMMON_SLICE.AQ" />
-    <direct name="BFF" input="BLK_BB-SLICE_FF.Q[1]" output="BLK_IG-COMMON_SLICE.BQ" />
-    <direct name="CFF" input="BLK_BB-SLICE_FF.Q[2]" output="BLK_IG-COMMON_SLICE.CQ" />
-    <direct name="DFF" input="BLK_BB-SLICE_FF.Q[3]" output="BLK_IG-COMMON_SLICE.DQ" />
+    <direct name="AFF" input="SLICE_FF.Q[0]" output="COMMON_SLICE.AQ" />
+    <direct name="BFF" input="SLICE_FF.Q[1]" output="COMMON_SLICE.BQ" />
+    <direct name="CFF" input="SLICE_FF.Q[2]" output="COMMON_SLICE.CQ" />
+    <direct name="DFF" input="SLICE_FF.Q[3]" output="COMMON_SLICE.DQ" />
 
     <!-- LUT O6 output -->
-    <direct name="BLK_IG-COMMON_SLICE_DOUT" input="BLK_IG-COMMON_SLICE.DO6" output="BLK_IG-COMMON_SLICE.D" />
-    <direct name="BLK_IG-COMMON_SLICE_COUT" input="BLK_IG-COMMON_SLICE.CO6" output="BLK_IG-COMMON_SLICE.C" />
-    <direct name="BLK_IG-COMMON_SLICE_BOUT" input="BLK_IG-COMMON_SLICE.BO6" output="BLK_IG-COMMON_SLICE.B" />
-    <direct name="BLK_IG-COMMON_SLICE_AOUT" input="BLK_IG-COMMON_SLICE.AO6" output="BLK_IG-COMMON_SLICE.A" />
+    <direct name="COMMON_SLICE_DOUT" input="COMMON_SLICE.DO6" output="COMMON_SLICE.D" />
+    <direct name="COMMON_SLICE_COUT" input="COMMON_SLICE.CO6" output="COMMON_SLICE.C" />
+    <direct name="COMMON_SLICE_BOUT" input="COMMON_SLICE.BO6" output="COMMON_SLICE.B" />
+    <direct name="COMMON_SLICE_AOUT" input="COMMON_SLICE.AO6" output="COMMON_SLICE.A" />
 
     <!-- Carry -->
 
     <!-- Carry initialization -->
     <direct name="PRECYINIT_MUX"
-      input="BLK_IG-COMMON_SLICE.AX"
-      output="BEL_BB-CARRY0.CI_INIT">
+      input="COMMON_SLICE.AX"
+      output="CARRY0.CI_INIT">
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.AX = PRECYINIT.AX
+          COMMON_SLICE.AX = PRECYINIT.AX
         </meta>
       </metadata>
     </direct>>
 
-    <direct name="CIN_TO_CARRY0" input="BLK_IG-COMMON_SLICE.CIN" output="BEL_BB-CARRY0.CI" >
-      <pack_pattern name="CARRYCHAIN" in_port="BLK_IG-COMMON_SLICE.CIN" out_port="BEL_BB-CARRY0.CI"/>
+    <direct name="CIN_TO_CARRY0" input="COMMON_SLICE.CIN" output="CARRY0.CI" >
+      <pack_pattern name="CARRYCHAIN" in_port="COMMON_SLICE.CIN" out_port="CARRY0.CI"/>
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.CIN = PRECYINIT.CIN
+          COMMON_SLICE.CIN = PRECYINIT.CIN
         </meta>
       </metadata>
     </direct>
 
     <!-- Tile internal carry -->
-    <direct name="CARRY0_TO_CARRY1"    input="BEL_BB-CARRY0.CO_CHAIN"   output="BEL_BB-CARRY[0].CI"      >
-      <pack_pattern name="CARRYCHAIN" in_port="BEL_BB-CARRY0.CO_CHAIN" out_port="BEL_BB-CARRY[0].CI"/>
+    <direct name="CARRY0_TO_CARRY1"    input="CARRY0.CO_CHAIN"   output="CARRY[0].CI"      >
+      <pack_pattern name="CARRYCHAIN" in_port="CARRY0.CO_CHAIN" out_port="CARRY[0].CI"/>
     </direct>
-    <direct name="CARRY1_TO_CARRY2"    input="BEL_BB-CARRY[0].CO_CHAIN"   output="BEL_BB-CARRY[1].CI"      >
-      <pack_pattern name="CARRYCHAIN" in_port="BEL_BB-CARRY[0].CO_CHAIN" out_port="BEL_BB-CARRY[1].CI"/>
+    <direct name="CARRY1_TO_CARRY2"    input="CARRY[0].CO_CHAIN"   output="CARRY[1].CI"      >
+      <pack_pattern name="CARRYCHAIN" in_port="CARRY[0].CO_CHAIN" out_port="CARRY[1].CI"/>
     </direct>
-    <direct name="CARRY2_TO_CARRY3"    input="BEL_BB-CARRY[1].CO_CHAIN"   output="BEL_BB-CARRY[2].CI"      >
-      <pack_pattern name="CARRYCHAIN" in_port="BEL_BB-CARRY[1].CO_CHAIN" out_port="BEL_BB-CARRY[2].CI"/>
+    <direct name="CARRY2_TO_CARRY3"    input="CARRY[1].CO_CHAIN"   output="CARRY[2].CI"      >
+      <pack_pattern name="CARRYCHAIN" in_port="CARRY[1].CO_CHAIN" out_port="CARRY[2].CI"/>
    </direct>
 
     <!-- Carry selects -->
-    <direct name="CARRY_S3" input="BLK_IG-COMMON_SLICE.DO6" output="BEL_BB-CARRY[2].S" />
-    <direct name="CARRY_S2" input="BLK_IG-COMMON_SLICE.CO6" output="BEL_BB-CARRY[1].S" />
-    <direct name="CARRY_S1" input="BLK_IG-COMMON_SLICE.BO6" output="BEL_BB-CARRY[0].S" />
-    <direct name="CARRY_S0" input="BLK_IG-COMMON_SLICE.AO6" output="BEL_BB-CARRY0.S" />
+    <direct name="CARRY_S3" input="COMMON_SLICE.DO6" output="CARRY[2].S" />
+    <direct name="CARRY_S2" input="COMMON_SLICE.CO6" output="CARRY[1].S" />
+    <direct name="CARRY_S1" input="COMMON_SLICE.BO6" output="CARRY[0].S" />
+    <direct name="CARRY_S0" input="COMMON_SLICE.AO6" output="CARRY0.S" />
 
     <!-- Carry MUXCY.DI -->
-    <mux name="CARRY_DI3" input="BLK_IG-COMMON_SLICE.DO5 BLK_IG-COMMON_SLICE.DX" output="BEL_BB-CARRY[2].DI" >
+    <mux name="CARRY_DI3" input="COMMON_SLICE.DO5 COMMON_SLICE.DX" output="CARRY[2].DI" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.DO5 = CARRY4.DCY0
-          BLK_IG-COMMON_SLICE.DX = NULL
+          COMMON_SLICE.DO5 = CARRY4.DCY0
+          COMMON_SLICE.DX = NULL
         </meta>
       </metadata>
     </mux>
-    <mux name="CARRY_DI2" input="BLK_IG-COMMON_SLICE.CO5 BLK_IG-COMMON_SLICE.CX" output="BEL_BB-CARRY[1].DI" >
+    <mux name="CARRY_DI2" input="COMMON_SLICE.CO5 COMMON_SLICE.CX" output="CARRY[1].DI" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.CO5 = CARRY4.CCY0
-          BLK_IG-COMMON_SLICE.CX = NULL
+          COMMON_SLICE.CO5 = CARRY4.CCY0
+          COMMON_SLICE.CX = NULL
         </meta>
       </metadata>
     </mux>
-    <mux name="CARRY_DI1" input="BLK_IG-COMMON_SLICE.BO5 BLK_IG-COMMON_SLICE.BX" output="BEL_BB-CARRY[0].DI" >
+    <mux name="CARRY_DI1" input="COMMON_SLICE.BO5 COMMON_SLICE.BX" output="CARRY[0].DI" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.BO5 = CARRY4.BCY0
-          BLK_IG-COMMON_SLICE.BX = NULL
+          COMMON_SLICE.BO5 = CARRY4.BCY0
+          COMMON_SLICE.BX = NULL
         </meta>
       </metadata>
     </mux>
-    <mux name="CARRY_DI0" input="BLK_IG-COMMON_SLICE.AO5 BLK_IG-COMMON_SLICE.AX" output="BEL_BB-CARRY0.DI" >
+    <mux name="CARRY_DI0" input="COMMON_SLICE.AO5 COMMON_SLICE.AX" output="CARRY0.DI" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.AO5 = CARRY4.ACY0
-          BLK_IG-COMMON_SLICE.AX = NULL
+          COMMON_SLICE.AO5 = CARRY4.ACY0
+          COMMON_SLICE.AX = NULL
         </meta>
       </metadata>
     </mux>
 
-    <direct name="COUT" input="BEL_BB-CARRY[2].CO_CHAIN" output="BLK_IG-COMMON_SLICE.COUT" >
-      <pack_pattern name="CARRYCHAIN" in_port="BEL_BB-CARRY[2].CO_CHAIN" out_port="BLK_IG-COMMON_SLICE.COUT"/>
+    <direct name="COUT" input="CARRY[2].CO_CHAIN" output="COMMON_SLICE.COUT" >
+      <pack_pattern name="CARRYCHAIN" in_port="CARRY[2].CO_CHAIN" out_port="COMMON_SLICE.COUT"/>
     </direct>
 
     <!-- Clock, Clock Enable and Reset -->
-    <direct name="CK" input="BLK_IG-COMMON_SLICE.CLK" output="BLK_BB-SLICE_FF.CK"/>
+    <direct name="CK" input="COMMON_SLICE.CLK" output="SLICE_FF.CK"/>
 
-    <direct name="CE" input="BLK_IG-COMMON_SLICE.CE" output="CEUSEDMUX.CE" >
+    <direct name="CE" input="COMMON_SLICE.CE" output="CEUSEDMUX.CE" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.CE = CEUSEDMUX
+          COMMON_SLICE.CE = CEUSEDMUX
         </meta>
       </metadata>
     </direct>
     <direct name="CE_OUT"
       input="CEUSEDMUX.CE_OUT"
-      output="BLK_BB-SLICE_FF.CE"
+      output="SLICE_FF.CE"
       />
 
-    <direct name="SR" input="BLK_IG-COMMON_SLICE.SR"  output="SRUSEDMUX.SR" >
+    <direct name="SR" input="COMMON_SLICE.SR"  output="SRUSEDMUX.SR" >
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-COMMON_SLICE.SR = SRUSEDMUX
+          COMMON_SLICE.SR = SRUSEDMUX
         </meta>
       </metadata>
     </direct>
     <direct name="SR_OUT"
       input="SRUSEDMUX.SR_OUT"
-      output="BLK_BB-SLICE_FF.SR"
+      output="SLICE_FF.SR"
       />
 
   </interconnect>
+  <metadata>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
+  </metadata>
 </pb_type>

--- a/xc7/primitives/ff/ff.pb_type.xml
+++ b/xc7/primitives/ff/ff.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- Model of FF group in SLICEL and SLICEM -->
-<pb_type name="BLK_BB-SLICE_FF" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="SLICE_FF" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- CK, CE and SR are slice wide. -->
   <input name="CE" num_pins="8"/>
   <input name="SR" num_pins="8"/>
@@ -18,15 +18,19 @@
   <!-- |LDPE  |      |  X  |     | -->
   <!-- |LDCE  |      |  X  |  X  | -->
   <mode name="NO_FF">
-    <pb_type name="BEL_FF-NO_FF" num_pb="4" blif_model=".subckt NO_FF">
+    <pb_type name="NO_FF" num_pb="4" blif_model=".subckt NO_FF">
       <input  name="D" num_pins="1"/>
+      <metadata>
+        <meta name="type">bel</meta>
+        <meta name="subtype">flipflop</meta>
+      </metadata>
     </pb_type>
     <interconnect>
-      <direct name="D" input="BLK_BB-SLICE_FF.D" output="BEL_FF-NO_FF.D"/>
+      <direct name="D" input="SLICE_FF.D" output="NO_FF.D"/>
     </interconnect>
   </mode>
   <mode name="FDSE_or_FDRE">
-    <pb_type name="BEL_FF-FDSE_or_FDRE" num_pb="8">
+    <pb_type name="FDSE_or_FDRE" num_pb="8">
       <input  name="D" num_pins="1"/>
       <input  name="CE" num_pins="1"/>
       <clock  name="C" num_pins="1"/>
@@ -34,94 +38,100 @@
       <output name="Q" num_pins="1"/>
 
       <mode name="FDSE">
-        <pb_type name="BEL_FF-FDSE" num_pb="1" blif_model=".subckt FDSE_ZINI">
+        <pb_type name="FDSE" num_pb="1" blif_model=".subckt FDSE_ZINI">
           <input  name="D" num_pins="1"/>
           <input  name="CE" num_pins="1"/>
           <clock  name="C" num_pins="1"/>
           <input  name="S" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="BEL_FF-FDSE.D" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDSE.CE" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDSE.S" clock="C" />
-          <T_clock_to_Q max="10e-12" port="BEL_FF-FDSE.Q" clock="C" />
+          <T_setup    value="10e-12" port="FDSE.D" clock="C" />
+          <T_setup    value="10e-12" port="FDSE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDSE.S" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDSE.Q" clock="C" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
+	    <meta name="type">bel</meta>
+	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="BEL_FF-FDSE_or_FDRE.D" output="BEL_FF-FDSE.D" />
-          <direct name="CE" input="BEL_FF-FDSE_or_FDRE.CE" output="BEL_FF-FDSE.CE" >
-            <pack_pattern name="CE_FF_FDSE" in_port="BEL_FF-FDSE_or_FDRE.CE" out_port="BEL_FF-FDSE.CE"/>
-            <pack_pattern name="CESR_FF_FDSE" in_port="BEL_FF-FDSE_or_FDRE.CE" out_port="BEL_FF-FDSE.CE"/>
+          <direct name="D" input="FDSE_or_FDRE.D" output="FDSE.D" />
+          <direct name="CE" input="FDSE_or_FDRE.CE" output="FDSE.CE" >
+            <pack_pattern name="CE_FF_FDSE" in_port="FDSE_or_FDRE.CE" out_port="FDSE.CE"/>
+            <pack_pattern name="CESR_FF_FDSE" in_port="FDSE_or_FDRE.CE" out_port="FDSE.CE"/>
           </direct>
-          <direct name="C" input="BEL_FF-FDSE_or_FDRE.C" output="BEL_FF-FDSE.C" />
-          <direct name="S" input="BEL_FF-FDSE_or_FDRE.SR" output="BEL_FF-FDSE.S" >
-            <pack_pattern name="SR_FF_FDSE" in_port="BEL_FF-FDSE_or_FDRE.SR" out_port="BEL_FF-FDSE.S"/>
-            <pack_pattern name="CESR_FF_FDSE" in_port="BEL_FF-FDSE_or_FDRE.SR" out_port="BEL_FF-FDSE.S"/>
+          <direct name="C" input="FDSE_or_FDRE.C" output="FDSE.C" />
+          <direct name="S" input="FDSE_or_FDRE.SR" output="FDSE.S" >
+            <pack_pattern name="SR_FF_FDSE" in_port="FDSE_or_FDRE.SR" out_port="FDSE.S"/>
+            <pack_pattern name="CESR_FF_FDSE" in_port="FDSE_or_FDRE.SR" out_port="FDSE.S"/>
           </direct>
-          <direct name="Q" input="BEL_FF-FDSE.Q" output="BEL_FF-FDSE_or_FDRE.Q" />
+          <direct name="Q" input="FDSE.Q" output="FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
       <mode name="FDRE">
-        <pb_type name="BEL_FF-FDRE" num_pb="1" blif_model=".subckt FDRE_ZINI">
+        <pb_type name="FDRE" num_pb="1" blif_model=".subckt FDRE_ZINI">
           <input  name="D" num_pins="1"/>
           <input  name="CE" num_pins="1"/>
           <clock  name="C" num_pins="1"/>
           <input  name="R" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="BEL_FF-FDRE.D" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDRE.CE" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDRE.R" clock="C" />
-          <T_clock_to_Q max="10e-12" port="BEL_FF-FDRE.Q" clock="C" />
+          <T_setup    value="10e-12" port="FDRE.D" clock="C" />
+          <T_setup    value="10e-12" port="FDRE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDRE.R" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDRE.Q" clock="C" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
             <meta name="fasm_features">ZRST</meta>
+	    <meta name="type">bel</meta>
+	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="BEL_FF-FDSE_or_FDRE.D" output="BEL_FF-FDRE.D" />
-          <direct name="CE" input="BEL_FF-FDSE_or_FDRE.CE" output="BEL_FF-FDRE.CE" >
-            <pack_pattern name="CE_FF_FDRE" in_port="BEL_FF-FDSE_or_FDRE.CE" out_port="BEL_FF-FDRE.CE"/>
-            <pack_pattern name="CESR_FF_FDRE" in_port="BEL_FF-FDSE_or_FDRE.CE" out_port="BEL_FF-FDRE.CE"/>
+          <direct name="D" input="FDSE_or_FDRE.D" output="FDRE.D" />
+          <direct name="CE" input="FDSE_or_FDRE.CE" output="FDRE.CE" >
+            <pack_pattern name="CE_FF_FDRE" in_port="FDSE_or_FDRE.CE" out_port="FDRE.CE"/>
+            <pack_pattern name="CESR_FF_FDRE" in_port="FDSE_or_FDRE.CE" out_port="FDRE.CE"/>
           </direct>
-          <direct name="C" input="BEL_FF-FDSE_or_FDRE.C" output="BEL_FF-FDRE.C" />
-          <direct name="R" input="BEL_FF-FDSE_or_FDRE.SR" output="BEL_FF-FDRE.R" >
-            <pack_pattern name="SR_FF_FDRE" in_port="BEL_FF-FDSE_or_FDRE.SR" out_port="BEL_FF-FDRE.R"/>
-            <pack_pattern name="CESR_FF_FDRE" in_port="BEL_FF-FDSE_or_FDRE.SR" out_port="BEL_FF-FDRE.R"/>
+          <direct name="C" input="FDSE_or_FDRE.C" output="FDRE.C" />
+          <direct name="R" input="FDSE_or_FDRE.SR" output="FDRE.R" >
+            <pack_pattern name="SR_FF_FDRE" in_port="FDSE_or_FDRE.SR" out_port="FDRE.R"/>
+            <pack_pattern name="CESR_FF_FDRE" in_port="FDSE_or_FDRE.SR" out_port="FDRE.R"/>
           </direct>
-          <direct name="Q" input="BEL_FF-FDRE.Q" output="BEL_FF-FDSE_or_FDRE.Q" />
+          <direct name="Q" input="FDRE.Q" output="FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
       <metadata>
         <meta name="fasm_prefix">AFF BFF CFF DFF A5FF B5FF C5FF D5FF</meta>
+        <meta name="type">block</meta>
+        <meta name="subtype">ignore</meta>
       </metadata>
     </pb_type>
 
     <interconnect>
-      <direct name="CE" input="BLK_BB-SLICE_FF.CE" output="BEL_FF-FDSE_or_FDRE.CE" />
-      <complete name="C" input="BLK_BB-SLICE_FF.CK" output="BEL_FF-FDSE_or_FDRE.C" />
-      <direct name="SR" input="BLK_BB-SLICE_FF.SR" output="BEL_FF-FDSE_or_FDRE.SR" />
+      <direct name="CE" input="SLICE_FF.CE" output="FDSE_or_FDRE.CE" />
+      <complete name="C" input="SLICE_FF.CK" output="FDSE_or_FDRE.C" />
+      <direct name="SR" input="SLICE_FF.SR" output="FDSE_or_FDRE.SR" />
 
-      <direct name="D" input="BLK_BB-SLICE_FF.D[3:0]" output="BEL_FF-FDSE_or_FDRE[3:0].D" />
-      <direct name="Q" input="BEL_FF-FDSE_or_FDRE[3:0].Q" output="BLK_BB-SLICE_FF.Q[3:0]" />
+      <direct name="D" input="SLICE_FF.D[3:0]" output="FDSE_or_FDRE[3:0].D" />
+      <direct name="Q" input="FDSE_or_FDRE[3:0].Q" output="SLICE_FF.Q[3:0]" />
 
-      <direct name="D5" input="BLK_BB-SLICE_FF.D5[3:0]" output="BEL_FF-FDSE_or_FDRE[7:4].D" />
-      <direct name="Q5" input="BEL_FF-FDSE_or_FDRE[7:4].Q" output="BLK_BB-SLICE_FF.Q5[3:0]" />
+      <direct name="D5" input="SLICE_FF.D5[3:0]" output="FDSE_or_FDRE[7:4].D" />
+      <direct name="Q5" input="FDSE_or_FDRE[7:4].Q" output="SLICE_FF.Q5[3:0]" />
     </interconnect>
     <metadata>
       <meta name="fasm_features">FFSYNC</meta>
     </metadata>
   </mode>
   <mode name="FDPE_or_FDCE">
-    <pb_type name="BEL_FF-FDPE_or_FDCE" num_pb="8">
+    <pb_type name="FDPE_or_FDCE" num_pb="8">
       <input  name="D" num_pins="1"/>
       <input  name="CE" num_pins="1"/>
       <clock  name="C" num_pins="1"/>
@@ -129,91 +139,97 @@
       <output name="Q" num_pins="1"/>
 
       <mode name="FDPE">
-        <pb_type name="BEL_FF-FDPE" num_pb="1" blif_model=".subckt FDPE_ZINI">
+        <pb_type name="FDPE" num_pb="1" blif_model=".subckt FDPE_ZINI">
           <input  name="D" num_pins="1"/>
           <input  name="CE" num_pins="1"/>
           <clock  name="C" num_pins="1"/>
           <input  name="PRE" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="BEL_FF-FDPE.D" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDPE.CE" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDPE.PRE" clock="C" />
-          <T_clock_to_Q max="10e-12" port="BEL_FF-FDPE.Q" clock="C" />
+          <T_setup    value="10e-12" port="FDPE.D" clock="C" />
+          <T_setup    value="10e-12" port="FDPE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDPE.PRE" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDPE.Q" clock="C" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
+	    <meta name="type">bel</meta>
+	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="BEL_FF-FDPE_or_FDCE.D" output="BEL_FF-FDPE.D" />
-          <direct name="CE" input="BEL_FF-FDPE_or_FDCE.CE" output="BEL_FF-FDPE.CE" >
-            <pack_pattern name="CE_FF_FDPE" in_port="BEL_FF-FDPE_or_FDCE.CE" out_port="BEL_FF-FDPE.CE"/>
-            <pack_pattern name="CESR_FF_FDPE" in_port="BEL_FF-FDPE_or_FDCE.CE" out_port="BEL_FF-FDPE.CE"/>
+          <direct name="D" input="FDPE_or_FDCE.D" output="FDPE.D" />
+          <direct name="CE" input="FDPE_or_FDCE.CE" output="FDPE.CE" >
+            <pack_pattern name="CE_FF_FDPE" in_port="FDPE_or_FDCE.CE" out_port="FDPE.CE"/>
+            <pack_pattern name="CESR_FF_FDPE" in_port="FDPE_or_FDCE.CE" out_port="FDPE.CE"/>
           </direct>
-          <direct name="C" input="BEL_FF-FDPE_or_FDCE.C" output="BEL_FF-FDPE.C" />
-          <direct name="PRE" input="BEL_FF-FDPE_or_FDCE.SR" output="BEL_FF-FDPE.PRE" >
-            <pack_pattern name="SR_FF_FDPE" in_port="BEL_FF-FDPE_or_FDCE.SR" out_port="BEL_FF-FDPE.PRE"/>
-            <pack_pattern name="CESR_FF_FDPE" in_port="BEL_FF-FDPE_or_FDCE.SR" out_port="BEL_FF-FDPE.PRE"/>
+          <direct name="C" input="FDPE_or_FDCE.C" output="FDPE.C" />
+          <direct name="PRE" input="FDPE_or_FDCE.SR" output="FDPE.PRE" >
+            <pack_pattern name="SR_FF_FDPE" in_port="FDPE_or_FDCE.SR" out_port="FDPE.PRE"/>
+            <pack_pattern name="CESR_FF_FDPE" in_port="FDPE_or_FDCE.SR" out_port="FDPE.PRE"/>
           </direct>
-          <direct name="Q" input="BEL_FF-FDPE.Q" output="BEL_FF-FDPE_or_FDCE.Q" />
+          <direct name="Q" input="FDPE.Q" output="FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
       <mode name="FDCE">
-        <pb_type name="BEL_FF-FDCE" num_pb="1" blif_model=".subckt FDCE_ZINI">
+        <pb_type name="FDCE" num_pb="1" blif_model=".subckt FDCE_ZINI">
           <input  name="D" num_pins="1"/>
           <input  name="CE" num_pins="1"/>
           <clock  name="C" num_pins="1"/>
           <input  name="CLR" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="BEL_FF-FDCE.D" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDCE.CE" clock="C" />
-          <T_setup    value="10e-12" port="BEL_FF-FDCE.CLR" clock="C" />
-          <T_clock_to_Q max="10e-12" port="BEL_FF-FDCE.Q" clock="C" />
+          <T_setup    value="10e-12" port="FDCE.D" clock="C" />
+          <T_setup    value="10e-12" port="FDCE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDCE.CLR" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDCE.Q" clock="C" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
             <meta name="fasm_features">ZRST</meta>
+	    <meta name="type">bel</meta>
+	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="BEL_FF-FDPE_or_FDCE.D" output="BEL_FF-FDCE.D" />
-          <direct name="CE" input="BEL_FF-FDPE_or_FDCE.CE" output="BEL_FF-FDCE.CE" >
-            <pack_pattern name="CE_FF_FDCE" in_port="BEL_FF-FDPE_or_FDCE.CE" out_port="BEL_FF-FDCE.CE"/>
-            <pack_pattern name="CESR_FF_FDCE" in_port="BEL_FF-FDPE_or_FDCE.CE" out_port="BEL_FF-FDCE.CE"/>
+          <direct name="D" input="FDPE_or_FDCE.D" output="FDCE.D" />
+          <direct name="CE" input="FDPE_or_FDCE.CE" output="FDCE.CE" >
+            <pack_pattern name="CE_FF_FDCE" in_port="FDPE_or_FDCE.CE" out_port="FDCE.CE"/>
+            <pack_pattern name="CESR_FF_FDCE" in_port="FDPE_or_FDCE.CE" out_port="FDCE.CE"/>
           </direct>
-          <direct name="C" input="BEL_FF-FDPE_or_FDCE.C" output="BEL_FF-FDCE.C" />
-          <direct name="CLR" input="BEL_FF-FDPE_or_FDCE.SR" output="BEL_FF-FDCE.CLR" >
-            <pack_pattern name="SR_FF_FDCE" in_port="BEL_FF-FDPE_or_FDCE.SR" out_port="BEL_FF-FDCE.CLR"/>
-            <pack_pattern name="CESR_FF_FDCE" in_port="BEL_FF-FDPE_or_FDCE.SR" out_port="BEL_FF-FDCE.CLR"/>
+          <direct name="C" input="FDPE_or_FDCE.C" output="FDCE.C" />
+          <direct name="CLR" input="FDPE_or_FDCE.SR" output="FDCE.CLR" >
+            <pack_pattern name="SR_FF_FDCE" in_port="FDPE_or_FDCE.SR" out_port="FDCE.CLR"/>
+            <pack_pattern name="CESR_FF_FDCE" in_port="FDPE_or_FDCE.SR" out_port="FDCE.CLR"/>
           </direct>
-          <direct name="Q" input="BEL_FF-FDCE.Q" output="BEL_FF-FDPE_or_FDCE.Q" />
+          <direct name="Q" input="FDCE.Q" output="FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
       <metadata>
         <meta name="fasm_prefix">AFF BFF CFF DFF A5FF B5FF C5FF D5FF</meta>
+        <meta name="type">block</meta>
+        <meta name="subtype">ignore</meta>
       </metadata>
     </pb_type>
 
     <interconnect>
-      <direct name="CE" input="BLK_BB-SLICE_FF.CE" output="BEL_FF-FDPE_or_FDCE.CE" />
-      <complete name="C" input="BLK_BB-SLICE_FF.CK" output="BEL_FF-FDPE_or_FDCE.C" />
-      <direct name="SR" input="BLK_BB-SLICE_FF.SR" output="BEL_FF-FDPE_or_FDCE.SR" />
+      <direct name="CE" input="SLICE_FF.CE" output="FDPE_or_FDCE.CE" />
+      <complete name="C" input="SLICE_FF.CK" output="FDPE_or_FDCE.C" />
+      <direct name="SR" input="SLICE_FF.SR" output="FDPE_or_FDCE.SR" />
 
-      <direct name="D" input="BLK_BB-SLICE_FF.D[3:0]" output="BEL_FF-FDPE_or_FDCE[3:0].D" />
-      <direct name="Q" input="BEL_FF-FDPE_or_FDCE[3:0].Q" output="BLK_BB-SLICE_FF.Q[3:0]" />
+      <direct name="D" input="SLICE_FF.D[3:0]" output="FDPE_or_FDCE[3:0].D" />
+      <direct name="Q" input="FDPE_or_FDCE[3:0].Q" output="SLICE_FF.Q[3:0]" />
 
-      <direct name="D5" input="BLK_BB-SLICE_FF.D5[3:0]" output="BEL_FF-FDPE_or_FDCE[7:4].D" />
-      <direct name="Q5" input="BEL_FF-FDPE_or_FDCE[7:4].Q" output="BLK_BB-SLICE_FF.Q5[3:0]" />
+      <direct name="D5" input="SLICE_FF.D5[3:0]" output="FDPE_or_FDCE[7:4].D" />
+      <direct name="Q5" input="FDPE_or_FDCE[7:4].Q" output="SLICE_FF.Q5[3:0]" />
     </interconnect>
   </mode>
   <mode name="LDPE_or_LDCE">
-    <pb_type name="BEL_FF-LDPE_or_LDCE" num_pb="4">
+    <pb_type name="LDPE_or_LDCE" num_pb="4">
       <input  name="D" num_pins="1"/>
       <input  name="CE" num_pins="1"/>
       <clock  name="C" num_pins="1"/>
@@ -221,75 +237,85 @@
       <output name="Q" num_pins="1"/>
 
       <mode name="LDPE">
-        <pb_type name="BEL_FF-LDPE" num_pb="1" blif_model=".subckt LDPE_ZINI">
+        <pb_type name="LDPE" num_pb="1" blif_model=".subckt LDPE_ZINI">
           <input  name="D" num_pins="1"/>
           <input  name="GE" num_pins="1"/>
           <clock  name="G" num_pins="1"/>
           <input  name="PRE" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="BEL_FF-LDPE.D" clock="G" />
-          <T_setup    value="10e-12" port="BEL_FF-LDPE.GE" clock="G" />
-          <T_setup    value="10e-12" port="BEL_FF-LDPE.PRE" clock="G" />
-          <T_clock_to_Q max="10e-12" port="BEL_FF-LDPE.Q" clock="G" />
+          <T_setup    value="10e-12" port="LDPE.D" clock="G" />
+          <T_setup    value="10e-12" port="LDPE.GE" clock="G" />
+          <T_setup    value="10e-12" port="LDPE.PRE" clock="G" />
+          <T_clock_to_Q max="10e-12" port="LDPE.Q" clock="G" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
+	    <meta name="type">bel</meta>
+	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="BEL_FF-LDPE_or_LDCE.D" output="BEL_FF-LDPE.D" />
-          <direct name="CE" input="BEL_FF-LDPE_or_LDCE.CE" output="BEL_FF-LDPE.GE" />
-          <direct name="C" input="BEL_FF-LDPE_or_LDCE.C" output="BEL_FF-LDPE.G" />
-          <direct name="SR" input="BEL_FF-LDPE_or_LDCE.SR" output="BEL_FF-LDPE.PRE" />
-          <direct name="Q" input="BEL_FF-LDPE.Q" output="BEL_FF-LDPE_or_LDCE.Q" />
+          <direct name="D" input="LDPE_or_LDCE.D" output="LDPE.D" />
+          <direct name="CE" input="LDPE_or_LDCE.CE" output="LDPE.GE" />
+          <direct name="C" input="LDPE_or_LDCE.C" output="LDPE.G" />
+          <direct name="SR" input="LDPE_or_LDCE.SR" output="LDPE.PRE" />
+          <direct name="Q" input="LDPE.Q" output="LDPE_or_LDCE.Q" />
         </interconnect>
       </mode>
       <mode name="LDCE">
-        <pb_type name="BEL_FF-LDCE" num_pb="1" blif_model=".subckt LDCE_ZINI">
+        <pb_type name="LDCE" num_pb="1" blif_model=".subckt LDCE_ZINI">
           <input  name="D" num_pins="1"/>
           <input  name="GE" num_pins="1"/>
           <clock  name="G" num_pins="1"/>
           <input  name="CLR" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="BEL_FF-LDCE.D" clock="G" />
-          <T_setup    value="10e-12" port="BEL_FF-LDCE.GE" clock="G" />
-          <T_setup    value="10e-12" port="BEL_FF-LDCE.CLR" clock="G" />
-          <T_clock_to_Q max="10e-12" port="BEL_FF-LDCE.Q" clock="G" />
+          <T_setup    value="10e-12" port="LDCE.D" clock="G" />
+          <T_setup    value="10e-12" port="LDCE.GE" clock="G" />
+          <T_setup    value="10e-12" port="LDCE.CLR" clock="G" />
+          <T_clock_to_Q max="10e-12" port="LDCE.Q" clock="G" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
             <meta name="fasm_features">ZRST</meta>
+	    <meta name="type">bel</meta>
+	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="BEL_FF-LDPE_or_LDCE.D" output="BEL_FF-LDCE.D" />
-          <direct name="CE" input="BEL_FF-LDPE_or_LDCE.CE" output="BEL_FF-LDCE.GE" />
-          <direct name="C" input="BEL_FF-LDPE_or_LDCE.C" output="BEL_FF-LDCE.G" />
-          <direct name="SR" input="BEL_FF-LDPE_or_LDCE.SR" output="BEL_FF-LDCE.CLR" />
-          <direct name="Q" input="BEL_FF-LDCE.Q" output="BEL_FF-LDPE_or_LDCE.Q" />
+          <direct name="D" input="LDPE_or_LDCE.D" output="LDCE.D" />
+          <direct name="CE" input="LDPE_or_LDCE.CE" output="LDCE.GE" />
+          <direct name="C" input="LDPE_or_LDCE.C" output="LDCE.G" />
+          <direct name="SR" input="LDPE_or_LDCE.SR" output="LDCE.CLR" />
+          <direct name="Q" input="LDCE.Q" output="LDPE_or_LDCE.Q" />
         </interconnect>
       </mode>
       <metadata>
         <meta name="fasm_prefix">AFF BFF CFF DFF</meta>
+        <meta name="type">block</meta>
+        <meta name="subtype">ignore</meta>
       </metadata>
     </pb_type>
 
     <interconnect>
-      <direct name="CE_TO_LD" input="BLK_BB-SLICE_FF.CE[0:3]" output="BEL_FF-LDPE_or_LDCE.CE" />
-      <complete name="C_TO_LD"  input="BLK_BB-SLICE_FF.CK" output="BEL_FF-LDPE_or_LDCE.C" />
-      <direct name="SR_TO_LD" input="BLK_BB-SLICE_FF.SR[0:3]" output="BEL_FF-LDPE_or_LDCE.SR" />
+      <direct name="CE_TO_LD" input="SLICE_FF.CE[0:3]" output="LDPE_or_LDCE.CE" />
+      <complete name="C_TO_LD"  input="SLICE_FF.CK" output="LDPE_or_LDCE.C" />
+      <direct name="SR_TO_LD" input="SLICE_FF.SR[0:3]" output="LDPE_or_LDCE.SR" />
 
-      <direct name="D" input="BLK_BB-SLICE_FF.D" output="BEL_FF-LDPE_or_LDCE.D" />
-      <direct name="Q" input="BEL_FF-LDPE_or_LDCE.Q" output="BLK_BB-SLICE_FF.Q" />
+      <direct name="D" input="SLICE_FF.D" output="LDPE_or_LDCE.D" />
+      <direct name="Q" input="LDPE_or_LDCE.Q" output="SLICE_FF.Q" />
     </interconnect>
     <metadata>
       <meta name="fasm_features">LATCH</meta>
     </metadata>
   </mode>
+  <metadata>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
+  </metadata>
 </pb_type>

--- a/xc7/primitives/io/io.pb_type.xml
+++ b/xc7/primitives/io/io.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_BB-IOB" num_pb="2">
+<pb_type name="IOB" num_pb="2">
  <input name="outpad" num_pins="1"/>
  <output name="inpad" num_pins="1"/>
 
@@ -7,6 +7,10 @@
  <mode name="inpad">
    <pb_type name="inpad" blif_model=".input" num_pb="1">
     <output name="inpad" num_pins="1"/>
+    <metadata>
+     <meta name="type">bel</meta>
+     <meta name="subtype">input</meta>
+    </metadata>
    </pb_type>
    <interconnect>
     <direct name="inpad" input="inpad.inpad" output="IOB.inpad">
@@ -19,6 +23,10 @@
  <mode name="outpad">
   <pb_type name="outpad" blif_model=".output" num_pb="1">
    <input name="outpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">output</meta>
+   </metadata>
   </pb_type>
   <interconnect>
    <direct name="outpad" input="IOB.outpad" output="outpad.outpad">
@@ -26,4 +34,8 @@
    </direct>
   </interconnect>
  </mode>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/xc7/primitives/iob33/iob33.pb_type.xml
+++ b/xc7/primitives/iob33/iob33.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- set: ai sw=1 ts=1 sta et -->
-<pb_type name="BLK_BB-IOB33" num_pb="1">
+<pb_type name="IOB33" num_pb="1">
  <input name="O" num_pins="1"/>
  <input name="PU_INT_EN" num_pins="1"/>
  <input name="T" num_pins="1"/>
@@ -21,23 +21,35 @@
 
  <!-- IO operating as an input -->
  <mode name="inpad">
-   <pb_type name="inpad" blif_model=".input" num_pb="1">
-    <output name="inpad" num_pins="1"/>
-   </pb_type>
-   <interconnect>
-     <direct name="inpad_to_PADOUT" input="inpad.inpad" output="BLK_BB-IOB33.PADOUT"/>
-     <direct name="inpad_to_I" input="inpad.inpad" output="BLK_BB-IOB33.I"/>
-   </interconnect>
+  <pb_type name="inpad" blif_model=".input" num_pb="1">
+   <output name="inpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">input</meta>
+   </metadata>
+  </pb_type>
+  <interconnect>
+    <direct name="inpad_to_PADOUT" input="inpad.inpad" output="IOB33.PADOUT"/>
+    <direct name="inpad_to_I" input="inpad.inpad" output="IOB33.I"/>
+  </interconnect>
  </mode>
 
  <!-- IO operating as an output -->
  <mode name="outpad">
   <pb_type name="outpad" blif_model=".output" num_pb="1">
    <input name="outpad" num_pins="1"/>
+   <metadata>
+    <meta name="type">bel</meta>
+    <meta name="subtype">output</meta>
+   </metadata>
   </pb_type>
   <interconnect>
-    <direct name="O_to_output" input="BLK_BB-IOB33.O" output="outpad.outpad"/>
-    <direct name="output_feedback" input="BLK_BB-IOB33.O" output="BLK_BB-IOB33.O_OUT"/>
+    <direct name="O_to_output" input="IOB33.O" output="outpad.outpad"/>
+    <direct name="output_feedback" input="IOB33.O" output="IOB33.O_OUT"/>
   </interconnect>
  </mode>
+ <metadata>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
+ </metadata>
 </pb_type>

--- a/xc7/primitives/slicel/ntemplate.slicelN.pb_type.xml
+++ b/xc7/primitives/slicel/ntemplate.slicelN.pb_type.xml
@@ -2,7 +2,7 @@
     7 Series FPGAs CLB User Guide UG474 (v1.8) September 27, 2016
     Figure 2-4: Diagram of SLICEL
   -->
-<pb_type name="BLK_IG-SLICEL{N}" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="SLICEL{N}" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <input name="DX" num_pins="1"/>
   <input name="D1" num_pins="1"/>
@@ -70,88 +70,92 @@
 
   <interconnect>
     <!-- LUT input pins -->
-    <direct name="D1" input="BLK_IG-SLICEL{N}.D1" output="BLK_IG-COMMON_LUT_AND_F78MUX.D1" />
-    <direct name="D2" input="BLK_IG-SLICEL{N}.D2" output="BLK_IG-COMMON_LUT_AND_F78MUX.D2" />
-    <direct name="D3" input="BLK_IG-SLICEL{N}.D3" output="BLK_IG-COMMON_LUT_AND_F78MUX.D3" />
-    <direct name="D4" input="BLK_IG-SLICEL{N}.D4" output="BLK_IG-COMMON_LUT_AND_F78MUX.D4" />
-    <direct name="D5" input="BLK_IG-SLICEL{N}.D5" output="BLK_IG-COMMON_LUT_AND_F78MUX.D5" />
-    <direct name="D6" input="BLK_IG-SLICEL{N}.D6" output="BLK_IG-COMMON_LUT_AND_F78MUX.D6" />
+    <direct name="D1" input="SLICEL{N}.D1" output="COMMON_LUT_AND_F78MUX.D1" />
+    <direct name="D2" input="SLICEL{N}.D2" output="COMMON_LUT_AND_F78MUX.D2" />
+    <direct name="D3" input="SLICEL{N}.D3" output="COMMON_LUT_AND_F78MUX.D3" />
+    <direct name="D4" input="SLICEL{N}.D4" output="COMMON_LUT_AND_F78MUX.D4" />
+    <direct name="D5" input="SLICEL{N}.D5" output="COMMON_LUT_AND_F78MUX.D5" />
+    <direct name="D6" input="SLICEL{N}.D6" output="COMMON_LUT_AND_F78MUX.D6" />
 
-    <direct name="C1" input="BLK_IG-SLICEL{N}.C1" output="BLK_IG-COMMON_LUT_AND_F78MUX.C1" />
-    <direct name="C2" input="BLK_IG-SLICEL{N}.C2" output="BLK_IG-COMMON_LUT_AND_F78MUX.C2" />
-    <direct name="C3" input="BLK_IG-SLICEL{N}.C3" output="BLK_IG-COMMON_LUT_AND_F78MUX.C3" />
-    <direct name="C4" input="BLK_IG-SLICEL{N}.C4" output="BLK_IG-COMMON_LUT_AND_F78MUX.C4" />
-    <direct name="C5" input="BLK_IG-SLICEL{N}.C5" output="BLK_IG-COMMON_LUT_AND_F78MUX.C5" />
-    <direct name="C6" input="BLK_IG-SLICEL{N}.C6" output="BLK_IG-COMMON_LUT_AND_F78MUX.C6" />
+    <direct name="C1" input="SLICEL{N}.C1" output="COMMON_LUT_AND_F78MUX.C1" />
+    <direct name="C2" input="SLICEL{N}.C2" output="COMMON_LUT_AND_F78MUX.C2" />
+    <direct name="C3" input="SLICEL{N}.C3" output="COMMON_LUT_AND_F78MUX.C3" />
+    <direct name="C4" input="SLICEL{N}.C4" output="COMMON_LUT_AND_F78MUX.C4" />
+    <direct name="C5" input="SLICEL{N}.C5" output="COMMON_LUT_AND_F78MUX.C5" />
+    <direct name="C6" input="SLICEL{N}.C6" output="COMMON_LUT_AND_F78MUX.C6" />
 
-    <direct name="B1" input="BLK_IG-SLICEL{N}.B1" output="BLK_IG-COMMON_LUT_AND_F78MUX.B1" />
-    <direct name="B2" input="BLK_IG-SLICEL{N}.B2" output="BLK_IG-COMMON_LUT_AND_F78MUX.B2" />
-    <direct name="B3" input="BLK_IG-SLICEL{N}.B3" output="BLK_IG-COMMON_LUT_AND_F78MUX.B3" />
-    <direct name="B4" input="BLK_IG-SLICEL{N}.B4" output="BLK_IG-COMMON_LUT_AND_F78MUX.B4" />
-    <direct name="B5" input="BLK_IG-SLICEL{N}.B5" output="BLK_IG-COMMON_LUT_AND_F78MUX.B5" />
-    <direct name="B6" input="BLK_IG-SLICEL{N}.B6" output="BLK_IG-COMMON_LUT_AND_F78MUX.B6" />
+    <direct name="B1" input="SLICEL{N}.B1" output="COMMON_LUT_AND_F78MUX.B1" />
+    <direct name="B2" input="SLICEL{N}.B2" output="COMMON_LUT_AND_F78MUX.B2" />
+    <direct name="B3" input="SLICEL{N}.B3" output="COMMON_LUT_AND_F78MUX.B3" />
+    <direct name="B4" input="SLICEL{N}.B4" output="COMMON_LUT_AND_F78MUX.B4" />
+    <direct name="B5" input="SLICEL{N}.B5" output="COMMON_LUT_AND_F78MUX.B5" />
+    <direct name="B6" input="SLICEL{N}.B6" output="COMMON_LUT_AND_F78MUX.B6" />
 
-    <direct name="A1" input="BLK_IG-SLICEL{N}.A1" output="BLK_IG-COMMON_LUT_AND_F78MUX.A1" />
-    <direct name="A2" input="BLK_IG-SLICEL{N}.A2" output="BLK_IG-COMMON_LUT_AND_F78MUX.A2" />
-    <direct name="A3" input="BLK_IG-SLICEL{N}.A3" output="BLK_IG-COMMON_LUT_AND_F78MUX.A3" />
-    <direct name="A4" input="BLK_IG-SLICEL{N}.A4" output="BLK_IG-COMMON_LUT_AND_F78MUX.A4" />
-    <direct name="A5" input="BLK_IG-SLICEL{N}.A5" output="BLK_IG-COMMON_LUT_AND_F78MUX.A5" />
-    <direct name="A6" input="BLK_IG-SLICEL{N}.A6" output="BLK_IG-COMMON_LUT_AND_F78MUX.A6" />
+    <direct name="A1" input="SLICEL{N}.A1" output="COMMON_LUT_AND_F78MUX.A1" />
+    <direct name="A2" input="SLICEL{N}.A2" output="COMMON_LUT_AND_F78MUX.A2" />
+    <direct name="A3" input="SLICEL{N}.A3" output="COMMON_LUT_AND_F78MUX.A3" />
+    <direct name="A4" input="SLICEL{N}.A4" output="COMMON_LUT_AND_F78MUX.A4" />
+    <direct name="A5" input="SLICEL{N}.A5" output="COMMON_LUT_AND_F78MUX.A5" />
+    <direct name="A6" input="SLICEL{N}.A6" output="COMMON_LUT_AND_F78MUX.A6" />
 
-    <direct name="CX"  input="BLK_IG-SLICEL{N}.CX" output="BLK_IG-COMMON_LUT_AND_F78MUX.CX" />
-    <direct name="BX"  input="BLK_IG-SLICEL{N}.BX" output="BLK_IG-COMMON_LUT_AND_F78MUX.BX" />
-    <direct name="AX"  input="BLK_IG-SLICEL{N}.AX" output="BLK_IG-COMMON_LUT_AND_F78MUX.AX" />
+    <direct name="CX"  input="SLICEL{N}.CX" output="COMMON_LUT_AND_F78MUX.CX" />
+    <direct name="BX"  input="SLICEL{N}.BX" output="COMMON_LUT_AND_F78MUX.BX" />
+    <direct name="AX"  input="SLICEL{N}.AX" output="COMMON_LUT_AND_F78MUX.AX" />
 
     <!-- COMMON_SLICE inputs -->
-    <direct name="DX2" input="BLK_IG-SLICEL{N}.DX" output="BLK_IG-COMMON_SLICE.DX" />
-    <direct name="DO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.DO6"   output="BLK_IG-COMMON_SLICE.DO6" />
-    <direct name="DO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.DO5"   output="BLK_IG-COMMON_SLICE.DO5" />
+    <direct name="DX2" input="SLICEL{N}.DX" output="COMMON_SLICE.DX" />
+    <direct name="DO6" input="COMMON_LUT_AND_F78MUX.DO6"   output="COMMON_SLICE.DO6" />
+    <direct name="DO5" input="COMMON_LUT_AND_F78MUX.DO5"   output="COMMON_SLICE.DO5" />
 
-    <direct name="CX2" input="BLK_IG-SLICEL{N}.CX" output="BLK_IG-COMMON_SLICE.CX" />
-    <direct name="CO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.CO6"   output="BLK_IG-COMMON_SLICE.CO6" />
-    <direct name="CO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.CO5"   output="BLK_IG-COMMON_SLICE.CO5" />
+    <direct name="CX2" input="SLICEL{N}.CX" output="COMMON_SLICE.CX" />
+    <direct name="CO6" input="COMMON_LUT_AND_F78MUX.CO6"   output="COMMON_SLICE.CO6" />
+    <direct name="CO5" input="COMMON_LUT_AND_F78MUX.CO5"   output="COMMON_SLICE.CO5" />
 
-    <direct name="BX2" input="BLK_IG-SLICEL{N}.BX" output="BLK_IG-COMMON_SLICE.BX" />
-    <direct name="BO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.BO6"   output="BLK_IG-COMMON_SLICE.BO6" />
-    <direct name="BO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.BO5"   output="BLK_IG-COMMON_SLICE.BO5" />
+    <direct name="BX2" input="SLICEL{N}.BX" output="COMMON_SLICE.BX" />
+    <direct name="BO6" input="COMMON_LUT_AND_F78MUX.BO6"   output="COMMON_SLICE.BO6" />
+    <direct name="BO5" input="COMMON_LUT_AND_F78MUX.BO5"   output="COMMON_SLICE.BO5" />
 
-    <direct name="AX2" input="BLK_IG-SLICEL{N}.AX" output="BLK_IG-COMMON_SLICE.AX" />
-    <direct name="AO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.AO6"   output="BLK_IG-COMMON_SLICE.AO6" />
-    <direct name="AO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.AO5"   output="BLK_IG-COMMON_SLICE.AO5" />
+    <direct name="AX2" input="SLICEL{N}.AX" output="COMMON_SLICE.AX" />
+    <direct name="AO6" input="COMMON_LUT_AND_F78MUX.AO6"   output="COMMON_SLICE.AO6" />
+    <direct name="AO5" input="COMMON_LUT_AND_F78MUX.AO5"   output="COMMON_SLICE.AO5" />
 
-    <direct name="F7AMUX_O" input="BLK_IG-COMMON_LUT_AND_F78MUX.F7AMUX_O"   output="BLK_IG-COMMON_SLICE.F7AMUX_O" />
-    <direct name="F7BMUX_O" input="BLK_IG-COMMON_LUT_AND_F78MUX.F7BMUX_O"   output="BLK_IG-COMMON_SLICE.F7BMUX_O" />
-    <direct name="F8MUX_O"  input="BLK_IG-COMMON_LUT_AND_F78MUX.F8MUX_O"    output="BLK_IG-COMMON_SLICE.F8MUX_O" />
+    <direct name="F7AMUX_O" input="COMMON_LUT_AND_F78MUX.F7AMUX_O"   output="COMMON_SLICE.F7AMUX_O" />
+    <direct name="F7BMUX_O" input="COMMON_LUT_AND_F78MUX.F7BMUX_O"   output="COMMON_SLICE.F7BMUX_O" />
+    <direct name="F8MUX_O"  input="COMMON_LUT_AND_F78MUX.F8MUX_O"    output="COMMON_SLICE.F8MUX_O" />
 
     <!-- [A-F]Q outputs -->
-    <direct name="AQ" input="BLK_IG-COMMON_SLICE.AQ" output="BLK_IG-SLICEL{N}.AQ" />
-    <direct name="BQ" input="BLK_IG-COMMON_SLICE.BQ" output="BLK_IG-SLICEL{N}.BQ" />
-    <direct name="CQ" input="BLK_IG-COMMON_SLICE.CQ" output="BLK_IG-SLICEL{N}.CQ" />
-    <direct name="DQ" input="BLK_IG-COMMON_SLICE.DQ" output="BLK_IG-SLICEL{N}.DQ" />
+    <direct name="AQ" input="COMMON_SLICE.AQ" output="SLICEL{N}.AQ" />
+    <direct name="BQ" input="COMMON_SLICE.BQ" output="SLICEL{N}.BQ" />
+    <direct name="CQ" input="COMMON_SLICE.CQ" output="SLICEL{N}.CQ" />
+    <direct name="DQ" input="COMMON_SLICE.DQ" output="SLICEL{N}.DQ" />
 
     <!-- A-D output -->
-    <direct name="BLK_IG-SLICEL_DOUT" input="BLK_IG-COMMON_SLICE.D" output="BLK_IG-SLICEL{N}.D" />
-    <direct name="BLK_IG-SLICEL_COUT" input="BLK_IG-COMMON_SLICE.C" output="BLK_IG-SLICEL{N}.C" />
-    <direct name="BLK_IG-SLICEL_BOUT" input="BLK_IG-COMMON_SLICE.B" output="BLK_IG-SLICEL{N}.B" />
-    <direct name="BLK_IG-SLICEL_AOUT" input="BLK_IG-COMMON_SLICE.A" output="BLK_IG-SLICEL{N}.A" />
+    <direct name="SLICEL_DOUT" input="COMMON_SLICE.D" output="SLICEL{N}.D" />
+    <direct name="SLICEL_COUT" input="COMMON_SLICE.C" output="SLICEL{N}.C" />
+    <direct name="SLICEL_BOUT" input="COMMON_SLICE.B" output="SLICEL{N}.B" />
+    <direct name="SLICEL_AOUT" input="COMMON_SLICE.A" output="SLICEL{N}.A" />
 
     <!-- AMUX-DMUX output -->
-    <direct name="BLK_IG-SLICEL_DMUX" input="BLK_IG-COMMON_SLICE.DMUX" output="BLK_IG-SLICEL{N}.DMUX" />
-    <direct name="BLK_IG-SLICEL_CMUX" input="BLK_IG-COMMON_SLICE.CMUX" output="BLK_IG-SLICEL{N}.CMUX" />
-    <direct name="BLK_IG-SLICEL_BMUX" input="BLK_IG-COMMON_SLICE.BMUX" output="BLK_IG-SLICEL{N}.BMUX" />
-    <direct name="BLK_IG-SLICEL_AMUX" input="BLK_IG-COMMON_SLICE.AMUX" output="BLK_IG-SLICEL{N}.AMUX" />
+    <direct name="SLICEL_DMUX" input="COMMON_SLICE.DMUX" output="SLICEL{N}.DMUX" />
+    <direct name="SLICEL_CMUX" input="COMMON_SLICE.CMUX" output="SLICEL{N}.CMUX" />
+    <direct name="SLICEL_BMUX" input="COMMON_SLICE.BMUX" output="SLICEL{N}.BMUX" />
+    <direct name="SLICEL_AMUX" input="COMMON_SLICE.AMUX" output="SLICEL{N}.AMUX" />
 
     <!-- Carry -->
 
-    <direct name="CIN" input="BLK_IG-SLICEL{N}.CIN" output="BLK_IG-COMMON_SLICE.CIN" >
+    <direct name="CIN" input="SLICEL{N}.CIN" output="COMMON_SLICE.CIN" >
     </direct>
-    <direct name="COUT" input="BLK_IG-COMMON_SLICE.COUT" output="BLK_IG-SLICEL{N}.COUT" >
+    <direct name="COUT" input="COMMON_SLICE.COUT" output="SLICEL{N}.COUT" >
     </direct>
 
     <!-- Clock, Clock Enable and Reset -->
-    <direct name="CK" input="BLK_IG-SLICEL{N}.CLK" output="BLK_IG-COMMON_SLICE.CLK"/>
-    <direct name="CE" input="BLK_IG-SLICEL{N}.CE"  output="BLK_IG-COMMON_SLICE.CE"/>
-    <direct name="SR" input="BLK_IG-SLICEL{N}.SR"  output="BLK_IG-COMMON_SLICE.SR"/>
+    <direct name="CK" input="SLICEL{N}.CLK" output="COMMON_SLICE.CLK"/>
+    <direct name="CE" input="SLICEL{N}.CE"  output="COMMON_SLICE.CE"/>
+    <direct name="SR" input="SLICEL{N}.SR"  output="COMMON_SLICE.SR"/>
 
   </interconnect>
+  <metadata>
+   <meta name="type">block</meta>
+   <meta name="subtype">ignore</meta>
+  </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_IG-D_DRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="D_DRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <clock  name="CLK" num_pins="1" />
   <input  name="A"   num_pins="6" />
   <input  name="WA7" num_pins="1" />
@@ -18,39 +18,41 @@
     <input  name="A" num_pins="6"/>
   </pb_type>
   <interconnect>
-    <direct name="A" input="BLK_IG-D_DRAM.A" output="BEL_NULL-NO_DRAM.A" />
+    <direct name="A" input="D_DRAM.A" output="BEL_NULL-NO_DRAM.A" />
   </interconnect>
  </mode>
  <mode name="64_SINGLE_PORT">
    <xi:include href="spram64.pb_type.xml" />
    <interconnect>
-     <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-SPRAM64.CLK" />
-     <direct name="A" input="BLK_IG-D_DRAM.A" output="BLK_MM-SPRAM64.A" />
-     <direct name="WA7" input="BLK_IG-D_DRAM.WA7" output="BLK_MM-SPRAM64.WA7" />
-     <direct name="WA8" input="BLK_IG-D_DRAM.WA8" output="BLK_MM-SPRAM64.WA8" />
-     <direct name="DI" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-SPRAM64.DI1" />
-     <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-SPRAM64.WE" />
+     <direct name="CLK" input="D_DRAM.CLK" output="SPRAM64.CLK" />
+     <direct name="A" input="D_DRAM.A" output="SPRAM64.A" />
+     <direct name="WA7" input="D_DRAM.WA7" output="SPRAM64.WA7" />
+     <direct name="WA8" input="D_DRAM.WA8" output="SPRAM64.WA8" />
+     <direct name="DI" input="D_DRAM.DI1" output="SPRAM64.DI1" />
+     <direct name="WE" input="D_DRAM.WE" output="SPRAM64.WE" />
 
-     <direct name="O6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-D_DRAM.O6" />
-     <direct name="SO6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-D_DRAM.SO6" />
+     <direct name="O6" input="SPRAM64.O6" output="D_DRAM.O6" />
+     <direct name="SO6" input="SPRAM64.O6" output="D_DRAM.SO6" />
    </interconnect>
  </mode>
  <mode name="32_SINGLE_PORT">
    <xi:include href="spram32.pb_type.xml" />
    <interconnect>
-     <direct name="CLK" input="BLK_IG-D_DRAM.CLK" output="BLK_MM-SPRAM32.CLK" />
-     <direct name="A" input="BLK_IG-D_DRAM.A[4:0]" output="BLK_MM-SPRAM32.A[4:0]" />
-     <direct name="DI1" input="BLK_IG-D_DRAM.DI1" output="BLK_MM-SPRAM32.DI1" />
-     <direct name="DI2" input="BLK_IG-D_DRAM.DI2" output="BLK_MM-SPRAM32.DI2" />
-     <direct name="WE" input="BLK_IG-D_DRAM.WE" output="BLK_MM-SPRAM32.WE" />
+     <direct name="CLK" input="D_DRAM.CLK" output="SPRAM32.CLK" />
+     <direct name="A" input="D_DRAM.A[4:0]" output="SPRAM32.A[4:0]" />
+     <direct name="DI1" input="D_DRAM.DI1" output="SPRAM32.DI1" />
+     <direct name="DI2" input="D_DRAM.DI2" output="SPRAM32.DI2" />
+     <direct name="WE" input="D_DRAM.WE" output="SPRAM32.WE" />
 
-     <direct name="O6" input="BLK_MM-SPRAM32.O6" output="BLK_IG-D_DRAM.O6" />
-     <direct name="O5" input="BLK_MM-SPRAM32.O5" output="BLK_IG-D_DRAM.O5" />
-     <direct name="SO6_32" input="BLK_MM-SPRAM32.O6" output="BLK_IG-D_DRAM.SO6_32" />
+     <direct name="O6" input="SPRAM32.O6" output="D_DRAM.O6" />
+     <direct name="O5" input="SPRAM32.O5" output="D_DRAM.O5" />
+     <direct name="SO6_32" input="SPRAM32.O6" output="D_DRAM.SO6_32" />
    </interconnect>
  </mode>
 
  <metadata>
   <meta name="fasm_prefix">DLUT</meta>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
  </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/d_dram128.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/d_dram128.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_IG-D_DRAM128" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="D_DRAM128" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <clock  name="CLK" num_pins="1" />
   <input  name="A"   num_pins="6" />
   <input  name="WA7" num_pins="1" />
@@ -10,17 +10,19 @@
  <mode name="128_SINGLE_PORT">
    <xi:include href="spram128.pb_type.xml" />
    <interconnect>
-     <direct name="CLK" input="BLK_IG-D_DRAM128.CLK" output="BLK_MM-SPRAM128.CLK" />
-     <direct name="A" input="BLK_IG-D_DRAM128.A" output="BLK_MM-SPRAM128.A" />
-     <direct name="WA7" input="BLK_IG-D_DRAM128.WA7" output="BLK_MM-SPRAM128.WA7" />
-     <direct name="DI" input="BLK_IG-D_DRAM128.DI1" output="BLK_MM-SPRAM128.DI1" />
-     <direct name="WE" input="BLK_IG-D_DRAM128.WE" output="BLK_MM-SPRAM128.WE" />
+     <direct name="CLK" input="D_DRAM128.CLK" output="SPRAM128.CLK" />
+     <direct name="A" input="D_DRAM128.A" output="SPRAM128.A" />
+     <direct name="WA7" input="D_DRAM128.WA7" output="SPRAM128.WA7" />
+     <direct name="DI" input="D_DRAM128.DI1" output="SPRAM128.DI1" />
+     <direct name="WE" input="D_DRAM128.WE" output="SPRAM128.WE" />
 
-     <direct name="O6" input="BLK_MM-SPRAM128.O6" output="BLK_IG-D_DRAM128.O6" />
+     <direct name="O6" input="SPRAM128.O6" output="D_DRAM128.O6" />
    </interconnect>
  </mode>
 
  <metadata>
   <meta name="fasm_prefix">DLUT</meta>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
  </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/dpram128.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram128.pb_type.xml
@@ -5,14 +5,14 @@
      128-bit.  This special casing is not required for 256x1 mode because it 
      always consumes the entire slice, so there is no ambiguity.
      -->
-<pb_type name="BLK_MM-DPRAM128" num_pb="1" blif_model=".subckt DPRAM128">
+<pb_type name="DPRAM128" num_pb="1" blif_model=".subckt DPRAM128">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A1 - Read port -->
   <input  name="A"   num_pins="6" />
   <output name="O6"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-DPRAM128.A" out_port="BLK_MM-DPRAM128.O6">
+  <delay_matrix type="max" in_port="DPRAM128.A" out_port="DPRAM128.O6">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -27,18 +27,18 @@
   <input  name="DI1" num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <T_setup      value="10e-12" port="BLK_MM-DPRAM128.WA"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM128.WA"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM128.WA"  out_port="BLK_MM-DPRAM128.O6" />
-  <T_setup      value="10e-12" port="BLK_MM-DPRAM128.WA7"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM128.WA7"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM128.WA7"  out_port="BLK_MM-DPRAM128.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM128.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM128.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM128.WE"  out_port="BLK_MM-DPRAM128.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM128.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM128.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM128.DI1"  out_port="BLK_MM-DPRAM128.O6" />
+  <T_setup      value="10e-12" port="DPRAM128.WA"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM128.WA"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM128.WA"  out_port="DPRAM128.O6" />
+  <T_setup      value="10e-12" port="DPRAM128.WA7"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM128.WA7"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM128.WA7"  out_port="DPRAM128.O6" />
+  <T_setup    value="10e-12" port="DPRAM128.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM128.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM128.WE"  out_port="DPRAM128.O6" />
+  <T_setup    value="10e-12" port="DPRAM128.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM128.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM128.DI1"  out_port="DPRAM128.O6" />
   <metadata>
     <meta name="fasm_params">
       INIT[63:0] = INIT
@@ -46,5 +46,7 @@
     <meta name="fasm_features">
       RAM
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_MM-DPRAM32" num_pb="1" blif_model=".subckt DPRAM32">
+<pb_type name="DPRAM32" num_pb="1" blif_model=".subckt DPRAM32">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A1 - Read port -->
@@ -6,14 +6,14 @@
   <output name="O6"  num_pins="1" />
   <output name="O5"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-DPRAM32.A" out_port="BLK_MM-DPRAM32.O6">
+  <delay_matrix type="max" in_port="DPRAM32.A" out_port="DPRAM32.O6">
     0.068e-9
     0.068e-9
     0.068e-9
     0.068e-9
     0.068e-9
   </delay_matrix>
-  <delay_matrix type="max" in_port="BLK_MM-DPRAM32.A" out_port="BLK_MM-DPRAM32.O5">
+  <delay_matrix type="max" in_port="DPRAM32.A" out_port="DPRAM32.O5">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -27,20 +27,20 @@
   <input  name="DI2" num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <T_setup      value="10e-12" port="BLK_MM-DPRAM32.WA"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM32.WA"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM32.WA"  out_port="BLK_MM-DPRAM32.O6" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM32.WA"  out_port="BLK_MM-DPRAM32.O5" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM32.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM32.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM32.WE"  out_port="BLK_MM-DPRAM32.O6" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM32.WE"  out_port="BLK_MM-DPRAM32.O5" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM32.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM32.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM32.DI1"  out_port="BLK_MM-DPRAM32.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM32.DI2"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM32.DI2"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM32.DI2"  out_port="BLK_MM-DPRAM32.O5" />
+  <T_setup      value="10e-12" port="DPRAM32.WA"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM32.WA"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM32.WA"  out_port="DPRAM32.O6" />
+  <delay_constant max="10e-12" in_port="DPRAM32.WA"  out_port="DPRAM32.O5" />
+  <T_setup    value="10e-12" port="DPRAM32.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM32.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM32.WE"  out_port="DPRAM32.O6" />
+  <delay_constant max="10e-12" in_port="DPRAM32.WE"  out_port="DPRAM32.O5" />
+  <T_setup    value="10e-12" port="DPRAM32.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM32.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM32.DI1"  out_port="DPRAM32.O6" />
+  <T_setup    value="10e-12" port="DPRAM32.DI2"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM32.DI2"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM32.DI2"  out_port="DPRAM32.O5" />
   <metadata>
     <meta name="fasm_params">
       INIT[31:0] = INIT_00
@@ -50,5 +50,7 @@
       RAM
       SMALL
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/dpram64.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram64.pb_type.xml
@@ -1,12 +1,12 @@
 <!-- Dual port 64x1 DRAM.  Used in 64x1 and 256x1 modes. -->
-<pb_type name="BLK_MM-DPRAM64" num_pb="1" blif_model=".subckt DPRAM64">
+<pb_type name="DPRAM64" num_pb="1" blif_model=".subckt DPRAM64">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A1 - Read port -->
   <input  name="A"   num_pins="6" />
   <output name="O6"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-DPRAM64.A" out_port="BLK_MM-DPRAM64.O6">
+  <delay_matrix type="max" in_port="DPRAM64.A" out_port="DPRAM64.O6">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -22,21 +22,21 @@
   <input  name="DI1" num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <T_setup      value="10e-12" port="BLK_MM-DPRAM64.WA"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM64.WA"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM64.WA"  out_port="BLK_MM-DPRAM64.O6" />
-  <T_setup      value="10e-12" port="BLK_MM-DPRAM64.WA7"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM64.WA7"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM64.WA7"  out_port="BLK_MM-DPRAM64.O6" />
-  <T_setup      value="10e-12" port="BLK_MM-DPRAM64.WA8"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM64.WA8"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM64.WA8"  out_port="BLK_MM-DPRAM64.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM64.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM64.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM64.WE"  out_port="BLK_MM-DPRAM64.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-DPRAM64.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-DPRAM64.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-DPRAM64.DI1"  out_port="BLK_MM-DPRAM64.O6" />
+  <T_setup      value="10e-12" port="DPRAM64.WA"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM64.WA"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM64.WA"  out_port="DPRAM64.O6" />
+  <T_setup      value="10e-12" port="DPRAM64.WA7"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM64.WA7"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM64.WA7"  out_port="DPRAM64.O6" />
+  <T_setup      value="10e-12" port="DPRAM64.WA8"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM64.WA8"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM64.WA8"  out_port="DPRAM64.O6" />
+  <T_setup    value="10e-12" port="DPRAM64.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM64.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM64.WE"  out_port="DPRAM64.O6" />
+  <T_setup    value="10e-12" port="DPRAM64.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="DPRAM64.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="DPRAM64.DI1"  out_port="DPRAM64.O6" />
   <metadata>
     <meta name="fasm_params">
       INIT[63:0] = INIT
@@ -44,5 +44,7 @@
     <meta name="fasm_features">
       RAM
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/ntemplate.N_dram.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/ntemplate.N_dram.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_IG-{N}_DRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="{N}_DRAM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <clock  name="CLK" num_pins="1" />
   <input  name="A"   num_pins="6" />
   <input  name="WA"  num_pins="8" />
@@ -18,50 +18,54 @@
 
   <!-- TODO: Missing modes: SRL -->
   <mode name="LUT">
-    <pb_type name="BEL_LT-{N}5LUT" num_pb="2" class="lut" blif_model=".names">
+    <pb_type name="{N}5LUT" num_pb="2" class="lut" blif_model=".names">
       <input  name="in"  num_pins="5" port_class="lut_in" />
       <output name="out" num_pins="1" port_class="lut_out" />
-      <delay_matrix type="max" in_port="BEL_LT-{N}5LUT.in" out_port="BEL_LT-{N}5LUT.out">
+      <delay_matrix type="max" in_port="{N}5LUT.in" out_port="{N}5LUT.out">
         0.068e-9
         0.068e-9
         0.068e-9
         0.068e-9
         0.068e-9
       </delay_matrix>
+      <metadata>
+        <meta name="type">bel</meta>
+        <meta name="subtype">lut</meta>
+      </metadata>
     </pb_type>
     <xi:include href="../../common_slice/muxes/f6mux/f6mux.pb_type.xml" />
 
     <interconnect>
       <!-- LUT5 (upper) -> O6 -->
-      <direct name="{N}LUT_A5_0" input="BLK_IG-{N}_DRAM.A[4:0]" output="BEL_LT-{N}5LUT[0].in[4:0]"/>
+      <direct name="{N}LUT_A5_0" input="{N}_DRAM.A[4:0]" output="{N}5LUT[0].in[4:0]"/>
 
       <!-- LUT5 (lower) -> O5 -->
-      <direct name="{N}LUT_A5_1" input="BLK_IG-{N}_DRAM.A[4:0]" output="BEL_LT-{N}5LUT[1].in[4:0]"/>
+      <direct name="{N}LUT_A5_1" input="{N}_DRAM.A[4:0]" output="{N}5LUT[1].in[4:0]"/>
 
       <!-- MUX used for LUT6 -->
-      <direct name="F6MUX_I0" input="BEL_LT-{N}5LUT[0].out" output="BEL_MX-F6MUX.I0">
-        <pack_pattern in_port="BEL_LT-{N}5LUT[0].out" name="LUT5toLUT6" out_port="BEL_MX-F6MUX.I0"/>
+      <direct name="F6MUX_I0" input="{N}5LUT[0].out" output="F6MUX.I0">
+        <pack_pattern in_port="{N}5LUT[0].out" name="LUT5toLUT6" out_port="F6MUX.I0"/>
       </direct>
-      <direct name="F6MUX_I1" input="BEL_LT-{N}5LUT[1].out" output="BEL_MX-F6MUX.I1">
-        <pack_pattern in_port="BEL_LT-{N}5LUT[1].out" name="LUT5toLUT6" out_port="BEL_MX-F6MUX.I1"/>
+      <direct name="F6MUX_I1" input="{N}5LUT[1].out" output="F6MUX.I1">
+        <pack_pattern in_port="{N}5LUT[1].out" name="LUT5toLUT6" out_port="F6MUX.I1"/>
       </direct>
-      <direct name="F6MUX_S"  input="BLK_IG-{N}_DRAM.A[5]" output="BEL_MX-F6MUX.S">
+      <direct name="F6MUX_S"  input="{N}_DRAM.A[5]" output="F6MUX.S">
       </direct>
 
       <!-- LUT outputs -->
-      <direct name="O5" input="BEL_LT-{N}5LUT[0].out"                output="BLK_IG-{N}_DRAM.O5">
-        <pack_pattern in_port="BEL_LT-{N}5LUT[0].out" name="LUT5x2"     out_port="BLK_IG-{N}_DRAM.O5"/>
+      <direct name="O5" input="{N}5LUT[0].out"                output="{N}_DRAM.O5">
+        <pack_pattern in_port="{N}5LUT[0].out" name="LUT5x2"     out_port="{N}_DRAM.O5"/>
       </direct>
-      <mux    name="O6" input="BEL_LT-{N}5LUT[1].out BEL_MX-F6MUX.O" output="BLK_IG-{N}_DRAM.O6">
-        <pack_pattern in_port="BEL_MX-F6MUX.O"        name="LUT5toLUT6" out_port="BLK_IG-{N}_DRAM.O6"/>
-        <pack_pattern in_port="BEL_LT-{N}5LUT[1].out" name="LUT5x2"     out_port="BLK_IG-{N}_DRAM.O6"/>
+      <mux    name="O6" input="{N}5LUT[1].out F6MUX.O" output="{N}_DRAM.O6">
+        <pack_pattern in_port="F6MUX.O"        name="LUT5toLUT6" out_port="{N}_DRAM.O6"/>
+        <pack_pattern in_port="{N}5LUT[1].out" name="LUT5x2"     out_port="{N}_DRAM.O6"/>
       </mux>
     </interconnect>
     <metadata>
       <meta name="fasm_type">SPLIT_LUT</meta>
       <meta name="fasm_lut">
-        INIT[31:0] = BEL_LT-{N}5LUT[0]
-        INIT[63:32] = BEL_LT-{N}5LUT[1]
+        INIT[31:0] = {N}5LUT[0]
+        INIT[63:32] = {N}5LUT[1]
       </meta>
     </metadata>
   </mode>
@@ -73,45 +77,45 @@
       </meta>
     </metadata>
     <interconnect>
-      <direct name="CLK" input="BLK_IG-{N}_DRAM.CLK" output="BLK_MM-SPRAM64.CLK" />
-      <direct name="A" input="BLK_IG-{N}_DRAM.A" output="BLK_MM-SPRAM64.A" />
-      <direct name="WA7" input="BLK_IG-{N}_DRAM.WA[6]" output="BLK_MM-SPRAM64.WA7" />
-      <direct name="WA8" input="BLK_IG-{N}_DRAM.WA[7]" output="BLK_MM-SPRAM64.WA8" />
-      <direct name="{N}I" input="BLK_IG-{N}_DRAM.{N}I" output="BLK_MM-SPRAM64.DI1" />
-      <direct name="WE" input="BLK_IG-{N}_DRAM.WE" output="BLK_MM-SPRAM64.WE" />
+      <direct name="CLK" input="{N}_DRAM.CLK" output="SPRAM64.CLK" />
+      <direct name="A" input="{N}_DRAM.A" output="SPRAM64.A" />
+      <direct name="WA7" input="{N}_DRAM.WA[6]" output="SPRAM64.WA7" />
+      <direct name="WA8" input="{N}_DRAM.WA[7]" output="SPRAM64.WA8" />
+      <direct name="{N}I" input="{N}_DRAM.{N}I" output="SPRAM64.DI1" />
+      <direct name="WE" input="{N}_DRAM.WE" output="SPRAM64.WE" />
 
-      <direct name="O6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-{N}_DRAM.O6" />
-      <direct name="SO6" input="BLK_MM-SPRAM64.O6" output="BLK_IG-{N}_DRAM.SO6" />
+      <direct name="O6" input="SPRAM64.O6" output="{N}_DRAM.O6" />
+      <direct name="SO6" input="SPRAM64.O6" output="{N}_DRAM.SO6" />
     </interconnect>
   </mode>
   <mode name="64_DUAL_PORT">
     <xi:include href="dpram64.pb_type.xml" />
     <interconnect>
-      <direct name="CLK" input="BLK_IG-{N}_DRAM.CLK" output="BLK_MM-DPRAM64.CLK" />
-      <direct name="A" input="BLK_IG-{N}_DRAM.A" output="BLK_MM-DPRAM64.A" />
-      <direct name="WA" input="BLK_IG-{N}_DRAM.WA[5:0]" output="BLK_MM-DPRAM64.WA[5:0]" />
-      <direct name="WA7" input="BLK_IG-{N}_DRAM.WA[6]" output="BLK_MM-DPRAM64.WA7" />
-      <direct name="WA8" input="BLK_IG-{N}_DRAM.WA[7]" output="BLK_MM-DPRAM64.WA8" />
-      <direct name="{N}I" input="BLK_IG-{N}_DRAM.PARENT_DI" output="BLK_MM-DPRAM64.DI1" />
-      <direct name="WE" input="BLK_IG-{N}_DRAM.WE" output="BLK_MM-DPRAM64.WE" />
+      <direct name="CLK" input="{N}_DRAM.CLK" output="DPRAM64.CLK" />
+      <direct name="A" input="{N}_DRAM.A" output="DPRAM64.A" />
+      <direct name="WA" input="{N}_DRAM.WA[5:0]" output="DPRAM64.WA[5:0]" />
+      <direct name="WA7" input="{N}_DRAM.WA[6]" output="DPRAM64.WA7" />
+      <direct name="WA8" input="{N}_DRAM.WA[7]" output="DPRAM64.WA8" />
+      <direct name="{N}I" input="{N}_DRAM.PARENT_DI" output="DPRAM64.DI1" />
+      <direct name="WE" input="{N}_DRAM.WE" output="DPRAM64.WE" />
 
-      <direct name="O6" input="BLK_MM-DPRAM64.O6" output="BLK_IG-{N}_DRAM.O6" />
-      <direct name="DO6" input="BLK_MM-DPRAM64.O6" output="BLK_IG-{N}_DRAM.DO6" />
+      <direct name="O6" input="DPRAM64.O6" output="{N}_DRAM.O6" />
+      <direct name="DO6" input="DPRAM64.O6" output="{N}_DRAM.DO6" />
     </interconnect>
   </mode>
   <mode name="32_DUAL_PORT">
     <xi:include href="dpram32.pb_type.xml" />
     <interconnect>
-      <direct name="CLK" input="BLK_IG-{N}_DRAM.CLK" output="BLK_MM-DPRAM32.CLK" />
-      <direct name="A" input="BLK_IG-{N}_DRAM.A[4:0]" output="BLK_MM-DPRAM32.A[4:0]" />
-      <direct name="WA" input="BLK_IG-{N}_DRAM.WA[4:0]" output="BLK_MM-DPRAM32.WA[4:0]" />
-      <direct name="{N}I" input="BLK_IG-{N}_DRAM.PARENT_DI" output="BLK_MM-DPRAM32.DI1" />
-      <direct name="DI2" input="BLK_IG-{N}_DRAM.DI2" output="BLK_MM-DPRAM32.DI2" />
-      <direct name="WE" input="BLK_IG-{N}_DRAM.WE" output="BLK_MM-DPRAM32.WE" />
+      <direct name="CLK" input="{N}_DRAM.CLK" output="DPRAM32.CLK" />
+      <direct name="A" input="{N}_DRAM.A[4:0]" output="DPRAM32.A[4:0]" />
+      <direct name="WA" input="{N}_DRAM.WA[4:0]" output="DPRAM32.WA[4:0]" />
+      <direct name="{N}I" input="{N}_DRAM.PARENT_DI" output="DPRAM32.DI1" />
+      <direct name="DI2" input="{N}_DRAM.DI2" output="DPRAM32.DI2" />
+      <direct name="WE" input="{N}_DRAM.WE" output="DPRAM32.WE" />
 
-      <direct name="O6" input="BLK_MM-DPRAM32.O6" output="BLK_IG-{N}_DRAM.O6" />
-      <direct name="DO6" input="BLK_MM-DPRAM32.O6" output="BLK_IG-{N}_DRAM.DO6_32" />
-      <direct name="O5" input="BLK_MM-DPRAM32.O5" output="BLK_IG-{N}_DRAM.O5" />
+      <direct name="O6" input="DPRAM32.O6" output="{N}_DRAM.O6" />
+      <direct name="DO6" input="DPRAM32.O6" output="{N}_DRAM.DO6_32" />
+      <direct name="O5" input="DPRAM32.O5" output="{N}_DRAM.O5" />
     </interconnect>
   </mode>
   <mode name="32_SINGLE_PORT">
@@ -122,19 +126,21 @@
       </meta>
     </metadata>
     <interconnect>
-      <direct name="CLK" input="BLK_IG-{N}_DRAM.CLK" output="BLK_MM-SPRAM32.CLK" />
-      <direct name="A" input="BLK_IG-{N}_DRAM.A[4:0]" output="BLK_MM-SPRAM32.A[4:0]" />
-      <direct name="{N}I" input="BLK_IG-{N}_DRAM.{N}I" output="BLK_MM-SPRAM32.DI1" />
-      <direct name="DI2" input="BLK_IG-{N}_DRAM.DI2" output="BLK_MM-SPRAM32.DI2" />
-      <direct name="WE" input="BLK_IG-{N}_DRAM.WE" output="BLK_MM-SPRAM32.WE" />
+      <direct name="CLK" input="{N}_DRAM.CLK" output="SPRAM32.CLK" />
+      <direct name="A" input="{N}_DRAM.A[4:0]" output="SPRAM32.A[4:0]" />
+      <direct name="{N}I" input="{N}_DRAM.{N}I" output="SPRAM32.DI1" />
+      <direct name="DI2" input="{N}_DRAM.DI2" output="SPRAM32.DI2" />
+      <direct name="WE" input="{N}_DRAM.WE" output="SPRAM32.WE" />
 
-      <direct name="O6" input="BLK_MM-SPRAM32.O6" output="BLK_IG-{N}_DRAM.O6" />
-      <direct name="SO6" input="BLK_MM-SPRAM32.O6" output="BLK_IG-{N}_DRAM.SO6_32" />
-      <direct name="O5" input="BLK_MM-SPRAM32.O5" output="BLK_IG-{N}_DRAM.O5" />
+      <direct name="O6" input="SPRAM32.O6" output="{N}_DRAM.O6" />
+      <direct name="SO6" input="SPRAM32.O6" output="{N}_DRAM.SO6_32" />
+      <direct name="O5" input="SPRAM32.O5" output="{N}_DRAM.O5" />
     </interconnect>
   </mode>
 
   <metadata>
     <meta name="fasm_prefix">{N}LUT</meta>
+    <meta name="type">block</meta>
+    <meta name="subtype">ignore</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/ntemplate.N_dram128.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/ntemplate.N_dram128.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_IG-{N}_DRAM128" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="{N}_DRAM128" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <clock  name="CLK" num_pins="1" />
   <input  name="A"   num_pins="6" />
   <input  name="WA"  num_pins="7" />
@@ -16,16 +16,16 @@
  <mode name="128_DUAL_PORT">
    <xi:include href="dpram128.pb_type.xml" />
    <interconnect>
-     <direct name="CLK" input="BLK_IG-{N}_DRAM128.CLK" output="BLK_MM-DPRAM128.CLK" />
-     <direct name="A" input="BLK_IG-{N}_DRAM128.A" output="BLK_MM-DPRAM128.A" />
-     <direct name="WA" input="BLK_IG-{N}_DRAM128.WA[5:0]" output="BLK_MM-DPRAM128.WA[5:0]" />
-     <direct name="WA7" input="BLK_IG-{N}_DRAM128.WA[6]" output="BLK_MM-DPRAM128.WA7" />
-     <direct name="{N}I" input="BLK_IG-{N}_DRAM128.PARENT_DI" output="BLK_MM-DPRAM128.DI1" />
-     <direct name="WE" input="BLK_IG-{N}_DRAM128.WE" output="BLK_MM-DPRAM128.WE" />
+     <direct name="CLK" input="{N}_DRAM128.CLK" output="DPRAM128.CLK" />
+     <direct name="A" input="{N}_DRAM128.A" output="DPRAM128.A" />
+     <direct name="WA" input="{N}_DRAM128.WA[5:0]" output="DPRAM128.WA[5:0]" />
+     <direct name="WA7" input="{N}_DRAM128.WA[6]" output="DPRAM128.WA7" />
+     <direct name="{N}I" input="{N}_DRAM128.PARENT_DI" output="DPRAM128.DI1" />
+     <direct name="WE" input="{N}_DRAM128.WE" output="DPRAM128.WE" />
 
-     <direct name="DO6" input="BLK_MM-DPRAM128.O6" output="BLK_IG-{N}_DRAM128.DO6" />
-     <direct name="O6" input="BLK_MM-DPRAM128.O6" output="BLK_IG-{N}_DRAM128.O6" />
-     <direct name="DI_OUT" input="BLK_IG-{N}_DRAM128.PARENT_DI" output="BLK_IG-{N}_DRAM128.DI_OUT" />
+     <direct name="DO6" input="DPRAM128.O6" output="{N}_DRAM128.DO6" />
+     <direct name="O6" input="DPRAM128.O6" output="{N}_DRAM128.O6" />
+     <direct name="DI_OUT" input="{N}_DRAM128.PARENT_DI" output="{N}_DRAM128.DI_OUT" />
    </interconnect>
  </mode>
  <mode name="128_SINGLE_PORT">
@@ -36,19 +36,21 @@
     </meta>
    </metadata>
    <interconnect>
-     <direct name="CLK" input="BLK_IG-{N}_DRAM128.CLK" output="BLK_MM-SPRAM128.CLK" />
-     <direct name="A" input="BLK_IG-{N}_DRAM128.A" output="BLK_MM-SPRAM128.A" />
-     <direct name="WA7" input="BLK_IG-{N}_DRAM128.WA[6]" output="BLK_MM-SPRAM128.WA7" />
-     <direct name="{N}I" input="BLK_IG-{N}_DRAM128.{N}I" output="BLK_MM-SPRAM128.DI1" />
-     <direct name="WE" input="BLK_IG-{N}_DRAM128.WE" output="BLK_MM-SPRAM128.WE" />
+     <direct name="CLK" input="{N}_DRAM128.CLK" output="SPRAM128.CLK" />
+     <direct name="A" input="{N}_DRAM128.A" output="SPRAM128.A" />
+     <direct name="WA7" input="{N}_DRAM128.WA[6]" output="SPRAM128.WA7" />
+     <direct name="{N}I" input="{N}_DRAM128.{N}I" output="SPRAM128.DI1" />
+     <direct name="WE" input="{N}_DRAM128.WE" output="SPRAM128.WE" />
 
-     <direct name="SO6" input="BLK_MM-SPRAM128.O6" output="BLK_IG-{N}_DRAM128.SO6" />
-     <direct name="O6" input="BLK_MM-SPRAM128.O6" output="BLK_IG-{N}_DRAM128.O6" />
-     <direct name="DI_OUT" input="BLK_IG-{N}_DRAM128.{N}I" output="BLK_IG-{N}_DRAM128.DI_OUT" />
+     <direct name="SO6" input="SPRAM128.O6" output="{N}_DRAM128.SO6" />
+     <direct name="O6" input="SPRAM128.O6" output="{N}_DRAM128.O6" />
+     <direct name="DI_OUT" input="{N}_DRAM128.{N}I" output="{N}_DRAM128.DI_OUT" />
    </interconnect>
  </mode>
  <metadata>
   <meta name="fasm_prefix">{N}LUT</meta>
+  <meta name="type">block</meta>
+  <meta name="subtype">ignore</meta>
  </metadata>
 </pb_type>
 

--- a/xc7/primitives/slicem/Ndram/ntemplate.spram64_N.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/ntemplate.spram64_N.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- Sinlge port 64x1 DRAM.  Used in 64x1 and 256x1 modes. -->
-<pb_type name="BLK_MM-SPRAM64_{N}" num_pb="1" blif_model=".subckt SPRAM64_{N}">
+<pb_type name="SPRAM64_{N}" num_pb="1" blif_model=".subckt SPRAM64_{N}">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A - Read/write port -->
@@ -11,7 +11,7 @@
 
   <output name="O6"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-SPRAM64_{N}.A" out_port="BLK_MM-SPRAM64_{N}.O6">
+  <delay_matrix type="max" in_port="SPRAM64_{N}.A" out_port="SPRAM64_{N}.O6">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -22,20 +22,20 @@
 
   <!-- B1 - Write Port -->
 
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM64_{N}.A"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64_{N}.A"  clock="CLK" />
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM64_{N}.WA7"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64_{N}.WA7"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64_{N}.WA7"  out_port="BLK_MM-SPRAM64_{N}.O6" />
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM64_{N}.WA8"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64_{N}.WA8"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64_{N}.WA8"  out_port="BLK_MM-SPRAM64_{N}.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM64_{N}.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64_{N}.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64_{N}.WE"  out_port="BLK_MM-SPRAM64_{N}.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM64_{N}.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64_{N}.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64_{N}.DI1"  out_port="BLK_MM-SPRAM64_{N}.O6" />
+  <T_setup      value="10e-12" port="SPRAM64_{N}.A"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64_{N}.A"  clock="CLK" />
+  <T_setup      value="10e-12" port="SPRAM64_{N}.WA7"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64_{N}.WA7"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64_{N}.WA7"  out_port="SPRAM64_{N}.O6" />
+  <T_setup      value="10e-12" port="SPRAM64_{N}.WA8"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64_{N}.WA8"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64_{N}.WA8"  out_port="SPRAM64_{N}.O6" />
+  <T_setup    value="10e-12" port="SPRAM64_{N}.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64_{N}.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64_{N}.WE"  out_port="SPRAM64_{N}.O6" />
+  <T_setup    value="10e-12" port="SPRAM64_{N}.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64_{N}.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64_{N}.DI1"  out_port="SPRAM64_{N}.O6" />
   <metadata>
     <meta name="fasm_params">
       INIT[63:0] = INIT
@@ -43,5 +43,7 @@
     <meta name="fasm_features">
       RAM
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/spram128.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/spram128.pb_type.xml
@@ -5,7 +5,7 @@
      128-bit.  This special casing is not required for 256x1 mode because it 
      always consumes the entire slice, so there is no ambiguity.
      -->
-<pb_type name="BLK_MM-SPRAM128" num_pb="1" blif_model=".subckt SPRAM128">
+<pb_type name="SPRAM128" num_pb="1" blif_model=".subckt SPRAM128">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A - Read/write port -->
@@ -16,7 +16,7 @@
 
   <output name="O6"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-SPRAM128.A" out_port="BLK_MM-SPRAM128.O6">
+  <delay_matrix type="max" in_port="SPRAM128.A" out_port="SPRAM128.O6">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -27,17 +27,17 @@
 
   <!-- B1 - Write Port -->
 
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM128.A"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM128.A"  clock="CLK" />
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM128.WA7"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM128.WA7"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM128.WA7"  out_port="BLK_MM-SPRAM128.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM128.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM128.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM128.WE"  out_port="BLK_MM-SPRAM128.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM128.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM128.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM128.DI1"  out_port="BLK_MM-SPRAM128.O6" />
+  <T_setup      value="10e-12" port="SPRAM128.A"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM128.A"  clock="CLK" />
+  <T_setup      value="10e-12" port="SPRAM128.WA7"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM128.WA7"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM128.WA7"  out_port="SPRAM128.O6" />
+  <T_setup    value="10e-12" port="SPRAM128.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM128.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM128.WE"  out_port="SPRAM128.O6" />
+  <T_setup    value="10e-12" port="SPRAM128.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM128.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM128.DI1"  out_port="SPRAM128.O6" />
   <metadata>
     <meta name="fasm_params">
       INIT[63:0] = INIT
@@ -45,5 +45,7 @@
     <meta name="fasm_features">
       RAM
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/spram32.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/spram32.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="BLK_MM-SPRAM32" num_pb="1" blif_model=".subckt SPRAM32">
+<pb_type name="SPRAM32" num_pb="1" blif_model=".subckt SPRAM32">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A - Read/write port -->
@@ -10,14 +10,14 @@
   <input  name="DI2" num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-SPRAM32.A" out_port="BLK_MM-SPRAM32.O6">
+  <delay_matrix type="max" in_port="SPRAM32.A" out_port="SPRAM32.O6">
     0.068e-9
     0.068e-9
     0.068e-9
     0.068e-9
     0.068e-9
   </delay_matrix>
-  <delay_matrix type="max" in_port="BLK_MM-SPRAM32.A" out_port="BLK_MM-SPRAM32.O5">
+  <delay_matrix type="max" in_port="SPRAM32.A" out_port="SPRAM32.O5">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -27,18 +27,18 @@
 
   <!-- B1 - Write Port -->
 
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM32.A"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM32.A"  clock="CLK" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM32.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM32.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM32.WE"  out_port="BLK_MM-SPRAM32.O6" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM32.WE"  out_port="BLK_MM-SPRAM32.O5" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM32.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM32.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM32.DI1"  out_port="BLK_MM-SPRAM32.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM32.DI2"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM32.DI2"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM32.DI2"  out_port="BLK_MM-SPRAM32.O5" />
+  <T_setup      value="10e-12" port="SPRAM32.A"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM32.A"  clock="CLK" />
+  <T_setup    value="10e-12" port="SPRAM32.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM32.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM32.WE"  out_port="SPRAM32.O6" />
+  <delay_constant max="10e-12" in_port="SPRAM32.WE"  out_port="SPRAM32.O5" />
+  <T_setup    value="10e-12" port="SPRAM32.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM32.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM32.DI1"  out_port="SPRAM32.O6" />
+  <T_setup    value="10e-12" port="SPRAM32.DI2"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM32.DI2"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM32.DI2"  out_port="SPRAM32.O5" />
   <metadata>
     <meta name="fasm_params">
       INIT[31:0] = INIT_00
@@ -48,5 +48,7 @@
       RAM
       SMALL
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
    </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/Ndram/spram64.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/spram64.pb_type.xml
@@ -1,5 +1,5 @@
 <!-- Sinlge port 64x1 DRAM.  Used in 64x1 and 256x1 modes. -->
-<pb_type name="BLK_MM-SPRAM64" num_pb="1" blif_model=".subckt SPRAM64">
+<pb_type name="SPRAM64" num_pb="1" blif_model=".subckt SPRAM64">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A - Read/write port -->
@@ -11,7 +11,7 @@
 
   <output name="O6"  num_pins="1" />
 
-  <delay_matrix type="max" in_port="BLK_MM-SPRAM64.A" out_port="BLK_MM-SPRAM64.O6">
+  <delay_matrix type="max" in_port="SPRAM64.A" out_port="SPRAM64.O6">
     0.068e-9
     0.068e-9
     0.068e-9
@@ -20,20 +20,20 @@
     0.068e-9
   </delay_matrix>
 
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM64.A"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64.A"  clock="CLK" />
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM64.WA7"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64.WA7"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64.WA7"  out_port="BLK_MM-SPRAM64.O6" />
-  <T_setup      value="10e-12" port="BLK_MM-SPRAM64.WA8"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64.WA8"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64.WA8"  out_port="BLK_MM-SPRAM64.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM64.WE"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64.WE"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64.WE"  out_port="BLK_MM-SPRAM64.O6" />
-  <T_setup    value="10e-12" port="BLK_MM-SPRAM64.DI1"  clock="CLK" />
-  <T_clock_to_Q   max="10e-12" port="BLK_MM-SPRAM64.DI1"  clock="CLK" />
-  <delay_constant max="10e-12" in_port="BLK_MM-SPRAM64.DI1"  out_port="BLK_MM-SPRAM64.O6" />
+  <T_setup      value="10e-12" port="SPRAM64.A"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64.A"  clock="CLK" />
+  <T_setup      value="10e-12" port="SPRAM64.WA7"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64.WA7"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64.WA7"  out_port="SPRAM64.O6" />
+  <T_setup      value="10e-12" port="SPRAM64.WA8"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64.WA8"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64.WA8"  out_port="SPRAM64.O6" />
+  <T_setup    value="10e-12" port="SPRAM64.WE"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64.WE"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64.WE"  out_port="SPRAM64.O6" />
+  <T_setup    value="10e-12" port="SPRAM64.DI1"  clock="CLK" />
+  <T_clock_to_Q   max="10e-12" port="SPRAM64.DI1"  clock="CLK" />
+  <delay_constant max="10e-12" in_port="SPRAM64.DI1"  out_port="SPRAM64.O6" />
   <metadata>
     <meta name="fasm_params">
       INIT[63:0] = INIT
@@ -41,5 +41,7 @@
     <meta name="fasm_features">
       RAM
     </meta>
+    <meta name="type">bel</meta>
+    <meta name="subtype">memory</meta>
   </metadata>
 </pb_type>

--- a/xc7/primitives/slicem/slicem.pb_type.xml
+++ b/xc7/primitives/slicem/slicem.pb_type.xml
@@ -1,7 +1,7 @@
 <!-- A diagram for the SLICEM is shown in;
     7 Series FPGAs CLB User Guide UG474 (v1.8) September 27, 2016
   -->
-<pb_type name="BLK_IG-SLICEM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
+<pb_type name="SLICEM" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
 
   <input name="DI" num_pins="1"/>
   <input name="DX" num_pins="1"/>
@@ -66,7 +66,7 @@
 
   <xi:include href="../common_slice/common_slice.pb_type.xml"/>
 
-  <pb_type name="BLK_IG-SLICEM_MODES" num_pb="1">
+  <pb_type name="SLICEM_MODES" num_pb="1">
     <input name="DI" num_pins="1"/>
     <input name="DX" num_pins="1"/>
     <input name="D1" num_pins="1"/>
@@ -132,54 +132,54 @@
 
       <interconnect>
         <!-- Normal LUT input pins -->
-        <direct name="D1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-COMMON_LUT_AND_F78MUX.D1" />
-        <direct name="D2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-COMMON_LUT_AND_F78MUX.D2" />
-        <direct name="D3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-COMMON_LUT_AND_F78MUX.D3" />
-        <direct name="D4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-COMMON_LUT_AND_F78MUX.D4" />
-        <direct name="D5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-COMMON_LUT_AND_F78MUX.D5" />
-        <direct name="D6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-COMMON_LUT_AND_F78MUX.D6" />
+        <direct name="D1" input="SLICEM_MODES.D1" output="COMMON_LUT_AND_F78MUX.D1" />
+        <direct name="D2" input="SLICEM_MODES.D2" output="COMMON_LUT_AND_F78MUX.D2" />
+        <direct name="D3" input="SLICEM_MODES.D3" output="COMMON_LUT_AND_F78MUX.D3" />
+        <direct name="D4" input="SLICEM_MODES.D4" output="COMMON_LUT_AND_F78MUX.D4" />
+        <direct name="D5" input="SLICEM_MODES.D5" output="COMMON_LUT_AND_F78MUX.D5" />
+        <direct name="D6" input="SLICEM_MODES.D6" output="COMMON_LUT_AND_F78MUX.D6" />
 
-        <direct name="C1" input="BLK_IG-SLICEM_MODES.C1" output="BLK_IG-COMMON_LUT_AND_F78MUX.C1" />
-        <direct name="C2" input="BLK_IG-SLICEM_MODES.C2" output="BLK_IG-COMMON_LUT_AND_F78MUX.C2" />
-        <direct name="C3" input="BLK_IG-SLICEM_MODES.C3" output="BLK_IG-COMMON_LUT_AND_F78MUX.C3" />
-        <direct name="C4" input="BLK_IG-SLICEM_MODES.C4" output="BLK_IG-COMMON_LUT_AND_F78MUX.C4" />
-        <direct name="C5" input="BLK_IG-SLICEM_MODES.C5" output="BLK_IG-COMMON_LUT_AND_F78MUX.C5" />
-        <direct name="C6" input="BLK_IG-SLICEM_MODES.C6" output="BLK_IG-COMMON_LUT_AND_F78MUX.C6" />
+        <direct name="C1" input="SLICEM_MODES.C1" output="COMMON_LUT_AND_F78MUX.C1" />
+        <direct name="C2" input="SLICEM_MODES.C2" output="COMMON_LUT_AND_F78MUX.C2" />
+        <direct name="C3" input="SLICEM_MODES.C3" output="COMMON_LUT_AND_F78MUX.C3" />
+        <direct name="C4" input="SLICEM_MODES.C4" output="COMMON_LUT_AND_F78MUX.C4" />
+        <direct name="C5" input="SLICEM_MODES.C5" output="COMMON_LUT_AND_F78MUX.C5" />
+        <direct name="C6" input="SLICEM_MODES.C6" output="COMMON_LUT_AND_F78MUX.C6" />
 
-        <direct name="B1" input="BLK_IG-SLICEM_MODES.B1" output="BLK_IG-COMMON_LUT_AND_F78MUX.B1" />
-        <direct name="B2" input="BLK_IG-SLICEM_MODES.B2" output="BLK_IG-COMMON_LUT_AND_F78MUX.B2" />
-        <direct name="B3" input="BLK_IG-SLICEM_MODES.B3" output="BLK_IG-COMMON_LUT_AND_F78MUX.B3" />
-        <direct name="B4" input="BLK_IG-SLICEM_MODES.B4" output="BLK_IG-COMMON_LUT_AND_F78MUX.B4" />
-        <direct name="B5" input="BLK_IG-SLICEM_MODES.B5" output="BLK_IG-COMMON_LUT_AND_F78MUX.B5" />
-        <direct name="B6" input="BLK_IG-SLICEM_MODES.B6" output="BLK_IG-COMMON_LUT_AND_F78MUX.B6" />
+        <direct name="B1" input="SLICEM_MODES.B1" output="COMMON_LUT_AND_F78MUX.B1" />
+        <direct name="B2" input="SLICEM_MODES.B2" output="COMMON_LUT_AND_F78MUX.B2" />
+        <direct name="B3" input="SLICEM_MODES.B3" output="COMMON_LUT_AND_F78MUX.B3" />
+        <direct name="B4" input="SLICEM_MODES.B4" output="COMMON_LUT_AND_F78MUX.B4" />
+        <direct name="B5" input="SLICEM_MODES.B5" output="COMMON_LUT_AND_F78MUX.B5" />
+        <direct name="B6" input="SLICEM_MODES.B6" output="COMMON_LUT_AND_F78MUX.B6" />
 
-        <direct name="A1" input="BLK_IG-SLICEM_MODES.A1" output="BLK_IG-COMMON_LUT_AND_F78MUX.A1" />
-        <direct name="A2" input="BLK_IG-SLICEM_MODES.A2" output="BLK_IG-COMMON_LUT_AND_F78MUX.A2" />
-        <direct name="A3" input="BLK_IG-SLICEM_MODES.A3" output="BLK_IG-COMMON_LUT_AND_F78MUX.A3" />
-        <direct name="A4" input="BLK_IG-SLICEM_MODES.A4" output="BLK_IG-COMMON_LUT_AND_F78MUX.A4" />
-        <direct name="A5" input="BLK_IG-SLICEM_MODES.A5" output="BLK_IG-COMMON_LUT_AND_F78MUX.A5" />
-        <direct name="A6" input="BLK_IG-SLICEM_MODES.A6" output="BLK_IG-COMMON_LUT_AND_F78MUX.A6" />
+        <direct name="A1" input="SLICEM_MODES.A1" output="COMMON_LUT_AND_F78MUX.A1" />
+        <direct name="A2" input="SLICEM_MODES.A2" output="COMMON_LUT_AND_F78MUX.A2" />
+        <direct name="A3" input="SLICEM_MODES.A3" output="COMMON_LUT_AND_F78MUX.A3" />
+        <direct name="A4" input="SLICEM_MODES.A4" output="COMMON_LUT_AND_F78MUX.A4" />
+        <direct name="A5" input="SLICEM_MODES.A5" output="COMMON_LUT_AND_F78MUX.A5" />
+        <direct name="A6" input="SLICEM_MODES.A6" output="COMMON_LUT_AND_F78MUX.A6" />
 
-        <direct name="CX"  input="BLK_IG-SLICEM_MODES.CX" output="BLK_IG-COMMON_LUT_AND_F78MUX.CX" />
-        <direct name="BX"  input="BLK_IG-SLICEM_MODES.BX" output="BLK_IG-COMMON_LUT_AND_F78MUX.BX" />
-        <direct name="AX"  input="BLK_IG-SLICEM_MODES.AX" output="BLK_IG-COMMON_LUT_AND_F78MUX.AX" />
+        <direct name="CX"  input="SLICEM_MODES.CX" output="COMMON_LUT_AND_F78MUX.CX" />
+        <direct name="BX"  input="SLICEM_MODES.BX" output="COMMON_LUT_AND_F78MUX.BX" />
+        <direct name="AX"  input="SLICEM_MODES.AX" output="COMMON_LUT_AND_F78MUX.AX" />
 
         <!-- COMMON_SLICE inputs -->
-        <direct name="DO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.DO6"   output="BLK_IG-SLICEM_MODES.DO6" />
-        <direct name="DO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.DO5"   output="BLK_IG-SLICEM_MODES.DO5" />
+        <direct name="DO6" input="COMMON_LUT_AND_F78MUX.DO6"   output="SLICEM_MODES.DO6" />
+        <direct name="DO5" input="COMMON_LUT_AND_F78MUX.DO5"   output="SLICEM_MODES.DO5" />
 
-        <direct name="CO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.CO6"   output="BLK_IG-SLICEM_MODES.CO6" />
-        <direct name="CO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.CO5"   output="BLK_IG-SLICEM_MODES.CO5" />
+        <direct name="CO6" input="COMMON_LUT_AND_F78MUX.CO6"   output="SLICEM_MODES.CO6" />
+        <direct name="CO5" input="COMMON_LUT_AND_F78MUX.CO5"   output="SLICEM_MODES.CO5" />
 
-        <direct name="BO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.BO6"   output="BLK_IG-SLICEM_MODES.BO6" />
-        <direct name="BO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.BO5"   output="BLK_IG-SLICEM_MODES.BO5" />
+        <direct name="BO6" input="COMMON_LUT_AND_F78MUX.BO6"   output="SLICEM_MODES.BO6" />
+        <direct name="BO5" input="COMMON_LUT_AND_F78MUX.BO5"   output="SLICEM_MODES.BO5" />
 
-        <direct name="AO6" input="BLK_IG-COMMON_LUT_AND_F78MUX.AO6"   output="BLK_IG-SLICEM_MODES.AO6" />
-        <direct name="AO5" input="BLK_IG-COMMON_LUT_AND_F78MUX.AO5"   output="BLK_IG-SLICEM_MODES.AO5" />
+        <direct name="AO6" input="COMMON_LUT_AND_F78MUX.AO6"   output="SLICEM_MODES.AO6" />
+        <direct name="AO5" input="COMMON_LUT_AND_F78MUX.AO5"   output="SLICEM_MODES.AO5" />
 
-        <direct name="F7AMUX_O" input="BLK_IG-COMMON_LUT_AND_F78MUX.F7AMUX_O"   output="BLK_IG-SLICEM_MODES.F7AMUX_O" />
-        <direct name="F7BMUX_O" input="BLK_IG-COMMON_LUT_AND_F78MUX.F7BMUX_O"   output="BLK_IG-SLICEM_MODES.F7BMUX_O" />
-        <direct name="F8MUX_O"  input="BLK_IG-COMMON_LUT_AND_F78MUX.F8MUX_O"    output="BLK_IG-SLICEM_MODES.F8MUX_O" />
+        <direct name="F7AMUX_O" input="COMMON_LUT_AND_F78MUX.F7AMUX_O"   output="SLICEM_MODES.F7AMUX_O" />
+        <direct name="F7BMUX_O" input="COMMON_LUT_AND_F78MUX.F7BMUX_O"   output="SLICEM_MODES.F7BMUX_O" />
+        <direct name="F8MUX_O"  input="COMMON_LUT_AND_F78MUX.F8MUX_O"    output="SLICEM_MODES.F8MUX_O" />
 
       </interconnect>
     </mode>
@@ -191,111 +191,123 @@
       <xi:include href="../common_slice/muxes/f7amux/f7amux.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f7bmux/f7bmux.pb_type.xml"/>
       <xi:include href="../common_slice/muxes/f8mux/f8mux.pb_type.xml"/>
-      <pb_type name="BEL_BB-DRAM_4_OUTPUT_STUB" blif_model=".subckt DRAM_4_OUTPUT_STUB" num_pb="2">
+      <pb_type name="DRAM_4_OUTPUT_STUB" blif_model=".subckt DRAM_4_OUTPUT_STUB" num_pb="2">
         <xi:include href="dram_4_output_stub.pb_type.xml"
                     xpointer="xpointer(pb_type/child::node())" />
+        <metadata>
+          <meta name="type">bel</meta>
+          <meta name="subtype">blackbox</meta>
+        </metadata>
       </pb_type>
-      <pb_type name="BEL_BB-DRAM_2_OUTPUT_STUB" blif_model=".subckt DRAM_2_OUTPUT_STUB" num_pb="4">
+      <pb_type name="DRAM_2_OUTPUT_STUB" blif_model=".subckt DRAM_2_OUTPUT_STUB" num_pb="4">
         <xi:include href="dram_2_output_stub.pb_type.xml"
                     xpointer="xpointer(pb_type/child::node())" />
+        <metadata>
+          <meta name="type">bel</meta>
+          <meta name="subtype">blackbox</meta>
+        </metadata>
       </pb_type>
 
-      <pb_type name="BLK_MM-WE_MUX" num_pb="1">
+      <pb_type name="WE_MUX" num_pb="1">
         <input name="CE" num_pins="1"/>
         <input name="WE" num_pins="1"/>
 
         <output name="WE_OUT"   num_pins="1"/>
 
         <interconnect>
-          <mux name="WE_MUX" input="BLK_MM-WE_MUX.CE BLK_MM-WE_MUX.WE"  output="BLK_MM-WE_MUX.WE_OUT">
+          <mux name="WE_MUX" input="WE_MUX.CE WE_MUX.WE"  output="WE_MUX.WE_OUT">
             <metadata>
               <meta name="fasm_mux">
-                BLK_MM-WE_MUX.CE = WEMUX.CE
-                BLK_MM-WE_MUX.WE = NULL
+                WE_MUX.CE = WEMUX.CE
+                WE_MUX.WE = NULL
               </meta>
             </metadata>
           </mux>
         </interconnect>
+        <metadata>
+          <meta name="type">bel</meta>
+          <meta name="subtype">routing</meta>
+        </metadata>
       </pb_type>
 
       <interconnect>
-        <direct name="AMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-A_DRAM.CLK"/>
-        <direct name="BMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-B_DRAM.CLK"/>
-        <direct name="CMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-C_DRAM.CLK"/>
-        <direct name="DMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-D_DRAM.CLK"/>
+        <direct name="AMEMCLK" input="SLICEM_MODES.CLK" output="A_DRAM.CLK"/>
+        <direct name="BMEMCLK" input="SLICEM_MODES.CLK" output="B_DRAM.CLK"/>
+        <direct name="CMEMCLK" input="SLICEM_MODES.CLK" output="C_DRAM.CLK"/>
+        <direct name="DMEMCLK" input="SLICEM_MODES.CLK" output="D_DRAM.CLK"/>
 
-        <direct name="D1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-D_DRAM.A[0]" />
-        <direct name="D2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-D_DRAM.A[1]" />
-        <direct name="D3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-D_DRAM.A[2]" />
-        <direct name="D4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-D_DRAM.A[3]" />
-        <direct name="D5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-D_DRAM.A[4]" />
-        <direct name="D6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-D_DRAM.A[5]" />
+        <direct name="D1" input="SLICEM_MODES.D1" output="D_DRAM.A[0]" />
+        <direct name="D2" input="SLICEM_MODES.D2" output="D_DRAM.A[1]" />
+        <direct name="D3" input="SLICEM_MODES.D3" output="D_DRAM.A[2]" />
+        <direct name="D4" input="SLICEM_MODES.D4" output="D_DRAM.A[3]" />
+        <direct name="D5" input="SLICEM_MODES.D5" output="D_DRAM.A[4]" />
+        <direct name="D6" input="SLICEM_MODES.D6" output="D_DRAM.A[5]" />
 
-        <direct name="C1" input="BLK_IG-SLICEM_MODES.C1" output="BLK_IG-C_DRAM.A[0]" />
-        <direct name="C2" input="BLK_IG-SLICEM_MODES.C2" output="BLK_IG-C_DRAM.A[1]" />
-        <direct name="C3" input="BLK_IG-SLICEM_MODES.C3" output="BLK_IG-C_DRAM.A[2]" />
-        <direct name="C4" input="BLK_IG-SLICEM_MODES.C4" output="BLK_IG-C_DRAM.A[3]" />
-        <direct name="C5" input="BLK_IG-SLICEM_MODES.C5" output="BLK_IG-C_DRAM.A[4]" />
-        <direct name="C6" input="BLK_IG-SLICEM_MODES.C6" output="BLK_IG-C_DRAM.A[5]" />
+        <direct name="C1" input="SLICEM_MODES.C1" output="C_DRAM.A[0]" />
+        <direct name="C2" input="SLICEM_MODES.C2" output="C_DRAM.A[1]" />
+        <direct name="C3" input="SLICEM_MODES.C3" output="C_DRAM.A[2]" />
+        <direct name="C4" input="SLICEM_MODES.C4" output="C_DRAM.A[3]" />
+        <direct name="C5" input="SLICEM_MODES.C5" output="C_DRAM.A[4]" />
+        <direct name="C6" input="SLICEM_MODES.C6" output="C_DRAM.A[5]" />
 
-        <direct name="B1" input="BLK_IG-SLICEM_MODES.B1" output="BLK_IG-B_DRAM.A[0]" />
-        <direct name="B2" input="BLK_IG-SLICEM_MODES.B2" output="BLK_IG-B_DRAM.A[1]" />
-        <direct name="B3" input="BLK_IG-SLICEM_MODES.B3" output="BLK_IG-B_DRAM.A[2]" />
-        <direct name="B4" input="BLK_IG-SLICEM_MODES.B4" output="BLK_IG-B_DRAM.A[3]" />
-        <direct name="B5" input="BLK_IG-SLICEM_MODES.B5" output="BLK_IG-B_DRAM.A[4]" />
-        <direct name="B6" input="BLK_IG-SLICEM_MODES.B6" output="BLK_IG-B_DRAM.A[5]" />
+        <direct name="B1" input="SLICEM_MODES.B1" output="B_DRAM.A[0]" />
+        <direct name="B2" input="SLICEM_MODES.B2" output="B_DRAM.A[1]" />
+        <direct name="B3" input="SLICEM_MODES.B3" output="B_DRAM.A[2]" />
+        <direct name="B4" input="SLICEM_MODES.B4" output="B_DRAM.A[3]" />
+        <direct name="B5" input="SLICEM_MODES.B5" output="B_DRAM.A[4]" />
+        <direct name="B6" input="SLICEM_MODES.B6" output="B_DRAM.A[5]" />
 
-        <direct name="A1" input="BLK_IG-SLICEM_MODES.A1" output="BLK_IG-A_DRAM.A[0]" />
-        <direct name="A2" input="BLK_IG-SLICEM_MODES.A2" output="BLK_IG-A_DRAM.A[1]" />
-        <direct name="A3" input="BLK_IG-SLICEM_MODES.A3" output="BLK_IG-A_DRAM.A[2]" />
-        <direct name="A4" input="BLK_IG-SLICEM_MODES.A4" output="BLK_IG-A_DRAM.A[3]" />
-        <direct name="A5" input="BLK_IG-SLICEM_MODES.A5" output="BLK_IG-A_DRAM.A[4]" />
-        <direct name="A6" input="BLK_IG-SLICEM_MODES.A6" output="BLK_IG-A_DRAM.A[5]" />
+        <direct name="A1" input="SLICEM_MODES.A1" output="A_DRAM.A[0]" />
+        <direct name="A2" input="SLICEM_MODES.A2" output="A_DRAM.A[1]" />
+        <direct name="A3" input="SLICEM_MODES.A3" output="A_DRAM.A[2]" />
+        <direct name="A4" input="SLICEM_MODES.A4" output="A_DRAM.A[3]" />
+        <direct name="A5" input="SLICEM_MODES.A5" output="A_DRAM.A[4]" />
+        <direct name="A6" input="SLICEM_MODES.A6" output="A_DRAM.A[5]" />
 
         <!-- W Address lines come in on the DLUT pins and go to all the LUTs.
             -->
-        <direct name="WC1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-C_DRAM.WA[0]" />
-        <direct name="WC2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-C_DRAM.WA[1]" />
-        <direct name="WC3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-C_DRAM.WA[2]" />
-        <direct name="WC4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-C_DRAM.WA[3]" />
-        <direct name="WC5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-C_DRAM.WA[4]" />
-        <direct name="WC6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-C_DRAM.WA[5]" />
+        <direct name="WC1" input="SLICEM_MODES.D1" output="C_DRAM.WA[0]" />
+        <direct name="WC2" input="SLICEM_MODES.D2" output="C_DRAM.WA[1]" />
+        <direct name="WC3" input="SLICEM_MODES.D3" output="C_DRAM.WA[2]" />
+        <direct name="WC4" input="SLICEM_MODES.D4" output="C_DRAM.WA[3]" />
+        <direct name="WC5" input="SLICEM_MODES.D5" output="C_DRAM.WA[4]" />
+        <direct name="WC6" input="SLICEM_MODES.D6" output="C_DRAM.WA[5]" />
 
-        <direct name="WB1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-B_DRAM.WA[0]" />
-        <direct name="WB2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-B_DRAM.WA[1]" />
-        <direct name="WB3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-B_DRAM.WA[2]" />
-        <direct name="WB4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-B_DRAM.WA[3]" />
-        <direct name="WB5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-B_DRAM.WA[4]" />
-        <direct name="WB6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-B_DRAM.WA[5]" />
+        <direct name="WB1" input="SLICEM_MODES.D1" output="B_DRAM.WA[0]" />
+        <direct name="WB2" input="SLICEM_MODES.D2" output="B_DRAM.WA[1]" />
+        <direct name="WB3" input="SLICEM_MODES.D3" output="B_DRAM.WA[2]" />
+        <direct name="WB4" input="SLICEM_MODES.D4" output="B_DRAM.WA[3]" />
+        <direct name="WB5" input="SLICEM_MODES.D5" output="B_DRAM.WA[4]" />
+        <direct name="WB6" input="SLICEM_MODES.D6" output="B_DRAM.WA[5]" />
 
-        <direct name="WA1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-A_DRAM.WA[0]" />
-        <direct name="WA2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-A_DRAM.WA[1]" />
-        <direct name="WA3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-A_DRAM.WA[2]" />
-        <direct name="WA4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-A_DRAM.WA[3]" />
-        <direct name="WA5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-A_DRAM.WA[4]" />
-        <direct name="WA6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-A_DRAM.WA[5]" />
+        <direct name="WA1" input="SLICEM_MODES.D1" output="A_DRAM.WA[0]" />
+        <direct name="WA2" input="SLICEM_MODES.D2" output="A_DRAM.WA[1]" />
+        <direct name="WA3" input="SLICEM_MODES.D3" output="A_DRAM.WA[2]" />
+        <direct name="WA4" input="SLICEM_MODES.D4" output="A_DRAM.WA[3]" />
+        <direct name="WA5" input="SLICEM_MODES.D5" output="A_DRAM.WA[4]" />
+        <direct name="WA6" input="SLICEM_MODES.D6" output="A_DRAM.WA[5]" />
 
         <!-- WA7 and WA8 should only be used in this mode if using 256x1S,
              which consumes the entire slice. -->
-        <direct name="D_WA7" input="BLK_IG-SLICEM_MODES.WA7"  output="BLK_IG-D_DRAM.WA7" />
-        <direct name="C_WA7" input="BLK_IG-SLICEM_MODES.WA7"  output="BLK_IG-C_DRAM.WA[6]" />
-        <direct name="B_WA7" input="BLK_IG-SLICEM_MODES.WA7"  output="BLK_IG-B_DRAM.WA[6]" />
-        <direct name="A_WA7" input="BLK_IG-SLICEM_MODES.WA7"  output="BLK_IG-A_DRAM.WA[6]" />
+        <direct name="D_WA7" input="SLICEM_MODES.WA7"  output="D_DRAM.WA7" />
+        <direct name="C_WA7" input="SLICEM_MODES.WA7"  output="C_DRAM.WA[6]" />
+        <direct name="B_WA7" input="SLICEM_MODES.WA7"  output="B_DRAM.WA[6]" />
+        <direct name="A_WA7" input="SLICEM_MODES.WA7"  output="A_DRAM.WA[6]" />
 
-        <direct name="D_WA8" input="BLK_IG-SLICEM_MODES.WA8"  output="BLK_IG-D_DRAM.WA8" />
-        <direct name="C_WA8" input="BLK_IG-SLICEM_MODES.WA8"  output="BLK_IG-C_DRAM.WA[7]" />
-        <direct name="B_WA8" input="BLK_IG-SLICEM_MODES.WA8"  output="BLK_IG-B_DRAM.WA[7]" />
-        <direct name="A_WA8" input="BLK_IG-SLICEM_MODES.WA8"  output="BLK_IG-A_DRAM.WA[7]" />
+        <direct name="D_WA8" input="SLICEM_MODES.WA8"  output="D_DRAM.WA8" />
+        <direct name="C_WA8" input="SLICEM_MODES.WA8"  output="C_DRAM.WA[7]" />
+        <direct name="B_WA8" input="SLICEM_MODES.WA8"  output="B_DRAM.WA[7]" />
+        <direct name="A_WA8" input="SLICEM_MODES.WA8"  output="A_DRAM.WA[7]" />
 
         <!-- Direct DI1 inputs -->
-        <direct name="DI" input="BLK_IG-SLICEM_MODES.DI" output="BLK_IG-D_DRAM.DI1" />
-        <direct name="CI" input="BLK_IG-SLICEM_MODES.CI" output="BLK_IG-C_DRAM.CI" />
-        <direct name="BI" input="BLK_IG-SLICEM_MODES.BI" output="BLK_IG-B_DRAM.BI" />
-        <direct name="AI" input="BLK_IG-SLICEM_MODES.AI" output="BLK_IG-A_DRAM.AI" />
+        <direct name="DI" input="SLICEM_MODES.DI" output="D_DRAM.DI1" />
+        <direct name="CI" input="SLICEM_MODES.CI" output="C_DRAM.CI" />
+        <direct name="BI" input="SLICEM_MODES.BI" output="B_DRAM.BI" />
+        <direct name="AI" input="SLICEM_MODES.AI" output="A_DRAM.AI" />
 
         <!-- Parent DI1 inputs -->
-        <direct name="P_CI" input="BLK_IG-SLICEM_MODES.DI" output="BLK_IG-C_DRAM.PARENT_DI" />
-        <direct name="P_BI" input="BLK_IG-SLICEM_MODES.DI" output="BLK_IG-B_DRAM.PARENT_DI" />
+        <direct name="P_CI" input="SLICEM_MODES.DI" output="C_DRAM.PARENT_DI" />
+        <direct name="P_BI" input="SLICEM_MODES.DI" output="B_DRAM.PARENT_DI" />
 
         <!-- This isn't quiet right.  SLICEM_MODES.DI is used if and only if
              B_DRAM is in dual-port mode, and SLICEM_MODES.BI is used if and
@@ -312,124 +324,124 @@
 
              It is worth noting that if B_DRAM only have 1 single port mode,
              this issue wouldn't arise, but that would require creating
-             BLK_IG-B_DRAM32 and another top level model for 32-bit DRAMs,
+             B_DRAM32 and another top level model for 32-bit DRAMs,
              which would duplicate SLICEM_MODES more than would otherwise be
              required.
              -->
-        <mux name="P_AI" input="BLK_IG-SLICEM_MODES.DI BLK_IG-SLICEM_MODES.BI" output="BLK_IG-A_DRAM.PARENT_DI" />
+        <mux name="P_AI" input="SLICEM_MODES.DI SLICEM_MODES.BI" output="A_DRAM.PARENT_DI" />
 
         <!-- DI2 inputs -->
-        <direct name="D_DI2" input="BLK_IG-SLICEM_MODES.DX" output="BLK_IG-D_DRAM.DI2" />
-        <direct name="C_DI2" input="BLK_IG-SLICEM_MODES.CX" output="BLK_IG-C_DRAM.DI2" />
-        <direct name="B_DI2" input="BLK_IG-SLICEM_MODES.BX" output="BLK_IG-B_DRAM.DI2" />
-        <direct name="A_DI2" input="BLK_IG-SLICEM_MODES.AX" output="BLK_IG-A_DRAM.DI2" />
+        <direct name="D_DI2" input="SLICEM_MODES.DX" output="D_DRAM.DI2" />
+        <direct name="C_DI2" input="SLICEM_MODES.CX" output="C_DRAM.DI2" />
+        <direct name="B_DI2" input="SLICEM_MODES.BX" output="B_DRAM.DI2" />
+        <direct name="A_DI2" input="SLICEM_MODES.AX" output="A_DRAM.DI2" />
 
         <!-- WE inputs -->
-        <direct name="CE_TO_WE_MUX" input="BLK_IG-SLICEM_MODES.CE"  output="BLK_MM-WE_MUX.CE"/>
-        <direct name="WE_TO_WE_MUX" input="BLK_IG-SLICEM_MODES.WE"  output="BLK_MM-WE_MUX.WE"/>
-        <direct name="WE1" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-A_DRAM.WE"/>
-        <direct name="WE2" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-B_DRAM.WE"/>
-        <direct name="WE3" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-C_DRAM.WE"/>
-        <direct name="WE4" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-D_DRAM.WE"/>
+        <direct name="CE_TO_WE_MUX" input="SLICEM_MODES.CE"  output="WE_MUX.CE"/>
+        <direct name="WE_TO_WE_MUX" input="SLICEM_MODES.WE"  output="WE_MUX.WE"/>
+        <direct name="WE1" input="WE_MUX.WE_OUT"  output="A_DRAM.WE"/>
+        <direct name="WE2" input="WE_MUX.WE_OUT"  output="B_DRAM.WE"/>
+        <direct name="WE3" input="WE_MUX.WE_OUT"  output="C_DRAM.WE"/>
+        <direct name="WE4" input="WE_MUX.WE_OUT"  output="D_DRAM.WE"/>
 
         <!-- Outputs -->
 
-        <direct name="SPO_0" input="BLK_IG-D_DRAM.SO6_32" output="BEL_BB-DRAM_2_OUTPUT_STUB[0].SPO">
-          <pack_pattern in_port="BLK_IG-D_DRAM.SO6_32" name="DRAM_DP_32" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[0].SPO" />
+        <direct name="SPO_0" input="D_DRAM.SO6_32" output="DRAM_2_OUTPUT_STUB[0].SPO">
+          <pack_pattern in_port="D_DRAM.SO6_32" name="DRAM_DP_32" out_port="DRAM_2_OUTPUT_STUB[0].SPO" />
         </direct>
-        <direct name="DPO_0" input="BLK_IG-C_DRAM.DO6_32" output="BEL_BB-DRAM_2_OUTPUT_STUB[0].DPO">
-          <pack_pattern in_port="BLK_IG-C_DRAM.DO6_32" name="DRAM_DP_32" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[0].DPO" />
+        <direct name="DPO_0" input="C_DRAM.DO6_32" output="DRAM_2_OUTPUT_STUB[0].DPO">
+          <pack_pattern in_port="C_DRAM.DO6_32" name="DRAM_DP_32" out_port="DRAM_2_OUTPUT_STUB[0].DPO" />
         </direct>
-        <direct name="SPO_1" input="BLK_IG-B_DRAM.SO6_32" output="BEL_BB-DRAM_2_OUTPUT_STUB[1].SPO">
-          <pack_pattern in_port="BLK_IG-B_DRAM.SO6_32" name="DRAM_DP_32" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[1].SPO" />
+        <direct name="SPO_1" input="B_DRAM.SO6_32" output="DRAM_2_OUTPUT_STUB[1].SPO">
+          <pack_pattern in_port="B_DRAM.SO6_32" name="DRAM_DP_32" out_port="DRAM_2_OUTPUT_STUB[1].SPO" />
         </direct>
-        <direct name="DPO_1" input="BLK_IG-A_DRAM.DO6_32" output="BEL_BB-DRAM_2_OUTPUT_STUB[1].DPO">
-          <pack_pattern in_port="BLK_IG-A_DRAM.DO6_32" name="DRAM_DP_32" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[1].DPO" />
-        </direct>
-
-        <direct name="SPO_2" input="BLK_IG-D_DRAM.SO6" output="BEL_BB-DRAM_2_OUTPUT_STUB[2].SPO">
-          <pack_pattern in_port="BLK_IG-D_DRAM.SO6" name="DRAM_DP" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[2].SPO" />
-        </direct>
-        <direct name="DPO_2" input="BLK_IG-C_DRAM.DO6" output="BEL_BB-DRAM_2_OUTPUT_STUB[2].DPO">
-          <pack_pattern in_port="BLK_IG-C_DRAM.DO6" name="DRAM_DP" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[2].DPO" />
-        </direct>
-        <direct name="SPO_3" input="BLK_IG-B_DRAM.SO6" output="BEL_BB-DRAM_2_OUTPUT_STUB[3].SPO">
-          <pack_pattern in_port="BLK_IG-B_DRAM.SO6" name="DRAM_DP" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[3].SPO" />
-        </direct>
-        <direct name="DPO_3" input="BLK_IG-A_DRAM.DO6" output="BEL_BB-DRAM_2_OUTPUT_STUB[3].DPO">
-          <pack_pattern in_port="BLK_IG-A_DRAM.DO6" name="DRAM_DP" out_port="BEL_BB-DRAM_2_OUTPUT_STUB[3].DPO" />
+        <direct name="DPO_1" input="A_DRAM.DO6_32" output="DRAM_2_OUTPUT_STUB[1].DPO">
+          <pack_pattern in_port="A_DRAM.DO6_32" name="DRAM_DP_32" out_port="DRAM_2_OUTPUT_STUB[1].DPO" />
         </direct>
 
-        <direct name="DOD32" input="BLK_IG-D_DRAM.SO6_32" output="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOD">
-          <pack_pattern  in_port="BLK_IG-D_DRAM.SO6_32" name="DRAM_QP_32" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOD" />
+        <direct name="SPO_2" input="D_DRAM.SO6" output="DRAM_2_OUTPUT_STUB[2].SPO">
+          <pack_pattern in_port="D_DRAM.SO6" name="DRAM_DP" out_port="DRAM_2_OUTPUT_STUB[2].SPO" />
         </direct>
-        <direct name="DOC32" input="BLK_IG-C_DRAM.DO6_32" output="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOC">
-          <pack_pattern  in_port="BLK_IG-C_DRAM.DO6_32" name="DRAM_QP_32" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOC" />
+        <direct name="DPO_2" input="C_DRAM.DO6" output="DRAM_2_OUTPUT_STUB[2].DPO">
+          <pack_pattern in_port="C_DRAM.DO6" name="DRAM_DP" out_port="DRAM_2_OUTPUT_STUB[2].DPO" />
         </direct>
-        <direct name="DOB32" input="BLK_IG-B_DRAM.DO6_32" output="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOB">
-          <pack_pattern  in_port="BLK_IG-B_DRAM.DO6_32" name="DRAM_QP_32" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOB" />
+        <direct name="SPO_3" input="B_DRAM.SO6" output="DRAM_2_OUTPUT_STUB[3].SPO">
+          <pack_pattern in_port="B_DRAM.SO6" name="DRAM_DP" out_port="DRAM_2_OUTPUT_STUB[3].SPO" />
         </direct>
-        <direct name="DOA32" input="BLK_IG-A_DRAM.DO6_32" output="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOA">
-          <pack_pattern  in_port="BLK_IG-A_DRAM.DO6_32" name="DRAM_QP_32" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[0].DOA" />
-        </direct>
-
-        <direct name="DOD" input="BLK_IG-D_DRAM.SO6" output="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOD">
-          <pack_pattern  in_port="BLK_IG-D_DRAM.SO6" name="DRAM_QP" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOD" />
-        </direct>
-        <direct name="DOC" input="BLK_IG-C_DRAM.DO6" output="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOC">
-          <pack_pattern  in_port="BLK_IG-C_DRAM.DO6" name="DRAM_QP" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOC" />
-        </direct>
-        <direct name="DOB" input="BLK_IG-B_DRAM.DO6" output="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOB">
-          <pack_pattern  in_port="BLK_IG-B_DRAM.DO6" name="DRAM_QP" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOB" />
-        </direct>
-        <direct name="DOA" input="BLK_IG-A_DRAM.DO6" output="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOA">
-          <pack_pattern  in_port="BLK_IG-A_DRAM.DO6" name="DRAM_QP" out_port="BEL_BB-DRAM_4_OUTPUT_STUB[1].DOA" />
+        <direct name="DPO_3" input="A_DRAM.DO6" output="DRAM_2_OUTPUT_STUB[3].DPO">
+          <pack_pattern in_port="A_DRAM.DO6" name="DRAM_DP" out_port="DRAM_2_OUTPUT_STUB[3].DPO" />
         </direct>
 
-        <mux    name="DO6" input="BLK_IG-D_DRAM.O6 BEL_BB-DRAM_2_OUTPUT_STUB[0].SPO_OUT BEL_BB-DRAM_2_OUTPUT_STUB[2].SPO_OUT BEL_BB-DRAM_4_OUTPUT_STUB[0].DOD_OUT BEL_BB-DRAM_4_OUTPUT_STUB[1].DOD_OUT"
-                output="BLK_IG-SLICEM_MODES.DO6" />
-        <direct name="DO5" input="BLK_IG-D_DRAM.O5"   output="BLK_IG-SLICEM_MODES.DO5" />
+        <direct name="DOD32" input="D_DRAM.SO6_32" output="DRAM_4_OUTPUT_STUB[0].DOD">
+          <pack_pattern  in_port="D_DRAM.SO6_32" name="DRAM_QP_32" out_port="DRAM_4_OUTPUT_STUB[0].DOD" />
+        </direct>
+        <direct name="DOC32" input="C_DRAM.DO6_32" output="DRAM_4_OUTPUT_STUB[0].DOC">
+          <pack_pattern  in_port="C_DRAM.DO6_32" name="DRAM_QP_32" out_port="DRAM_4_OUTPUT_STUB[0].DOC" />
+        </direct>
+        <direct name="DOB32" input="B_DRAM.DO6_32" output="DRAM_4_OUTPUT_STUB[0].DOB">
+          <pack_pattern  in_port="B_DRAM.DO6_32" name="DRAM_QP_32" out_port="DRAM_4_OUTPUT_STUB[0].DOB" />
+        </direct>
+        <direct name="DOA32" input="A_DRAM.DO6_32" output="DRAM_4_OUTPUT_STUB[0].DOA">
+          <pack_pattern  in_port="A_DRAM.DO6_32" name="DRAM_QP_32" out_port="DRAM_4_OUTPUT_STUB[0].DOA" />
+        </direct>
 
-        <mux    name="CO6" input="BLK_IG-C_DRAM.O6 BEL_BB-DRAM_2_OUTPUT_STUB[0].DPO_OUT BEL_BB-DRAM_2_OUTPUT_STUB[2].DPO_OUT BEL_BB-DRAM_4_OUTPUT_STUB[0].DOC_OUT BEL_BB-DRAM_4_OUTPUT_STUB[1].DOC_OUT"
-                output="BLK_IG-SLICEM_MODES.CO6" />
-        <direct name="CO5" input="BLK_IG-C_DRAM.O5"   output="BLK_IG-SLICEM_MODES.CO5" />
+        <direct name="DOD" input="D_DRAM.SO6" output="DRAM_4_OUTPUT_STUB[1].DOD">
+          <pack_pattern  in_port="D_DRAM.SO6" name="DRAM_QP" out_port="DRAM_4_OUTPUT_STUB[1].DOD" />
+        </direct>
+        <direct name="DOC" input="C_DRAM.DO6" output="DRAM_4_OUTPUT_STUB[1].DOC">
+          <pack_pattern  in_port="C_DRAM.DO6" name="DRAM_QP" out_port="DRAM_4_OUTPUT_STUB[1].DOC" />
+        </direct>
+        <direct name="DOB" input="B_DRAM.DO6" output="DRAM_4_OUTPUT_STUB[1].DOB">
+          <pack_pattern  in_port="B_DRAM.DO6" name="DRAM_QP" out_port="DRAM_4_OUTPUT_STUB[1].DOB" />
+        </direct>
+        <direct name="DOA" input="A_DRAM.DO6" output="DRAM_4_OUTPUT_STUB[1].DOA">
+          <pack_pattern  in_port="A_DRAM.DO6" name="DRAM_QP" out_port="DRAM_4_OUTPUT_STUB[1].DOA" />
+        </direct>
 
-        <mux    name="BO6" input="BLK_IG-B_DRAM.O6 BEL_BB-DRAM_2_OUTPUT_STUB[1].SPO_OUT BEL_BB-DRAM_2_OUTPUT_STUB[3].SPO_OUT BEL_BB-DRAM_4_OUTPUT_STUB[0].DOB_OUT BEL_BB-DRAM_4_OUTPUT_STUB[1].DOB_OUT"
-                output="BLK_IG-SLICEM_MODES.BO6" />
-        <direct name="BO5" input="BLK_IG-B_DRAM.O5"   output="BLK_IG-SLICEM_MODES.BO5" />
+        <mux    name="DO6" input="D_DRAM.O6 DRAM_2_OUTPUT_STUB[0].SPO_OUT DRAM_2_OUTPUT_STUB[2].SPO_OUT DRAM_4_OUTPUT_STUB[0].DOD_OUT DRAM_4_OUTPUT_STUB[1].DOD_OUT"
+                output="SLICEM_MODES.DO6" />
+        <direct name="DO5" input="D_DRAM.O5"   output="SLICEM_MODES.DO5" />
 
-        <mux    name="AO6" input="BLK_IG-A_DRAM.O6 BEL_BB-DRAM_2_OUTPUT_STUB[1].DPO_OUT BEL_BB-DRAM_2_OUTPUT_STUB[3].DPO_OUT BEL_BB-DRAM_4_OUTPUT_STUB[0].DOA_OUT BEL_BB-DRAM_4_OUTPUT_STUB[1].DOA_OUT"
-                output="BLK_IG-SLICEM_MODES.AO6" />
-        <direct name="AO5" input="BLK_IG-A_DRAM.O5"   output="BLK_IG-SLICEM_MODES.AO5" />
+        <mux    name="CO6" input="C_DRAM.O6 DRAM_2_OUTPUT_STUB[0].DPO_OUT DRAM_2_OUTPUT_STUB[2].DPO_OUT DRAM_4_OUTPUT_STUB[0].DOC_OUT DRAM_4_OUTPUT_STUB[1].DOC_OUT"
+                output="SLICEM_MODES.CO6" />
+        <direct name="CO5" input="C_DRAM.O5"   output="SLICEM_MODES.CO5" />
+
+        <mux    name="BO6" input="B_DRAM.O6 DRAM_2_OUTPUT_STUB[1].SPO_OUT DRAM_2_OUTPUT_STUB[3].SPO_OUT DRAM_4_OUTPUT_STUB[0].DOB_OUT DRAM_4_OUTPUT_STUB[1].DOB_OUT"
+                output="SLICEM_MODES.BO6" />
+        <direct name="BO5" input="B_DRAM.O5"   output="SLICEM_MODES.BO5" />
+
+        <mux    name="AO6" input="A_DRAM.O6 DRAM_2_OUTPUT_STUB[1].DPO_OUT DRAM_2_OUTPUT_STUB[3].DPO_OUT DRAM_4_OUTPUT_STUB[0].DOA_OUT DRAM_4_OUTPUT_STUB[1].DOA_OUT"
+                output="SLICEM_MODES.AO6" />
+        <direct name="AO5" input="A_DRAM.O5"   output="SLICEM_MODES.AO5" />
 
         <!-- F7AMUX inputs -->
-        <direct name="F7AMUX_I0" input="BLK_IG-B_DRAM.DO6"   output="BEL_MX-F7AMUX.I0">
-          <pack_pattern in_port="BLK_IG-B_DRAM.DO6" name="DRAM256" out_port="BEL_MX-F7AMUX.I0"/>
+        <direct name="F7AMUX_I0" input="B_DRAM.DO6"   output="F7AMUX.I0">
+          <pack_pattern in_port="B_DRAM.DO6" name="DRAM256" out_port="F7AMUX.I0"/>
         </direct>
-        <direct name="F7AMUX_I1" input="BLK_IG-A_DRAM.DO6"   output="BEL_MX-F7AMUX.I1">
-          <pack_pattern in_port="BLK_IG-A_DRAM.DO6" name="DRAM256" out_port="BEL_MX-F7AMUX.I1"/>
+        <direct name="F7AMUX_I1" input="A_DRAM.DO6"   output="F7AMUX.I1">
+          <pack_pattern in_port="A_DRAM.DO6" name="DRAM256" out_port="F7AMUX.I1"/>
         </direct>
-        <direct name="F7AMUX_S"  input="BLK_IG-SLICEM_MODES.AX" output="BEL_MX-F7AMUX.S" />
+        <direct name="F7AMUX_S"  input="SLICEM_MODES.AX" output="F7AMUX.S" />
         <!-- F7BMUX inputs -->
-        <direct name="F7BMUX_I0" input="BLK_IG-D_DRAM.SO6"   output="BEL_MX-F7BMUX.I0">
-          <pack_pattern in_port="BLK_IG-D_DRAM.SO6" name="DRAM256" out_port="BEL_MX-F7BMUX.I0"/>
+        <direct name="F7BMUX_I0" input="D_DRAM.SO6"   output="F7BMUX.I0">
+          <pack_pattern in_port="D_DRAM.SO6" name="DRAM256" out_port="F7BMUX.I0"/>
         </direct>
-        <direct name="F7BMUX_I1" input="BLK_IG-C_DRAM.DO6"   output="BEL_MX-F7BMUX.I1">
-          <pack_pattern in_port="BLK_IG-C_DRAM.DO6" name="DRAM256" out_port="BEL_MX-F7BMUX.I1"/>
+        <direct name="F7BMUX_I1" input="C_DRAM.DO6"   output="F7BMUX.I1">
+          <pack_pattern in_port="C_DRAM.DO6" name="DRAM256" out_port="F7BMUX.I1"/>
         </direct>
-        <direct name="F7BMUX_S"  input="BLK_IG-SLICEM_MODES.CX" output="BEL_MX-F7BMUX.S" />
+        <direct name="F7BMUX_S"  input="SLICEM_MODES.CX" output="F7BMUX.S" />
         <!-- F8MUX inputs -->
-        <direct name="F8MUX_I0"  input="BEL_MX-F7BMUX.O"  output="BEL_MX-F8MUX.I0">
-          <pack_pattern in_port="BEL_MX-F7BMUX.O" name="DRAM256" out_port="BEL_MX-F8MUX.I0"/>
+        <direct name="F8MUX_I0"  input="F7BMUX.O"  output="F8MUX.I0">
+          <pack_pattern in_port="F7BMUX.O" name="DRAM256" out_port="F8MUX.I0"/>
         </direct>
-        <direct name="F8MUX_I1"  input="BEL_MX-F7AMUX.O"  output="BEL_MX-F8MUX.I1">
-          <pack_pattern in_port="BEL_MX-F7AMUX.O" name="DRAM256" out_port="BEL_MX-F8MUX.I1"/>
+        <direct name="F8MUX_I1"  input="F7AMUX.O"  output="F8MUX.I1">
+          <pack_pattern in_port="F7AMUX.O" name="DRAM256" out_port="F8MUX.I1"/>
         </direct>
-        <direct name="F8MUX_S"   input="BLK_IG-SLICEM_MODES.BX" output="BEL_MX-F8MUX.S" />
+        <direct name="F8MUX_S"   input="SLICEM_MODES.BX" output="F8MUX.S" />
 
-        <direct name="F7AMUX_O"   input="BEL_MX-F7AMUX.O" output="BLK_IG-SLICEM_MODES.F7AMUX_O" />
-        <direct name="F7BMUX_O"   input="BEL_MX-F7BMUX.O" output="BLK_IG-SLICEM_MODES.F7BMUX_O" />
-        <direct name="F8MUX_O"   input="BEL_MX-F8MUX.O" output="BLK_IG-SLICEM_MODES.F8MUX_O" />
+        <direct name="F7AMUX_O"   input="F7AMUX.O" output="SLICEM_MODES.F7AMUX_O" />
+        <direct name="F7BMUX_O"   input="F7BMUX.O" output="SLICEM_MODES.F7BMUX_O" />
+        <direct name="F8MUX_O"   input="F8MUX.O" output="SLICEM_MODES.F8MUX_O" />
 
       </interconnect>
     </mode>
@@ -442,259 +454,271 @@
       <xi:include href="../common_slice/muxes/f7bmux/f7bmux.pb_type.xml"/>
       <xi:include href="dram_2_output_stub.pb_type.xml"/>
 
-      <pb_type name="BLK_MM-WE_MUX" num_pb="1">
+      <pb_type name="WE_MUX" num_pb="1">
         <input name="CE" num_pins="1"/>
         <input name="WE" num_pins="1"/>
 
         <output name="WE_OUT"   num_pins="1"/>
 
         <interconnect>
-          <mux name="WE_MUX" input="BLK_MM-WE_MUX.CE BLK_MM-WE_MUX.WE"  output="BLK_MM-WE_MUX.WE_OUT">
+          <mux name="WE_MUX" input="WE_MUX.CE WE_MUX.WE"  output="WE_MUX.WE_OUT">
             <metadata>
               <meta name="fasm_mux">
-                BLK_MM-WE_MUX.CE = WEMUX.CE
-                BLK_MM-WE_MUX.WE = NULL
+                WE_MUX.CE = WEMUX.CE
+                WE_MUX.WE = NULL
               </meta>
             </metadata>
           </mux>
         </interconnect>
+        <metadata>
+          <meta name="type">bel</meta>
+          <meta name="subtype">routing</meta>
+        </metadata>
       </pb_type>
 
       <interconnect>
-        <direct name="AMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-A_DRAM128.CLK"/>
-        <direct name="BMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-B_DRAM128.CLK"/>
-        <direct name="CMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-C_DRAM128.CLK"/>
-        <direct name="DMEMCLK" input="BLK_IG-SLICEM_MODES.CLK" output="BLK_IG-D_DRAM128.CLK"/>
+        <direct name="AMEMCLK" input="SLICEM_MODES.CLK" output="A_DRAM128.CLK"/>
+        <direct name="BMEMCLK" input="SLICEM_MODES.CLK" output="B_DRAM128.CLK"/>
+        <direct name="CMEMCLK" input="SLICEM_MODES.CLK" output="C_DRAM128.CLK"/>
+        <direct name="DMEMCLK" input="SLICEM_MODES.CLK" output="D_DRAM128.CLK"/>
 
-        <direct name="D1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-D_DRAM128.A[0]" />
-        <direct name="D2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-D_DRAM128.A[1]" />
-        <direct name="D3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-D_DRAM128.A[2]" />
-        <direct name="D4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-D_DRAM128.A[3]" />
-        <direct name="D5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-D_DRAM128.A[4]" />
-        <direct name="D6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-D_DRAM128.A[5]" />
+        <direct name="D1" input="SLICEM_MODES.D1" output="D_DRAM128.A[0]" />
+        <direct name="D2" input="SLICEM_MODES.D2" output="D_DRAM128.A[1]" />
+        <direct name="D3" input="SLICEM_MODES.D3" output="D_DRAM128.A[2]" />
+        <direct name="D4" input="SLICEM_MODES.D4" output="D_DRAM128.A[3]" />
+        <direct name="D5" input="SLICEM_MODES.D5" output="D_DRAM128.A[4]" />
+        <direct name="D6" input="SLICEM_MODES.D6" output="D_DRAM128.A[5]" />
 
-        <direct name="C1" input="BLK_IG-SLICEM_MODES.C1" output="BLK_IG-C_DRAM128.A[0]" />
-        <direct name="C2" input="BLK_IG-SLICEM_MODES.C2" output="BLK_IG-C_DRAM128.A[1]" />
-        <direct name="C3" input="BLK_IG-SLICEM_MODES.C3" output="BLK_IG-C_DRAM128.A[2]" />
-        <direct name="C4" input="BLK_IG-SLICEM_MODES.C4" output="BLK_IG-C_DRAM128.A[3]" />
-        <direct name="C5" input="BLK_IG-SLICEM_MODES.C5" output="BLK_IG-C_DRAM128.A[4]" />
-        <direct name="C6" input="BLK_IG-SLICEM_MODES.C6" output="BLK_IG-C_DRAM128.A[5]" />
+        <direct name="C1" input="SLICEM_MODES.C1" output="C_DRAM128.A[0]" />
+        <direct name="C2" input="SLICEM_MODES.C2" output="C_DRAM128.A[1]" />
+        <direct name="C3" input="SLICEM_MODES.C3" output="C_DRAM128.A[2]" />
+        <direct name="C4" input="SLICEM_MODES.C4" output="C_DRAM128.A[3]" />
+        <direct name="C5" input="SLICEM_MODES.C5" output="C_DRAM128.A[4]" />
+        <direct name="C6" input="SLICEM_MODES.C6" output="C_DRAM128.A[5]" />
 
-        <direct name="B1" input="BLK_IG-SLICEM_MODES.B1" output="BLK_IG-B_DRAM128.A[0]" />
-        <direct name="B2" input="BLK_IG-SLICEM_MODES.B2" output="BLK_IG-B_DRAM128.A[1]" />
-        <direct name="B3" input="BLK_IG-SLICEM_MODES.B3" output="BLK_IG-B_DRAM128.A[2]" />
-        <direct name="B4" input="BLK_IG-SLICEM_MODES.B4" output="BLK_IG-B_DRAM128.A[3]" />
-        <direct name="B5" input="BLK_IG-SLICEM_MODES.B5" output="BLK_IG-B_DRAM128.A[4]" />
-        <direct name="B6" input="BLK_IG-SLICEM_MODES.B6" output="BLK_IG-B_DRAM128.A[5]" />
+        <direct name="B1" input="SLICEM_MODES.B1" output="B_DRAM128.A[0]" />
+        <direct name="B2" input="SLICEM_MODES.B2" output="B_DRAM128.A[1]" />
+        <direct name="B3" input="SLICEM_MODES.B3" output="B_DRAM128.A[2]" />
+        <direct name="B4" input="SLICEM_MODES.B4" output="B_DRAM128.A[3]" />
+        <direct name="B5" input="SLICEM_MODES.B5" output="B_DRAM128.A[4]" />
+        <direct name="B6" input="SLICEM_MODES.B6" output="B_DRAM128.A[5]" />
 
-        <direct name="A1" input="BLK_IG-SLICEM_MODES.A1" output="BLK_IG-A_DRAM128.A[0]" />
-        <direct name="A2" input="BLK_IG-SLICEM_MODES.A2" output="BLK_IG-A_DRAM128.A[1]" />
-        <direct name="A3" input="BLK_IG-SLICEM_MODES.A3" output="BLK_IG-A_DRAM128.A[2]" />
-        <direct name="A4" input="BLK_IG-SLICEM_MODES.A4" output="BLK_IG-A_DRAM128.A[3]" />
-        <direct name="A5" input="BLK_IG-SLICEM_MODES.A5" output="BLK_IG-A_DRAM128.A[4]" />
-        <direct name="A6" input="BLK_IG-SLICEM_MODES.A6" output="BLK_IG-A_DRAM128.A[5]" />
+        <direct name="A1" input="SLICEM_MODES.A1" output="A_DRAM128.A[0]" />
+        <direct name="A2" input="SLICEM_MODES.A2" output="A_DRAM128.A[1]" />
+        <direct name="A3" input="SLICEM_MODES.A3" output="A_DRAM128.A[2]" />
+        <direct name="A4" input="SLICEM_MODES.A4" output="A_DRAM128.A[3]" />
+        <direct name="A5" input="SLICEM_MODES.A5" output="A_DRAM128.A[4]" />
+        <direct name="A6" input="SLICEM_MODES.A6" output="A_DRAM128.A[5]" />
 
         <!-- W Address lines come in on the DLUT pins and go to all the LUTs.
             -->
-        <direct name="WD7" input="BLK_IG-SLICEM_MODES.WA7" output="BLK_IG-D_DRAM128.WA7" />
+        <direct name="WD7" input="SLICEM_MODES.WA7" output="D_DRAM128.WA7" />
 
-        <direct name="WC1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-C_DRAM128.WA[0]" />
-        <direct name="WC2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-C_DRAM128.WA[1]" />
-        <direct name="WC3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-C_DRAM128.WA[2]" />
-        <direct name="WC4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-C_DRAM128.WA[3]" />
-        <direct name="WC5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-C_DRAM128.WA[4]" />
-        <direct name="WC6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-C_DRAM128.WA[5]" />
-        <direct name="WC7" input="BLK_IG-SLICEM_MODES.WA7" output="BLK_IG-C_DRAM128.WA[6]" />
+        <direct name="WC1" input="SLICEM_MODES.D1" output="C_DRAM128.WA[0]" />
+        <direct name="WC2" input="SLICEM_MODES.D2" output="C_DRAM128.WA[1]" />
+        <direct name="WC3" input="SLICEM_MODES.D3" output="C_DRAM128.WA[2]" />
+        <direct name="WC4" input="SLICEM_MODES.D4" output="C_DRAM128.WA[3]" />
+        <direct name="WC5" input="SLICEM_MODES.D5" output="C_DRAM128.WA[4]" />
+        <direct name="WC6" input="SLICEM_MODES.D6" output="C_DRAM128.WA[5]" />
+        <direct name="WC7" input="SLICEM_MODES.WA7" output="C_DRAM128.WA[6]" />
 
-        <direct name="WB1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-B_DRAM128.WA[0]" />
-        <direct name="WB2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-B_DRAM128.WA[1]" />
-        <direct name="WB3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-B_DRAM128.WA[2]" />
-        <direct name="WB4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-B_DRAM128.WA[3]" />
-        <direct name="WB5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-B_DRAM128.WA[4]" />
-        <direct name="WB6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-B_DRAM128.WA[5]" />
-        <direct name="WB7" input="BLK_IG-SLICEM_MODES.WA7" output="BLK_IG-B_DRAM128.WA[6]" />
+        <direct name="WB1" input="SLICEM_MODES.D1" output="B_DRAM128.WA[0]" />
+        <direct name="WB2" input="SLICEM_MODES.D2" output="B_DRAM128.WA[1]" />
+        <direct name="WB3" input="SLICEM_MODES.D3" output="B_DRAM128.WA[2]" />
+        <direct name="WB4" input="SLICEM_MODES.D4" output="B_DRAM128.WA[3]" />
+        <direct name="WB5" input="SLICEM_MODES.D5" output="B_DRAM128.WA[4]" />
+        <direct name="WB6" input="SLICEM_MODES.D6" output="B_DRAM128.WA[5]" />
+        <direct name="WB7" input="SLICEM_MODES.WA7" output="B_DRAM128.WA[6]" />
 
-        <direct name="WA1" input="BLK_IG-SLICEM_MODES.D1" output="BLK_IG-A_DRAM128.WA[0]" />
-        <direct name="WA2" input="BLK_IG-SLICEM_MODES.D2" output="BLK_IG-A_DRAM128.WA[1]" />
-        <direct name="WA3" input="BLK_IG-SLICEM_MODES.D3" output="BLK_IG-A_DRAM128.WA[2]" />
-        <direct name="WA4" input="BLK_IG-SLICEM_MODES.D4" output="BLK_IG-A_DRAM128.WA[3]" />
-        <direct name="WA5" input="BLK_IG-SLICEM_MODES.D5" output="BLK_IG-A_DRAM128.WA[4]" />
-        <direct name="WA6" input="BLK_IG-SLICEM_MODES.D6" output="BLK_IG-A_DRAM128.WA[5]" />
-        <direct name="WA7" input="BLK_IG-SLICEM_MODES.WA7" output="BLK_IG-A_DRAM128.WA[6]" />
+        <direct name="WA1" input="SLICEM_MODES.D1" output="A_DRAM128.WA[0]" />
+        <direct name="WA2" input="SLICEM_MODES.D2" output="A_DRAM128.WA[1]" />
+        <direct name="WA3" input="SLICEM_MODES.D3" output="A_DRAM128.WA[2]" />
+        <direct name="WA4" input="SLICEM_MODES.D4" output="A_DRAM128.WA[3]" />
+        <direct name="WA5" input="SLICEM_MODES.D5" output="A_DRAM128.WA[4]" />
+        <direct name="WA6" input="SLICEM_MODES.D6" output="A_DRAM128.WA[5]" />
+        <direct name="WA7" input="SLICEM_MODES.WA7" output="A_DRAM128.WA[6]" />
 
         <!-- Direct DI1 inputs -->
-        <direct name="DI" input="BLK_IG-SLICEM_MODES.DI" output="BLK_IG-D_DRAM128.DI1" />
-        <direct name="CI" input="BLK_IG-SLICEM_MODES.CI" output="BLK_IG-C_DRAM128.CI" />
-        <direct name="BI" input="BLK_IG-SLICEM_MODES.BI" output="BLK_IG-B_DRAM128.BI" />
-        <direct name="AI" input="BLK_IG-SLICEM_MODES.AI" output="BLK_IG-A_DRAM128.AI" />
+        <direct name="DI" input="SLICEM_MODES.DI" output="D_DRAM128.DI1" />
+        <direct name="CI" input="SLICEM_MODES.CI" output="C_DRAM128.CI" />
+        <direct name="BI" input="SLICEM_MODES.BI" output="B_DRAM128.BI" />
+        <direct name="AI" input="SLICEM_MODES.AI" output="A_DRAM128.AI" />
 
         <!-- Parent DI1 inputs -->
-        <direct name="P_CI" input="BLK_IG-SLICEM_MODES.DI" output="BLK_IG-C_DRAM128.PARENT_DI" />
-        <direct name="P_BI" input="BLK_IG-SLICEM_MODES.DI" output="BLK_IG-B_DRAM128.PARENT_DI" />
-        <direct name="P_AI" input="BLK_IG-B_DRAM128.DI_OUT" output="BLK_IG-A_DRAM128.PARENT_DI" />
+        <direct name="P_CI" input="SLICEM_MODES.DI" output="C_DRAM128.PARENT_DI" />
+        <direct name="P_BI" input="SLICEM_MODES.DI" output="B_DRAM128.PARENT_DI" />
+        <direct name="P_AI" input="B_DRAM128.DI_OUT" output="A_DRAM128.PARENT_DI" />
 
         <!-- WE inputs -->
-        <direct name="CE_TO_WE_MUX" input="BLK_IG-SLICEM_MODES.CE"  output="BLK_MM-WE_MUX.CE"/>
-        <direct name="WE_TO_WE_MUX" input="BLK_IG-SLICEM_MODES.WE"  output="BLK_MM-WE_MUX.WE"/>
-        <direct name="WE1" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-A_DRAM128.WE"/>
-        <direct name="WE2" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-B_DRAM128.WE"/>
-        <direct name="WE3" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-C_DRAM128.WE"/>
-        <direct name="WE4" input="BLK_MM-WE_MUX.WE_OUT"  output="BLK_IG-D_DRAM128.WE"/>
+        <direct name="CE_TO_WE_MUX" input="SLICEM_MODES.CE"  output="WE_MUX.CE"/>
+        <direct name="WE_TO_WE_MUX" input="SLICEM_MODES.WE"  output="WE_MUX.WE"/>
+        <direct name="WE1" input="WE_MUX.WE_OUT"  output="A_DRAM128.WE"/>
+        <direct name="WE2" input="WE_MUX.WE_OUT"  output="B_DRAM128.WE"/>
+        <direct name="WE3" input="WE_MUX.WE_OUT"  output="C_DRAM128.WE"/>
+        <direct name="WE4" input="WE_MUX.WE_OUT"  output="D_DRAM128.WE"/>
 
         <!-- Outputs -->
-        <direct name="DO6" input="BLK_IG-D_DRAM128.O6"   output="BLK_IG-SLICEM_MODES.DO6" />
-        <direct name="CO6" input="BLK_IG-C_DRAM128.O6"   output="BLK_IG-SLICEM_MODES.CO6" />
-        <direct name="BO6" input="BLK_IG-B_DRAM128.O6"   output="BLK_IG-SLICEM_MODES.BO6" />
-        <direct name="AO6" input="BLK_IG-A_DRAM128.O6"   output="BLK_IG-SLICEM_MODES.AO6" />
+        <direct name="DO6" input="D_DRAM128.O6"   output="SLICEM_MODES.DO6" />
+        <direct name="CO6" input="C_DRAM128.O6"   output="SLICEM_MODES.CO6" />
+        <direct name="BO6" input="B_DRAM128.O6"   output="SLICEM_MODES.BO6" />
+        <direct name="AO6" input="A_DRAM128.O6"   output="SLICEM_MODES.AO6" />
 
         <!-- F7AMUX inputs -->
-        <mux name="F7AMUX_I0" input="BLK_IG-B_DRAM128.DO6 BLK_IG-B_DRAM128.SO6"   output="BEL_MX-F7AMUX.I0">
-          <pack_pattern in_port="BLK_IG-B_DRAM128.SO6" name="DRAM128" out_port="BEL_MX-F7AMUX.I0"/>
-          <pack_pattern in_port="BLK_IG-B_DRAM128.DO6" name="DRAM128_D" out_port="BEL_MX-F7AMUX.I0"/>
+        <mux name="F7AMUX_I0" input="B_DRAM128.DO6 B_DRAM128.SO6"   output="F7AMUX.I0">
+          <pack_pattern in_port="B_DRAM128.SO6" name="DRAM128" out_port="F7AMUX.I0"/>
+          <pack_pattern in_port="B_DRAM128.DO6" name="DRAM128_D" out_port="F7AMUX.I0"/>
         </mux>
-        <direct name="F7AMUX_I1" input="BLK_IG-A_DRAM128.DO6"   output="BEL_MX-F7AMUX.I1">
-          <pack_pattern in_port="BLK_IG-A_DRAM128.DO6" name="DRAM128" out_port="BEL_MX-F7AMUX.I1"/>
-          <pack_pattern in_port="BLK_IG-A_DRAM128.DO6" name="DRAM128_D" out_port="BEL_MX-F7AMUX.I1"/>
+        <direct name="F7AMUX_I1" input="A_DRAM128.DO6"   output="F7AMUX.I1">
+          <pack_pattern in_port="A_DRAM128.DO6" name="DRAM128" out_port="F7AMUX.I1"/>
+          <pack_pattern in_port="A_DRAM128.DO6" name="DRAM128_D" out_port="F7AMUX.I1"/>
         </direct>
-        <direct name="F7AMUX_S"  input="BLK_IG-SLICEM_MODES.AX" output="BEL_MX-F7AMUX.S" />
+        <direct name="F7AMUX_S"  input="SLICEM_MODES.AX" output="F7AMUX.S" />
         <!-- F7BMUX inputs -->
-        <direct name="F7BMUX_I0" input="BLK_IG-D_DRAM128.O6"   output="BEL_MX-F7BMUX.I0">
-          <pack_pattern in_port="BLK_IG-D_DRAM128.O6" name="DRAM128" out_port="BEL_MX-F7BMUX.I0"/>
+        <direct name="F7BMUX_I0" input="D_DRAM128.O6"   output="F7BMUX.I0">
+          <pack_pattern in_port="D_DRAM128.O6" name="DRAM128" out_port="F7BMUX.I0"/>
         </direct>
-        <direct name="F7BMUX_I1" input="BLK_IG-C_DRAM128.DO6"   output="BEL_MX-F7BMUX.I1">
-          <pack_pattern in_port="BLK_IG-C_DRAM128.DO6" name="DRAM128" out_port="BEL_MX-F7BMUX.I1"/>
+        <direct name="F7BMUX_I1" input="C_DRAM128.DO6"   output="F7BMUX.I1">
+          <pack_pattern in_port="C_DRAM128.DO6" name="DRAM128" out_port="F7BMUX.I1"/>
         </direct>
-        <direct name="F7BMUX_S"  input="BLK_IG-SLICEM_MODES.CX" output="BEL_MX-F7BMUX.S" />
+        <direct name="F7BMUX_S"  input="SLICEM_MODES.CX" output="F7BMUX.S" />
 
-        <direct name="DPO" input="BEL_MX-F7AMUX.O" output="BEL_BB-DRAM_2_OUTPUT_STUB.DPO">
-          <pack_pattern in_port="BEL_MX-F7AMUX.O" name="DRAM128_DP" out_port="BEL_BB-DRAM_2_OUTPUT_STUB.DPO" />
+        <direct name="DPO" input="F7AMUX.O" output="DRAM_2_OUTPUT_STUB.DPO">
+          <pack_pattern in_port="F7AMUX.O" name="DRAM128_DP" out_port="DRAM_2_OUTPUT_STUB.DPO" />
         </direct>
-        <direct name="SPO" input="BEL_MX-F7BMUX.O" output="BEL_BB-DRAM_2_OUTPUT_STUB.SPO">
-          <pack_pattern in_port="BEL_MX-F7BMUX.O" name="DRAM128_DP" out_port="BEL_BB-DRAM_2_OUTPUT_STUB.SPO" />
+        <direct name="SPO" input="F7BMUX.O" output="DRAM_2_OUTPUT_STUB.SPO">
+          <pack_pattern in_port="F7BMUX.O" name="DRAM128_DP" out_port="DRAM_2_OUTPUT_STUB.SPO" />
         </direct>
 
-        <mux name="F7AMUX_O"   input="BEL_MX-F7AMUX.O BEL_BB-DRAM_2_OUTPUT_STUB.DPO_OUT" output="BLK_IG-SLICEM_MODES.F7AMUX_O" />
-        <mux name="F7BMUX_O"   input="BEL_MX-F7BMUX.O BEL_BB-DRAM_2_OUTPUT_STUB.SPO_OUT" output="BLK_IG-SLICEM_MODES.F7BMUX_O" />
+        <mux name="F7AMUX_O"   input="F7AMUX.O DRAM_2_OUTPUT_STUB.DPO_OUT" output="SLICEM_MODES.F7AMUX_O" />
+        <mux name="F7BMUX_O"   input="F7BMUX.O DRAM_2_OUTPUT_STUB.SPO_OUT" output="SLICEM_MODES.F7BMUX_O" />
       </interconnect>
     </mode>
+    <metadata>
+      <meta name="type">block</meta>
+      <meta name="subtype">ignore</meta>
+    </metadata>
   </pb_type>
 
   <interconnect>
     <!-- SLICEM_MODES inputs -->
-    <direct name="DI" input="BLK_IG-SLICEM.DI" output="BLK_IG-SLICEM_MODES.DI" />
-    <direct name="DX2" input="BLK_IG-SLICEM.DX" output="BLK_IG-SLICEM_MODES.DX" />
-    <direct name="D1" input="BLK_IG-SLICEM.D1" output="BLK_IG-SLICEM_MODES.D1" />
-    <direct name="D2" input="BLK_IG-SLICEM.D2" output="BLK_IG-SLICEM_MODES.D2" />
-    <direct name="D3" input="BLK_IG-SLICEM.D3" output="BLK_IG-SLICEM_MODES.D3" />
-    <direct name="D4" input="BLK_IG-SLICEM.D4" output="BLK_IG-SLICEM_MODES.D4" />
-    <direct name="D5" input="BLK_IG-SLICEM.D5" output="BLK_IG-SLICEM_MODES.D5" />
-    <direct name="D6" input="BLK_IG-SLICEM.D6" output="BLK_IG-SLICEM_MODES.D6" />
+    <direct name="DI" input="SLICEM.DI" output="SLICEM_MODES.DI" />
+    <direct name="DX2" input="SLICEM.DX" output="SLICEM_MODES.DX" />
+    <direct name="D1" input="SLICEM.D1" output="SLICEM_MODES.D1" />
+    <direct name="D2" input="SLICEM.D2" output="SLICEM_MODES.D2" />
+    <direct name="D3" input="SLICEM.D3" output="SLICEM_MODES.D3" />
+    <direct name="D4" input="SLICEM.D4" output="SLICEM_MODES.D4" />
+    <direct name="D5" input="SLICEM.D5" output="SLICEM_MODES.D5" />
+    <direct name="D6" input="SLICEM.D6" output="SLICEM_MODES.D6" />
 
-    <direct name="CI" input="BLK_IG-SLICEM.CI" output="BLK_IG-SLICEM_MODES.CI" />
-    <direct name="CX2" input="BLK_IG-SLICEM.CX" output="BLK_IG-SLICEM_MODES.CX" />
-    <direct name="C1" input="BLK_IG-SLICEM.C1" output="BLK_IG-SLICEM_MODES.C1" />
-    <direct name="C2" input="BLK_IG-SLICEM.C2" output="BLK_IG-SLICEM_MODES.C2" />
-    <direct name="C3" input="BLK_IG-SLICEM.C3" output="BLK_IG-SLICEM_MODES.C3" />
-    <direct name="C4" input="BLK_IG-SLICEM.C4" output="BLK_IG-SLICEM_MODES.C4" />
-    <direct name="C5" input="BLK_IG-SLICEM.C5" output="BLK_IG-SLICEM_MODES.C5" />
-    <direct name="C6" input="BLK_IG-SLICEM.C6" output="BLK_IG-SLICEM_MODES.C6" />
+    <direct name="CI" input="SLICEM.CI" output="SLICEM_MODES.CI" />
+    <direct name="CX2" input="SLICEM.CX" output="SLICEM_MODES.CX" />
+    <direct name="C1" input="SLICEM.C1" output="SLICEM_MODES.C1" />
+    <direct name="C2" input="SLICEM.C2" output="SLICEM_MODES.C2" />
+    <direct name="C3" input="SLICEM.C3" output="SLICEM_MODES.C3" />
+    <direct name="C4" input="SLICEM.C4" output="SLICEM_MODES.C4" />
+    <direct name="C5" input="SLICEM.C5" output="SLICEM_MODES.C5" />
+    <direct name="C6" input="SLICEM.C6" output="SLICEM_MODES.C6" />
 
-    <direct name="BI" input="BLK_IG-SLICEM.BI" output="BLK_IG-SLICEM_MODES.BI" />
-    <direct name="BX2" input="BLK_IG-SLICEM.BX" output="BLK_IG-SLICEM_MODES.BX" />
-    <direct name="B1" input="BLK_IG-SLICEM.B1" output="BLK_IG-SLICEM_MODES.B1" />
-    <direct name="B2" input="BLK_IG-SLICEM.B2" output="BLK_IG-SLICEM_MODES.B2" />
-    <direct name="B3" input="BLK_IG-SLICEM.B3" output="BLK_IG-SLICEM_MODES.B3" />
-    <direct name="B4" input="BLK_IG-SLICEM.B4" output="BLK_IG-SLICEM_MODES.B4" />
-    <direct name="B5" input="BLK_IG-SLICEM.B5" output="BLK_IG-SLICEM_MODES.B5" />
-    <direct name="B6" input="BLK_IG-SLICEM.B6" output="BLK_IG-SLICEM_MODES.B6" />
+    <direct name="BI" input="SLICEM.BI" output="SLICEM_MODES.BI" />
+    <direct name="BX2" input="SLICEM.BX" output="SLICEM_MODES.BX" />
+    <direct name="B1" input="SLICEM.B1" output="SLICEM_MODES.B1" />
+    <direct name="B2" input="SLICEM.B2" output="SLICEM_MODES.B2" />
+    <direct name="B3" input="SLICEM.B3" output="SLICEM_MODES.B3" />
+    <direct name="B4" input="SLICEM.B4" output="SLICEM_MODES.B4" />
+    <direct name="B5" input="SLICEM.B5" output="SLICEM_MODES.B5" />
+    <direct name="B6" input="SLICEM.B6" output="SLICEM_MODES.B6" />
 
-    <direct name="AI" input="BLK_IG-SLICEM.AI" output="BLK_IG-SLICEM_MODES.AI" />
-    <direct name="AX2" input="BLK_IG-SLICEM.AX" output="BLK_IG-SLICEM_MODES.AX" />
-    <direct name="A1" input="BLK_IG-SLICEM.A1" output="BLK_IG-SLICEM_MODES.A1" />
-    <direct name="A2" input="BLK_IG-SLICEM.A2" output="BLK_IG-SLICEM_MODES.A2" />
-    <direct name="A3" input="BLK_IG-SLICEM.A3" output="BLK_IG-SLICEM_MODES.A3" />
-    <direct name="A4" input="BLK_IG-SLICEM.A4" output="BLK_IG-SLICEM_MODES.A4" />
-    <direct name="A5" input="BLK_IG-SLICEM.A5" output="BLK_IG-SLICEM_MODES.A5" />
-    <direct name="A6" input="BLK_IG-SLICEM.A6" output="BLK_IG-SLICEM_MODES.A6" />
+    <direct name="AI" input="SLICEM.AI" output="SLICEM_MODES.AI" />
+    <direct name="AX2" input="SLICEM.AX" output="SLICEM_MODES.AX" />
+    <direct name="A1" input="SLICEM.A1" output="SLICEM_MODES.A1" />
+    <direct name="A2" input="SLICEM.A2" output="SLICEM_MODES.A2" />
+    <direct name="A3" input="SLICEM.A3" output="SLICEM_MODES.A3" />
+    <direct name="A4" input="SLICEM.A4" output="SLICEM_MODES.A4" />
+    <direct name="A5" input="SLICEM.A5" output="SLICEM_MODES.A5" />
+    <direct name="A6" input="SLICEM.A6" output="SLICEM_MODES.A6" />
 
-    <direct name="CK2" input="BLK_IG-SLICEM.CLK" output="BLK_IG-SLICEM_MODES.CLK">
+    <direct name="CK2" input="SLICEM.CLK" output="SLICEM_MODES.CLK">
         <!-- The DLUT must be in RAM-mode for any of the RAM's to work.
              As a corollary, a DRAM requires the clock, so only turn on the
              DRAM if the clock is also connected.
         -->
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-SLICEM.CLK = DLUT.RAM
+          SLICEM.CLK = DLUT.RAM
         </meta>
       </metadata>
     </direct>
-    <direct name="CE2" input="BLK_IG-SLICEM.CE"  output="BLK_IG-SLICEM_MODES.CE"/>
-    <direct name="WE2" input="BLK_IG-SLICEM.WE"  output="BLK_IG-SLICEM_MODES.WE"/>
+    <direct name="CE2" input="SLICEM.CE"  output="SLICEM_MODES.CE"/>
+    <direct name="WE2" input="SLICEM.WE"  output="SLICEM_MODES.WE"/>
 
     <!-- SLICEM_MODES Outputs -->
-    <direct name="DO6" input="BLK_IG-SLICEM_MODES.DO6"   output="BLK_IG-COMMON_SLICE.DO6" />
-    <direct name="DO5" input="BLK_IG-SLICEM_MODES.DO5"   output="BLK_IG-COMMON_SLICE.DO5" />
+    <direct name="DO6" input="SLICEM_MODES.DO6"   output="COMMON_SLICE.DO6" />
+    <direct name="DO5" input="SLICEM_MODES.DO5"   output="COMMON_SLICE.DO5" />
 
-    <direct name="CO6" input="BLK_IG-SLICEM_MODES.CO6"   output="BLK_IG-COMMON_SLICE.CO6" />
-    <direct name="CO5" input="BLK_IG-SLICEM_MODES.CO5"   output="BLK_IG-COMMON_SLICE.CO5" />
+    <direct name="CO6" input="SLICEM_MODES.CO6"   output="COMMON_SLICE.CO6" />
+    <direct name="CO5" input="SLICEM_MODES.CO5"   output="COMMON_SLICE.CO5" />
 
-    <direct name="BO6" input="BLK_IG-SLICEM_MODES.BO6"   output="BLK_IG-COMMON_SLICE.BO6" />
-    <direct name="BO5" input="BLK_IG-SLICEM_MODES.BO5"   output="BLK_IG-COMMON_SLICE.BO5" />
+    <direct name="BO6" input="SLICEM_MODES.BO6"   output="COMMON_SLICE.BO6" />
+    <direct name="BO5" input="SLICEM_MODES.BO5"   output="COMMON_SLICE.BO5" />
 
-    <direct name="AO6" input="BLK_IG-SLICEM_MODES.AO6"   output="BLK_IG-COMMON_SLICE.AO6" />
-    <direct name="AO5" input="BLK_IG-SLICEM_MODES.AO5"   output="BLK_IG-COMMON_SLICE.AO5" />
+    <direct name="AO6" input="SLICEM_MODES.AO6"   output="COMMON_SLICE.AO6" />
+    <direct name="AO5" input="SLICEM_MODES.AO5"   output="COMMON_SLICE.AO5" />
 
-    <direct name="F7AMUX_O" input="BLK_IG-SLICEM_MODES.F7AMUX_O"   output="BLK_IG-COMMON_SLICE.F7AMUX_O" />
-    <direct name="F7BMUX_O" input="BLK_IG-SLICEM_MODES.F7BMUX_O"   output="BLK_IG-COMMON_SLICE.F7BMUX_O" />
-    <direct name="F8MUX_O"  input="BLK_IG-SLICEM_MODES.F8MUX_O"    output="BLK_IG-COMMON_SLICE.F8MUX_O" />
+    <direct name="F7AMUX_O" input="SLICEM_MODES.F7AMUX_O"   output="COMMON_SLICE.F7AMUX_O" />
+    <direct name="F7BMUX_O" input="SLICEM_MODES.F7BMUX_O"   output="COMMON_SLICE.F7BMUX_O" />
+    <direct name="F8MUX_O"  input="SLICEM_MODES.F8MUX_O"    output="COMMON_SLICE.F8MUX_O" />
 
     <!-- A-DX inputs -->
-    <direct name="DX"  input="BLK_IG-SLICEM.DX" output="BLK_IG-COMMON_SLICE.DX" />
-    <direct name="CX"  input="BLK_IG-SLICEM.CX" output="BLK_IG-COMMON_SLICE.CX" />
-    <direct name="BX"  input="BLK_IG-SLICEM.BX" output="BLK_IG-COMMON_SLICE.BX" />
-    <direct name="AX"  input="BLK_IG-SLICEM.AX" output="BLK_IG-COMMON_SLICE.AX" />
+    <direct name="DX"  input="SLICEM.DX" output="COMMON_SLICE.DX" />
+    <direct name="CX"  input="SLICEM.CX" output="COMMON_SLICE.CX" />
+    <direct name="BX"  input="SLICEM.BX" output="COMMON_SLICE.BX" />
+    <direct name="AX"  input="SLICEM.AX" output="COMMON_SLICE.AX" />
 
     <!-- [A-F]Q outputs -->
-    <direct name="AQ" input="BLK_IG-COMMON_SLICE.AQ" output="BLK_IG-SLICEM.AQ" />
-    <direct name="BQ" input="BLK_IG-COMMON_SLICE.BQ" output="BLK_IG-SLICEM.BQ" />
-    <direct name="CQ" input="BLK_IG-COMMON_SLICE.CQ" output="BLK_IG-SLICEM.CQ" />
-    <direct name="DQ" input="BLK_IG-COMMON_SLICE.DQ" output="BLK_IG-SLICEM.DQ" />
+    <direct name="AQ" input="COMMON_SLICE.AQ" output="SLICEM.AQ" />
+    <direct name="BQ" input="COMMON_SLICE.BQ" output="SLICEM.BQ" />
+    <direct name="CQ" input="COMMON_SLICE.CQ" output="SLICEM.CQ" />
+    <direct name="DQ" input="COMMON_SLICE.DQ" output="SLICEM.DQ" />
 
     <!-- A-D output -->
-    <direct name="BLK_IG-SLICEM_DOUT" input="BLK_IG-COMMON_SLICE.D" output="BLK_IG-SLICEM.D" />
-    <direct name="BLK_IG-SLICEM_COUT" input="BLK_IG-COMMON_SLICE.C" output="BLK_IG-SLICEM.C" />
-    <direct name="BLK_IG-SLICEM_BOUT" input="BLK_IG-COMMON_SLICE.B" output="BLK_IG-SLICEM.B" />
-    <direct name="BLK_IG-SLICEM_AOUT" input="BLK_IG-COMMON_SLICE.A" output="BLK_IG-SLICEM.A" />
+    <direct name="SLICEM_DOUT" input="COMMON_SLICE.D" output="SLICEM.D" />
+    <direct name="SLICEM_COUT" input="COMMON_SLICE.C" output="SLICEM.C" />
+    <direct name="SLICEM_BOUT" input="COMMON_SLICE.B" output="SLICEM.B" />
+    <direct name="SLICEM_AOUT" input="COMMON_SLICE.A" output="SLICEM.A" />
 
     <!-- AMUX-DMUX output -->
-    <direct name="BLK_IG-SLICEM_DMUX" input="BLK_IG-COMMON_SLICE.DMUX" output="BLK_IG-SLICEM.DMUX" />
-    <direct name="BLK_IG-SLICEM_CMUX" input="BLK_IG-COMMON_SLICE.CMUX" output="BLK_IG-SLICEM.CMUX" />
-    <direct name="BLK_IG-SLICEM_BMUX" input="BLK_IG-COMMON_SLICE.BMUX" output="BLK_IG-SLICEM.BMUX" />
-    <direct name="BLK_IG-SLICEM_AMUX" input="BLK_IG-COMMON_SLICE.AMUX" output="BLK_IG-SLICEM.AMUX" />
+    <direct name="SLICEM_DMUX" input="COMMON_SLICE.DMUX" output="SLICEM.DMUX" />
+    <direct name="SLICEM_CMUX" input="COMMON_SLICE.CMUX" output="SLICEM.CMUX" />
+    <direct name="SLICEM_BMUX" input="COMMON_SLICE.BMUX" output="SLICEM.BMUX" />
+    <direct name="SLICEM_AMUX" input="COMMON_SLICE.AMUX" output="SLICEM.AMUX" />
 
     <!-- Carry -->
-    <direct name="CIN" input="BLK_IG-SLICEM.CIN" output="BLK_IG-COMMON_SLICE.CIN" />
-    <direct name="COUT" input="BLK_IG-COMMON_SLICE.COUT" output="BLK_IG-SLICEM.COUT" />
+    <direct name="CIN" input="SLICEM.CIN" output="COMMON_SLICE.CIN" />
+    <direct name="COUT" input="COMMON_SLICE.COUT" output="SLICEM.COUT" />
 
     <!-- Clock, Clock Enable and Reset -->
-    <direct name="CK" input="BLK_IG-SLICEM.CLK" output="BLK_IG-COMMON_SLICE.CLK"/>
-    <direct name="CE" input="BLK_IG-SLICEM.CE"  output="BLK_IG-COMMON_SLICE.CE"/>
-    <direct name="SR" input="BLK_IG-SLICEM.SR"  output="BLK_IG-COMMON_SLICE.SR"/>
+    <direct name="CK" input="SLICEM.CLK" output="COMMON_SLICE.CLK"/>
+    <direct name="CE" input="SLICEM.CE"  output="COMMON_SLICE.CE"/>
+    <direct name="SR" input="SLICEM.SR"  output="COMMON_SLICE.SR"/>
 
     <!-- WA7 and WA8 -->
-    <direct name="WA7"  input="BLK_IG-SLICEM.CX" output="BLK_IG-SLICEM_MODES.WA7">
+    <direct name="WA7"  input="SLICEM.CX" output="SLICEM_MODES.WA7">
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-SLICEM.CX = WA7USED
+          SLICEM.CX = WA7USED
         </meta>
       </metadata>
     </direct>
-    <direct name="WA8"  input="BLK_IG-SLICEM.BX" output="BLK_IG-SLICEM_MODES.WA8">
+    <direct name="WA8"  input="SLICEM.BX" output="SLICEM_MODES.WA8">
       <metadata>
         <meta name="fasm_mux">
-          BLK_IG-SLICEM.BX = WA8USED
+          SLICEM.BX = WA8USED
         </meta>
       </metadata>
     </direct>
   </interconnect>
+  <metadata>
+    <meta name="type">block</meta>
+    <meta name="subtype">tile</meta>
+  </metadata>
 </pb_type>

--- a/xc7/tests/dram/CMakeLists.txt
+++ b/xc7/tests/dram/CMakeLists.txt
@@ -3,7 +3,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_4_32x1s.pcf
   SOURCES dram_4_32x1s.v
-  ASSERT_USAGE BLK_SY-OUTPAD=4,BLK_SY-INPAD=11,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=4,SYN-INPAD=11,CLBLM_R=1
   )
 
 add_fpga_target(
@@ -11,7 +11,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_4_32x2s.pcf
   SOURCES dram_4_32x2s.v
-  ASSERT_USAGE BLK_SY-OUTPAD=8,BLK_SY-INPAD=15,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=8,SYN-INPAD=15,CLBLM_R=1
   )
 
 add_fpga_target(
@@ -19,7 +19,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_2_32x1d.pcf
   SOURCES dram_2_32x1d.v
-  ASSERT_USAGE BLK_SY-OUTPAD=4,BLK_SY-INPAD=14,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=4,SYN-INPAD=14,CLBLM_R=1
   )
 
 add_fpga_target(
@@ -27,7 +27,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_4_64x1s.pcf
   SOURCES dram_4_64x1s.v
-  ASSERT_USAGE BLK_SY-OUTPAD=4,BLK_SY-INPAD=12,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=4,SYN-INPAD=12,CLBLM_R=1
   )
 
 add_fpga_target(
@@ -35,7 +35,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_2_64x1d.pcf
   SOURCES dram_2_64x1d.v
-  ASSERT_USAGE BLK_SY-OUTPAD=4,BLK_SY-INPAD=16,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=4,SYN-INPAD=16,CLBLM_R=1
   )
 
 add_fpga_target(
@@ -43,7 +43,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_2_128x1s.pcf
   SOURCES dram_2_128x1s.v
-  ASSERT_USAGE BLK_SY-OUTPAD=2,BLK_SY-INPAD=11,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=2,SYN-INPAD=11,CLBLM_R=1
   )
 
 # TODO(#549) RAM128X1D is no longer packing.
@@ -52,7 +52,7 @@ add_fpga_target(
 #  BOARD basys3
 #  INPUT_IO_FILE dram_1_128x1d.pcf
 #  SOURCES dram_1_128x1d.v
-#  ASSERT_USAGE BLK_SY-OUTPAD=2,BLK_SY-INPAD=17,BLK_TI-CLBLM_R=1
+#  ASSERT_USAGE SYN-OUTPAD=2,SYN-INPAD=17,CLBLM_R=1
 #  )
 
 add_fpga_target(
@@ -60,7 +60,7 @@ add_fpga_target(
   BOARD basys3
   INPUT_IO_FILE dram_1_256x1s.pcf
   SOURCES dram_1_256x1s.v
-  ASSERT_USAGE BLK_SY-OUTPAD=1,BLK_SY-INPAD=11,BLK_TI-CLBLM_R=1
+  ASSERT_USAGE SYN-OUTPAD=1,SYN-INPAD=11,CLBLM_R=1
   )
 
 add_custom_target(test_dram_packing)

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -177,22 +177,20 @@ def create_synth_constant_tiles(
 
 
 def add_synthetic_tiles(model_xml, complexblocklist_xml):
-    create_synth_io_tiles(complexblocklist_xml, 'BLK_SY-INPAD', is_input=True)
-    create_synth_io_tiles(
-        complexblocklist_xml, 'BLK_SY-OUTPAD', is_input=False
+    create_synth_io_tiles(complexblocklist_xml, 'SYN-INPAD', is_input=True)
+    create_synth_io_tiles(complexblocklist_xml, 'SYN-OUTPAD', is_input=False)
+    create_synth_constant_tiles(
+        model_xml, complexblocklist_xml, 'SYN-VCC', 'VCC'
     )
     create_synth_constant_tiles(
-        model_xml, complexblocklist_xml, 'BLK_SY-VCC', 'VCC'
-    )
-    create_synth_constant_tiles(
-        model_xml, complexblocklist_xml, 'BLK_SY-GND', 'GND'
+        model_xml, complexblocklist_xml, 'SYN-GND', 'GND'
     )
 
     return {
-        'output': 'BLK_SY-INPAD',
-        'input': 'BLK_SY-OUTPAD',
-        'VCC': 'BLK_SY-VCC',
-        'GND': 'BLK_SY-GND',
+        'output': 'SYN-INPAD',
+        'input': 'SYN-OUTPAD',
+        'VCC': 'SYN-VCC',
+        'GND': 'SYN-GND',
     }
 
 
@@ -311,7 +309,7 @@ def main():
             continue
         elif gridinfo.tile_type in tile_types:
             # We want to import this tile type.
-            vpr_tile_type = 'BLK_TI-{}'.format(gridinfo.tile_type)
+            vpr_tile_type = gridinfo.tile_type
         else:
             # We don't want this tile
             continue
@@ -473,9 +471,9 @@ def main():
                         direct['x_offset'], direct['y_offset']
                     ),
                 'from_pin':
-                    'BLK_TI-' + direct['from_pin'],
+                    direct['from_pin'],
                 'to_pin':
-                    'BLK_TI-' + direct['to_pin'],
+                    direct['to_pin'],
                 'x_offset':
                     str(direct['x_offset']),
                 'y_offset':

--- a/xc7/utils/prjxray_generate_dummy_site.py
+++ b/xc7/utils/prjxray_generate_dummy_site.py
@@ -58,7 +58,7 @@ def main():
     pb_type_xml = ET.Element(
         'pb_type',
         {
-            'name': 'BLK_DU-{}'.format(args.site_type),
+            'name': 'DUMMY-{}'.format(args.site_type),
         },
     )
 

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -79,8 +79,8 @@ def check_feature(feature):
     return feature
 
 
-# BLK_TI-CLBLL_L.CLBLL_LL_A1[0] -> (CLBLL_L, CLBLL_LL_A1)
-PIN_NAME_TO_PARTS = re.compile(r'^BLK_TI-([^\.]+)\.([^\]]+)\[0\]$')
+# CLBLL_L.CLBLL_LL_A1[0] -> (CLBLL_L, CLBLL_LL_A1)
+PIN_NAME_TO_PARTS = re.compile(r'^([^\.]+)\.([^\]]+)\[0\]$')
 
 
 def import_graph_nodes(conn, graph, node_mapping):
@@ -97,7 +97,7 @@ def import_graph_nodes(conn, graph, node_mapping):
             (gridloc.block_type_id, node.loc.ptc)]
 
         # Synthetic blocks are handled below.
-        if pin_name.startswith('BLK_SY-'):
+        if pin_name.startswith('SYN-'):
             continue
 
         m = PIN_NAME_TO_PARTS.match(pin_name)
@@ -333,16 +333,16 @@ WHERE
                 assert len(option) > 0, (pin, len(option))
 
                 if pin['port_type'] == 'input':
-                    tile_type = 'BLK_SY-OUTPAD'
+                    tile_type = 'SYN-OUTPAD'
                     wire = 'outpad'
                 elif pin['port_type'] == 'output':
-                    tile_type = 'BLK_SY-INPAD'
+                    tile_type = 'SYN-INPAD'
                     wire = 'inpad'
                 elif pin['port_type'] == 'VCC':
-                    tile_type = 'BLK_SY-VCC'
+                    tile_type = 'SYN-VCC'
                     wire = 'VCC'
                 elif pin['port_type'] == 'GND':
-                    tile_type = 'BLK_SY-GND'
+                    tile_type = 'SYN-GND'
                     wire = 'GND'
                 else:
                     assert False, pin

--- a/xc7/utils/prjxray_tile_import.py
+++ b/xc7/utils/prjxray_tile_import.py
@@ -244,7 +244,7 @@ def main():
             }
         )
 
-    tile_name = "BLK_TI-{}".format(args.tile)
+    tile_name = args.tile
 
     pb_type_xml = ET.Element(
         'pb_type',


### PR DESCRIPTION
This metadata was originally encoded in the name as there was nowhere else to store it. Now that VPR has metadata support, we should store the information there.

Fixes #561.