### PR TITLE
Add the RAM_SHIFTER module to make it easy to build simple RAM tests

### DIFF
--- a/xc7/tests/CMakeLists.txt
+++ b/xc7/tests/CMakeLists.txt
@@ -13,4 +13,4 @@ add_subdirectory(bram)
 add_subdirectory(chain_packing)
 add_subdirectory(uart_loopback)
 add_subdirectory(ff_sr_ce)
-
+add_subdirectory(dram_shifter)

--- a/xc7/tests/common/CMakeLists.txt
+++ b/xc7/tests/common/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_file_target(FILE basys3.pcf)
 add_file_target(FILE error_output_logic.v SCANNER_TYPE verilog)
+add_file_target(FILE ram_shifter.v SCANNER_TYPE verilog)

--- a/xc7/tests/common/ram_shifter.v
+++ b/xc7/tests/common/ram_shifter.v
@@ -1,0 +1,52 @@
+// adapts single bit memory to parallel inputs and outputs
+module RAM_SHIFTER #(
+    parameter IO_WIDTH = 16,
+    parameter ADDR_WIDTH = 4,
+    parameter PHASE_SHIFT = 2
+) (
+    input                       clk,
+
+    // parallel I/O
+    input [IO_WIDTH-1:0]        in,
+    output reg [IO_WIDTH-1:0]   out,
+
+    // memory interface
+    output reg [ADDR_WIDTH-1:0] addr,
+    input                       ram_out,
+    output                      ram_in
+);
+
+    // shift registers
+    reg [IO_WIDTH-1:0]          shift_in;
+    reg [IO_WIDTH-1:0]          shift_out;
+
+    assign ram_in = shift_in[0];
+
+    initial begin
+        out       <= 0;
+        addr      <= 0;
+        shift_in  <= 0;
+        shift_out <= 0;
+    end
+
+    always @(posedge clk) begin
+        if(addr == 0)
+          begin // shift registers are aligned with I/O
+              // write output shift register, which is a little out of phase
+              out <= {shift_out[IO_WIDTH-PHASE_SHIFT-1:0], shift_out[IO_WIDTH-1:IO_WIDTH-PHASE_SHIFT]};
+
+              // input shift register is aligned with input, so sample it
+              shift_in <= in;
+          end
+        else
+          begin
+              // rotate the input
+              shift_in <= {shift_in[IO_WIDTH-2:0], shift_in[IO_WIDTH-1]};
+          end
+
+        // insert a new bit on the right and push everything to the left
+        shift_out <= {shift_out[IO_WIDTH-2:0], ram_out};
+
+        addr <= addr + 1;
+    end
+endmodule

--- a/xc7/tests/dram_shifter/CMakeLists.txt
+++ b/xc7/tests/dram_shifter/CMakeLists.txt
@@ -1,0 +1,39 @@
+add_file_target(FILE dram_shifter_32x1s.v SCANNER_TYPE verilog)
+
+add_fpga_target(
+  NAME dram_shifter_32x1s
+  BOARD basys3
+  INPUT_IO_FILE ../common/basys3.pcf
+  SOURCES ../common/ram_shifter.v dram_shifter_32x1s.v
+  EXPLICIT_ADD_FILE_TARGET
+  )
+
+add_file_target(FILE dram_shifter_32x1d.v SCANNER_TYPE verilog)
+
+add_fpga_target(
+  NAME dram_shifter_32x1d
+  BOARD basys3
+  INPUT_IO_FILE ../common/basys3.pcf
+  SOURCES ../common/ram_shifter.v dram_shifter_32x1d.v
+  EXPLICIT_ADD_FILE_TARGET
+  )
+
+add_file_target(FILE dram_shifter_64x1s.v SCANNER_TYPE verilog)
+
+add_fpga_target(
+  NAME dram_shifter_64x1s
+  BOARD basys3
+  INPUT_IO_FILE ../common/basys3.pcf
+  SOURCES ../common/ram_shifter.v dram_shifter_64x1s.v
+  EXPLICIT_ADD_FILE_TARGET
+  )
+
+add_file_target(FILE dram_shifter_64x1d.v SCANNER_TYPE verilog)
+
+add_fpga_target(
+  NAME dram_shifter_64x1d
+  BOARD basys3
+  INPUT_IO_FILE ../common/basys3.pcf
+  SOURCES ../common/ram_shifter.v dram_shifter_64x1d.v
+  EXPLICIT_ADD_FILE_TARGET
+  )

--- a/xc7/tests/dram_shifter/dram_shifter_32x1d.v
+++ b/xc7/tests/dram_shifter/dram_shifter_32x1d.v
@@ -1,0 +1,50 @@
+// Double buffering with dual-port RAM
+// Uses dual-port RAM to write switches to one section, while reading another to control LEDs.
+// Flip SW0 to swap the buffers.
+module top (
+        input         clk,
+        input [15:0]  sw,
+        output [15:0] led,
+
+        // not used
+        input         rx,
+        output        tx
+);
+
+    assign tx = rx;  // TODO(#658): Remove this work-around
+
+    wire [3:0]        addr;
+    wire              ram_out;
+    wire              ram_in;
+
+    RAM_SHIFTER #(
+        .IO_WIDTH(16),
+        .ADDR_WIDTH(4)
+    ) shifter (
+        .clk(clk),
+        .in(sw),
+        .out(led),
+        .addr(addr),
+        .ram_out(ram_out),
+        .ram_in(ram_in)
+    );
+
+    RAM32X1D #(
+        .INIT(32'h96A5_96A5)
+    ) ram0 (
+        .WCLK(clk),
+        .A4(sw[0]),
+        .A3(addr[3]),
+        .A2(addr[2]),
+        .A1(addr[1]),
+        .A0(addr[0]),
+        .DPRA4(~sw[0]),
+        .DPRA3(addr[3]),
+        .DPRA2(addr[2]),
+        .DPRA1(addr[1]),
+        .DPRA0(addr[0]),
+        .DPO(ram_out),
+        .D(ram_in),
+        .WE(1'b1)
+    );
+endmodule

--- a/xc7/tests/dram_shifter/dram_shifter_32x1s.v
+++ b/xc7/tests/dram_shifter/dram_shifter_32x1s.v
@@ -1,0 +1,46 @@
+// Double buffering with dual-port RAM
+// Uses single-port RAM to write switches to a section while reading from the same section to control LEDs,
+// so each switch acts as if connected directly to the corresponding LED.
+// Flip SW0 to change sections.
+module top (
+        input         clk,
+        input [15:0]  sw,
+        output [15:0] led,
+
+        // not used
+        input         rx,
+        output        tx
+);
+
+    assign tx = rx;  // TODO(#658): Remove this work-around
+
+    wire [3:0]        addr;
+    wire              ram_out;
+    wire              ram_in;
+
+    RAM_SHIFTER #(
+        .IO_WIDTH(16),
+        .ADDR_WIDTH(4)
+    ) shifter (
+        .clk(clk),
+        .in(sw),
+        .out(led),
+        .addr(addr),
+        .ram_out(ram_out),
+        .ram_in(ram_in)
+    );
+
+    RAM32X1S #(
+        .INIT(32'h96A5_96A5)
+    ) ram0 (
+        .WCLK(clk),
+        .A4(sw[0]),
+        .A3(addr[3]),
+        .A2(addr[2]),
+        .A1(addr[1]),
+        .A0(addr[0]),
+        .O(ram_out),
+        .D(ram_in),
+        .WE(1'b1)
+    );
+endmodule

--- a/xc7/tests/dram_shifter/dram_shifter_64x1d.v
+++ b/xc7/tests/dram_shifter/dram_shifter_64x1d.v
@@ -1,0 +1,52 @@
+// Double buffering with dual-port RAM
+// Uses dual-port RAM to write switches to one section, while reading another to control LEDs.
+// Flip SW0 to swap the buffers.
+module top (
+        input         clk,
+        input [15:0]  sw,
+        output [15:0] led,
+
+        // not used
+        input         rx,
+        output        tx
+);
+
+    assign tx = rx;  // TODO(#658): Remove this work-around
+
+    wire [4:0]        addr;
+    wire              ram_out;
+    wire              ram_in;
+
+    RAM_SHIFTER #(
+        .IO_WIDTH(16),
+        .ADDR_WIDTH(5)
+    ) shifter (
+        .clk(clk),
+        .in(sw),
+        .out(led),
+        .addr(addr),
+        .ram_out(ram_out),
+        .ram_in(ram_in)
+    );
+
+    RAM64X1D #(
+        .INIT(64'h96A5_96A5_96A5_96A5)
+    ) ram0 (
+        .WCLK(clk),
+        .A5(sw[0]),
+        .A4(addr[4]),
+        .A3(addr[3]),
+        .A2(addr[2]),
+        .A1(addr[1]),
+        .A0(addr[0]),
+        .DPRA5(~sw[0]),
+        .DPRA4(addr[4]),
+        .DPRA3(addr[3]),
+        .DPRA2(addr[2]),
+        .DPRA1(addr[1]),
+        .DPRA0(addr[0]),
+        .DPO(ram_out),
+        .D(ram_in),
+        .WE(1'b1)
+    );
+endmodule

--- a/xc7/tests/dram_shifter/dram_shifter_64x1s.v
+++ b/xc7/tests/dram_shifter/dram_shifter_64x1s.v
@@ -1,0 +1,47 @@
+// Double buffering with dual-port RAM
+// Uses single-port RAM to write switches to a section while reading from the same section to control LEDs,
+// so each switch acts as if connected directly to the corresponding LED.
+// Flip SW0 to change sections.
+module top (
+        input         clk,
+        input [15:0]  sw,
+        output [15:0] led,
+
+        // not used
+        input         rx,
+        output        tx
+);
+
+    assign tx = rx;  // TODO(#658): Remove this work-around
+
+    wire [4:0]        addr;
+    wire              ram_out;
+    wire              ram_in;
+
+    RAM_SHIFTER #(
+        .IO_WIDTH(16),
+        .ADDR_WIDTH(5)
+    ) shifter (
+        .clk(clk),
+        .in(sw),
+        .out(led),
+        .addr(addr),
+        .ram_out(ram_out),
+        .ram_in(ram_in)
+    );
+
+    RAM64X1S #(
+        .INIT(64'h96A5_96A5_96A5_96A5)
+    ) ram0 (
+        .WCLK(clk),
+        .A5(sw[0]),
+        .A4(addr[4]),
+        .A3(addr[3]),
+        .A2(addr[2]),
+        .A1(addr[1]),
+        .A0(addr[0]),
+        .O(ram_out),
+        .D(ram_in),
+        .WE(1'b1)
+    );
+endmodule


### PR DESCRIPTION
This adds a test that runs input from switches and output to LEDs on the BASYS3 through a single bit output RAM.

I'm adding one target in this PR to get feedback, and then I'll duplicate it across all memory types.