### PR TITLE
v2x: adding update_golden command in v2x cmake

### DIFF
--- a/utils/vlog/tests/v2x_tests.cmake
+++ b/utils/vlog/tests/v2x_tests.cmake
@@ -5,7 +5,6 @@ function(V2X_GENERIC_TEST)
   # ~~~
   # V2X_GENERIC_TEST(
   #   NAME name
-  #   TOP_MODULE name
   #   TYPE pb_type | model
   #   )
   # ~~~
@@ -15,14 +14,13 @@ function(V2X_GENERIC_TEST)
   # Therefore, this function is used to generalize and perform the desired test.
   #
   # NAME name of the test.
-  # TOP_MODULE name of the top verilog module that has to be tested.
   # TYPE type of test that has to be performed (model or pb_type generation).
   #
   # In addition it adds the newly created target to the `all_v2x_tests` dependencies. (all tests will be performed with `make all_v2x_tests`)
   #
-  # Usage: v2x_generic_test(NAME <test_name> TOP_MODULE <top_module.v> TYPE <model|pb_type>) (All fields are required)
+  # Usage: v2x_generic_test(NAME <test_name> TYPE <model|pb_type>) (All fields are required)
 
-  set(oneValueArgs NAME TOP_MODULE TYPE)
+  set(oneValueArgs NAME TYPE)
   cmake_parse_arguments(
     V2X_GENERIC_TEST
     "${options}"
@@ -31,21 +29,28 @@ function(V2X_GENERIC_TEST)
     ${ARGN}
   )
 
+  set(TYPE ${V2X_GENERIC_TEST_TYPE})
+  set(NAME ${V2X_GENERIC_TEST_NAME})
 
   # pb_type checking
-  set(V2X_GENERIC_TEST_GOLDEN_XML golden.${V2X_GENERIC_TEST_TYPE}.xml)
-  add_file_target(FILE ${V2X_GENERIC_TEST_GOLDEN_XML} SCANNER_TYPE xml)
-  xml_sort(NAME ${V2X_GENERIC_TEST_NAME}_${V2X_GENERIC_TEST_TYPE}_golden_sort FILE ${V2X_GENERIC_TEST_GOLDEN_XML} OUTPUT ${V2X_GENERIC_TEST_NAME}.${V2X_GENERIC_TEST_TYPE}.golden.xml)
+  set(GOLDEN_XML golden.${TYPE}.xml)
+  add_file_target(FILE ${GOLDEN_XML} SCANNER_TYPE xml)
+  xml_sort(NAME ${NAME}_${TYPE}_golden_sort FILE ${GOLDEN_XML} OUTPUT ${NAME}.${TYPE}.golden.xml)
 
-  set(V2X_GENERIC_TEST_ACTUAL_XML ${V2X_GENERIC_TEST_NAME}.${V2X_GENERIC_TEST_TYPE}.xml)
-  xml_sort(NAME ${V2X_GENERIC_TEST_NAME}_${V2X_GENERIC_TEST_TYPE}_actual_sort FILE ${V2X_GENERIC_TEST_ACTUAL_XML} OUTPUT ${V2X_GENERIC_TEST_NAME}.${V2X_GENERIC_TEST_TYPE}.actual.xml)
+  set(ACTUAL_XML ${NAME}.${TYPE}.xml)
+  xml_sort(NAME ${NAME}_${TYPE}_actual_sort FILE ${ACTUAL_XML} OUTPUT ${NAME}.${TYPE}.actual.xml)
 
-  diff(NAME ${V2X_GENERIC_TEST_NAME}_${V2X_GENERIC_TEST_TYPE}_diff GOLDEN ${V2X_GENERIC_TEST_NAME}.${V2X_GENERIC_TEST_TYPE}.golden.xml ACTUAL ${V2X_GENERIC_TEST_NAME}.${V2X_GENERIC_TEST_TYPE}.actual.xml)
+  diff(NAME ${NAME}_${TYPE}_diff GOLDEN ${NAME}.${TYPE}.golden.xml ACTUAL ${NAME}.${TYPE}.actual.xml)
 
-  add_dependencies(all_v2x_tests ${V2X_GENERIC_TEST_NAME}_${V2X_GENERIC_TEST_TYPE}_diff)
+  add_dependencies(all_v2x_tests ${NAME}_${TYPE}_diff)
 
   # TODO This has to be completed in order update the golden pb_type/model accordingly
-  add_custom_target(${V2X_GENERIC_TEST_NAME}_update_golden_${V2X_GENERIC_TEST_TYPE})
+  add_custom_target(${NAME}_update_golden_${TYPE})
+  add_custom_command(
+    TARGET ${NAME}_update_golden_${TYPE}
+    POST_BUILD
+    COMMAND cp ${ACTUAL_XML} ${CMAKE_CURRENT_SOURCE_DIR}/golden.${TYPE}.xml
+    )
 endfunction(V2X_GENERIC_TEST)
 
 function(V2X_TEST_MODEL)
@@ -63,7 +68,7 @@ function(V2X_TEST_MODEL)
   #
   # Usage: v2x_test_model(NAME <test_name> TOP_MODULE <top_module.v>) (All fields are required)
 
-  set(oneValueArgs NAME TOP_MODULE TYPE)
+  set(oneValueArgs NAME TOP_MODULE)
   cmake_parse_arguments(
     V2X_TEST_MODEL
     "${options}"
@@ -72,13 +77,16 @@ function(V2X_TEST_MODEL)
     ${ARGN}
   )
 
-  set(V2X_TEST_MODEL_SRC ${V2X_TEST_MODEL_NAME}.sim.v)
-  add_file_target(FILE ${V2X_TEST_MODEL_SRC} SCANNER_TYPE verilog)
-  v2x(NAME ${V2X_TEST_MODEL_NAME} SRCS ${V2X_TEST_MODEL_SRC} TOP_MODULE ${V2X_TEST_MODEL_TOP_MODULE})
+  set(NAME ${V2X_TEST_MODEL_NAME})
+  set(TOP_MODULE ${V2X_TEST_MODEL_TOP_MODULE})
 
-  v2x_generic_test(NAME ${V2X_TEST_MODEL_NAME} TOP_MODULE ${V2X_TEST_MODEL_TOP_MODULE} TYPE model)
+  set(SRC ${NAME}.sim.v)
+  add_file_target(FILE ${SRC} SCANNER_TYPE verilog)
+  v2x(NAME ${NAME} SRCS ${SRC} TOP_MODULE ${TOP_MODULE})
 
-  add_custom_target(${V2X_TEST_MODEL_NAME}_diff ALL DEPENDS ${V2X_TEST_MODEL_NAME}_model_diff)
+  v2x_generic_test(NAME ${NAME} TOP_MODULE ${TOP_MODULE} TYPE model)
+
+  add_custom_target(${NAME}_diff ALL DEPENDS ${NAME}_model_diff)
 endfunction(V2X_TEST_MODEL)
 
 function(V2X_TEST_PB_TYPE)
@@ -96,7 +104,7 @@ function(V2X_TEST_PB_TYPE)
   #
   # Usage: v2x_test_model(NAME <test_name> TOP_MODULE <top_module.v>) (All fields are required)
 
-  set(oneValueArgs NAME TOP_MODULE TYPE)
+  set(oneValueArgs NAME TOP_MODULE)
   cmake_parse_arguments(
     V2X_TEST_PB_TYPE
     "${options}"
@@ -105,13 +113,16 @@ function(V2X_TEST_PB_TYPE)
     ${ARGN}
   )
 
-  set(V2X_TEST_PB_TYPE_SRC ${V2X_TEST_PB_TYPE_NAME}.sim.v)
-  add_file_target(FILE ${V2X_TEST_PB_TYPE_SRC} SCANNER_TYPE verilog)
-  v2x(NAME ${V2X_TEST_PB_TYPE_NAME} SRCS ${V2X_TEST_PB_TYPE_SRC} TOP_MODULE ${V2X_TEST_PB_TYPE_TOP_MODULE})
+  set(NAME ${V2X_TEST_MODEL_NAME})
+  set(TOP_MODULE ${V2X_TEST_MODEL_TOP_MODULE})
 
-  v2x_generic_test(NAME ${V2X_TEST_PB_TYPE_NAME} TOP_MODULE ${V2X_TEST_PB_TYPE_TOP_MODULE} TYPE pb_type)
+  set(SRC ${NAME}.sim.v)
+  add_file_target(FILE ${SRC} SCANNER_TYPE verilog)
+  v2x(NAME ${NAME} SRCS ${SRC} TOP_MODULE ${TOP_MODULE})
 
-  add_custom_target(${V2X_TEST_PB_TYPE_NAME}_diff ALL DEPENDS ${V2X_TEST_PB_TYPE_NAME}_pb_type_diff)
+  v2x_generic_test(NAME ${NAME} TOP_MODULE ${TOP_MODULE} TYPE pb_type)
+
+  add_custom_target(${NAME}_diff ALL DEPENDS ${NAME}_pb_type_diff)
 endfunction(V2X_TEST_PB_TYPE)
 
 function(V2X_TEST_BOTH)
@@ -130,7 +141,7 @@ function(V2X_TEST_BOTH)
   #
   # Usage: v2x_test_model(NAME <test_name> TOP_MODULE <top_module.v>) (All fields are required)
 
-  set(oneValueArgs NAME TOP_MODULE TYPE)
+  set(oneValueArgs NAME TOP_MODULE)
   cmake_parse_arguments(
     V2X_TEST_BOTH
     "${options}"
@@ -139,12 +150,15 @@ function(V2X_TEST_BOTH)
     ${ARGN}
   )
 
-  set(V2X_TEST_BOTH_SRC ${V2X_TEST_BOTH_NAME}.sim.v)
-  add_file_target(FILE ${V2X_TEST_BOTH_SRC} SCANNER_TYPE verilog)
-  v2x(NAME ${V2X_TEST_BOTH_NAME} SRCS ${V2X_TEST_BOTH_SRC} TOP_MODULE ${V2X_TEST_BOTH_TOP_MODULE})
+  set(NAME ${V2X_TEST_BOTH_NAME})
+  set(TOP_MODULE ${V2X_TEST_BOTH_TOP_MODULE})
 
-  v2x_generic_test(NAME ${V2X_TEST_BOTH_NAME} TOP_MODULE ${V2X_TEST_BOTH_TOP_MODULE} TYPE pb_type)
-  v2x_generic_test(NAME ${V2X_TEST_BOTH_NAME} TOP_MODULE ${V2X_TEST_BOTH_TOP_MODULE} TYPE model)
+  set(SRC ${NAME}.sim.v)
+  add_file_target(FILE ${SRC} SCANNER_TYPE verilog)
+  v2x(NAME ${NAME} SRCS ${SRC} TOP_MODULE ${TOP_MODULE})
 
-  add_custom_target(${V2X_TEST_BOTH_NAME}_diff ALL DEPENDS ${V2X_TEST_BOTH_NAME}_pb_type_diff ${V2X_TEST_BOTH_NAME}_model_diff)
+  v2x_generic_test(NAME ${NAME} TOP_MODULE ${MODULE} TYPE pb_type)
+  v2x_generic_test(NAME ${NAME} TOP_MODULE ${TOP_MODULE} TYPE model)
+
+  add_custom_target(${NAME}_diff ALL DEPENDS ${NAME}_pb_type_diff ${NAME}_model_diff)
 endfunction(V2X_TEST_BOTH)


### PR DESCRIPTION
This PR has two different changes:
- clean the v2x_cmake file by adding local variables for the test names and types (this increases readability).
- Added custom command to automatically update the `golden.<pb_type/model>.xml` in the relative source directory. (The update golden target should be used only if the developer is sure that the output of v2x is correct)

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>