### PR TITLE
devices.cmake: added disable check route option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 7.0.5_7049_g125359595 20190502_223059"
+  PACKAGE_SPEC "vtr 7.0.5_7051_g984125b33 20190507_162506"
   )
 add_conda_package(
   NAME libxslt

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -24,6 +24,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --enable_timing_computations off
       --allow_unrelated_clustering on
       --clustering_pin_feasibility_filter off
+      --disable_check_route on
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the `--disable_check_route` option after https://github.com/SymbiFlow/vtr-verilog-to-routing/pull/48