### PR TITLE
Change from blackbox to whitebox annotation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ setup_env(
 add_conda_package(
   NAME yosys
   PROVIDES yosys
-  PACKAGE_SPEC "yosys 0.8 0669.1904122152.g2c7e2541"
+  PACKAGE_SPEC "yosys 0.8_1059_g996d4e82 20190516_233014"
   )
 add_conda_package(
   NAME openocd

--- a/testarch/primitives/ff/ff.sim.v
+++ b/testarch/primitives/ff/ff.sim.v
@@ -1,4 +1,4 @@
-(* blackbox *) (* CLASS="flipflop" *)
+(* whitebox *) (* CLASS="flipflop" *)
 module FF(clk, D, Q);
 
 	(* PORT_CLASS = "clock" *)

--- a/testarch/primitives/lut/lut.sim.v
+++ b/testarch/primitives/lut/lut.sim.v
@@ -1,4 +1,4 @@
-(* blackbox *)  (* CLASS="lut" *)
+(* whitebox *)  (* CLASS="lut" *)
 module LUT (in, out);
 	parameter [15:0] INIT = 16'hDEAD;
 

--- a/utils/mux_gen.py
+++ b/utils/mux_gen.py
@@ -315,7 +315,7 @@ Generated with %s
             )
         )
         f.write("\n")
-        f.write('(* blackbox *) (* CLASS="%s" *)\n' % mux_class)
+        f.write('(* whitebox *) (* CLASS="%s" *)\n' % mux_class)
         f.write("module %s(%s);\n" % (args.name_mux, ", ".join(module_args)))
         previous_type = None
         for port in port_names:

--- a/utils/vlog/tests/clocks/input_attr_clock/input_attr_clock.sim.v
+++ b/utils/vlog/tests/clocks/input_attr_clock/input_attr_clock.sim.v
@@ -2,7 +2,7 @@
  * `input wire a` should be detected as a clock because of the `(* CLOCK *)`
  * attribute.
  */
-(* blackbox *)
+(* whitebox *)
 module block(a, b, o);
 	(* CLOCK *)
 	input wire a;

--- a/utils/vlog/tests/clocks/input_named_clk/input_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/input_named_clk/input_named_clk.sim.v
@@ -2,7 +2,7 @@
  * `input wire clk` should be detected as a clock despite this being a black
  * box module.
  */
-(* blackbox *)
+(* whitebox *)
 module block(clk, a, o);
 	input wire clk;
 	input wire a;

--- a/utils/vlog/tests/clocks/input_named_rdclk/input_named_rdclk.sim.v
+++ b/utils/vlog/tests/clocks/input_named_rdclk/input_named_rdclk.sim.v
@@ -2,7 +2,7 @@
  * `input wire rdclk` should be detected as a clock despite this being a black
  * box module.
  */
-(* blackbox *)
+(* whitebox *)
 module block(rdclk, a, o);
 	input wire rdclk;
 	input wire a;

--- a/utils/vlog/tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
@@ -2,7 +2,7 @@
  * `input wire rdclk` and `input wire wrclk` should be detected as a clock
  * despite this being a black box module.
  */
-(* blackbox *)
+(* whitebox *)
 module block(a, rdclk, b, wrclk, c, o);
 	input wire a;
 	input wire rdclk;

--- a/utils/vlog/tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
@@ -2,7 +2,7 @@
  * `output wire rdclk` and `output wire wrclk` should be detected as a clock
  * despite this being a black box module.
  */
-(* blackbox *)
+(* whitebox *)
 module block(a, b, rdclk, o, wrclk);
 	input wire a;
 	input wire b;

--- a/utils/vlog/tests/clocks/output_attr_clock/output_attr_clock.sim.v
+++ b/utils/vlog/tests/clocks/output_attr_clock/output_attr_clock.sim.v
@@ -2,7 +2,7 @@
  * `output wire o` should be detected as a clock because of the `(* CLOCK *)`
  * attribute.
  */
-(* blackbox *)
+(* whitebox *)
 module block(a, b, o);
 	input wire a;
 	input wire b;

--- a/utils/vlog/tests/clocks/output_named_clk/output_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/output_named_clk/output_named_clk.sim.v
@@ -2,7 +2,7 @@
  * `output wire clk` should be detected as a clock despite this being a black
  * box module.
  */
-(* blackbox *)
+(* whitebox *)
 module block(a, b, clk);
 	input wire a;
 	input wire b;

--- a/utils/vlog/tests/clocks/output_named_rdclk/output_named_rdclk.sim.v
+++ b/utils/vlog/tests/clocks/output_named_rdclk/output_named_rdclk.sim.v
@@ -2,7 +2,7 @@
  * `output wire rdclk` should be detected as a clock despite this being a black
  * box module.
  */
-(* blackbox *)
+(* whitebox *)
 module block(a, b, rdclk);
 	input wire a;
 	input wire b;

--- a/utils/vlog/tests/dsp_combinational/dsp_combinational.sim.v
+++ b/utils/vlog/tests/dsp_combinational/dsp_combinational.sim.v
@@ -1,6 +1,6 @@
 `ifndef DSP_COMB
 `define DSP_COMB
-(* blackbox *)
+(* whitebox *)
 module dsp_combinational (
 	a, b, m,
 	out

--- a/utils/vlog/tests/fig41-full-adder/adder.sim.v
+++ b/utils/vlog/tests/fig41-full-adder/adder.sim.v
@@ -1,4 +1,4 @@
-(* blackbox *)
+(* whitebox *)
 module adder (
 	a, b, cin,
 	sum, cout

--- a/utils/vlog/tests/fig42-dff/dff.sim.v
+++ b/utils/vlog/tests/fig42-dff/dff.sim.v
@@ -1,4 +1,4 @@
-(* blackbox *)
+(* whitebox *)
 module dff (d, clk, q);
 	input wire d;
 	input wire clk;

--- a/vpr/ff/vpr_ff.sim.v
+++ b/vpr/ff/vpr_ff.sim.v
@@ -1,6 +1,6 @@
 `ifndef VPR_FF
 `define VPR_FF
-(* blackbox *) (* CLASS="flipflop" *)
+(* whitebox *) (* CLASS="flipflop" *)
 module VPR_FF (D, Q, clk);
 
 (* PORT_CLASS = "D" *)

--- a/vpr/muxes/logic/mux8/mux8.sim.v
+++ b/vpr/muxes/logic/mux8/mux8.sim.v
@@ -3,7 +3,7 @@
 
 `include "../mux2/mux2.sim.v"
 
-(* blackbox *) (* CLASS="mux" *)
+(* whitebox *) (* CLASS="mux" *)
 module MUX8(I0, I1, I2, I3, I4, I5, I6, I7, S0, S1, S2, O);
    input wire I0;
    input wire I1;

--- a/xc7/primitives/common_slice/carry/carry.sim.v
+++ b/xc7/primitives/common_slice/carry/carry.sim.v
@@ -1,4 +1,4 @@
-(*blackbox*)
+(* whitebox *)
 module CARRY(O, CO_CHAIN, CO_FABRIC, CI, DI, S);
   (* DELAY_CONST_CI="10e-12" *)
   (* DELAY_CONST_S="10e-12" *)

--- a/xc7/primitives/common_slice/carry/carry0.sim.v
+++ b/xc7/primitives/common_slice/carry/carry0.sim.v
@@ -1,4 +1,4 @@
-(*blackbox*)
+(* whitebox *)
 module CARRY0_CONST(O, CO_CHAIN, CO_FABRIC, CI_INIT, CI, DI, S);
   (* DELAY_CONST_CI="10e-12" *)
   (* DELAY_CONST_CI_INIT="10e-12" *)

--- a/xc7/primitives/slicem/dram_2_output_stub.sim.v
+++ b/xc7/primitives/slicem/dram_2_output_stub.sim.v
@@ -1,6 +1,6 @@
 // To ensure that all DRAMs are co-located within a SLICE, this block is
 // a simple passthrough black box to allow a pack pattern for dual port DRAMs.
-(* blackbox *)
+(* whitebox *)
 module DRAM_2_OUTPUT_STUB(
     input SPO, DPO,
     output SPO_OUT, DPO_OUT

--- a/xc7/primitives/slicem/dram_4_output_stub.sim.v
+++ b/xc7/primitives/slicem/dram_4_output_stub.sim.v
@@ -1,6 +1,6 @@
 // To ensure that all DRAMs are co-located within a SLICE, this block is
 // a simple passthrough black box to allow a pack pattern for dual port DRAMs.
-(* blackbox *)
+(* whitebox *)
 module DRAM_4_OUTPUT_STUB(
     input DOA, DOB, DOC, DOD,
     output DOA_OUT, DOB_OUT, DOC_OUT, DOD_OUT

--- a/xc7/primitives/slicem/dram_8_output_stub.sim.v
+++ b/xc7/primitives/slicem/dram_8_output_stub.sim.v
@@ -1,6 +1,6 @@
 // To ensure that all DRAMs are co-located within a SLICE, this block is
 // a simple passthrough black box to allow a pack pattern for dual port DRAMs.
-(* blackbox *)
+(* whitebox *)
 module DRAM_8_OUTPUT_STUB(
     input DOA1, DOB1, DOC1, DOD1, DOA0, DOB0, DOC0, DOD0,
     output DOA1_OUT, DOB1_OUT, DOC1_OUT, DOD1_OUT, DOA0_OUT, DOB0_OUT, DOC0_OUT, DOD0_OUT

--- a/xc7/primitives/tieoff/tieoff.sim.v
+++ b/xc7/primitives/tieoff/tieoff.sim.v
@@ -1,4 +1,4 @@
-(* blackbox *)
+(* whitebox *)
 module TIEOFF(
 	HARD0, HARD1
 );

--- a/xc7/yosys/synth.tcl
+++ b/xc7/yosys/synth.tcl
@@ -2,7 +2,7 @@ yosys -import
 
 # -flatten is used to ensure that the output eblif has only one module.
 # Some of symbiflow expects eblifs with only one module.
-synth_xilinx -vpr -flatten
+synth_xilinx -vpr -flatten -nosrl
 
 # Map Xilinx tech library to 7-series VPR tech library.
 read_verilog -lib $::env(symbiflow-arch-defs_SOURCE_DIR)/xc7/techmap/cells_sim.v


### PR DESCRIPTION
Yosys's treatment of blackbox attributes's now includes stripping all contents
within the blackbox.  The whitebox attribute is what should be used to
explicitly define contents of a blackbox.

This PR also updates Yosys (as of 4 days ago at b6345b1).