### PR TITLE
Make xc7 counter test for basys3 fasm2v compatible.

### DIFF
--- a/xc7/tests/counter/CMakeLists.txt
+++ b/xc7/tests/counter/CMakeLists.txt
@@ -1,9 +1,26 @@
-add_fpga_target_boards(
-  NAME counter
-  BOARDS basys3 zybo
+add_fpga_target(
+  NAME counter_zybo
+  BOARD zybo
   SOURCES counter.v
-  IMPLICIT_INPUT_IO_FILES
+  INPUT_IO_FILE zybo.pcf
   )
+
+add_file_target(FILE counter_basys3.v SCANNER_TYPE verilog)
+
+add_fpga_target(
+  NAME counter_basys3
+  BOARD basys3
+  SOURCES counter_basys3.v
+  INPUT_IO_FILE ../common/basys3.pcf
+  EXPLICIT_ADD_FILE_TARGET
+  )
+
+add_vivado_target(
+    NAME counter_basys3_vivado
+    PARENT_NAME counter_basys3
+    CLOCK_PINS clk
+    CLOCK_PERIODS 10.0
+    )
 
 add_fpga_target_boards(
   NAME counter

--- a/xc7/tests/counter/counter_basys3.v
+++ b/xc7/tests/counter/counter_basys3.v
@@ -1,0 +1,22 @@
+module top (
+    input  clk,
+    input rx,
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
+);
+
+    localparam BITS = 4;
+    localparam LOG2DELAY = 22;
+
+    reg [BITS+LOG2DELAY-1:0] counter = 0;
+
+    always @(posedge clk) begin
+        counter <= counter + 1;
+    end
+
+    assign led[3:0] = counter >> LOG2DELAY;
+    assign led[14:4] = sw[14:4];
+    assign tx = rx;
+    assign led[15] = ^sw;
+endmodule


### PR DESCRIPTION
This enables timing analysis comparisons between the two designs.