### PR TITLE
Enable Cinternal output.

### DIFF
--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -8,7 +8,7 @@ import contextlib
 # Set to True once
 # https://github.com/verilog-to-routing/vtr-verilog-to-routing/compare/c_internal
 # is merged and included in VTR conda.
-VPR_HAS_C_INTERNAL_SUPPORT = False
+VPR_HAS_C_INTERNAL_SUPPORT = True
 
 
 def serialize_nodes(xf, nodes):


### PR DESCRIPTION
This should fix master on CI, currently xc7 is broken at HEAD on master.