### PR TITLE
WIP: Re-enable routing failure detector.

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -548,7 +548,6 @@ set(VPR_BASE_ARGS
     --min_route_chan_width_hint 100
     --max_criticality 0.0
     --max_router_iterations 500
-    --routing_failure_predictor off
     --router_high_fanout_threshold -1
     --constant_net_method route
     CACHE STRING "Base VPR arguments")

--- a/testarch/CMakeLists.txt
+++ b/testarch/CMakeLists.txt
@@ -6,8 +6,6 @@ define_arch(
   ARCH testarch
   YOSYS_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/testarch/yosys/synth.tcl
   DEVICE_FULL_TEMPLATE \${DEVICE}
-  VPR_ARCH_ARGS
-    --router_init_wirelength_abort_threshold 20
   RR_PATCH_TOOL
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/testarch_graph.py
   RR_PATCH_CMD "\${CMAKE_COMMAND} -E env PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils


### PR DESCRIPTION
This requires https://github.com/verilog-to-routing/vtr-verilog-to-routing/commit/616833ee243d03fd9a927296b6ff2a851a691923
present in VTR.

This PR requires a new version of VTR containing the upstream fix.