### PR TITLE
[DNM][WIP] Use Yosys to generate blif in v2x tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,9 @@ add_custom_target(all_xml_lint)
 add_custom_target(all_vpr_test_pbtype)
 
 add_subdirectory(common)
-add_subdirectory(utils)
 add_subdirectory(vpr)
+# FIXME: utils tests depend on targets from vpr
+add_subdirectory(utils)
 add_subdirectory(library)
 # Disable 7-series support in CI because it consumes too much memory.
 if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})

--- a/utils/update_test_eblif.py
+++ b/utils/update_test_eblif.py
@@ -2,8 +2,10 @@
 
 import sys
 
+
 def remove_brackets(port):
     return (port.replace("[", "")).replace("]", "")
+
 
 def process_line(line, inputs, outputs):
 
@@ -20,6 +22,7 @@ def process_line(line, inputs, outputs):
         newline.append("=".join(port))
 
     return " ".join(newline)
+
 
 def main(argv):
 
@@ -58,14 +61,13 @@ def main(argv):
     for port in outputs:
         newoutputs.append(remove_brackets(port))
 
-
     with open(outfile, "w") as fp:
-       fp.write(".model {}\n".format(model))
-       fp.write(".inputs {}\n".format(" ".join(newinputs)))
-       fp.write(".outputs {}\n".format(" ".join(newoutputs)))
-       for line in body:
-           fp.write("{}\n".format(line))
+        fp.write(".model {}\n".format(model))
+        fp.write(".inputs {}\n".format(" ".join(newinputs)))
+        fp.write(".outputs {}\n".format(" ".join(newoutputs)))
+        for line in body:
+            fp.write("{}\n".format(line))
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))
-

--- a/utils/update_test_eblif.py
+++ b/utils/update_test_eblif.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import sys
+
+def remove_brackets(port):
+    return (port.replace("[", "")).replace("]", "")
+
+def process_line(line, inputs, outputs):
+
+    if not line.startswith(".subckt"):
+        return line
+
+    newline = list()
+    line_to_process = line.split()[2:]
+    newline.append(" ".join(line.split()[:2]))
+    for port in line_to_process:
+        port = port.split("=")
+        if port[1] in inputs or port[1] in outputs:
+            port[1] = remove_brackets(port[1])
+        newline.append("=".join(port))
+
+    return " ".join(newline)
+
+def main(argv):
+
+    if len(argv) != 3:
+        print("Usage: {} <inputfile> <outputfile>".format(argv[0]))
+        return 1
+
+    infile = argv[1]
+    outfile = argv[2]
+
+    inputs = list()
+    outputs = list()
+    body = list()
+    with open(infile, "r") as fp:
+        for line in fp:
+            if line.startswith(".inputs"):
+                inputs = line.split()[1:]
+                continue
+            if line.startswith(".outputs"):
+                outputs = line.split()[1:]
+                continue
+            if line.startswith(".model"):
+                model = line.split()[1]
+                continue
+
+            if line.startswith(".names") or (not line.startswith(".")):
+                continue
+
+            body.append(process_line(line, inputs, outputs))
+
+    newinputs = list()
+    newoutputs = list()
+
+    for port in inputs:
+        newinputs.append(remove_brackets(port))
+    for port in outputs:
+        newoutputs.append(remove_brackets(port))
+
+
+    with open(outfile, "w") as fp:
+       fp.write(".model {}\n".format(model))
+       fp.write(".inputs {}\n".format(" ".join(newinputs)))
+       fp.write(".outputs {}\n".format(" ".join(newoutputs)))
+       for line in body:
+           fp.write("{}\n".format(line))
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))
+

--- a/utils/vlog/tests/CMakeLists.txt
+++ b/utils/vlog/tests/CMakeLists.txt
@@ -23,15 +23,15 @@ add_subdirectory(single_port_rom_mixed)
 # Tests which demonstrate DSP style systems
 add_subdirectory(dsp_combinational)
 # FIXME: Output is incorrectly marked as being clocked.
-#add_subdirectory(dsp_in_registered)
+add_subdirectory(dsp_in_registered)
 # FIXME: utils/vlog/tests/dsp_inout_registered/dsp_inout_registered.arch.merged.xml:-1
 # <pb_type> 'dff' timing-annotation/<model> mismatch on port 'd' of model
 # 'dff', port is a sequential input but has neither T_setup nor T_hold
 # specified
-#add_subdirectory(dsp_inout_registered)
-#add_subdirectory(dsp_inout_registered_dualclk)
+add_subdirectory(dsp_inout_registered)
+add_subdirectory(dsp_inout_registered_dualclk)
 # FIXME: Input is incorrectly marked as being clocked.
-#add_subdirectory(dsp_out_registered)
+add_subdirectory(dsp_out_registered)
 # FIXME: Input `m` and output is incorrectly marked as being clocked.
-#add_subdirectory(dsp_partial_registered)
+add_subdirectory(dsp_partial_registered)
 add_subdirectory(dsp_modes)

--- a/utils/vlog/tests/CMakeLists.txt
+++ b/utils/vlog/tests/CMakeLists.txt
@@ -2,10 +2,8 @@ include(v2x_tests.cmake)
 
 # Functional testing
 add_subdirectory(clocks)
-add_subdirectory(multiple_instance)
 
 # Simple design tests
-add_subdirectory(single_port_rom_mixed)
 add_subdirectory(simple_pll)
 
 # Tests from the VtR timing tutorial
@@ -15,6 +13,12 @@ add_subdirectory(fig43-single_port_ram_mixed)
 #add_subdirectory(fig44-single_port_ram_seq)
 #add_subdirectory(fig45-single_port_ram_seq_comb)
 #add_subdirectory(fig46-multiclock_dual_port_ram)
+
+# FIXME: Should be in the functional testing section but depends on tests from
+# the VtR timing tutorial.
+add_subdirectory(multiple_instance)
+# FIXME: Where should this be?
+add_subdirectory(single_port_rom_mixed)
 
 # Tests which demonstrate DSP style systems
 add_subdirectory(dsp_combinational)

--- a/utils/vlog/tests/CMakeLists.txt
+++ b/utils/vlog/tests/CMakeLists.txt
@@ -1,8 +1,22 @@
 include(v2x_tests.cmake)
 
+# Functional testing
+add_subdirectory(clocks)
+add_subdirectory(multiple_instance)
+
+# Simple design tests
+add_subdirectory(single_port_rom_mixed)
+add_subdirectory(simple_pll)
+
+# Tests from the VtR timing tutorial
 add_subdirectory(fig41-full-adder)
 add_subdirectory(fig42-dff)
-add_subdirectory(clocks)
+#add_subdirectory(fig43-single_port_ram_mixed)
+#add_subdirectory(fig44-single_port_ram_seq)
+#add_subdirectory(fig45-single_port_ram_seq_comb)
+#add_subdirectory(fig46-multiclock_dual_port_ram)
+
+# Tests which demonstrate DSP style systems
 add_subdirectory(dsp_combinational)
 # FIXME: Output is incorrectly marked as being clocked.
 #add_subdirectory(dsp_in_registered)
@@ -16,6 +30,4 @@ add_subdirectory(dsp_combinational)
 #add_subdirectory(dsp_out_registered)
 # FIXME: Input `m` and output is incorrectly marked as being clocked.
 #add_subdirectory(dsp_partial_registered)
-#add_subdirectory(dsp_modes)
-add_subdirectory(simple_pll)
-add_subdirectory(multiple_instance)
+add_subdirectory(dsp_modes)

--- a/utils/vlog/tests/CMakeLists.txt
+++ b/utils/vlog/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(simple_pll)
 # Tests from the VtR timing tutorial
 add_subdirectory(fig41-full-adder)
 add_subdirectory(fig42-dff)
-#add_subdirectory(fig43-single_port_ram_mixed)
+add_subdirectory(fig43-single_port_ram_mixed)
 #add_subdirectory(fig44-single_port_ram_seq)
 #add_subdirectory(fig45-single_port_ram_seq_comb)
 #add_subdirectory(fig46-multiclock_dual_port_ram)

--- a/utils/vlog/tests/CMakeLists.txt
+++ b/utils/vlog/tests/CMakeLists.txt
@@ -1,15 +1,15 @@
 include(v2x_tests.cmake)
 
 # Functional testing
-add_subdirectory(clocks)
-
-# Simple design tests
-add_subdirectory(simple_pll)
+#add_subdirectory(clocks)
+#
+## Simple design tests
+#add_subdirectory(simple_pll)
 
 # Tests from the VtR timing tutorial
 add_subdirectory(fig41-full-adder)
-add_subdirectory(fig42-dff)
-add_subdirectory(fig43-single_port_ram_mixed)
+#add_subdirectory(fig42-dff)
+#add_subdirectory(fig43-single_port_ram_mixed)
 #add_subdirectory(fig44-single_port_ram_seq)
 #add_subdirectory(fig45-single_port_ram_seq_comb)
 #add_subdirectory(fig46-multiclock_dual_port_ram)
@@ -18,20 +18,20 @@ add_subdirectory(fig43-single_port_ram_mixed)
 # the VtR timing tutorial.
 add_subdirectory(multiple_instance)
 # FIXME: Where should this be?
-add_subdirectory(single_port_rom_mixed)
-
+#add_subdirectory(single_port_rom_mixed)
+#
 # Tests which demonstrate DSP style systems
-add_subdirectory(dsp_combinational)
+#add_subdirectory(dsp_combinational)
 # FIXME: Output is incorrectly marked as being clocked.
-add_subdirectory(dsp_in_registered)
+#add_subdirectory(dsp_in_registered)
 # FIXME: utils/vlog/tests/dsp_inout_registered/dsp_inout_registered.arch.merged.xml:-1
 # <pb_type> 'dff' timing-annotation/<model> mismatch on port 'd' of model
 # 'dff', port is a sequential input but has neither T_setup nor T_hold
 # specified
-add_subdirectory(dsp_inout_registered)
-add_subdirectory(dsp_inout_registered_dualclk)
+#add_subdirectory(dsp_inout_registered)
+#add_subdirectory(dsp_inout_registered_dualclk)
 # FIXME: Input is incorrectly marked as being clocked.
-add_subdirectory(dsp_out_registered)
+#add_subdirectory(dsp_out_registered)
 # FIXME: Input `m` and output is incorrectly marked as being clocked.
-add_subdirectory(dsp_partial_registered)
-add_subdirectory(dsp_modes)
+#add_subdirectory(dsp_partial_registered)
+#add_subdirectory(dsp_modes)

--- a/utils/vlog/tests/dsp_in_registered/golden.model.xml
+++ b/utils/vlog/tests/dsp_in_registered/golden.model.xml
@@ -1,15 +1,4 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../fig42-dff/dff.model.xml" xpointer="xpointer(models/child::node())"/>
-  <model name="dsp_in_registered">
-    <input_ports>
-      <port clock="clk" combinational_sink_ports="out" name="a"/>
-      <port clock="clk" combinational_sink_ports="out" name="b"/>
-      <port is_clock="1" name="clk"/>
-      <port clock="clk" combinational_sink_ports="out" name="m"/>
-    </input_ports>
-    <output_ports>
-      <port name="out"/>
-    </output_ports>
-  </model>
 </models>

--- a/utils/vlog/tests/dsp_modes/golden.model.xml
+++ b/utils/vlog/tests/dsp_modes/golden.model.xml
@@ -1,15 +1,4 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../dsp_inout_registered/dsp_inout_registered.model.xml" xpointer="xpointer(models/child::node())"/>
-  <model name="dsp_modes">
-    <input_ports>
-      <port clock="clk" combinational_sink_ports="out" name="a"/>
-      <port clock="clk" combinational_sink_ports="out" name="b"/>
-      <port is_clock="1" name="clk"/>
-      <port clock="clk" combinational_sink_ports="out" name="m"/>
-    </input_ports>
-    <output_ports>
-      <port clock="clk" name="out"/>
-    </output_ports>
-  </model>
 </models>

--- a/utils/vlog/tests/fig41-full-adder/CMakeLists.txt
+++ b/utils/vlog/tests/fig41-full-adder/CMakeLists.txt
@@ -1,2 +1,6 @@
 add_file_target(FILE adder.sim.v SCANNER_TYPE verilog)
-v2x_test_both(NAME adder TOP_MODULE adder)
+#v2x_test_both(NAME adder TOP_MODULE adder)
+v2x(
+    NAME adder
+    SRCS adder.sim.v
+    )

--- a/utils/vlog/tests/fig41-full-adder/adder.sim.v
+++ b/utils/vlog/tests/fig41-full-adder/adder.sim.v
@@ -1,5 +1,5 @@
 (* blackbox *)
-module adder (
+module ADDER (
 	a, b, cin,
 	sum, cout
 );

--- a/utils/vlog/tests/fig42-dff/dff.sim.v
+++ b/utils/vlog/tests/fig42-dff/dff.sim.v
@@ -1,7 +1,10 @@
 (* blackbox *)
 module dff (d, clk, q);
+	(* SETUP="clk 10e-12" *)
+	(* HOLD="clk 10e-12" *)
 	input wire d;
 	input wire clk;
+	(* CLK_TO_Q="clk 10e-12" *)
 	output reg q;
 
 	always @ ( posedge clk ) begin

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/CMakeLists.txt
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_file_target(FILE single_port_ram_mixed.sim.v SCANNER_TYPE verilog)
 v2x_test_model(NAME single_port_ram_mixed TOP_MODULE single_port_ram_mixed)

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/CMakeLists.txt
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/CMakeLists.txt
@@ -1,0 +1,1 @@
+v2x_test_model(NAME single_port_ram_mixed TOP_MODULE single_port_ram_mixed)

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/README.md
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/README.md
@@ -1,0 +1,15 @@
+
+# Figure 43 - Signal Port RAM Mixed
+
+ * [Example shown in 'Figure 43' of the Verilog to Routing Timing Tutorial](). Also shown below;
+
+
+![]()
+
+
+## Features
+
+ - Single address port, captured on clock
+ - Write data port, captured on clock
+ - Read data port, updated after combinational delay (but address is only updated on clock).
+

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/golden.model.xml
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/golden.model.xml
@@ -1,14 +1,13 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
-  <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#mixed-sequential-combinational-block -->
   <model name="single_port_ram_mixed">
     <input_ports>
-      <port name="addr" combinational_sink_ports="out"/>
-      <port name="clk" is_clock="1"/>
+      <port clock="clk" combinational_sink_ports="out" name="addr"/>
+      <port is_clock="1" name="clk"/>
       <port name="data"/>
       <port name="we"/>
     </input_ports>
     <output_ports>
-      <port name="out"/>
+      <port clock="clk" name="out"/>
     </output_ports>
   </model>
 </models>

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/golden.model.xml
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/golden.model.xml
@@ -1,0 +1,14 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#mixed-sequential-combinational-block -->
+  <model name="single_port_ram_mixed">
+    <input_ports>
+      <port name="we" combinational_sink_ports="out"/>
+      <port name="addr" combinational_sink_ports="out"/>
+      <port name="data" combinational_sink_ports="out"/>
+      <port name="clk" is_clock="1"/>
+    </input_ports>
+    <output_ports>
+      <port name="out"/>
+    </output_ports>
+  </model>
+</models>

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/golden.model.xml
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/golden.model.xml
@@ -2,10 +2,10 @@
   <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#mixed-sequential-combinational-block -->
   <model name="single_port_ram_mixed">
     <input_ports>
-      <port name="we" combinational_sink_ports="out"/>
       <port name="addr" combinational_sink_ports="out"/>
-      <port name="data" combinational_sink_ports="out"/>
       <port name="clk" is_clock="1"/>
+      <port name="data"/>
+      <port name="we"/>
     </input_ports>
     <output_ports>
       <port name="out"/>

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/golden.pb_type.xml
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/golden.pb_type.xml
@@ -1,0 +1,22 @@
+<pb_type name="mem_sp" blif_model=".subckt single_port_ram_mixed" num_pb="1">
+  <input name="addr" num_pins="9"/>
+  <input name="data" num_pins="64"/>
+  <input name="we" num_pins="1"/>
+  <output name="out" num_pins="64"/>
+  <clock name="clk" num_pins="1"/>
+
+  <!-- External input register timing -->
+  <T_setup value="50e-12" port="mem_sp.addr" clock="clk"/>
+  <T_setup value="50e-12" port="mem_sp.data" clock="clk"/>
+  <T_setup value="50e-12" port="mem_sp.we" clock="clk"/>
+
+  <!-- Internal input register timing -->
+  <T_clock_to_Q max="200e-12" port="mem_sp.addr" clock="clk"/>
+  <T_clock_to_Q max="200e-12" port="mem_sp.data" clock="clk"/>
+  <T_clock_to_Q max="200e-12" port="mem_sp.we" clock="clk"/>
+
+  <!-- Internal combinational delay -->
+  <delay_constant max="800e-12" in_port="mem_sp.addr" out_port="mem_sp.out"/>
+  <delay_constant max="800e-12" in_port="mem_sp.data" out_port="mem_sp.out"/>
+  <delay_constant max="800e-12" in_port="mem_sp.we" out_port="mem_sp.out"/>
+</pb_type>

--- a/utils/vlog/tests/fig43-single_port_ram_mixed/single_port_ram_mixed.sim.v
+++ b/utils/vlog/tests/fig43-single_port_ram_mixed/single_port_ram_mixed.sim.v
@@ -1,0 +1,28 @@
+module single_port_ram_mixed (we, addr, data, clk, out);
+	localparam ADDR_WIDTH = 9;
+	localparam DATA_WIDTH = 64;
+
+	input wire we;
+	input wire [ADDR_WIDTH-1:0] addr;
+	input wire [DATA_WIDTH-1:0] data;
+	input wire clk;
+	output wire [DATA_WIDTH-1:0] out;
+
+	localparam MEM_SIZE = 2 ** ADDR_WIDTH;
+	reg [DATA_WIDTH-1:0] storage[MEM_SIZE-1:0];
+
+	reg q_we;
+	reg q_addr;
+	reg q_data;
+	always @(posedge clk) begin
+		q_we = we;
+		q_addr = addr;
+		q_data = data;
+		if (q_we) begin
+			storage[q_addr] <= q_data;
+		end
+	end
+
+	assign out = storage[q_addr];
+
+endmodule

--- a/utils/vlog/tests/fig44-single_port_ram_seq/CMakeLists.txt
+++ b/utils/vlog/tests/fig44-single_port_ram_seq/CMakeLists.txt
@@ -1,0 +1,1 @@
+v2x_test_model(NAME single_port_ram_seq TOP_MODULE single_port_ram_seq)

--- a/utils/vlog/tests/fig44-single_port_ram_seq/README.md
+++ b/utils/vlog/tests/fig44-single_port_ram_seq/README.md
@@ -1,0 +1,15 @@
+# Figure 44 - Sequential Single Port RAM
+
+ * [Example shown in 'Figure 44' of the Verilog to Routing Timing Tutorial](). Also shown below;
+
+
+![]()
+
+
+## Features
+
+ - Single address port, captured on clock
+ - Write data port, captured on clock
+ - Read data port, registered output on clock. (IE Read data available the cycle after address updates (?)).
+    * FIXME: Check this is accurate.
+

--- a/utils/vlog/tests/fig44-single_port_ram_seq/golden.model.xml
+++ b/utils/vlog/tests/fig44-single_port_ram_seq/golden.model.xml
@@ -1,0 +1,13 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="single_port_ram_seq">
+    <input_ports>
+      <port name="we" clock="clk" combinational_sink_ports="out"/>
+      <port name="addr" clock="clk" combinational_sink_ports="out"/>
+      <port name="data" clock="clk" combinational_sink_ports="out"/>
+      <port name="clk" is_clock="1"/>
+    </input_ports>
+    <output_ports>
+      <port name="out" clock="clk"/>
+    </output_ports>
+  </model>
+</models>

--- a/utils/vlog/tests/fig44-single_port_ram_seq/golden.pb_type.xml
+++ b/utils/vlog/tests/fig44-single_port_ram_seq/golden.pb_type.xml
@@ -1,0 +1,28 @@
+<pb_type name="mem_sp" blif_model=".subckt single_port_ram_seq" num_pb="1">
+  <input name="addr" num_pins="9"/>
+  <input name="data" num_pins="64"/>
+  <input name="we" num_pins="1"/>
+  <output name="out" num_pins="64"/>
+  <clock name="clk" num_pins="1"/>
+
+  <!-- External input register timing -->
+  <T_setup value="50e-12" port="mem_sp.addr" clock="clk"/>
+  <T_setup value="50e-12" port="mem_sp.data" clock="clk"/>
+  <T_setup value="50e-12" port="mem_sp.we" clock="clk"/>
+
+  <!-- Internal input register timing -->
+  <T_clock_to_Q max="200e-12" port="mem_sp.addr" clock="clk"/>
+  <T_clock_to_Q max="200e-12" port="mem_sp.data" clock="clk"/>
+  <T_clock_to_Q max="200e-12" port="mem_sp.we" clock="clk"/>
+
+  <!-- Internal combinational delay -->
+  <delay_constant max="740e-12" in_port="mem_sp.addr" out_port="mem_sp.out"/>
+  <delay_constant max="740e-12" in_port="mem_sp.data" out_port="mem_sp.out"/>
+  <delay_constant max="740e-12" in_port="mem_sp.we" out_port="mem_sp.out"/>
+
+  <!-- Internal output register timing -->
+  <T_setup value="60e-12" port="mem_sp.out" clock="clk"/>
+
+  <!-- External output register timing -->
+  <T_clock_to_Q max="300e-12" port="mem_sp.out" clock="clk"/>
+</pb_type>

--- a/utils/vlog/tests/fig44-single_port_ram_seq/single_port_ram_seq.sim.v
+++ b/utils/vlog/tests/fig44-single_port_ram_seq/single_port_ram_seq.sim.v
@@ -1,0 +1,67 @@
+`include "../../../../vpr/ff/vpr_ff.sim.v"
+`include "../../../../vpr/mem/vpr_sp_ram.sim.v"
+
+module single_port_ram_seq (we, addr, data, clk, out);
+	localparam ADDR_WIDTH = 9;
+	localparam DATA_WIDTH = 64;
+
+	input wire we;
+	input wire [ADDR_WIDTH-1:0] addr;
+	input wire [DATA_WIDTH-1:0] data;
+	input wire clk;
+	output wire [DATA_WIDTH-1:0] out;
+
+	wire q_we;
+        VPR_FF ff(
+                .D(we),
+                .clk(clk),
+                .Q(q_we),
+        );
+
+	wire [ADDR_WIDTH-1:0] q_addr;
+	generate
+		genvar i;
+		for (i=0; i < ADDR_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(addr[i]),
+				.clk(clk),
+				.Q(q_addr[i]),
+			);
+		end
+	endgenerate
+
+	wire [DATA_WIDTH-1:0] q_data;
+	generate
+		genvar i;
+		for (i=0; i < DATA_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(data[i]),
+				.clk(clk),
+				.Q(q_data[i]),
+			);
+		end
+	endgenerate
+
+	VPR_SP_RAM #(
+		.ADDR_WIDTH(ADDR_WIDTH),
+		.DATA_WIDTH(DATA_WIDTH)
+	) storage (
+		.we(q_we),
+		.addr(q_addr),
+		.data(q_data),
+		.out(out)
+	);
+
+	wire [DATA_WIDTH-1:0] o_out;
+	generate
+		genvar i;
+		for (i=0; i < DATA_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(o_out[i]),
+				.clk(clk),
+				.Q(out[i]),
+			);
+		end
+	endgenerate
+
+endmodule

--- a/utils/vlog/tests/fig45-single_port_ram_seq_comb/CMakeLists.txt
+++ b/utils/vlog/tests/fig45-single_port_ram_seq_comb/CMakeLists.txt
@@ -1,0 +1,1 @@
+v2x_test_model(NAME single_port_ram_seq_comb TOP_MODULE single_port_ram_seq_comb)

--- a/utils/vlog/tests/fig45-single_port_ram_seq_comb/README.md
+++ b/utils/vlog/tests/fig45-single_port_ram_seq_comb/README.md
@@ -1,0 +1,14 @@
+# Figure 45 - Combinational Signal Port RAM
+
+ * [Example shown in 'Figure 45' of the Verilog to Routing Timing Tutorial](). Also shown below;
+
+
+![]()
+
+
+## Features
+
+ - Single address port, captured on clock
+ - Write data port, captured on clock
+ - Read data port, registered output on clock. (IE Read data available the cycle after address updates (?)).
+  * FIXME: Check this is true.

--- a/utils/vlog/tests/fig45-single_port_ram_seq_comb/golden.model.xml
+++ b/utils/vlog/tests/fig45-single_port_ram_seq_comb/golden.model.xml
@@ -1,0 +1,14 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-with-internal-paths-and-combinational-input -->
+  <model name="single_port_ram_seq_comb">
+    <input_ports>
+      <port name="we" combinational_sink_ports="out"/>
+      <port name="addr" clock="clk" combinational_sink_ports="out"/>
+      <port name="data" clock="clk" combinational_sink_ports="out"/>
+      <port name="clk" is_clock="1"/>
+    </input_ports>
+    <output_ports>
+      <port name="out" clock="clk"/>
+    </output_ports>
+  </model>
+</models>

--- a/utils/vlog/tests/fig45-single_port_ram_seq_comb/golden.pb_type.xml
+++ b/utils/vlog/tests/fig45-single_port_ram_seq_comb/golden.pb_type.xml
@@ -1,0 +1,28 @@
+<pb_type name="mem_sp" blif_model=".subckt single_port_ram_seq_comb" num_pb="1">
+  <input name="addr" num_pins="9"/>
+  <input name="data" num_pins="64"/>
+  <input name="we" num_pins="1"/>
+  <output name="out" num_pins="64"/>
+  <clock name="clk" num_pins="1"/>
+
+  <!-- External input register timing -->
+  <T_setup value="50e-12" port="mem_sp.addr" clock="clk"/>
+  <T_setup value="50e-12" port="mem_sp.data" clock="clk"/>
+
+  <!-- Internal input register timing -->
+  <T_clock_to_Q max="200e-12" port="mem_sp.addr" clock="clk"/>
+  <T_clock_to_Q max="200e-12" port="mem_sp.data" clock="clk"/>
+
+  <!-- External combinational delay -->
+  <delay_constant max="800e-12" in_port="mem_sp.we" out_port="mem_sp.out"/>
+
+  <!-- Internal combinational delay -->
+  <delay_constant max="740e-12" in_port="mem_sp.addr" out_port="mem_sp.out"/>
+  <delay_constant max="740e-12" in_port="mem_sp.data" out_port="mem_sp.out"/>
+
+  <!-- Internal output register timing -->
+  <T_setup value="60e-12" port="mem_sp.out" clock="clk"/>
+
+  <!-- External output register timing -->
+  <T_clock_to_Q max="300e-12" port="mem_sp.out" clock="clk"/>
+</pb_type>

--- a/utils/vlog/tests/fig45-single_port_ram_seq_comb/single_port_ram_seq_comb.sim.v
+++ b/utils/vlog/tests/fig45-single_port_ram_seq_comb/single_port_ram_seq_comb.sim.v
@@ -1,0 +1,60 @@
+`include "../../../../vpr/ff/vpr_ff.sim.v"
+`include "../../../../vpr/mem/vpr_sp_ram.sim.v"
+
+module single_port_ram_seq_comb (we, addr, data, clk, out);
+	localparam ADDR_WIDTH = 9;
+	localparam DATA_WIDTH = 64;
+
+	input wire we;
+	input wire [ADDR_WIDTH-1:0] addr;
+	input wire [DATA_WIDTH-1:0] data;
+	input wire clk;
+	output wire [DATA_WIDTH-1:0] out;
+
+	wire [ADDR_WIDTH-1:0] q_addr;
+	generate
+		genvar i;
+		for (i=0; i < ADDR_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(addr[i]),
+				.clk(clk),
+				.Q(q_addr[i]),
+			);
+		end
+	endgenerate
+
+	wire [DATA_WIDTH-1:0] q_data;
+	generate
+		genvar i;
+		for (i=0; i < DATA_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(data[i]),
+				.clk(clk),
+				.Q(q_data[i]),
+			);
+		end
+	endgenerate
+
+	VPR_SP_RAM #(
+		.ADDR_WIDTH(ADDR_WIDTH),
+		.DATA_WIDTH(DATA_WIDTH)
+	) storage (
+		.we(we),
+		.addr(q_addr),
+		.data(q_data),
+		.out(out)
+	);
+
+	wire [DATA_WIDTH-1:0] o_out;
+	generate
+		genvar i;
+		for (i=0; i < DATA_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(o_out[i]),
+				.clk(clk),
+				.Q(out[i]),
+			);
+		end
+	endgenerate
+
+endmodule

--- a/utils/vlog/tests/fig46-multiclock_dual_port_ram/CMakeLists.txt
+++ b/utils/vlog/tests/fig46-multiclock_dual_port_ram/CMakeLists.txt
@@ -1,0 +1,1 @@
+v2x_test_model(NAME multiclock_dual_port_ram TOP_MODULE multiclock_dual_port_ram)

--- a/utils/vlog/tests/fig46-multiclock_dual_port_ram/README.md
+++ b/utils/vlog/tests/fig46-multiclock_dual_port_ram/README.md
@@ -1,0 +1,18 @@
+
+# Figure 46 - Multiclock Dual Port RAM
+
+ * [Example shown in 'Figure 46' of the Verilog to Routing Timing Tutorial](). Also shown below;
+
+
+![]()
+
+
+## Features
+
+ - Separate read and write ports.
+ - Both ports synchronous but use different clocks.
+
+ - Two address ports.
+ - Write data port connected to first address port.
+ - Read data port connected to second address port.
+

--- a/utils/vlog/tests/fig46-multiclock_dual_port_ram/golden.model.xml
+++ b/utils/vlog/tests/fig46-multiclock_dual_port_ram/golden.model.xml
@@ -1,0 +1,20 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#multi-clock-sequential-block-with-internal-paths -->
+  <model name="multiclock_dual_port_ram">
+    <input_ports>
+      <!-- Write Port -->
+      <port name="we1" clock="clk1" combinational_sink_ports="data2"/>
+      <port name="addr1" clock="clk1" combinational_sink_ports="data2"/>
+      <port name="data1" clock="clk1" combinational_sink_ports="data2"/>
+      <port name="clk1" is_clock="1"/>
+
+      <!-- Read Port -->
+      <port name="addr2" clock="clk2" combinational_sink_ports="data2"/>
+      <port name="clk2" is_clock="1"/>
+    </input_ports>
+    <output_ports>
+      <!-- Read Port -->
+      <port name="data2" clock="clk2" combinational_sink_ports="data2"/>
+    </output_ports>
+  </model>
+</models>

--- a/utils/vlog/tests/fig46-multiclock_dual_port_ram/golden.pb_type.xml
+++ b/utils/vlog/tests/fig46-multiclock_dual_port_ram/golden.pb_type.xml
@@ -1,0 +1,33 @@
+<pb_type name="mem_dp" blif_model=".subckt multiclock_dual_port_ram" num_pb="1">
+  <input name="addr1" num_pins="9"/>
+  <input name="data1" num_pins="64"/>
+  <input name="we1" num_pins="1"/>
+  <input name="addr2" num_pins="9"/>
+  <output name="data2" num_pins="64"/>
+  <clock name="clk1" num_pins="1"/>
+  <clock name="clk2" num_pins="1"/>
+
+  <!-- External input register timing -->
+  <T_setup value="50e-12" port="mem_dp.addr1" clock="clk1"/>
+  <T_setup value="50e-12" port="mem_dp.data1" clock="clk1"/>
+  <T_setup value="50e-12" port="mem_dp.we1" clock="clk1"/>
+  <T_setup value="50e-12" port="mem_dp.addr2" clock="clk2"/>
+
+  <!-- Internal input register timing -->
+  <T_clock_to_Q max="200e-12" port="mem_dp.addr1" clock="clk1"/>
+  <T_clock_to_Q max="200e-12" port="mem_dp.data1" clock="clk1"/>
+  <T_clock_to_Q max="200e-12" port="mem_dp.we1" clock="clk1"/>
+  <T_clock_to_Q max="200e-12" port="mem_dp.addr2" clock="clk2"/>
+
+  <!-- Internal combinational delay -->
+  <delay_constant max="740e-12" in_port="mem_dp.addr1" out_port="mem_dp.data2"/>
+  <delay_constant max="740e-12" in_port="mem_dp.data1" out_port="mem_dp.data2"/>
+  <delay_constant max="740e-12" in_port="mem_dp.we1" out_port="mem_dp.data2"/>
+  <delay_constant max="740e-12" in_port="mem_dp.addr2" out_port="mem_dp.data2"/>
+
+  <!-- Internal output register timing -->
+  <T_setup value="60e-12" port="mem_dp.data2" clock="clk2"/>
+
+  <!-- External output register timing -->
+  <T_clock_to_Q max="300e-12" port="mem_dp.data2" clock="clk2"/>
+</pb_type>

--- a/utils/vlog/tests/fig46-multiclock_dual_port_ram/multiclock_dual_port_ram.sim.v
+++ b/utils/vlog/tests/fig46-multiclock_dual_port_ram/multiclock_dual_port_ram.sim.v
@@ -1,0 +1,77 @@
+`include "../../../../vpr/ff/vpr_ff.sim.v"
+
+module multiclock_dual_port_ram (we1, addr1, data1, clk1, addr2, clk2, data2);
+	localparam ADDR_WIDTH = 9;
+	localparam DATA_WIDTH = 64;
+	localparam MEM_SIZE = 2 ** ADDR_WIDTH;
+
+	input wire we1;
+	input wire [ADDR_WIDTH-1:0] addr1;
+	input wire [DATA_WIDTH-1:0] data1;
+	input wire clk1;
+
+	input wire [ADDR_WIDTH-1:0] addr2;
+	input wire clk2;
+	output wire [DATA_WIDTH-1:0] data2;
+
+	wire q_we1;
+        VPR_FF ff(
+                .D(we1),
+                .clk(clk1),
+                .Q(q_we1),
+        );
+
+	wire [ADDR_WIDTH-1:0] q_addr1;
+	generate
+		genvar i;
+		for (i=0; i < ADDR_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(addr1[i]),
+				.clk(clk1),
+				.Q(q_addr1[i]),
+			);
+		end
+	endgenerate
+
+	wire [DATA_WIDTH-1:0] q_data1;
+	generate
+		genvar i;
+		for (i=0; i < DATA_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(data1[i]),
+				.clk(clk1),
+				.Q(q_data1[i]),
+			);
+		end
+	endgenerate
+
+	wire [ADDR_WIDTH-1:0] q_addr2;
+	generate
+		genvar i;
+		for (i=0; i < ADDR_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(addr2[i]),
+				.clk(clk2),
+				.Q(q_addr2[i]),
+			);
+		end
+	endgenerate
+
+	wire [DATA_WIDTH-1:0] o_data2;
+	generate
+		genvar i;
+		for (i=0; i < DATA_WIDTH; i=i+1) begin
+			VPR_FF ff(
+				.D(o_data2[i]),
+				.clk(clk2),
+				.Q(data2[i]),
+			);
+		end
+	endgenerate
+
+	reg [DATA_WIDTH-1:0] storage[MEM_SIZE-1:0];
+
+	assign o_data2 = storage[q_addr2];
+	//assign storage[q_addr1] = q_data1;
+
+endmodule

--- a/utils/vlog/tests/multiple_instance/golden.pb_type.xml
+++ b/utils/vlog/tests/multiple_instance/golden.pb_type.xml
@@ -1,1292 +1,1292 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="multiple_instance" num_pb="1">
-  <input  name="a"    num_pins="64"/>
-  <input  name="b"    num_pins="64"/>
-  <input  name="cin"  num_pins="64"/>
+  <input name="a" num_pins="64"/>
+  <input name="b" num_pins="64"/>
+  <input name="cin" num_pins="64"/>
   <output name="cout" num_pins="64"/>
-  <output name="sum"  num_pins="64"/>
-  <pb_type blif_model=".subckt adder" name="adder" num_pb="64">
-    <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())" />
+  <output name="sum" num_pins="64"/>
+  <pb_type blif_model=".subckt ADDER" name="ADDER" num_pb="64">
+    <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
   </pb_type>
   <interconnect>
     <direct>
       <port name="a[0]" type="input"/>
-      <port from="adder[0]" name="a" type="output"/>
+      <port from="ADDER[0]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[0]" type="input"/>
-      <port from="adder[0]" name="b" type="output"/>
+      <port from="ADDER[0]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[0]" type="input"/>
-      <port from="adder[0]" name="cin" type="output"/>
+      <port from="ADDER[0]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[0]" name="cout" type="input"/>
+      <port from="ADDER[0]" name="cout" type="input"/>
       <port name="cout[0]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[0]" name="sum" type="input"/>
+      <port from="ADDER[0]" name="sum" type="input"/>
       <port name="sum[0]" type="output"/>
     </direct>
     <direct>
       <port name="a[10]" type="input"/>
-      <port from="adder[1]" name="a" type="output"/>
+      <port from="ADDER[1]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[10]" type="input"/>
-      <port from="adder[1]" name="b" type="output"/>
+      <port from="ADDER[1]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[10]" type="input"/>
-      <port from="adder[1]" name="cin" type="output"/>
+      <port from="ADDER[1]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[1]" name="cout" type="input"/>
+      <port from="ADDER[1]" name="cout" type="input"/>
       <port name="cout[10]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[1]" name="sum" type="input"/>
+      <port from="ADDER[1]" name="sum" type="input"/>
       <port name="sum[10]" type="output"/>
     </direct>
     <direct>
       <port name="a[11]" type="input"/>
-      <port from="adder[2]" name="a" type="output"/>
+      <port from="ADDER[2]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[11]" type="input"/>
-      <port from="adder[2]" name="b" type="output"/>
+      <port from="ADDER[2]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[11]" type="input"/>
-      <port from="adder[2]" name="cin" type="output"/>
+      <port from="ADDER[2]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[2]" name="cout" type="input"/>
+      <port from="ADDER[2]" name="cout" type="input"/>
       <port name="cout[11]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[2]" name="sum" type="input"/>
+      <port from="ADDER[2]" name="sum" type="input"/>
       <port name="sum[11]" type="output"/>
     </direct>
     <direct>
       <port name="a[12]" type="input"/>
-      <port from="adder[3]" name="a" type="output"/>
+      <port from="ADDER[3]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[12]" type="input"/>
-      <port from="adder[3]" name="b" type="output"/>
+      <port from="ADDER[3]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[12]" type="input"/>
-      <port from="adder[3]" name="cin" type="output"/>
+      <port from="ADDER[3]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[3]" name="cout" type="input"/>
+      <port from="ADDER[3]" name="cout" type="input"/>
       <port name="cout[12]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[3]" name="sum" type="input"/>
+      <port from="ADDER[3]" name="sum" type="input"/>
       <port name="sum[12]" type="output"/>
     </direct>
     <direct>
       <port name="a[13]" type="input"/>
-      <port from="adder[4]" name="a" type="output"/>
+      <port from="ADDER[4]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[13]" type="input"/>
-      <port from="adder[4]" name="b" type="output"/>
+      <port from="ADDER[4]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[13]" type="input"/>
-      <port from="adder[4]" name="cin" type="output"/>
+      <port from="ADDER[4]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[4]" name="cout" type="input"/>
+      <port from="ADDER[4]" name="cout" type="input"/>
       <port name="cout[13]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[4]" name="sum" type="input"/>
+      <port from="ADDER[4]" name="sum" type="input"/>
       <port name="sum[13]" type="output"/>
     </direct>
     <direct>
       <port name="a[14]" type="input"/>
-      <port from="adder[5]" name="a" type="output"/>
+      <port from="ADDER[5]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[14]" type="input"/>
-      <port from="adder[5]" name="b" type="output"/>
+      <port from="ADDER[5]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[14]" type="input"/>
-      <port from="adder[5]" name="cin" type="output"/>
+      <port from="ADDER[5]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[5]" name="cout" type="input"/>
+      <port from="ADDER[5]" name="cout" type="input"/>
       <port name="cout[14]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[5]" name="sum" type="input"/>
+      <port from="ADDER[5]" name="sum" type="input"/>
       <port name="sum[14]" type="output"/>
     </direct>
     <direct>
       <port name="a[15]" type="input"/>
-      <port from="adder[6]" name="a" type="output"/>
+      <port from="ADDER[6]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[15]" type="input"/>
-      <port from="adder[6]" name="b" type="output"/>
+      <port from="ADDER[6]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[15]" type="input"/>
-      <port from="adder[6]" name="cin" type="output"/>
+      <port from="ADDER[6]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[6]" name="cout" type="input"/>
+      <port from="ADDER[6]" name="cout" type="input"/>
       <port name="cout[15]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[6]" name="sum" type="input"/>
+      <port from="ADDER[6]" name="sum" type="input"/>
       <port name="sum[15]" type="output"/>
     </direct>
     <direct>
       <port name="a[16]" type="input"/>
-      <port from="adder[7]" name="a" type="output"/>
+      <port from="ADDER[7]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[16]" type="input"/>
-      <port from="adder[7]" name="b" type="output"/>
+      <port from="ADDER[7]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[16]" type="input"/>
-      <port from="adder[7]" name="cin" type="output"/>
+      <port from="ADDER[7]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[7]" name="cout" type="input"/>
+      <port from="ADDER[7]" name="cout" type="input"/>
       <port name="cout[16]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[7]" name="sum" type="input"/>
+      <port from="ADDER[7]" name="sum" type="input"/>
       <port name="sum[16]" type="output"/>
     </direct>
     <direct>
       <port name="a[17]" type="input"/>
-      <port from="adder[8]" name="a" type="output"/>
+      <port from="ADDER[8]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[17]" type="input"/>
-      <port from="adder[8]" name="b" type="output"/>
+      <port from="ADDER[8]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[17]" type="input"/>
-      <port from="adder[8]" name="cin" type="output"/>
+      <port from="ADDER[8]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[8]" name="cout" type="input"/>
+      <port from="ADDER[8]" name="cout" type="input"/>
       <port name="cout[17]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[8]" name="sum" type="input"/>
+      <port from="ADDER[8]" name="sum" type="input"/>
       <port name="sum[17]" type="output"/>
     </direct>
     <direct>
       <port name="a[18]" type="input"/>
-      <port from="adder[9]" name="a" type="output"/>
+      <port from="ADDER[9]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[18]" type="input"/>
-      <port from="adder[9]" name="b" type="output"/>
+      <port from="ADDER[9]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[18]" type="input"/>
-      <port from="adder[9]" name="cin" type="output"/>
+      <port from="ADDER[9]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[9]" name="cout" type="input"/>
+      <port from="ADDER[9]" name="cout" type="input"/>
       <port name="cout[18]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[9]" name="sum" type="input"/>
+      <port from="ADDER[9]" name="sum" type="input"/>
       <port name="sum[18]" type="output"/>
     </direct>
     <direct>
       <port name="a[19]" type="input"/>
-      <port from="adder[10]" name="a" type="output"/>
+      <port from="ADDER[10]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[19]" type="input"/>
-      <port from="adder[10]" name="b" type="output"/>
+      <port from="ADDER[10]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[19]" type="input"/>
-      <port from="adder[10]" name="cin" type="output"/>
+      <port from="ADDER[10]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[10]" name="cout" type="input"/>
+      <port from="ADDER[10]" name="cout" type="input"/>
       <port name="cout[19]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[10]" name="sum" type="input"/>
+      <port from="ADDER[10]" name="sum" type="input"/>
       <port name="sum[19]" type="output"/>
     </direct>
     <direct>
       <port name="a[1]" type="input"/>
-      <port from="adder[11]" name="a" type="output"/>
+      <port from="ADDER[11]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[1]" type="input"/>
-      <port from="adder[11]" name="b" type="output"/>
+      <port from="ADDER[11]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[1]" type="input"/>
-      <port from="adder[11]" name="cin" type="output"/>
+      <port from="ADDER[11]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[11]" name="cout" type="input"/>
+      <port from="ADDER[11]" name="cout" type="input"/>
       <port name="cout[1]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[11]" name="sum" type="input"/>
+      <port from="ADDER[11]" name="sum" type="input"/>
       <port name="sum[1]" type="output"/>
     </direct>
     <direct>
       <port name="a[20]" type="input"/>
-      <port from="adder[12]" name="a" type="output"/>
+      <port from="ADDER[12]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[20]" type="input"/>
-      <port from="adder[12]" name="b" type="output"/>
+      <port from="ADDER[12]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[20]" type="input"/>
-      <port from="adder[12]" name="cin" type="output"/>
+      <port from="ADDER[12]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[12]" name="cout" type="input"/>
+      <port from="ADDER[12]" name="cout" type="input"/>
       <port name="cout[20]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[12]" name="sum" type="input"/>
+      <port from="ADDER[12]" name="sum" type="input"/>
       <port name="sum[20]" type="output"/>
     </direct>
     <direct>
       <port name="a[21]" type="input"/>
-      <port from="adder[13]" name="a" type="output"/>
+      <port from="ADDER[13]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[21]" type="input"/>
-      <port from="adder[13]" name="b" type="output"/>
+      <port from="ADDER[13]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[21]" type="input"/>
-      <port from="adder[13]" name="cin" type="output"/>
+      <port from="ADDER[13]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[13]" name="cout" type="input"/>
+      <port from="ADDER[13]" name="cout" type="input"/>
       <port name="cout[21]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[13]" name="sum" type="input"/>
+      <port from="ADDER[13]" name="sum" type="input"/>
       <port name="sum[21]" type="output"/>
     </direct>
     <direct>
       <port name="a[22]" type="input"/>
-      <port from="adder[14]" name="a" type="output"/>
+      <port from="ADDER[14]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[22]" type="input"/>
-      <port from="adder[14]" name="b" type="output"/>
+      <port from="ADDER[14]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[22]" type="input"/>
-      <port from="adder[14]" name="cin" type="output"/>
+      <port from="ADDER[14]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[14]" name="cout" type="input"/>
+      <port from="ADDER[14]" name="cout" type="input"/>
       <port name="cout[22]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[14]" name="sum" type="input"/>
+      <port from="ADDER[14]" name="sum" type="input"/>
       <port name="sum[22]" type="output"/>
     </direct>
     <direct>
       <port name="a[23]" type="input"/>
-      <port from="adder[15]" name="a" type="output"/>
+      <port from="ADDER[15]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[23]" type="input"/>
-      <port from="adder[15]" name="b" type="output"/>
+      <port from="ADDER[15]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[23]" type="input"/>
-      <port from="adder[15]" name="cin" type="output"/>
+      <port from="ADDER[15]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[15]" name="cout" type="input"/>
+      <port from="ADDER[15]" name="cout" type="input"/>
       <port name="cout[23]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[15]" name="sum" type="input"/>
+      <port from="ADDER[15]" name="sum" type="input"/>
       <port name="sum[23]" type="output"/>
     </direct>
     <direct>
       <port name="a[24]" type="input"/>
-      <port from="adder[16]" name="a" type="output"/>
+      <port from="ADDER[16]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[24]" type="input"/>
-      <port from="adder[16]" name="b" type="output"/>
+      <port from="ADDER[16]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[24]" type="input"/>
-      <port from="adder[16]" name="cin" type="output"/>
+      <port from="ADDER[16]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[16]" name="cout" type="input"/>
+      <port from="ADDER[16]" name="cout" type="input"/>
       <port name="cout[24]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[16]" name="sum" type="input"/>
+      <port from="ADDER[16]" name="sum" type="input"/>
       <port name="sum[24]" type="output"/>
     </direct>
     <direct>
       <port name="a[25]" type="input"/>
-      <port from="adder[17]" name="a" type="output"/>
+      <port from="ADDER[17]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[25]" type="input"/>
-      <port from="adder[17]" name="b" type="output"/>
+      <port from="ADDER[17]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[25]" type="input"/>
-      <port from="adder[17]" name="cin" type="output"/>
+      <port from="ADDER[17]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[17]" name="cout" type="input"/>
+      <port from="ADDER[17]" name="cout" type="input"/>
       <port name="cout[25]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[17]" name="sum" type="input"/>
+      <port from="ADDER[17]" name="sum" type="input"/>
       <port name="sum[25]" type="output"/>
     </direct>
     <direct>
       <port name="a[26]" type="input"/>
-      <port from="adder[18]" name="a" type="output"/>
+      <port from="ADDER[18]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[26]" type="input"/>
-      <port from="adder[18]" name="b" type="output"/>
+      <port from="ADDER[18]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[26]" type="input"/>
-      <port from="adder[18]" name="cin" type="output"/>
+      <port from="ADDER[18]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[18]" name="cout" type="input"/>
+      <port from="ADDER[18]" name="cout" type="input"/>
       <port name="cout[26]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[18]" name="sum" type="input"/>
+      <port from="ADDER[18]" name="sum" type="input"/>
       <port name="sum[26]" type="output"/>
     </direct>
     <direct>
       <port name="a[27]" type="input"/>
-      <port from="adder[19]" name="a" type="output"/>
+      <port from="ADDER[19]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[27]" type="input"/>
-      <port from="adder[19]" name="b" type="output"/>
+      <port from="ADDER[19]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[27]" type="input"/>
-      <port from="adder[19]" name="cin" type="output"/>
+      <port from="ADDER[19]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[19]" name="cout" type="input"/>
+      <port from="ADDER[19]" name="cout" type="input"/>
       <port name="cout[27]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[19]" name="sum" type="input"/>
+      <port from="ADDER[19]" name="sum" type="input"/>
       <port name="sum[27]" type="output"/>
     </direct>
     <direct>
       <port name="a[28]" type="input"/>
-      <port from="adder[20]" name="a" type="output"/>
+      <port from="ADDER[20]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[28]" type="input"/>
-      <port from="adder[20]" name="b" type="output"/>
+      <port from="ADDER[20]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[28]" type="input"/>
-      <port from="adder[20]" name="cin" type="output"/>
+      <port from="ADDER[20]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[20]" name="cout" type="input"/>
+      <port from="ADDER[20]" name="cout" type="input"/>
       <port name="cout[28]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[20]" name="sum" type="input"/>
+      <port from="ADDER[20]" name="sum" type="input"/>
       <port name="sum[28]" type="output"/>
     </direct>
     <direct>
       <port name="a[29]" type="input"/>
-      <port from="adder[21]" name="a" type="output"/>
+      <port from="ADDER[21]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[29]" type="input"/>
-      <port from="adder[21]" name="b" type="output"/>
+      <port from="ADDER[21]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[29]" type="input"/>
-      <port from="adder[21]" name="cin" type="output"/>
+      <port from="ADDER[21]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[21]" name="cout" type="input"/>
+      <port from="ADDER[21]" name="cout" type="input"/>
       <port name="cout[29]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[21]" name="sum" type="input"/>
+      <port from="ADDER[21]" name="sum" type="input"/>
       <port name="sum[29]" type="output"/>
     </direct>
     <direct>
       <port name="a[2]" type="input"/>
-      <port from="adder[22]" name="a" type="output"/>
+      <port from="ADDER[22]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[2]" type="input"/>
-      <port from="adder[22]" name="b" type="output"/>
+      <port from="ADDER[22]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[2]" type="input"/>
-      <port from="adder[22]" name="cin" type="output"/>
+      <port from="ADDER[22]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[22]" name="cout" type="input"/>
+      <port from="ADDER[22]" name="cout" type="input"/>
       <port name="cout[2]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[22]" name="sum" type="input"/>
+      <port from="ADDER[22]" name="sum" type="input"/>
       <port name="sum[2]" type="output"/>
     </direct>
     <direct>
       <port name="a[30]" type="input"/>
-      <port from="adder[23]" name="a" type="output"/>
+      <port from="ADDER[23]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[30]" type="input"/>
-      <port from="adder[23]" name="b" type="output"/>
+      <port from="ADDER[23]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[30]" type="input"/>
-      <port from="adder[23]" name="cin" type="output"/>
+      <port from="ADDER[23]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[23]" name="cout" type="input"/>
+      <port from="ADDER[23]" name="cout" type="input"/>
       <port name="cout[30]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[23]" name="sum" type="input"/>
+      <port from="ADDER[23]" name="sum" type="input"/>
       <port name="sum[30]" type="output"/>
     </direct>
     <direct>
       <port name="a[31]" type="input"/>
-      <port from="adder[24]" name="a" type="output"/>
+      <port from="ADDER[24]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[31]" type="input"/>
-      <port from="adder[24]" name="b" type="output"/>
+      <port from="ADDER[24]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[31]" type="input"/>
-      <port from="adder[24]" name="cin" type="output"/>
+      <port from="ADDER[24]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[24]" name="cout" type="input"/>
+      <port from="ADDER[24]" name="cout" type="input"/>
       <port name="cout[31]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[24]" name="sum" type="input"/>
+      <port from="ADDER[24]" name="sum" type="input"/>
       <port name="sum[31]" type="output"/>
     </direct>
     <direct>
       <port name="a[32]" type="input"/>
-      <port from="adder[25]" name="a" type="output"/>
+      <port from="ADDER[25]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[32]" type="input"/>
-      <port from="adder[25]" name="b" type="output"/>
+      <port from="ADDER[25]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[32]" type="input"/>
-      <port from="adder[25]" name="cin" type="output"/>
+      <port from="ADDER[25]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[25]" name="cout" type="input"/>
+      <port from="ADDER[25]" name="cout" type="input"/>
       <port name="cout[32]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[25]" name="sum" type="input"/>
+      <port from="ADDER[25]" name="sum" type="input"/>
       <port name="sum[32]" type="output"/>
     </direct>
     <direct>
       <port name="a[33]" type="input"/>
-      <port from="adder[26]" name="a" type="output"/>
+      <port from="ADDER[26]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[33]" type="input"/>
-      <port from="adder[26]" name="b" type="output"/>
+      <port from="ADDER[26]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[33]" type="input"/>
-      <port from="adder[26]" name="cin" type="output"/>
+      <port from="ADDER[26]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[26]" name="cout" type="input"/>
+      <port from="ADDER[26]" name="cout" type="input"/>
       <port name="cout[33]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[26]" name="sum" type="input"/>
+      <port from="ADDER[26]" name="sum" type="input"/>
       <port name="sum[33]" type="output"/>
     </direct>
     <direct>
       <port name="a[34]" type="input"/>
-      <port from="adder[27]" name="a" type="output"/>
+      <port from="ADDER[27]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[34]" type="input"/>
-      <port from="adder[27]" name="b" type="output"/>
+      <port from="ADDER[27]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[34]" type="input"/>
-      <port from="adder[27]" name="cin" type="output"/>
+      <port from="ADDER[27]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[27]" name="cout" type="input"/>
+      <port from="ADDER[27]" name="cout" type="input"/>
       <port name="cout[34]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[27]" name="sum" type="input"/>
+      <port from="ADDER[27]" name="sum" type="input"/>
       <port name="sum[34]" type="output"/>
     </direct>
     <direct>
       <port name="a[35]" type="input"/>
-      <port from="adder[28]" name="a" type="output"/>
+      <port from="ADDER[28]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[35]" type="input"/>
-      <port from="adder[28]" name="b" type="output"/>
+      <port from="ADDER[28]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[35]" type="input"/>
-      <port from="adder[28]" name="cin" type="output"/>
+      <port from="ADDER[28]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[28]" name="cout" type="input"/>
+      <port from="ADDER[28]" name="cout" type="input"/>
       <port name="cout[35]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[28]" name="sum" type="input"/>
+      <port from="ADDER[28]" name="sum" type="input"/>
       <port name="sum[35]" type="output"/>
     </direct>
     <direct>
       <port name="a[36]" type="input"/>
-      <port from="adder[29]" name="a" type="output"/>
+      <port from="ADDER[29]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[36]" type="input"/>
-      <port from="adder[29]" name="b" type="output"/>
+      <port from="ADDER[29]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[36]" type="input"/>
-      <port from="adder[29]" name="cin" type="output"/>
+      <port from="ADDER[29]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[29]" name="cout" type="input"/>
+      <port from="ADDER[29]" name="cout" type="input"/>
       <port name="cout[36]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[29]" name="sum" type="input"/>
+      <port from="ADDER[29]" name="sum" type="input"/>
       <port name="sum[36]" type="output"/>
     </direct>
     <direct>
       <port name="a[37]" type="input"/>
-      <port from="adder[30]" name="a" type="output"/>
+      <port from="ADDER[30]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[37]" type="input"/>
-      <port from="adder[30]" name="b" type="output"/>
+      <port from="ADDER[30]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[37]" type="input"/>
-      <port from="adder[30]" name="cin" type="output"/>
+      <port from="ADDER[30]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[30]" name="cout" type="input"/>
+      <port from="ADDER[30]" name="cout" type="input"/>
       <port name="cout[37]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[30]" name="sum" type="input"/>
+      <port from="ADDER[30]" name="sum" type="input"/>
       <port name="sum[37]" type="output"/>
     </direct>
     <direct>
       <port name="a[38]" type="input"/>
-      <port from="adder[31]" name="a" type="output"/>
+      <port from="ADDER[31]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[38]" type="input"/>
-      <port from="adder[31]" name="b" type="output"/>
+      <port from="ADDER[31]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[38]" type="input"/>
-      <port from="adder[31]" name="cin" type="output"/>
+      <port from="ADDER[31]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[31]" name="cout" type="input"/>
+      <port from="ADDER[31]" name="cout" type="input"/>
       <port name="cout[38]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[31]" name="sum" type="input"/>
+      <port from="ADDER[31]" name="sum" type="input"/>
       <port name="sum[38]" type="output"/>
     </direct>
     <direct>
       <port name="a[39]" type="input"/>
-      <port from="adder[32]" name="a" type="output"/>
+      <port from="ADDER[32]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[39]" type="input"/>
-      <port from="adder[32]" name="b" type="output"/>
+      <port from="ADDER[32]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[39]" type="input"/>
-      <port from="adder[32]" name="cin" type="output"/>
+      <port from="ADDER[32]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[32]" name="cout" type="input"/>
+      <port from="ADDER[32]" name="cout" type="input"/>
       <port name="cout[39]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[32]" name="sum" type="input"/>
+      <port from="ADDER[32]" name="sum" type="input"/>
       <port name="sum[39]" type="output"/>
     </direct>
     <direct>
       <port name="a[3]" type="input"/>
-      <port from="adder[33]" name="a" type="output"/>
+      <port from="ADDER[33]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[3]" type="input"/>
-      <port from="adder[33]" name="b" type="output"/>
+      <port from="ADDER[33]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[3]" type="input"/>
-      <port from="adder[33]" name="cin" type="output"/>
+      <port from="ADDER[33]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[33]" name="cout" type="input"/>
+      <port from="ADDER[33]" name="cout" type="input"/>
       <port name="cout[3]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[33]" name="sum" type="input"/>
+      <port from="ADDER[33]" name="sum" type="input"/>
       <port name="sum[3]" type="output"/>
     </direct>
     <direct>
       <port name="a[40]" type="input"/>
-      <port from="adder[34]" name="a" type="output"/>
+      <port from="ADDER[34]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[40]" type="input"/>
-      <port from="adder[34]" name="b" type="output"/>
+      <port from="ADDER[34]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[40]" type="input"/>
-      <port from="adder[34]" name="cin" type="output"/>
+      <port from="ADDER[34]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[34]" name="cout" type="input"/>
+      <port from="ADDER[34]" name="cout" type="input"/>
       <port name="cout[40]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[34]" name="sum" type="input"/>
+      <port from="ADDER[34]" name="sum" type="input"/>
       <port name="sum[40]" type="output"/>
     </direct>
     <direct>
       <port name="a[41]" type="input"/>
-      <port from="adder[35]" name="a" type="output"/>
+      <port from="ADDER[35]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[41]" type="input"/>
-      <port from="adder[35]" name="b" type="output"/>
+      <port from="ADDER[35]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[41]" type="input"/>
-      <port from="adder[35]" name="cin" type="output"/>
+      <port from="ADDER[35]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[35]" name="cout" type="input"/>
+      <port from="ADDER[35]" name="cout" type="input"/>
       <port name="cout[41]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[35]" name="sum" type="input"/>
+      <port from="ADDER[35]" name="sum" type="input"/>
       <port name="sum[41]" type="output"/>
     </direct>
     <direct>
       <port name="a[42]" type="input"/>
-      <port from="adder[36]" name="a" type="output"/>
+      <port from="ADDER[36]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[42]" type="input"/>
-      <port from="adder[36]" name="b" type="output"/>
+      <port from="ADDER[36]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[42]" type="input"/>
-      <port from="adder[36]" name="cin" type="output"/>
+      <port from="ADDER[36]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[36]" name="cout" type="input"/>
+      <port from="ADDER[36]" name="cout" type="input"/>
       <port name="cout[42]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[36]" name="sum" type="input"/>
+      <port from="ADDER[36]" name="sum" type="input"/>
       <port name="sum[42]" type="output"/>
     </direct>
     <direct>
       <port name="a[43]" type="input"/>
-      <port from="adder[37]" name="a" type="output"/>
+      <port from="ADDER[37]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[43]" type="input"/>
-      <port from="adder[37]" name="b" type="output"/>
+      <port from="ADDER[37]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[43]" type="input"/>
-      <port from="adder[37]" name="cin" type="output"/>
+      <port from="ADDER[37]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[37]" name="cout" type="input"/>
+      <port from="ADDER[37]" name="cout" type="input"/>
       <port name="cout[43]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[37]" name="sum" type="input"/>
+      <port from="ADDER[37]" name="sum" type="input"/>
       <port name="sum[43]" type="output"/>
     </direct>
     <direct>
       <port name="a[44]" type="input"/>
-      <port from="adder[38]" name="a" type="output"/>
+      <port from="ADDER[38]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[44]" type="input"/>
-      <port from="adder[38]" name="b" type="output"/>
+      <port from="ADDER[38]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[44]" type="input"/>
-      <port from="adder[38]" name="cin" type="output"/>
+      <port from="ADDER[38]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[38]" name="cout" type="input"/>
+      <port from="ADDER[38]" name="cout" type="input"/>
       <port name="cout[44]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[38]" name="sum" type="input"/>
+      <port from="ADDER[38]" name="sum" type="input"/>
       <port name="sum[44]" type="output"/>
     </direct>
     <direct>
       <port name="a[45]" type="input"/>
-      <port from="adder[39]" name="a" type="output"/>
+      <port from="ADDER[39]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[45]" type="input"/>
-      <port from="adder[39]" name="b" type="output"/>
+      <port from="ADDER[39]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[45]" type="input"/>
-      <port from="adder[39]" name="cin" type="output"/>
+      <port from="ADDER[39]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[39]" name="cout" type="input"/>
+      <port from="ADDER[39]" name="cout" type="input"/>
       <port name="cout[45]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[39]" name="sum" type="input"/>
+      <port from="ADDER[39]" name="sum" type="input"/>
       <port name="sum[45]" type="output"/>
     </direct>
     <direct>
       <port name="a[46]" type="input"/>
-      <port from="adder[40]" name="a" type="output"/>
+      <port from="ADDER[40]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[46]" type="input"/>
-      <port from="adder[40]" name="b" type="output"/>
+      <port from="ADDER[40]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[46]" type="input"/>
-      <port from="adder[40]" name="cin" type="output"/>
+      <port from="ADDER[40]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[40]" name="cout" type="input"/>
+      <port from="ADDER[40]" name="cout" type="input"/>
       <port name="cout[46]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[40]" name="sum" type="input"/>
+      <port from="ADDER[40]" name="sum" type="input"/>
       <port name="sum[46]" type="output"/>
     </direct>
     <direct>
       <port name="a[47]" type="input"/>
-      <port from="adder[41]" name="a" type="output"/>
+      <port from="ADDER[41]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[47]" type="input"/>
-      <port from="adder[41]" name="b" type="output"/>
+      <port from="ADDER[41]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[47]" type="input"/>
-      <port from="adder[41]" name="cin" type="output"/>
+      <port from="ADDER[41]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[41]" name="cout" type="input"/>
+      <port from="ADDER[41]" name="cout" type="input"/>
       <port name="cout[47]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[41]" name="sum" type="input"/>
+      <port from="ADDER[41]" name="sum" type="input"/>
       <port name="sum[47]" type="output"/>
     </direct>
     <direct>
       <port name="a[48]" type="input"/>
-      <port from="adder[42]" name="a" type="output"/>
+      <port from="ADDER[42]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[48]" type="input"/>
-      <port from="adder[42]" name="b" type="output"/>
+      <port from="ADDER[42]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[48]" type="input"/>
-      <port from="adder[42]" name="cin" type="output"/>
+      <port from="ADDER[42]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[42]" name="cout" type="input"/>
+      <port from="ADDER[42]" name="cout" type="input"/>
       <port name="cout[48]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[42]" name="sum" type="input"/>
+      <port from="ADDER[42]" name="sum" type="input"/>
       <port name="sum[48]" type="output"/>
     </direct>
     <direct>
       <port name="a[49]" type="input"/>
-      <port from="adder[43]" name="a" type="output"/>
+      <port from="ADDER[43]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[49]" type="input"/>
-      <port from="adder[43]" name="b" type="output"/>
+      <port from="ADDER[43]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[49]" type="input"/>
-      <port from="adder[43]" name="cin" type="output"/>
+      <port from="ADDER[43]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[43]" name="cout" type="input"/>
+      <port from="ADDER[43]" name="cout" type="input"/>
       <port name="cout[49]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[43]" name="sum" type="input"/>
+      <port from="ADDER[43]" name="sum" type="input"/>
       <port name="sum[49]" type="output"/>
     </direct>
     <direct>
       <port name="a[4]" type="input"/>
-      <port from="adder[44]" name="a" type="output"/>
+      <port from="ADDER[44]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[4]" type="input"/>
-      <port from="adder[44]" name="b" type="output"/>
+      <port from="ADDER[44]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[4]" type="input"/>
-      <port from="adder[44]" name="cin" type="output"/>
+      <port from="ADDER[44]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[44]" name="cout" type="input"/>
+      <port from="ADDER[44]" name="cout" type="input"/>
       <port name="cout[4]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[44]" name="sum" type="input"/>
+      <port from="ADDER[44]" name="sum" type="input"/>
       <port name="sum[4]" type="output"/>
     </direct>
     <direct>
       <port name="a[50]" type="input"/>
-      <port from="adder[45]" name="a" type="output"/>
+      <port from="ADDER[45]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[50]" type="input"/>
-      <port from="adder[45]" name="b" type="output"/>
+      <port from="ADDER[45]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[50]" type="input"/>
-      <port from="adder[45]" name="cin" type="output"/>
+      <port from="ADDER[45]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[45]" name="cout" type="input"/>
+      <port from="ADDER[45]" name="cout" type="input"/>
       <port name="cout[50]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[45]" name="sum" type="input"/>
+      <port from="ADDER[45]" name="sum" type="input"/>
       <port name="sum[50]" type="output"/>
     </direct>
     <direct>
       <port name="a[51]" type="input"/>
-      <port from="adder[46]" name="a" type="output"/>
+      <port from="ADDER[46]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[51]" type="input"/>
-      <port from="adder[46]" name="b" type="output"/>
+      <port from="ADDER[46]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[51]" type="input"/>
-      <port from="adder[46]" name="cin" type="output"/>
+      <port from="ADDER[46]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[46]" name="cout" type="input"/>
+      <port from="ADDER[46]" name="cout" type="input"/>
       <port name="cout[51]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[46]" name="sum" type="input"/>
+      <port from="ADDER[46]" name="sum" type="input"/>
       <port name="sum[51]" type="output"/>
     </direct>
     <direct>
       <port name="a[52]" type="input"/>
-      <port from="adder[47]" name="a" type="output"/>
+      <port from="ADDER[47]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[52]" type="input"/>
-      <port from="adder[47]" name="b" type="output"/>
+      <port from="ADDER[47]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[52]" type="input"/>
-      <port from="adder[47]" name="cin" type="output"/>
+      <port from="ADDER[47]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[47]" name="cout" type="input"/>
+      <port from="ADDER[47]" name="cout" type="input"/>
       <port name="cout[52]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[47]" name="sum" type="input"/>
+      <port from="ADDER[47]" name="sum" type="input"/>
       <port name="sum[52]" type="output"/>
     </direct>
     <direct>
       <port name="a[53]" type="input"/>
-      <port from="adder[48]" name="a" type="output"/>
+      <port from="ADDER[48]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[53]" type="input"/>
-      <port from="adder[48]" name="b" type="output"/>
+      <port from="ADDER[48]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[53]" type="input"/>
-      <port from="adder[48]" name="cin" type="output"/>
+      <port from="ADDER[48]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[48]" name="cout" type="input"/>
+      <port from="ADDER[48]" name="cout" type="input"/>
       <port name="cout[53]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[48]" name="sum" type="input"/>
+      <port from="ADDER[48]" name="sum" type="input"/>
       <port name="sum[53]" type="output"/>
     </direct>
     <direct>
       <port name="a[54]" type="input"/>
-      <port from="adder[49]" name="a" type="output"/>
+      <port from="ADDER[49]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[54]" type="input"/>
-      <port from="adder[49]" name="b" type="output"/>
+      <port from="ADDER[49]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[54]" type="input"/>
-      <port from="adder[49]" name="cin" type="output"/>
+      <port from="ADDER[49]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[49]" name="cout" type="input"/>
+      <port from="ADDER[49]" name="cout" type="input"/>
       <port name="cout[54]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[49]" name="sum" type="input"/>
+      <port from="ADDER[49]" name="sum" type="input"/>
       <port name="sum[54]" type="output"/>
     </direct>
     <direct>
       <port name="a[55]" type="input"/>
-      <port from="adder[50]" name="a" type="output"/>
+      <port from="ADDER[50]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[55]" type="input"/>
-      <port from="adder[50]" name="b" type="output"/>
+      <port from="ADDER[50]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[55]" type="input"/>
-      <port from="adder[50]" name="cin" type="output"/>
+      <port from="ADDER[50]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[50]" name="cout" type="input"/>
+      <port from="ADDER[50]" name="cout" type="input"/>
       <port name="cout[55]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[50]" name="sum" type="input"/>
+      <port from="ADDER[50]" name="sum" type="input"/>
       <port name="sum[55]" type="output"/>
     </direct>
     <direct>
       <port name="a[56]" type="input"/>
-      <port from="adder[51]" name="a" type="output"/>
+      <port from="ADDER[51]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[56]" type="input"/>
-      <port from="adder[51]" name="b" type="output"/>
+      <port from="ADDER[51]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[56]" type="input"/>
-      <port from="adder[51]" name="cin" type="output"/>
+      <port from="ADDER[51]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[51]" name="cout" type="input"/>
+      <port from="ADDER[51]" name="cout" type="input"/>
       <port name="cout[56]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[51]" name="sum" type="input"/>
+      <port from="ADDER[51]" name="sum" type="input"/>
       <port name="sum[56]" type="output"/>
     </direct>
     <direct>
       <port name="a[57]" type="input"/>
-      <port from="adder[52]" name="a" type="output"/>
+      <port from="ADDER[52]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[57]" type="input"/>
-      <port from="adder[52]" name="b" type="output"/>
+      <port from="ADDER[52]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[57]" type="input"/>
-      <port from="adder[52]" name="cin" type="output"/>
+      <port from="ADDER[52]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[52]" name="cout" type="input"/>
+      <port from="ADDER[52]" name="cout" type="input"/>
       <port name="cout[57]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[52]" name="sum" type="input"/>
+      <port from="ADDER[52]" name="sum" type="input"/>
       <port name="sum[57]" type="output"/>
     </direct>
     <direct>
       <port name="a[58]" type="input"/>
-      <port from="adder[53]" name="a" type="output"/>
+      <port from="ADDER[53]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[58]" type="input"/>
-      <port from="adder[53]" name="b" type="output"/>
+      <port from="ADDER[53]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[58]" type="input"/>
-      <port from="adder[53]" name="cin" type="output"/>
+      <port from="ADDER[53]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[53]" name="cout" type="input"/>
+      <port from="ADDER[53]" name="cout" type="input"/>
       <port name="cout[58]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[53]" name="sum" type="input"/>
+      <port from="ADDER[53]" name="sum" type="input"/>
       <port name="sum[58]" type="output"/>
     </direct>
     <direct>
       <port name="a[59]" type="input"/>
-      <port from="adder[54]" name="a" type="output"/>
+      <port from="ADDER[54]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[59]" type="input"/>
-      <port from="adder[54]" name="b" type="output"/>
+      <port from="ADDER[54]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[59]" type="input"/>
-      <port from="adder[54]" name="cin" type="output"/>
+      <port from="ADDER[54]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[54]" name="cout" type="input"/>
+      <port from="ADDER[54]" name="cout" type="input"/>
       <port name="cout[59]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[54]" name="sum" type="input"/>
+      <port from="ADDER[54]" name="sum" type="input"/>
       <port name="sum[59]" type="output"/>
     </direct>
     <direct>
       <port name="a[5]" type="input"/>
-      <port from="adder[55]" name="a" type="output"/>
+      <port from="ADDER[55]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[5]" type="input"/>
-      <port from="adder[55]" name="b" type="output"/>
+      <port from="ADDER[55]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[5]" type="input"/>
-      <port from="adder[55]" name="cin" type="output"/>
+      <port from="ADDER[55]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[55]" name="cout" type="input"/>
+      <port from="ADDER[55]" name="cout" type="input"/>
       <port name="cout[5]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[55]" name="sum" type="input"/>
+      <port from="ADDER[55]" name="sum" type="input"/>
       <port name="sum[5]" type="output"/>
     </direct>
     <direct>
       <port name="a[60]" type="input"/>
-      <port from="adder[56]" name="a" type="output"/>
+      <port from="ADDER[56]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[60]" type="input"/>
-      <port from="adder[56]" name="b" type="output"/>
+      <port from="ADDER[56]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[60]" type="input"/>
-      <port from="adder[56]" name="cin" type="output"/>
+      <port from="ADDER[56]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[56]" name="cout" type="input"/>
+      <port from="ADDER[56]" name="cout" type="input"/>
       <port name="cout[60]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[56]" name="sum" type="input"/>
+      <port from="ADDER[56]" name="sum" type="input"/>
       <port name="sum[60]" type="output"/>
     </direct>
     <direct>
       <port name="a[61]" type="input"/>
-      <port from="adder[57]" name="a" type="output"/>
+      <port from="ADDER[57]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[61]" type="input"/>
-      <port from="adder[57]" name="b" type="output"/>
+      <port from="ADDER[57]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[61]" type="input"/>
-      <port from="adder[57]" name="cin" type="output"/>
+      <port from="ADDER[57]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[57]" name="cout" type="input"/>
+      <port from="ADDER[57]" name="cout" type="input"/>
       <port name="cout[61]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[57]" name="sum" type="input"/>
+      <port from="ADDER[57]" name="sum" type="input"/>
       <port name="sum[61]" type="output"/>
     </direct>
     <direct>
       <port name="a[62]" type="input"/>
-      <port from="adder[58]" name="a" type="output"/>
+      <port from="ADDER[58]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[62]" type="input"/>
-      <port from="adder[58]" name="b" type="output"/>
+      <port from="ADDER[58]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[62]" type="input"/>
-      <port from="adder[58]" name="cin" type="output"/>
+      <port from="ADDER[58]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[58]" name="cout" type="input"/>
+      <port from="ADDER[58]" name="cout" type="input"/>
       <port name="cout[62]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[58]" name="sum" type="input"/>
+      <port from="ADDER[58]" name="sum" type="input"/>
       <port name="sum[62]" type="output"/>
     </direct>
     <direct>
       <port name="a[63]" type="input"/>
-      <port from="adder[59]" name="a" type="output"/>
+      <port from="ADDER[59]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[63]" type="input"/>
-      <port from="adder[59]" name="b" type="output"/>
+      <port from="ADDER[59]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[63]" type="input"/>
-      <port from="adder[59]" name="cin" type="output"/>
+      <port from="ADDER[59]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[59]" name="cout" type="input"/>
+      <port from="ADDER[59]" name="cout" type="input"/>
       <port name="cout[63]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[59]" name="sum" type="input"/>
+      <port from="ADDER[59]" name="sum" type="input"/>
       <port name="sum[63]" type="output"/>
     </direct>
     <direct>
       <port name="a[6]" type="input"/>
-      <port from="adder[60]" name="a" type="output"/>
+      <port from="ADDER[60]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[6]" type="input"/>
-      <port from="adder[60]" name="b" type="output"/>
+      <port from="ADDER[60]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[6]" type="input"/>
-      <port from="adder[60]" name="cin" type="output"/>
+      <port from="ADDER[60]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[60]" name="cout" type="input"/>
+      <port from="ADDER[60]" name="cout" type="input"/>
       <port name="cout[6]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[60]" name="sum" type="input"/>
+      <port from="ADDER[60]" name="sum" type="input"/>
       <port name="sum[6]" type="output"/>
     </direct>
     <direct>
       <port name="a[7]" type="input"/>
-      <port from="adder[61]" name="a" type="output"/>
+      <port from="ADDER[61]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[7]" type="input"/>
-      <port from="adder[61]" name="b" type="output"/>
+      <port from="ADDER[61]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[7]" type="input"/>
-      <port from="adder[61]" name="cin" type="output"/>
+      <port from="ADDER[61]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[61]" name="cout" type="input"/>
+      <port from="ADDER[61]" name="cout" type="input"/>
       <port name="cout[7]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[61]" name="sum" type="input"/>
+      <port from="ADDER[61]" name="sum" type="input"/>
       <port name="sum[7]" type="output"/>
     </direct>
     <direct>
       <port name="a[8]" type="input"/>
-      <port from="adder[62]" name="a" type="output"/>
+      <port from="ADDER[62]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[8]" type="input"/>
-      <port from="adder[62]" name="b" type="output"/>
+      <port from="ADDER[62]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[8]" type="input"/>
-      <port from="adder[62]" name="cin" type="output"/>
+      <port from="ADDER[62]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[62]" name="cout" type="input"/>
+      <port from="ADDER[62]" name="cout" type="input"/>
       <port name="cout[8]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[62]" name="sum" type="input"/>
+      <port from="ADDER[62]" name="sum" type="input"/>
       <port name="sum[8]" type="output"/>
     </direct>
     <direct>
       <port name="a[9]" type="input"/>
-      <port from="adder[63]" name="a" type="output"/>
+      <port from="ADDER[63]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[9]" type="input"/>
-      <port from="adder[63]" name="b" type="output"/>
+      <port from="ADDER[63]" name="b" type="output"/>
     </direct>
     <direct>
       <port name="cin[9]" type="input"/>
-      <port from="adder[63]" name="cin" type="output"/>
+      <port from="ADDER[63]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[63]" name="cout" type="input"/>
+      <port from="ADDER[63]" name="cout" type="input"/>
       <port name="cout[9]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[63]" name="sum" type="input"/>
+      <port from="ADDER[63]" name="sum" type="input"/>
       <port name="sum[9]" type="output"/>
     </direct>
   </interconnect>

--- a/utils/vlog/tests/multiple_instance/multiple_instance.sim.v
+++ b/utils/vlog/tests/multiple_instance/multiple_instance.sim.v
@@ -10,7 +10,7 @@ module multiple_instance (a, b, cin, cout, sum);
 
 	genvar i;
 	for(i=0; i<DATA_WIDTH; i=i+1) begin:gentest
-		adder comb (.a(a[i]), .b(b[i]), .cin(cin[i]), .cout(cout[i]), .sum(sum[i]));
+		ADDER comb (.a(a[i]), .b(b[i]), .cin(cin[i]), .cout(cout[i]), .sum(sum[i]));
 	end
 
 endmodule

--- a/utils/vlog/tests/single_port_rom_mixed/CMakeLists.txt
+++ b/utils/vlog/tests/single_port_rom_mixed/CMakeLists.txt
@@ -1,0 +1,1 @@
+v2x_test_model(NAME single_port_rom_mixed TOP_MODULE single_port_rom_mixed)

--- a/utils/vlog/tests/single_port_rom_mixed/CMakeLists.txt
+++ b/utils/vlog/tests/single_port_rom_mixed/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_file_target(FILE single_port_rom_mixed.sim.v SCANNER_TYPE verilog)
 v2x_test_model(NAME single_port_rom_mixed TOP_MODULE single_port_rom_mixed)

--- a/utils/vlog/tests/single_port_rom_mixed/golden.model.xml
+++ b/utils/vlog/tests/single_port_rom_mixed/golden.model.xml
@@ -1,0 +1,11 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="single_port_rom_mixed">
+    <input_ports>
+      <port clock="clk" combinational_sink_ports="out" name="addr"/>
+      <port is_clock="1" name="clk"/>
+    </input_ports>
+    <output_ports>
+      <port clock="clk" name="out"/>
+    </output_ports>
+  </model>
+</models>

--- a/utils/vlog/tests/single_port_rom_mixed/single_port_rom_mixed.sim.v
+++ b/utils/vlog/tests/single_port_rom_mixed/single_port_rom_mixed.sim.v
@@ -1,4 +1,4 @@
-module single_port_ram_mixed (addr, clk, out);
+module single_port_rom_mixed (addr, clk, out);
 	localparam ADDR_WIDTH = 9;
 	localparam DATA_WIDTH = 64;
 

--- a/utils/vlog/tests/single_port_rom_mixed/single_port_rom_mixed.sim.v
+++ b/utils/vlog/tests/single_port_rom_mixed/single_port_rom_mixed.sim.v
@@ -1,0 +1,19 @@
+module single_port_ram_mixed (addr, clk, out);
+	localparam ADDR_WIDTH = 9;
+	localparam DATA_WIDTH = 64;
+
+	input wire [ADDR_WIDTH-1:0] addr;
+	input wire clk;
+	output wire [DATA_WIDTH-1:0] out;
+
+	localparam MEM_SIZE = 2 ** ADDR_WIDTH;
+	reg [DATA_WIDTH-1:0] storage[MEM_SIZE-1:0];
+
+	reg q_addr;
+	always @(posedge clk) begin
+		q_addr <= addr;
+	end
+
+	assign out = storage[q_addr];
+
+endmodule

--- a/utils/vpr_pbtype_arch_wrapper.py
+++ b/utils/vpr_pbtype_arch_wrapper.py
@@ -422,7 +422,7 @@ def main(args):
         args.pb_type
     )
 
-    tile_height = layout_xml(arch_root, pbtype_leaf)
+    tile_height = layout_xml(arch_root, pbtype_root)
     tname = tile_xml(arch_root, pbtype_root, outfile, tile_height)
 
     dirpath = os.path.dirname(outfile)

--- a/vpr/CMakeLists.txt
+++ b/vpr/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(buf)
+add_subdirectory(mem)
 add_subdirectory(const)
 add_subdirectory(ff)
 add_subdirectory(ibuf)

--- a/vpr/mem/CMakeLists.txt
+++ b/vpr/mem/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_file_target(FILE vpr_sp_ram.sim.v SCANNER_TYPE verilog)
+v2x(NAME vpr_sp_ram SRCS vpr_sp_ram.sim.v)

--- a/vpr/mem/vpr_sp_ram.sim.v
+++ b/vpr/mem/vpr_sp_ram.sim.v
@@ -1,0 +1,18 @@
+module VPR_SP_RAM #(
+	parameter ADDR_WIDTH = 1,
+	parameter DATA_WIDTH = 1
+) (
+	addr, data, we, out
+);
+	input wire [ADDR_WIDTH-1:0] addr;
+	input wire [DATA_WIDTH-1:0] data;
+	input wire we;
+	output wire [DATA_WIDTH-1:0] out;
+
+	localparam MEM_SIZE = 2 ** ADDR_WIDTH;
+
+	reg [DATA_WIDTH-1:0] storage[MEM_SIZE-1:0];
+
+	assign out = storage[addr];
+
+endmodule


### PR DESCRIPTION
This is PR is to discuss the VPR issues discovered when attempting to pack the test circuit to the arch generated basing on the pb_type xmls (see  #755 ) 

This PR is based on #645, but only one test is enabled. Also the flow has been modified to use Yosys for blif generation and the ` update_test_eblif.py`  script to transofr the yosys generated blif to a form expected by the test arch.

Once the issues in this PR are resolved, we can close it and cherry-pick the solution to #645 