### PR TITLE
Output pre-symbiflow techmap'd Verilog.

### DIFF
--- a/xc7/techmap/unmap.v
+++ b/xc7/techmap/unmap.v
@@ -1,0 +1,17 @@
+module CARRY4_COUT(output [3:0] CO, O, output COUT, input CI, CYINIT, input [3:0] DI, S);
+
+wire [3:0] CO_INTERNAL;
+
+assign COUT = CO_INTERNAL[3];
+assign CO = CO_INTERNAL;
+
+CARRY4 _TECHMAP_REPLACE_ (
+    .CO(CO_INTERNAL),
+    .O(O),
+    .CI(CI),
+    .CYINIT(CYINIT),
+    .DI(DI),
+    .S(S)
+);
+
+endmodule

--- a/xc7/yosys/synth.tcl
+++ b/xc7/yosys/synth.tcl
@@ -4,6 +4,8 @@ yosys -import
 # Some of symbiflow expects eblifs with only one module.
 synth_xilinx -vpr -flatten -nosrl
 
+write_verilog $::env(OUT_SYNTH_V).premap.v
+
 # Map Xilinx tech library to 7-series VPR tech library.
 read_verilog -lib $::env(symbiflow-arch-defs_SOURCE_DIR)/xc7/techmap/cells_sim.v
 techmap -map  $::env(symbiflow-arch-defs_SOURCE_DIR)/xc7/techmap/cells_map.v


### PR DESCRIPTION
This pre-symbiflow verilog can be used with Vivado synthesis if xc7/techmap/unmap.v is
applied.  This allows for post-Yosys timing comparisions between VPR and Vivado.