### PR TITLE
xc7: `DPRAM32` doesn't have `INIT_01` parameter.

### DIFF
--- a/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
@@ -32,7 +32,6 @@
   <metadata>
     <meta name="fasm_params">
       INIT[31:0] = INIT_00
-      INIT[63:32] = INIT_01
     </meta>
     <meta name="fasm_features">
       RAM


### PR DESCRIPTION
Fixes #777.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>