### PR TITLE
infra: Keep running and then rerun the errors.

### DIFF
--- a/.github/kokoro/ice40.sh
+++ b/.github/kokoro/ice40.sh
@@ -11,7 +11,9 @@ echo "Running ice40 tests"
 echo "----------------------------------------"
 (
 	cd build
-	VPR_NUM_WORKERS=${CORES} make -j ${MAX_CORES} --output-sync=target \
-		all_ice40
+	export VPR_NUM_WORKERS=${CORES}
+	export MAKE_ARGS="-j${MAX_CORES} --output-sync=target"
+	# Run as many tests as we can.    Rerun individually on failure.
+	make -k ${MAKE_ARGS} all_ice40 || make all_ice40
 )
 echo "----------------------------------------"

--- a/.github/kokoro/testarch.sh
+++ b/.github/kokoro/testarch.sh
@@ -11,7 +11,9 @@ echo "Running testarch tests"
 echo "----------------------------------------"
 (
 	cd build
-	VPR_NUM_WORKERS=${CORES} make -j ${MAX_CORES} --output-sync=target \
-		all_testarch
+	export VPR_NUM_WORKERS=${CORES}
+	export MAKE_ARGS="-j${MAX_CORES} --output-sync=target"
+	# Run as many tests as we can.       Rerun individually on failure.
+	make -k ${MAKE_ARGS} all_testarch || make all_testarch
 )
 echo "----------------------------------------"

--- a/.github/kokoro/xc7.sh
+++ b/.github/kokoro/xc7.sh
@@ -11,7 +11,9 @@ echo "Running xc7 tests"
 echo "----------------------------------------"
 (
 	cd build
-	VPR_NUM_WORKERS=${CORES} make -j ${MAX_CORES} --output-sync=target \
-		all_xc7
+	export VPR_NUM_WORKERS=${CORES}
+	export MAKE_ARGS="-j${MAX_CORES} --output-sync=target"
+	# Run as many tests as we can.  Rerun individually on failure.
+	make -k ${MAKE_ARGS} all_xc7 || make all_xc7
 )
 echo "----------------------------------------"


### PR DESCRIPTION
To make it easier to see the errors when there is a failure on Kokoro while still running everything in parallel, we first;

 1. Run tests in parallel and keep going on failure until all targets which can build have done so (`-k`).

 2. Re-run in single threaded mode, stopping at the first error.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>