### PR TITLE
Add Python lint target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,21 +135,23 @@ add_subdirectory(testarch)
 add_subdirectory(tests)
 
 get_target_property_required(YAPF env YAPF)
+get_target_property_required(YAPF_TARGET env YAPF_TARGET)
 add_custom_target(
   check_python
-  DEPENDS conda_yapf
+  DEPENDS ${YAPF_TARGET}
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -c -y ${YAPF}
   )
 add_custom_target(
   format_python
-  DEPENDS conda_yapf
+  DEPENDS ${YAPF_TARGET}
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -f -y ${YAPF}
   )
 
 get_target_property_required(FLAKE8 env FLAKE8)
+get_target_property_required(FLAKE8_TARGET env FLAKE8_TARGET)
 add_custom_target(
   lint_python
-  DEPENDS conda_flake8
+  DEPENDS ${FLAKE8_TARGET}
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -l -p "${FLAKE8} --exit-zero"
   )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,10 @@ add_conda_package(
   PROVIDES pytest
   )
 add_conda_package(
+  NAME flake8
+  PROVIDES flake8
+  )
+add_conda_package(
   NAME yapf
   PROVIDES yapf
   PACKAGE_SPEC "yapf 0.26.0 py_0"
@@ -134,20 +138,19 @@ get_target_property_required(YAPF env YAPF)
 add_custom_target(
   check_python
   DEPENDS conda_yapf
+  COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -c -y ${YAPF}
   )
 add_custom_target(
   format_python
   DEPENDS conda_yapf
+  COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -f -y ${YAPF}
   )
 
-add_custom_command(
-  TARGET check_python
-  COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/yapf_helper.sh -c -y ${YAPF}
-  )
-
-add_custom_command(
-  TARGET format_python
-  COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/yapf_helper.sh -f -y ${YAPF}
+get_target_property_required(FLAKE8 env FLAKE8)
+add_custom_target(
+  lint_python
+  DEPENDS conda_flake8
+  COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -l -p "${FLAKE8} --exit-zero"
   )
 
 

--- a/common/python_health_helper.sh
+++ b/common/python_health_helper.sh
@@ -18,17 +18,23 @@ run() {
   }
 
 lint_file() {
-  run "$1 $2" "lint failed on $2"
+  cmd=$1
+  file=$2
+  run "$cmd $file" "lint failed on $file"
   return $?
 }
 
 check_file() {
-  run "$1 -d $2 > /dev/null" "yapf needs to reformat $2"
+  cmd=$1
+  file=$2
+  run "$cmd -d $file > /dev/null" "yapf needs to reformat $file"
   return $?
 }
 
 format_file() {
-  run "$1 -i $2" "yapf failed to format $2"
+  cmd=$1
+  file=$2
+  run "$cmd -i $file" "yapf failed to format $file"
   return $?
 }
 

--- a/common/python_health_helper.sh
+++ b/common/python_health_helper.sh
@@ -4,7 +4,7 @@ usage() {
   if [ -n "$1" ]; then
     echo "$1" > /dev/stderr;
   fi
-  echo "Usage: $0 -y <yapf_exec> [-c] [-f]" > /dev/stderr
+  echo "Usage: $0 -y <yapf_exec> -p lint_program<> [-l|-c|-f]" > /dev/stderr
   exit 1
 }
 
@@ -17,6 +17,11 @@ run() {
   return $res
   }
 
+lint_file() {
+  run "$1 $2" "lint failed on $2"
+  return $?
+}
+
 check_file() {
   run "$1 -d $2 > /dev/null" "yapf needs to reformat $2"
   return $?
@@ -27,11 +32,13 @@ format_file() {
   return $?
 }
 
-do_check=0;
-do_format=0;
+do_check=0
+do_format=0
+do_lint=0
 
-YAPF=yapf
-while getopts "cfy:" opt; do
+yapf_exec=yapf
+lint_exec=pyflakes
+while getopts "lcfy:p:" opt; do
   case $opt in
     c)
       do_check=1;
@@ -40,7 +47,13 @@ while getopts "cfy:" opt; do
       do_format=1;
       ;;
     y)
-      YAPF=$OPTARG
+      yapf_exec=$OPTARG
+      ;;
+    p)
+      lint_exec=$OPTARG
+      ;;
+    l)
+      do_lint=1;
       ;;
     *)
       usage
@@ -53,7 +66,7 @@ if [ -n "$*" ]; then
   usage "leftover args: '$*'"
 fi
 
-if [ $do_check == $do_format ]; then
+if (( do_check + do_format + do_lint != 1 )); then
   usage "Provide exactly one option"
 fi
 
@@ -63,10 +76,13 @@ ret=0
 TOP_DIR=`git rev-parse --show-toplevel`
 for file in $(git ls-tree --full-tree --name-only -r HEAD | grep "\.py$"); do
   if [ $do_check != 0 ]; then
-    check_file $YAPF $TOP_DIR/$file;
+    check_file $yapf_exec $TOP_DIR/$file;
     res=$?
   elif [ $do_format != 0 ]; then
-    format_file $YAPF $TOP_DIR/$file;
+    format_file "$yapf_exec" $TOP_DIR/$file;
+    res=$?
+  elif [ $do_lint != 0 ]; then
+    lint_file "$lint_exec" $TOP_DIR/$file;
     res=$?
   fi;
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 100
+max-doc-lentgh = 100


### PR DESCRIPTION
This adds a target that will display all linting errors. Once errors are addressed, this should be added to CI and the `--zero-exit` flag should be removed.