### PR TITLE
xc7: dff: split dff into {FF|REG}_INIT and update timings

### DIFF
--- a/xc7/primitives/ff/ff.model.xml
+++ b/xc7/primitives/ff/ff.model.xml
@@ -45,24 +45,24 @@
   </model>
   <model name="LDPE_ZINI">
     <input_ports>
-      <port name="G"  is_clock="1" />
-      <port name="GE" clock="G" />
-      <port name="PRE"  clock="G" />
-      <port name="D"  clock="G" />
+      <port name="G" combinational_sink_ports="Q" is_clock="1" />
+      <port name="GE" combinational_sink_ports="Q" />
+      <port name="PRE" combinational_sink_ports="Q" />
+      <port name="D" clock="G" />
     </input_ports>
     <output_ports>
-      <port name="Q" clock="G"  />
+      <port name="Q" />
     </output_ports>
   </model>
   <model name="LDCE_ZINI">
     <input_ports>
-      <port name="G"  is_clock="1" />
-      <port name="GE" clock="G" />
-      <port name="CLR"  clock="G" />
-      <port name="D"  clock="G" />
+      <port name="G" combinational_sink_ports="Q" is_clock="1" />
+      <port name="GE" combinational_sink_ports="Q" />
+      <port name="CLR" combinational_sink_ports="Q" />
+      <port name="D" clock="G" />
     </input_ports>
     <output_ports>
-      <port name="Q" clock="G"  />
+      <port name="Q" />
     </output_ports>
   </model>
   <model name="NO_FF">

--- a/xc7/primitives/ff/ff.pb_type.xml
+++ b/xc7/primitives/ff/ff.pb_type.xml
@@ -30,7 +30,7 @@
     </interconnect>
   </mode>
   <mode name="FDSE_or_FDRE">
-    <pb_type name="FDSE_or_FDRE" num_pb="8">
+    <pb_type name="FF_FDSE_or_FDRE" num_pb="4">
       <input  name="D" num_pins="1"/>
       <input  name="CE" num_pins="1"/>
       <clock  name="C" num_pins="1"/>
@@ -47,29 +47,32 @@
           <T_setup    value="10e-12" port="D" clock="C" />
           <T_setup    value="10e-12" port="CE" clock="C" />
           <T_setup    value="10e-12" port="S" clock="C" />
+          <T_hold    value="10e-12" port="D" clock="C" />
+          <T_hold    value="10e-12" port="CE" clock="C" />
+          <T_hold    value="10e-12" port="S" clock="C" />
           <T_clock_to_Q max="10e-12" port="Q" clock="C" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
-	    <meta name="type">bel</meta>
-	    <meta name="subtype">flipflop</meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="FDSE_or_FDRE.D" output="FDSE.D" />
-          <direct name="CE" input="FDSE_or_FDRE.CE" output="FDSE.CE" >
+          <direct name="D" input="FF_FDSE_or_FDRE.D" output="FDSE.D" />
+          <direct name="CE" input="FF_FDSE_or_FDRE.CE" output="FDSE.CE" >
             <pack_pattern name="CE_FF_FDSE"/>
             <pack_pattern name="CESR_FF_FDSE"/>
           </direct>
-          <direct name="C" input="FDSE_or_FDRE.C" output="FDSE.C" />
-          <direct name="S" input="FDSE_or_FDRE.SR" output="FDSE.S" >
+          <direct name="C" input="FF_FDSE_or_FDRE.C" output="FDSE.C" />
+          <direct name="S" input="FF_FDSE_or_FDRE.SR" output="FDSE.S" >
             <pack_pattern name="SR_FF_FDSE"/>
             <pack_pattern name="CESR_FF_FDSE"/>
           </direct>
-          <direct name="Q" input="FDSE.Q" output="FDSE_or_FDRE.Q" />
+          <direct name="Q" input="FDSE.Q" output="FF_FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
       <mode name="FDRE">
@@ -82,6 +85,9 @@
           <T_setup    value="10e-12" port="D" clock="C" />
           <T_setup    value="10e-12" port="CE" clock="C" />
           <T_setup    value="10e-12" port="R" clock="C" />
+          <T_hold    value="10e-12" port="D" clock="C" />
+          <T_hold    value="10e-12" port="CE" clock="C" />
+          <T_hold    value="10e-12" port="R" clock="C" />
           <T_clock_to_Q max="10e-12" port="Q" clock="C" />
 
           <metadata>
@@ -89,49 +95,142 @@
               ZINI = ZINI
             </meta>
             <meta name="fasm_features">ZRST</meta>
-	    <meta name="type">bel</meta>
-	    <meta name="subtype">flipflop</meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
+          </metadata>
+        </pb_type>
+        <interconnect>
+          <direct name="D" input="FF_FDSE_or_FDRE.D" output="FDRE.D" />
+          <direct name="CE" input="FF_FDSE_or_FDRE.CE" output="FDRE.CE" >
+            <pack_pattern name="CE_FF_FDRE" in_port="FF_FDSE_or_FDRE.CE" out_port="FDRE.CE"/>
+            <pack_pattern name="CESR_FF_FDRE" in_port="FF_FDSE_or_FDRE.CE" out_port="FDRE.CE"/>
+          </direct>
+          <direct name="C" input="FF_FDSE_or_FDRE.C" output="FDRE.C" />
+          <direct name="R" input="FF_FDSE_or_FDRE.SR" output="FDRE.R" >
+            <pack_pattern name="SR_FF_FDRE" in_port="FF_FDSE_or_FDRE.SR" out_port="FDRE.R"/>
+            <pack_pattern name="CESR_FF_FDRE" in_port="FF_FDSE_or_FDRE.SR" out_port="FDRE.R"/>
+          </direct>
+          <direct name="Q" input="FDRE.Q" output="FF_FDSE_or_FDRE.Q" />
+        </interconnect>
+      </mode>
+      <metadata>
+        <meta name="fasm_prefix">A5FF B5FF C5FF D5FF</meta>
+        <meta name="type">block</meta>
+        <meta name="subtype">ignore</meta>
+      </metadata>
+    </pb_type>
+
+    <pb_type name="REG_FDSE_or_FDRE" num_pb="4">
+      <input  name="D" num_pins="1"/>
+      <input  name="CE" num_pins="1"/>
+      <clock  name="C" num_pins="1"/>
+      <input  name="SR" num_pins="1"/>
+      <output name="Q" num_pins="1"/>
+
+      <mode name="FDSE">
+        <pb_type name="FDSE" num_pb="1" blif_model=".subckt FDSE_ZINI">
+          <input  name="D" num_pins="1"/>
+          <input  name="CE" num_pins="1"/>
+          <clock  name="C" num_pins="1"/>
+          <input  name="S" num_pins="1"/>
+          <output name="Q" num_pins="1"/>
+          <T_setup    value="10e-12" port="FDSE.D" clock="C" />
+          <T_setup    value="10e-12"  port="FDSE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDSE.S" clock="C" />
+          <T_hold    value="10e-12" port="FDSE.D" clock="C" />
+          <T_hold    value="10e-12"  port="FDSE.CE" clock="C" />
+          <T_hold    value="10e-12" port="FDSE.S" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDSE.Q" clock="C" />
+
+          <metadata>
+            <meta name="fasm_params">
+              ZINI = ZINI
+            </meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="FDSE_or_FDRE.D" output="FDRE.D" />
-          <direct name="CE" input="FDSE_or_FDRE.CE" output="FDRE.CE" >
+          <direct name="D" input="REG_FDSE_or_FDRE.D" output="FDSE.D" />
+          <direct name="CE" input="REG_FDSE_or_FDRE.CE" output="FDSE.CE" >
+            <pack_pattern name="CE_FF_FDSE" in_port="REG_FDSE_or_FDRE.CE" out_port="FDSE.CE"/>
+            <pack_pattern name="CESR_FF_FDSE" in_port="REG_FDSE_or_FDRE.CE" out_port="FDSE.CE"/>
+          </direct>
+          <direct name="C" input="REG_FDSE_or_FDRE.C" output="FDSE.C" />
+          <direct name="S" input="REG_FDSE_or_FDRE.SR" output="FDSE.S" >
+            <pack_pattern name="SR_FF_FDSE" in_port="REG_FDSE_or_FDRE.SR" out_port="FDSE.S"/>
+            <pack_pattern name="CESR_FF_FDSE" in_port="REG_FDSE_or_FDRE.SR" out_port="FDSE.S"/>
+          </direct>
+          <direct name="Q" input="FDSE.Q" output="REG_FDSE_or_FDRE.Q" />
+        </interconnect>
+      </mode>
+      <mode name="FDRE">
+        <pb_type name="FDRE" num_pb="1" blif_model=".subckt FDRE_ZINI">
+          <input  name="D" num_pins="1"/>
+          <input  name="CE" num_pins="1"/>
+          <clock  name="C" num_pins="1"/>
+          <input  name="R" num_pins="1"/>
+          <output name="Q" num_pins="1"/>
+          <T_setup    value="10e-12" port="FDRE.D" clock="C" />
+          <T_setup    value="10e-12"  port="FDRE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDRE.R" clock="C" />
+          <T_hold    value="10e-12" port="FDRE.D" clock="C" />
+          <T_hold    value="10e-12"  port="FDRE.CE" clock="C" />
+          <T_hold    value="10e-12" port="FDRE.R" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDRE.Q" clock="C" />
+
+          <metadata>
+            <meta name="fasm_params">
+              ZINI = ZINI
+            </meta>
+            <meta name="fasm_features">ZRST</meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
+          </metadata>
+        </pb_type>
+
+        <interconnect>
+          <direct name="D" input="REG_FDSE_or_FDRE.D" output="FDRE.D" />
+          <direct name="CE" input="REG_FDSE_or_FDRE.CE" output="FDRE.CE" >
             <pack_pattern name="CE_FF_FDRE"/>
             <pack_pattern name="CESR_FF_FDRE"/>
           </direct>
-          <direct name="C" input="FDSE_or_FDRE.C" output="FDRE.C" />
-          <direct name="R" input="FDSE_or_FDRE.SR" output="FDRE.R" >
+          <direct name="C" input="REG_FDSE_or_FDRE.C" output="FDRE.C" />
+          <direct name="R" input="REG_FDSE_or_FDRE.SR" output="FDRE.R" >
             <pack_pattern name="SR_FF_FDRE"/>
             <pack_pattern name="CESR_FF_FDRE"/>
           </direct>
-          <direct name="Q" input="FDRE.Q" output="FDSE_or_FDRE.Q" />
+          <direct name="Q" input="FDRE.Q" output="REG_FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
       <metadata>
-        <meta name="fasm_prefix">AFF BFF CFF DFF A5FF B5FF C5FF D5FF</meta>
+        <meta name="fasm_prefix">AFF BFF CFF DFF</meta>
         <meta name="type">block</meta>
         <meta name="subtype">ignore</meta>
       </metadata>
     </pb_type>
 
     <interconnect>
-      <direct name="CE" input="SLICE_FF.CE" output="FDSE_or_FDRE.CE" />
-      <complete name="C" input="SLICE_FF.CK" output="FDSE_or_FDRE.C" />
-      <direct name="SR" input="SLICE_FF.SR" output="FDSE_or_FDRE.SR" />
+      <direct name="CE_FF" input="SLICE_FF.CE[7:4]" output="FF_FDSE_or_FDRE.CE" />
+      <direct name="CE_REG" input="SLICE_FF.CE[3:0]" output="REG_FDSE_or_FDRE.CE" />
+      <complete name="C_FF" input="SLICE_FF.CK" output="FF_FDSE_or_FDRE.C" />
+      <complete name="C_REG" input="SLICE_FF.CK" output="REG_FDSE_or_FDRE.C" />
+      <direct name="SR_FF" input="SLICE_FF.SR[7:4]" output="FF_FDSE_or_FDRE.SR" />
+      <direct name="SR_REG" input="SLICE_FF.SR[3:0]" output="REG_FDSE_or_FDRE.SR" />
 
-      <direct name="D" input="SLICE_FF.D[3:0]" output="FDSE_or_FDRE[3:0].D" />
-      <direct name="Q" input="FDSE_or_FDRE[3:0].Q" output="SLICE_FF.Q[3:0]" />
+      <direct name="D" input="SLICE_FF.D" output="REG_FDSE_or_FDRE.D" />
+      <direct name="Q" input="REG_FDSE_or_FDRE.Q" output="SLICE_FF.Q" />
 
-      <direct name="D5" input="SLICE_FF.D5[3:0]" output="FDSE_or_FDRE[7:4].D" />
-      <direct name="Q5" input="FDSE_or_FDRE[7:4].Q" output="SLICE_FF.Q5[3:0]" />
+      <direct name="D5" input="SLICE_FF.D5" output="FF_FDSE_or_FDRE.D" />
+      <direct name="Q5" input="FF_FDSE_or_FDRE.Q" output="SLICE_FF.Q5" />
     </interconnect>
     <metadata>
       <meta name="fasm_features">FFSYNC</meta>
     </metadata>
   </mode>
   <mode name="FDPE_or_FDCE">
-    <pb_type name="FDPE_or_FDCE" num_pb="8">
+    <pb_type name="FF_FDPE_or_FDCE" num_pb="4">
       <input  name="D" num_pins="1"/>
       <input  name="CE" num_pins="1"/>
       <clock  name="C" num_pins="1"/>
@@ -148,29 +247,32 @@
           <T_setup    value="10e-12" port="D" clock="C" />
           <T_setup    value="10e-12" port="CE" clock="C" />
           <T_setup    value="10e-12" port="PRE" clock="C" />
+          <T_hold    value="10e-12" port="D" clock="C" />
+          <T_hold    value="10e-12"  port="CE" clock="C" />
+          <T_hold    value="10e-12" port="PRE" clock="C" />
           <T_clock_to_Q max="10e-12" port="Q" clock="C" />
 
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
             </meta>
-	    <meta name="type">bel</meta>
-	    <meta name="subtype">flipflop</meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="FDPE_or_FDCE.D" output="FDPE.D" />
-          <direct name="CE" input="FDPE_or_FDCE.CE" output="FDPE.CE" >
+          <direct name="D" input="FF_FDPE_or_FDCE.D" output="FDPE.D" />
+          <direct name="CE" input="FF_FDPE_or_FDCE.CE" output="FDPE.CE" >
             <pack_pattern name="CE_FF_FDPE"/>
             <pack_pattern name="CESR_FF_FDPE"/>
           </direct>
-          <direct name="C" input="FDPE_or_FDCE.C" output="FDPE.C" />
-          <direct name="PRE" input="FDPE_or_FDCE.SR" output="FDPE.PRE" >
+          <direct name="C" input="FF_FDPE_or_FDCE.C" output="FDPE.C" />
+          <direct name="PRE" input="FF_FDPE_or_FDCE.SR" output="FDPE.PRE" >
             <pack_pattern name="SR_FF_FDPE"/>
             <pack_pattern name="CESR_FF_FDPE"/>
           </direct>
-          <direct name="Q" input="FDPE.Q" output="FDPE_or_FDCE.Q" />
+          <direct name="Q" input="FDPE.Q" output="FF_FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
       <mode name="FDCE">
@@ -183,6 +285,9 @@
           <T_setup    value="10e-12" port="D" clock="C" />
           <T_setup    value="10e-12" port="CE" clock="C" />
           <T_setup    value="10e-12" port="CLR" clock="C" />
+          <T_hold    value="10e-12" port="D" clock="C" />
+          <T_hold    value="10e-12" port="CE" clock="C" />
+          <T_hold    value="10e-12" port="CLR" clock="C" />
           <T_clock_to_Q max="10e-12" port="Q" clock="C" />
 
           <metadata>
@@ -190,42 +295,135 @@
               ZINI = ZINI
             </meta>
             <meta name="fasm_features">ZRST</meta>
-	    <meta name="type">bel</meta>
-	    <meta name="subtype">flipflop</meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
 
         <interconnect>
-          <direct name="D" input="FDPE_or_FDCE.D" output="FDCE.D" />
-          <direct name="CE" input="FDPE_or_FDCE.CE" output="FDCE.CE" >
+          <direct name="D" input="FF_FDPE_or_FDCE.D" output="FDCE.D" />
+          <direct name="CE" input="FF_FDPE_or_FDCE.CE" output="FDCE.CE" >
             <pack_pattern name="CE_FF_FDCE"/>
             <pack_pattern name="CESR_FF_FDCE"/>
           </direct>
-          <direct name="C" input="FDPE_or_FDCE.C" output="FDCE.C" />
-          <direct name="CLR" input="FDPE_or_FDCE.SR" output="FDCE.CLR" >
+          <direct name="C" input="FF_FDPE_or_FDCE.C" output="FDCE.C" />
+          <direct name="CLR" input="FF_FDPE_or_FDCE.SR" output="FDCE.CLR" >
             <pack_pattern name="SR_FF_FDCE"/>
             <pack_pattern name="CESR_FF_FDCE"/>
           </direct>
-          <direct name="Q" input="FDCE.Q" output="FDPE_or_FDCE.Q" />
+          <direct name="Q" input="FDCE.Q" output="FF_FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
       <metadata>
-        <meta name="fasm_prefix">AFF BFF CFF DFF A5FF B5FF C5FF D5FF</meta>
+        <meta name="fasm_prefix">A5FF B5FF C5FF D5FF</meta>
+        <meta name="type">block</meta>
+        <meta name="subtype">ignore</meta>
+      </metadata>
+    </pb_type>
+    <pb_type name="REG_FDPE_or_FDCE" num_pb="4">
+      <input  name="D" num_pins="1"/>
+      <input  name="CE" num_pins="1"/>
+      <clock  name="C" num_pins="1"/>
+      <input  name="SR" num_pins="1"/>
+      <output name="Q" num_pins="1"/>
+<mode name="FDPE">
+        <pb_type name="FDPE" num_pb="1" blif_model=".subckt FDPE_ZINI">
+          <input  name="D" num_pins="1"/>
+          <input  name="CE" num_pins="1"/>
+          <clock  name="C" num_pins="1"/>
+          <input  name="PRE" num_pins="1"/>
+          <output name="Q" num_pins="1"/>
+          <T_setup    value="10e-12" port="FDPE.D" clock="C" />
+          <T_setup    value="10e-12" port="FDPE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDPE.PRE" clock="C" />
+          <T_hold    value="10e-12" port="FDPE.D" clock="C" />
+          <T_hold    value="10e-12" port="FDPE.CE" clock="C" />
+          <T_hold    value="10e-12" port="FDPE.PRE" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDPE.Q" clock="C" />
+
+          <metadata>
+            <meta name="fasm_params">
+              ZINI = ZINI
+            </meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
+          </metadata>
+        </pb_type>
+
+        <interconnect>
+          <direct name="D" input="REG_FDPE_or_FDCE.D" output="FDPE.D" />
+          <direct name="CE" input="REG_FDPE_or_FDCE.CE" output="FDPE.CE" >
+            <pack_pattern name="CE_FF_FDPE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDPE.CE"/>
+            <pack_pattern name="CESR_FF_FDPE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDPE.CE"/>
+          </direct>
+          <direct name="C" input="REG_FDPE_or_FDCE.C" output="FDPE.C" />
+          <direct name="PRE" input="REG_FDPE_or_FDCE.SR" output="FDPE.PRE" >
+            <pack_pattern name="SR_FF_FDPE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDPE.PRE"/>
+            <pack_pattern name="CESR_FF_FDPE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDPE.PRE"/>
+          </direct>
+          <direct name="Q" input="FDPE.Q" output="REG_FDPE_or_FDCE.Q" />
+        </interconnect>
+      </mode>
+      <mode name="FDCE">
+        <pb_type name="FDCE" num_pb="1" blif_model=".subckt FDCE_ZINI">
+          <input  name="D" num_pins="1"/>
+          <input  name="CE" num_pins="1"/>
+          <clock  name="C" num_pins="1"/>
+          <input  name="CLR" num_pins="1"/>
+          <output name="Q" num_pins="1"/>
+          <T_setup    value="10e-12" port="FDCE.D" clock="C" />
+          <T_setup    value="10e-12" port="FDCE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDCE.CLR" clock="C" />
+          <T_hold    value="10e-12" port="FDCE.D" clock="C" />
+          <T_hold    value="10e-12" port="FDCE.CE" clock="C" />
+          <T_hold    value="10e-12" port="FDCE.CLR" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDCE.Q" clock="C" />
+
+          <metadata>
+            <meta name="fasm_params">
+              ZINI = ZINI
+            </meta>
+            <meta name="fasm_features">ZRST</meta>
+            <meta name="type">bel</meta>
+            <meta name="subtype">flipflop</meta>
+          </metadata>
+        </pb_type>
+
+        <interconnect>
+          <direct name="D" input="REG_FDPE_or_FDCE.D" output="FDCE.D" />
+          <direct name="CE" input="REG_FDPE_or_FDCE.CE" output="FDCE.CE" >
+            <pack_pattern name="CE_FF_FDCE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDCE.CE"/>
+            <pack_pattern name="CESR_FF_FDCE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDCE.CE"/>
+          </direct>
+          <direct name="C" input="REG_FDPE_or_FDCE.C" output="FDCE.C" />
+          <direct name="CLR" input="REG_FDPE_or_FDCE.SR" output="FDCE.CLR" >
+            <pack_pattern name="SR_FF_FDCE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDCE.CLR"/>
+            <pack_pattern name="CESR_FF_FDCE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDCE.CLR"/>
+          </direct>
+          <direct name="Q" input="FDCE.Q" output="REG_FDPE_or_FDCE.Q" />
+        </interconnect>
+      </mode>
+      <metadata>
+        <meta name="fasm_prefix">AFF BFF CFF DFF</meta>
         <meta name="type">block</meta>
         <meta name="subtype">ignore</meta>
       </metadata>
     </pb_type>
 
     <interconnect>
-      <direct name="CE" input="SLICE_FF.CE" output="FDPE_or_FDCE.CE" />
-      <complete name="C" input="SLICE_FF.CK" output="FDPE_or_FDCE.C" />
-      <direct name="SR" input="SLICE_FF.SR" output="FDPE_or_FDCE.SR" />
+      <direct name="CE_FF" input="SLICE_FF.CE[7:4]" output="FF_FDPE_or_FDCE.CE" />
+      <complete name="C_FF" input="SLICE_FF.CK" output="FF_FDPE_or_FDCE.C" />
+      <direct name="SR_FF" input="SLICE_FF.SR[7:4]" output="FF_FDPE_or_FDCE.SR" />
 
-      <direct name="D" input="SLICE_FF.D[3:0]" output="FDPE_or_FDCE[3:0].D" />
-      <direct name="Q" input="FDPE_or_FDCE[3:0].Q" output="SLICE_FF.Q[3:0]" />
+      <direct name="CE_REG" input="SLICE_FF.CE[3:0]" output="REG_FDPE_or_FDCE.CE" />
+      <complete name="C_REG" input="SLICE_FF.CK" output="REG_FDPE_or_FDCE.C" />
+      <direct name="SR_REG" input="SLICE_FF.SR[3:0]" output="REG_FDPE_or_FDCE.SR" />
 
-      <direct name="D5" input="SLICE_FF.D5[3:0]" output="FDPE_or_FDCE[7:4].D" />
-      <direct name="Q5" input="FDPE_or_FDCE[7:4].Q" output="SLICE_FF.Q5[3:0]" />
+      <direct name="D" input="SLICE_FF.D[3:0]" output="REG_FDPE_or_FDCE.D" />
+      <direct name="Q" input="REG_FDPE_or_FDCE.Q" output="SLICE_FF.Q" />
+
+      <direct name="D5" input="SLICE_FF.D5[3:0]" output="FF_FDPE_or_FDCE.D" />
+      <direct name="Q5" input="FF_FDPE_or_FDCE.Q" output="SLICE_FF.Q5" />
     </interconnect>
   </mode>
   <mode name="LDPE_or_LDCE">
@@ -244,9 +442,11 @@
           <input  name="PRE" num_pins="1"/>
           <output name="Q" num_pins="1"/>
           <T_setup    value="10e-12" port="D" clock="G" />
-          <T_setup    value="10e-12" port="GE" clock="G" />
-          <T_setup    value="10e-12" port="PRE" clock="G" />
-          <T_clock_to_Q max="10e-12" port="Q" clock="G" />
+          <T_clock_to_Q max="10e-12" port="D" clock="G" />
+
+          <delay_constant max="10e-12" in_port="G" out_port="Q" />
+          <delay_constant max="10e-12" in_port="GE" out_port="Q"/>
+          <delay_constant max="10e-12" in_port="PRE" out_port="Q"/>
 
           <metadata>
             <meta name="fasm_params">
@@ -273,10 +473,11 @@
           <input  name="CLR" num_pins="1"/>
           <output name="Q" num_pins="1"/>
           <T_setup    value="10e-12" port="D" clock="G" />
-          <T_setup    value="10e-12" port="GE" clock="G" />
-          <T_setup    value="10e-12" port="CLR" clock="G" />
-          <T_clock_to_Q max="10e-12" port="Q" clock="G" />
+          <T_clock_to_Q max="10e-12" port="D" clock="G" />
 
+          <delay_constant max="10e-12" in_port="G" out_port="Q" />
+          <delay_constant max="10e-12" in_port="GE" out_port="Q"/>
+          <delay_constant max="10e-12" in_port="CLR" out_port="Q"/>
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI


### PR DESCRIPTION
This PR splits FFs definitions in the arch.xml so it corresponds with the actual FPGA arch. Also timings definitions are updated, but they do not have correct delay values.

This PR was originally a part of #738 