### PR TITLE
Removed blackbox attribute.

### DIFF
--- a/xc7/techmap/cells_sim.v
+++ b/xc7/techmap/cells_sim.v
@@ -59,7 +59,6 @@ endmodule
 // ============================================================================
 // Carry chain primitives
 
-(*blackbox*)
 module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, CO_FABRIC3, CYINIT, CIN, DI0, DI1, DI2, DI3, S0, S1, S2, S3);
   parameter CYINIT_AX = 1'b0;
   parameter CYINIT_C0 = 1'b0;
@@ -157,7 +156,10 @@ module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, 
   wire CI3;
   wire CI4;
 
-  assign CI0 = (CYINIT & CYINIT_AX) | CYINIT_C1 | (CIN & (!CYINIT_AX && !CYINIT_C0 && !CYINIT_C1));
+  assign CI0 = CYINIT_AX ? CYINIT :
+               CYINIT_C1 ? 1'b1 :
+               CYINIT_C0 ? 1'b0 :
+               CIN;
   assign CI1 = S0 ? CI0 : DI0;
   assign CI2 = S1 ? CI1 : DI1;
   assign CI3 = S2 ? CI2 : DI2;


### PR DESCRIPTION
This was causing simulations to output 1'bx for all CARRY4_VPR outputs.

This does not fix DRAM test error output problem, but it does fix autosim for cases where a sim model exists.