### PR TITLE
xc7: Fix formatting in ff XML files.

### DIFF
--- a/xc7/primitives/ff/ff.model.xml
+++ b/xc7/primitives/ff/ff.model.xml
@@ -7,48 +7,48 @@
       <port name="D"  clock="C" />
     </input_ports>
     <output_ports>
-    <port name="Q" clock="C"  />
+      <port name="Q"  clock="C" />
     </output_ports>
   </model>
   <model name="FDSE_ZINI">
     <input_ports>
-    <port name="C"  is_clock="1" />
-    <port name="CE" clock="C" />
-    <port name="S"  clock="C" />
-    <port name="D"  clock="C" />
+      <port name="C"  is_clock="1" />
+      <port name="CE" clock="C" />
+      <port name="S"  clock="C" />
+      <port name="D"  clock="C" />
     </input_ports>
     <output_ports>
-    <port name="Q" clock="C"  />
+      <port name="Q"  clock="C" />
     </output_ports>
   </model>
   <model name="FDPE_ZINI">
     <input_ports>
-    <port name="C"  is_clock="1" />
-    <port name="CE" clock="C" />
-    <port name="PRE"  clock="C" />
-    <port name="D"  clock="C" />
+      <port name="C"   is_clock="1" />
+      <port name="CE"  clock="C" />
+      <port name="PRE" clock="C" />
+      <port name="D"   clock="C" />
     </input_ports>
     <output_ports>
-    <port name="Q" clock="C"  />
+      <port name="Q"   clock="C" />
     </output_ports>
   </model>
   <model name="FDCE_ZINI">
     <input_ports>
-      <port name="C"  is_clock="1" />
-      <port name="CE" clock="C" />
-      <port name="CLR"  clock="C" />
-      <port name="D"  clock="C" />
+      <port name="C"   is_clock="1" />
+      <port name="CE"  clock="C" />
+      <port name="CLR" clock="C" />
+      <port name="D"   clock="C" />
     </input_ports>
     <output_ports>
-      <port name="Q" clock="C"  />
+      <port name="Q"   clock="C"  />
     </output_ports>
   </model>
   <model name="LDPE_ZINI">
     <input_ports>
-      <port name="G" combinational_sink_ports="Q" is_clock="1" />
-      <port name="GE" combinational_sink_ports="Q" />
+      <port name="G"   combinational_sink_ports="Q" is_clock="1" />
+      <port name="GE"  combinational_sink_ports="Q" />
       <port name="PRE" combinational_sink_ports="Q" />
-      <port name="D" clock="G" />
+      <port name="D"   clock="G" />
     </input_ports>
     <output_ports>
       <port name="Q" />
@@ -56,10 +56,10 @@
   </model>
   <model name="LDCE_ZINI">
     <input_ports>
-      <port name="G" combinational_sink_ports="Q" is_clock="1" />
-      <port name="GE" combinational_sink_ports="Q" />
+      <port name="G"   combinational_sink_ports="Q" is_clock="1" />
+      <port name="GE"  combinational_sink_ports="Q" />
       <port name="CLR" combinational_sink_ports="Q" />
-      <port name="D" clock="G" />
+      <port name="D"   clock="G" />
     </input_ports>
     <output_ports>
       <port name="Q" />

--- a/xc7/primitives/ff/ff.pb_type.xml
+++ b/xc7/primitives/ff/ff.pb_type.xml
@@ -1,13 +1,13 @@
 <!-- Model of FF group in SLICEL and SLICEM -->
 <pb_type name="SLICE_FF" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- CK, CE and SR are slice wide. -->
-  <input name="CE" num_pins="8"/>
-  <input name="SR" num_pins="8"/>
-  <clock name="CK" num_pins="1"/>
+  <input name="CE"  num_pins="8"/>
+  <input name="SR"  num_pins="8"/>
+  <clock name="CK"  num_pins="1"/>
 
-  <input name="D" num_pins="4"/>
-  <output name="Q" num_pins="4"/>
-  <input name="D5" num_pins="4"/>
+  <input  name="D"  num_pins="4"/>
+  <output name="Q"  num_pins="4"/>
+  <input  name="D5" num_pins="4"/>
   <output name="Q5" num_pins="4"/>
 
   <!-- |      |FFSYNC|LATCH|ZRST | -->
@@ -29,29 +29,29 @@
       <direct name="D" input="SLICE_FF.D" output="NO_FF.D"/>
     </interconnect>
   </mode>
+
   <mode name="FDSE_or_FDRE">
     <pb_type name="FF_FDSE_or_FDRE" num_pb="4">
-      <input  name="D" num_pins="1"/>
+      <input  name="D"  num_pins="1"/>
       <input  name="CE" num_pins="1"/>
-      <clock  name="C" num_pins="1"/>
+      <clock  name="C"  num_pins="1"/>
       <input  name="SR" num_pins="1"/>
-      <output name="Q" num_pins="1"/>
+      <output name="Q"  num_pins="1"/>
 
       <mode name="FDSE">
         <pb_type name="FDSE" num_pb="1" blif_model=".subckt FDSE_ZINI">
-          <input  name="D" num_pins="1"/>
+          <input  name="D"  num_pins="1"/>
           <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
-          <input  name="S" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="D" clock="C" />
-          <T_setup    value="10e-12" port="CE" clock="C" />
-          <T_setup    value="10e-12" port="S" clock="C" />
-          <T_hold    value="10e-12" port="D" clock="C" />
+          <clock  name="C"  num_pins="1"/>
+          <input  name="S"  num_pins="1"/>
+          <output name="Q"  num_pins="1"/>
+          <T_setup   value="10e-12" port="D"  clock="C" />
+          <T_setup   value="10e-12" port="CE" clock="C" />
+          <T_setup   value="10e-12" port="S"  clock="C" />
+          <T_hold    value="10e-12" port="D"  clock="C" />
           <T_hold    value="10e-12" port="CE" clock="C" />
-          <T_hold    value="10e-12" port="S" clock="C" />
+          <T_hold    value="10e-12" port="S"  clock="C" />
           <T_clock_to_Q max="10e-12" port="Q" clock="C" />
-
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -60,36 +60,35 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="FF_FDSE_or_FDRE.D" output="FDSE.D" />
-          <direct name="CE" input="FF_FDSE_or_FDRE.CE" output="FDSE.CE" >
+          <direct name="D"  input="FF_FDSE_or_FDRE.D"  output="FDSE.D" />
+          <direct name="CE" input="FF_FDSE_or_FDRE.CE" output="FDSE.CE">
             <pack_pattern name="CE_FF_FDSE"/>
             <pack_pattern name="CESR_FF_FDSE"/>
           </direct>
-          <direct name="C" input="FF_FDSE_or_FDRE.C" output="FDSE.C" />
-          <direct name="S" input="FF_FDSE_or_FDRE.SR" output="FDSE.S" >
+          <direct name="C"  input="FF_FDSE_or_FDRE.C"  output="FDSE.C" />
+          <direct name="S"  input="FF_FDSE_or_FDRE.SR" output="FDSE.S">
             <pack_pattern name="SR_FF_FDSE"/>
             <pack_pattern name="CESR_FF_FDSE"/>
           </direct>
-          <direct name="Q" input="FDSE.Q" output="FF_FDSE_or_FDRE.Q" />
+          <direct name="Q"  input="FDSE.Q" output="FF_FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
+
       <mode name="FDRE">
         <pb_type name="FDRE" num_pb="1" blif_model=".subckt FDRE_ZINI">
-          <input  name="D" num_pins="1"/>
+          <input  name="D"  num_pins="1"/>
           <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
-          <input  name="R" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="D" clock="C" />
+          <clock  name="C"  num_pins="1"/>
+          <input  name="R"  num_pins="1"/>
+          <output name="Q"  num_pins="1"/>
+          <T_setup    value="10e-12" port="D"  clock="C" />
           <T_setup    value="10e-12" port="CE" clock="C" />
-          <T_setup    value="10e-12" port="R" clock="C" />
-          <T_hold    value="10e-12" port="D" clock="C" />
-          <T_hold    value="10e-12" port="CE" clock="C" />
-          <T_hold    value="10e-12" port="R" clock="C" />
-          <T_clock_to_Q max="10e-12" port="Q" clock="C" />
-
+          <T_setup    value="10e-12" port="R"  clock="C" />
+          <T_hold     value="10e-12" port="D"  clock="C" />
+          <T_hold     value="10e-12" port="CE" clock="C" />
+          <T_hold     value="10e-12" port="R"  clock="C" />
+          <T_clock_to_Q max="10e-12" port="Q"  clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -100,19 +99,20 @@
           </metadata>
         </pb_type>
         <interconnect>
-          <direct name="D" input="FF_FDSE_or_FDRE.D" output="FDRE.D" />
-          <direct name="CE" input="FF_FDSE_or_FDRE.CE" output="FDRE.CE" >
-            <pack_pattern name="CE_FF_FDRE" in_port="FF_FDSE_or_FDRE.CE" out_port="FDRE.CE"/>
-            <pack_pattern name="CESR_FF_FDRE" in_port="FF_FDSE_or_FDRE.CE" out_port="FDRE.CE"/>
+          <direct name="D"  input="FF_FDSE_or_FDRE.D"  output="FDRE.D" />
+          <direct name="CE" input="FF_FDSE_or_FDRE.CE" output="FDRE.CE">
+            <pack_pattern name="CE_FF_FDRE"/>
+            <pack_pattern name="CESR_FF_FDRE"/>
           </direct>
-          <direct name="C" input="FF_FDSE_or_FDRE.C" output="FDRE.C" />
-          <direct name="R" input="FF_FDSE_or_FDRE.SR" output="FDRE.R" >
-            <pack_pattern name="SR_FF_FDRE" in_port="FF_FDSE_or_FDRE.SR" out_port="FDRE.R"/>
-            <pack_pattern name="CESR_FF_FDRE" in_port="FF_FDSE_or_FDRE.SR" out_port="FDRE.R"/>
+          <direct name="C"  input="FF_FDSE_or_FDRE.C"  output="FDRE.C" />
+          <direct name="R"  input="FF_FDSE_or_FDRE.SR" output="FDRE.R">
+            <pack_pattern name="SR_FF_FDRE"/>
+            <pack_pattern name="CESR_FF_FDRE"/>
           </direct>
-          <direct name="Q" input="FDRE.Q" output="FF_FDSE_or_FDRE.Q" />
+          <direct name="Q"  input="FDRE.Q" output="FF_FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
+
       <metadata>
         <meta name="fasm_prefix">A5FF B5FF C5FF D5FF</meta>
         <meta name="type">block</meta>
@@ -121,27 +121,26 @@
     </pb_type>
 
     <pb_type name="REG_FDSE_or_FDRE" num_pb="4">
-      <input  name="D" num_pins="1"/>
+      <input  name="D"  num_pins="1"/>
       <input  name="CE" num_pins="1"/>
-      <clock  name="C" num_pins="1"/>
+      <clock  name="C"  num_pins="1"/>
       <input  name="SR" num_pins="1"/>
-      <output name="Q" num_pins="1"/>
+      <output name="Q"  num_pins="1"/>
 
       <mode name="FDSE">
         <pb_type name="FDSE" num_pb="1" blif_model=".subckt FDSE_ZINI">
-          <input  name="D" num_pins="1"/>
+          <input  name="D"  num_pins="1"/>
           <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
-          <input  name="S" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="FDSE.D" clock="C" />
-          <T_setup    value="10e-12"  port="FDSE.CE" clock="C" />
-          <T_setup    value="10e-12" port="FDSE.S" clock="C" />
-          <T_hold    value="10e-12" port="FDSE.D" clock="C" />
-          <T_hold    value="10e-12"  port="FDSE.CE" clock="C" />
-          <T_hold    value="10e-12" port="FDSE.S" clock="C" />
-          <T_clock_to_Q max="10e-12" port="FDSE.Q" clock="C" />
-
+          <clock  name="C"  num_pins="1"/>
+          <input  name="S"  num_pins="1"/>
+          <output name="Q"  num_pins="1"/>
+          <T_setup    value="10e-12" port="FDSE.D"  clock="C" />
+          <T_setup    value="10e-12" port="FDSE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDSE.S"  clock="C" />
+          <T_hold     value="10e-12" port="FDSE.D"  clock="C" />
+          <T_hold     value="10e-12" port="FDSE.CE" clock="C" />
+          <T_hold     value="10e-12" port="FDSE.S"  clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDSE.Q"  clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -150,21 +149,21 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="REG_FDSE_or_FDRE.D" output="FDSE.D" />
-          <direct name="CE" input="REG_FDSE_or_FDRE.CE" output="FDSE.CE" >
-            <pack_pattern name="CE_FF_FDSE" in_port="REG_FDSE_or_FDRE.CE" out_port="FDSE.CE"/>
-            <pack_pattern name="CESR_FF_FDSE" in_port="REG_FDSE_or_FDRE.CE" out_port="FDSE.CE"/>
+          <direct name="D"  input="REG_FDSE_or_FDRE.D"  output="FDSE.D" />
+          <direct name="CE" input="REG_FDSE_or_FDRE.CE" output="FDSE.CE">
+            <pack_pattern name="CE_FF_FDSE"/>
+            <pack_pattern name="CESR_FF_FDSE"/>
           </direct>
-          <direct name="C" input="REG_FDSE_or_FDRE.C" output="FDSE.C" />
-          <direct name="S" input="REG_FDSE_or_FDRE.SR" output="FDSE.S" >
-            <pack_pattern name="SR_FF_FDSE" in_port="REG_FDSE_or_FDRE.SR" out_port="FDSE.S"/>
-            <pack_pattern name="CESR_FF_FDSE" in_port="REG_FDSE_or_FDRE.SR" out_port="FDSE.S"/>
+          <direct name="C"  input="REG_FDSE_or_FDRE.C"  output="FDSE.C" />
+          <direct name="S"  input="REG_FDSE_or_FDRE.SR" output="FDSE.S">
+            <pack_pattern name="SR_FF_FDSE"/>
+            <pack_pattern name="CESR_FF_FDSE"/>
           </direct>
-          <direct name="Q" input="FDSE.Q" output="REG_FDSE_or_FDRE.Q" />
+          <direct name="Q"  input="FDSE.Q" output="REG_FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
+
       <mode name="FDRE">
         <pb_type name="FDRE" num_pb="1" blif_model=".subckt FDRE_ZINI">
           <input  name="D" num_pins="1"/>
@@ -172,14 +171,13 @@
           <clock  name="C" num_pins="1"/>
           <input  name="R" num_pins="1"/>
           <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="FDRE.D" clock="C" />
-          <T_setup    value="10e-12"  port="FDRE.CE" clock="C" />
-          <T_setup    value="10e-12" port="FDRE.R" clock="C" />
-          <T_hold    value="10e-12" port="FDRE.D" clock="C" />
-          <T_hold    value="10e-12"  port="FDRE.CE" clock="C" />
-          <T_hold    value="10e-12" port="FDRE.R" clock="C" />
-          <T_clock_to_Q max="10e-12" port="FDRE.Q" clock="C" />
-
+          <T_setup    value="10e-12" port="FDRE.D"  clock="C" />
+          <T_setup    value="10e-12" port="FDRE.CE" clock="C" />
+          <T_setup    value="10e-12" port="FDRE.R"  clock="C" />
+          <T_hold     value="10e-12" port="FDRE.D"  clock="C" />
+          <T_hold     value="10e-12" port="FDRE.CE" clock="C" />
+          <T_hold     value="10e-12" port="FDRE.R"  clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDRE.Q"  clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -189,21 +187,21 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="REG_FDSE_or_FDRE.D" output="FDRE.D" />
-          <direct name="CE" input="REG_FDSE_or_FDRE.CE" output="FDRE.CE" >
+          <direct name="D"  input="REG_FDSE_or_FDRE.D"  output="FDRE.D" />
+          <direct name="CE" input="REG_FDSE_or_FDRE.CE" output="FDRE.CE">
             <pack_pattern name="CE_FF_FDRE"/>
             <pack_pattern name="CESR_FF_FDRE"/>
           </direct>
-          <direct name="C" input="REG_FDSE_or_FDRE.C" output="FDRE.C" />
-          <direct name="R" input="REG_FDSE_or_FDRE.SR" output="FDRE.R" >
+          <direct name="C"  input="REG_FDSE_or_FDRE.C"  output="FDRE.C" />
+          <direct name="R"  input="REG_FDSE_or_FDRE.SR" output="FDRE.R">
             <pack_pattern name="SR_FF_FDRE"/>
             <pack_pattern name="CESR_FF_FDRE"/>
           </direct>
-          <direct name="Q" input="FDRE.Q" output="REG_FDSE_or_FDRE.Q" />
+          <direct name="Q"  input="FDRE.Q" output="REG_FDSE_or_FDRE.Q" />
         </interconnect>
       </mode>
+
       <metadata>
         <meta name="fasm_prefix">AFF BFF CFF DFF</meta>
         <meta name="type">block</meta>
@@ -212,18 +210,18 @@
     </pb_type>
 
     <interconnect>
-      <direct name="CE_FF" input="SLICE_FF.CE[7:4]" output="FF_FDSE_or_FDRE.CE" />
-      <direct name="CE_REG" input="SLICE_FF.CE[3:0]" output="REG_FDSE_or_FDRE.CE" />
-      <complete name="C_FF" input="SLICE_FF.CK" output="FF_FDSE_or_FDRE.C" />
-      <complete name="C_REG" input="SLICE_FF.CK" output="REG_FDSE_or_FDRE.C" />
-      <direct name="SR_FF" input="SLICE_FF.SR[7:4]" output="FF_FDSE_or_FDRE.SR" />
-      <direct name="SR_REG" input="SLICE_FF.SR[3:0]" output="REG_FDSE_or_FDRE.SR" />
+      <direct   name="CE_FF"  input="SLICE_FF.CE[7:4]"   output="FF_FDSE_or_FDRE.CE"  />
+      <direct   name="CE_REG" input="SLICE_FF.CE[3:0]"   output="REG_FDSE_or_FDRE.CE" />
+      <complete name="C_FF"   input="SLICE_FF.CK"        output="FF_FDSE_or_FDRE.C"   />
+      <complete name="C_REG"  input="SLICE_FF.CK"        output="REG_FDSE_or_FDRE.C"  />
+      <direct   name="SR_FF"  input="SLICE_FF.SR[7:4]"   output="FF_FDSE_or_FDRE.SR"  />
+      <direct   name="SR_REG" input="SLICE_FF.SR[3:0]"   output="REG_FDSE_or_FDRE.SR" />
 
-      <direct name="D" input="SLICE_FF.D" output="REG_FDSE_or_FDRE.D" />
-      <direct name="Q" input="REG_FDSE_or_FDRE.Q" output="SLICE_FF.Q" />
+      <direct   name="D"      input="SLICE_FF.D"         output="REG_FDSE_or_FDRE.D"  />
+      <direct   name="Q"      input="REG_FDSE_or_FDRE.Q" output="SLICE_FF.Q"          />
 
-      <direct name="D5" input="SLICE_FF.D5" output="FF_FDSE_or_FDRE.D" />
-      <direct name="Q5" input="FF_FDSE_or_FDRE.Q" output="SLICE_FF.Q5" />
+      <direct   name="D5"     input="SLICE_FF.D5"        output="FF_FDSE_or_FDRE.D"   />
+      <direct   name="Q5"     input="FF_FDSE_or_FDRE.Q"  output="SLICE_FF.Q5"         />
     </interconnect>
     <metadata>
       <meta name="fasm_features">FFSYNC</meta>
@@ -231,27 +229,26 @@
   </mode>
   <mode name="FDPE_or_FDCE">
     <pb_type name="FF_FDPE_or_FDCE" num_pb="4">
-      <input  name="D" num_pins="1"/>
+      <input  name="D"  num_pins="1"/>
       <input  name="CE" num_pins="1"/>
-      <clock  name="C" num_pins="1"/>
+      <clock  name="C"  num_pins="1"/>
       <input  name="SR" num_pins="1"/>
-      <output name="Q" num_pins="1"/>
+      <output name="Q"  num_pins="1"/>
 
       <mode name="FDPE">
         <pb_type name="FDPE" num_pb="1" blif_model=".subckt FDPE_ZINI">
-          <input  name="D" num_pins="1"/>
-          <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
+          <input  name="D"   num_pins="1"/>
+          <input  name="CE"  num_pins="1"/>
+          <clock  name="C"   num_pins="1"/>
           <input  name="PRE" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="D" clock="C" />
-          <T_setup    value="10e-12" port="CE" clock="C" />
+          <output name="Q"   num_pins="1"/>
+          <T_setup    value="10e-12" port="D"   clock="C" />
+          <T_setup    value="10e-12" port="CE"  clock="C" />
           <T_setup    value="10e-12" port="PRE" clock="C" />
-          <T_hold    value="10e-12" port="D" clock="C" />
-          <T_hold    value="10e-12"  port="CE" clock="C" />
-          <T_hold    value="10e-12" port="PRE" clock="C" />
-          <T_clock_to_Q max="10e-12" port="Q" clock="C" />
-
+          <T_hold     value="10e-12" port="D"   clock="C" />
+          <T_hold     value="10e-12" port="CE"  clock="C" />
+          <T_hold     value="10e-12" port="PRE" clock="C" />
+          <T_clock_to_Q max="10e-12" port="Q"   clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -260,36 +257,35 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="FF_FDPE_or_FDCE.D" output="FDPE.D" />
-          <direct name="CE" input="FF_FDPE_or_FDCE.CE" output="FDPE.CE" >
+          <direct name="D"   input="FF_FDPE_or_FDCE.D"  output="FDPE.D" />
+          <direct name="CE"  input="FF_FDPE_or_FDCE.CE" output="FDPE.CE">
             <pack_pattern name="CE_FF_FDPE"/>
             <pack_pattern name="CESR_FF_FDPE"/>
           </direct>
-          <direct name="C" input="FF_FDPE_or_FDCE.C" output="FDPE.C" />
-          <direct name="PRE" input="FF_FDPE_or_FDCE.SR" output="FDPE.PRE" >
+          <direct name="C"   input="FF_FDPE_or_FDCE.C"  output="FDPE.C" />
+          <direct name="PRE" input="FF_FDPE_or_FDCE.SR" output="FDPE.PRE">
             <pack_pattern name="SR_FF_FDPE"/>
             <pack_pattern name="CESR_FF_FDPE"/>
           </direct>
-          <direct name="Q" input="FDPE.Q" output="FF_FDPE_or_FDCE.Q" />
+          <direct name="Q"   input="FDPE.Q" output="FF_FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
+
       <mode name="FDCE">
         <pb_type name="FDCE" num_pb="1" blif_model=".subckt FDCE_ZINI">
-          <input  name="D" num_pins="1"/>
-          <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
+          <input  name="D"   num_pins="1"/>
+          <input  name="CE"  num_pins="1"/>
+          <clock  name="C"   num_pins="1"/>
           <input  name="CLR" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="D" clock="C" />
-          <T_setup    value="10e-12" port="CE" clock="C" />
+          <output name="Q"   num_pins="1"/>
+          <T_setup    value="10e-12" port="D"   clock="C" />
+          <T_setup    value="10e-12" port="CE"  clock="C" />
           <T_setup    value="10e-12" port="CLR" clock="C" />
-          <T_hold    value="10e-12" port="D" clock="C" />
-          <T_hold    value="10e-12" port="CE" clock="C" />
-          <T_hold    value="10e-12" port="CLR" clock="C" />
-          <T_clock_to_Q max="10e-12" port="Q" clock="C" />
-
+          <T_hold     value="10e-12" port="D"   clock="C" />
+          <T_hold     value="10e-12" port="CE"  clock="C" />
+          <T_hold     value="10e-12" port="CLR" clock="C" />
+          <T_clock_to_Q max="10e-12" port="Q"   clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -299,48 +295,49 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="FF_FDPE_or_FDCE.D" output="FDCE.D" />
-          <direct name="CE" input="FF_FDPE_or_FDCE.CE" output="FDCE.CE" >
+          <direct name="D"   input="FF_FDPE_or_FDCE.D"  output="FDCE.D" />
+          <direct name="CE"  input="FF_FDPE_or_FDCE.CE" output="FDCE.CE">
             <pack_pattern name="CE_FF_FDCE"/>
             <pack_pattern name="CESR_FF_FDCE"/>
           </direct>
-          <direct name="C" input="FF_FDPE_or_FDCE.C" output="FDCE.C" />
-          <direct name="CLR" input="FF_FDPE_or_FDCE.SR" output="FDCE.CLR" >
+          <direct name="C"   input="FF_FDPE_or_FDCE.C"  output="FDCE.C" />
+          <direct name="CLR" input="FF_FDPE_or_FDCE.SR" output="FDCE.CLR">
             <pack_pattern name="SR_FF_FDCE"/>
             <pack_pattern name="CESR_FF_FDCE"/>
           </direct>
           <direct name="Q" input="FDCE.Q" output="FF_FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
+
       <metadata>
         <meta name="fasm_prefix">A5FF B5FF C5FF D5FF</meta>
         <meta name="type">block</meta>
         <meta name="subtype">ignore</meta>
       </metadata>
     </pb_type>
-    <pb_type name="REG_FDPE_or_FDCE" num_pb="4">
-      <input  name="D" num_pins="1"/>
-      <input  name="CE" num_pins="1"/>
-      <clock  name="C" num_pins="1"/>
-      <input  name="SR" num_pins="1"/>
-      <output name="Q" num_pins="1"/>
-<mode name="FDPE">
-        <pb_type name="FDPE" num_pb="1" blif_model=".subckt FDPE_ZINI">
-          <input  name="D" num_pins="1"/>
-          <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
-          <input  name="PRE" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="FDPE.D" clock="C" />
-          <T_setup    value="10e-12" port="FDPE.CE" clock="C" />
-          <T_setup    value="10e-12" port="FDPE.PRE" clock="C" />
-          <T_hold    value="10e-12" port="FDPE.D" clock="C" />
-          <T_hold    value="10e-12" port="FDPE.CE" clock="C" />
-          <T_hold    value="10e-12" port="FDPE.PRE" clock="C" />
-          <T_clock_to_Q max="10e-12" port="FDPE.Q" clock="C" />
 
+    <pb_type name="REG_FDPE_or_FDCE" num_pb="4">
+      <input  name="D"  num_pins="1"/>
+      <input  name="CE" num_pins="1"/>
+      <clock  name="C"  num_pins="1"/>
+      <input  name="SR" num_pins="1"/>
+      <output name="Q"  num_pins="1"/>
+
+      <mode name="FDPE">
+        <pb_type name="FDPE" num_pb="1" blif_model=".subckt FDPE_ZINI">
+          <input  name="D"   num_pins="1"/>
+          <input  name="CE"  num_pins="1"/>
+          <clock  name="C"   num_pins="1"/>
+          <input  name="PRE" num_pins="1"/>
+          <output name="Q"   num_pins="1"/>
+          <T_setup    value="10e-12" port="FDPE.D"   clock="C" />
+          <T_setup    value="10e-12" port="FDPE.CE"  clock="C" />
+          <T_setup    value="10e-12" port="FDPE.PRE" clock="C" />
+          <T_hold     value="10e-12" port="FDPE.D"   clock="C" />
+          <T_hold     value="10e-12" port="FDPE.CE"  clock="C" />
+          <T_hold     value="10e-12" port="FDPE.PRE" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDPE.Q"   clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -349,36 +346,35 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="REG_FDPE_or_FDCE.D" output="FDPE.D" />
-          <direct name="CE" input="REG_FDPE_or_FDCE.CE" output="FDPE.CE" >
-            <pack_pattern name="CE_FF_FDPE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDPE.CE"/>
-            <pack_pattern name="CESR_FF_FDPE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDPE.CE"/>
+          <direct name="D"   input="REG_FDPE_or_FDCE.D"  output="FDPE.D" />
+          <direct name="CE"  input="REG_FDPE_or_FDCE.CE" output="FDPE.CE">
+            <pack_pattern name="CE_FF_FDPE"/>
+            <pack_pattern name="CESR_FF_FDPE"/>
           </direct>
-          <direct name="C" input="REG_FDPE_or_FDCE.C" output="FDPE.C" />
-          <direct name="PRE" input="REG_FDPE_or_FDCE.SR" output="FDPE.PRE" >
-            <pack_pattern name="SR_FF_FDPE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDPE.PRE"/>
-            <pack_pattern name="CESR_FF_FDPE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDPE.PRE"/>
+          <direct name="C"   input="REG_FDPE_or_FDCE.C"  output="FDPE.C" />
+          <direct name="PRE" input="REG_FDPE_or_FDCE.SR" output="FDPE.PRE">
+            <pack_pattern name="SR_FF_FDPE"/>
+            <pack_pattern name="CESR_FF_FDPE"/>
           </direct>
-          <direct name="Q" input="FDPE.Q" output="REG_FDPE_or_FDCE.Q" />
+          <direct name="Q"   input="FDPE.Q" output="REG_FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
+
       <mode name="FDCE">
         <pb_type name="FDCE" num_pb="1" blif_model=".subckt FDCE_ZINI">
-          <input  name="D" num_pins="1"/>
-          <input  name="CE" num_pins="1"/>
-          <clock  name="C" num_pins="1"/>
+          <input  name="D"   num_pins="1"/>
+          <input  name="CE"  num_pins="1"/>
+          <clock  name="C"   num_pins="1"/>
           <input  name="CLR" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
-          <T_setup    value="10e-12" port="FDCE.D" clock="C" />
-          <T_setup    value="10e-12" port="FDCE.CE" clock="C" />
+          <output name="Q"   num_pins="1"/>
+          <T_setup    value="10e-12" port="FDCE.D"   clock="C" />
+          <T_setup    value="10e-12" port="FDCE.CE"  clock="C" />
           <T_setup    value="10e-12" port="FDCE.CLR" clock="C" />
-          <T_hold    value="10e-12" port="FDCE.D" clock="C" />
-          <T_hold    value="10e-12" port="FDCE.CE" clock="C" />
-          <T_hold    value="10e-12" port="FDCE.CLR" clock="C" />
-          <T_clock_to_Q max="10e-12" port="FDCE.Q" clock="C" />
-
+          <T_hold     value="10e-12" port="FDCE.D"   clock="C" />
+          <T_hold     value="10e-12" port="FDCE.CE"  clock="C" />
+          <T_hold     value="10e-12" port="FDCE.CLR" clock="C" />
+          <T_clock_to_Q max="10e-12" port="FDCE.Q"   clock="C" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -388,19 +384,18 @@
             <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="REG_FDPE_or_FDCE.D" output="FDCE.D" />
-          <direct name="CE" input="REG_FDPE_or_FDCE.CE" output="FDCE.CE" >
-            <pack_pattern name="CE_FF_FDCE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDCE.CE"/>
-            <pack_pattern name="CESR_FF_FDCE" in_port="REG_FDPE_or_FDCE.CE" out_port="FDCE.CE"/>
+          <direct name="D"   input="REG_FDPE_or_FDCE.D"  output="FDCE.D" />
+          <direct name="CE"  input="REG_FDPE_or_FDCE.CE" output="FDCE.CE">
+            <pack_pattern name="CE_FF_FDCE"/>
+            <pack_pattern name="CESR_FF_FDCE"/>
           </direct>
-          <direct name="C" input="REG_FDPE_or_FDCE.C" output="FDCE.C" />
-          <direct name="CLR" input="REG_FDPE_or_FDCE.SR" output="FDCE.CLR" >
-            <pack_pattern name="SR_FF_FDCE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDCE.CLR"/>
-            <pack_pattern name="CESR_FF_FDCE" in_port="REG_FDPE_or_FDCE.SR" out_port="FDCE.CLR"/>
+          <direct name="C"   input="REG_FDPE_or_FDCE.C"  output="FDCE.C" />
+          <direct name="CLR" input="REG_FDPE_or_FDCE.SR" output="FDCE.CLR">
+            <pack_pattern name="SR_FF_FDCE"/>
+            <pack_pattern name="CESR_FF_FDCE"/>
           </direct>
-          <direct name="Q" input="FDCE.Q" output="REG_FDPE_or_FDCE.Q" />
+          <direct name="Q"   input="FDCE.Q" output="REG_FDPE_or_FDCE.Q" />
         </interconnect>
       </mode>
       <metadata>
@@ -411,43 +406,41 @@
     </pb_type>
 
     <interconnect>
-      <direct name="CE_FF" input="SLICE_FF.CE[7:4]" output="FF_FDPE_or_FDCE.CE" />
-      <complete name="C_FF" input="SLICE_FF.CK" output="FF_FDPE_or_FDCE.C" />
-      <direct name="SR_FF" input="SLICE_FF.SR[7:4]" output="FF_FDPE_or_FDCE.SR" />
+      <direct   name="CE_FF"  input="SLICE_FF.CE[7:4]"   output="FF_FDPE_or_FDCE.CE"  />
+      <complete name="C_FF"   input="SLICE_FF.CK"        output="FF_FDPE_or_FDCE.C"   />
+      <direct   name="SR_FF"  input="SLICE_FF.SR[7:4]"   output="FF_FDPE_or_FDCE.SR"  />
 
-      <direct name="CE_REG" input="SLICE_FF.CE[3:0]" output="REG_FDPE_or_FDCE.CE" />
-      <complete name="C_REG" input="SLICE_FF.CK" output="REG_FDPE_or_FDCE.C" />
-      <direct name="SR_REG" input="SLICE_FF.SR[3:0]" output="REG_FDPE_or_FDCE.SR" />
+      <direct   name="CE_REG" input="SLICE_FF.CE[3:0]"   output="REG_FDPE_or_FDCE.CE" />
+      <complete name="C_REG"  input="SLICE_FF.CK"        output="REG_FDPE_or_FDCE.C"  />
+      <direct   name="SR_REG" input="SLICE_FF.SR[3:0]"   output="REG_FDPE_or_FDCE.SR" />
 
-      <direct name="D" input="SLICE_FF.D[3:0]" output="REG_FDPE_or_FDCE.D" />
-      <direct name="Q" input="REG_FDPE_or_FDCE.Q" output="SLICE_FF.Q" />
+      <direct   name="D"      input="SLICE_FF.D[3:0]"    output="REG_FDPE_or_FDCE.D"  />
+      <direct   name="Q"      input="REG_FDPE_or_FDCE.Q" output="SLICE_FF.Q"          />
 
-      <direct name="D5" input="SLICE_FF.D5[3:0]" output="FF_FDPE_or_FDCE.D" />
-      <direct name="Q5" input="FF_FDPE_or_FDCE.Q" output="SLICE_FF.Q5" />
+      <direct   name="D5"     input="SLICE_FF.D5[3:0]"   output="FF_FDPE_or_FDCE.D"   />
+      <direct   name="Q5"     input="FF_FDPE_or_FDCE.Q"  output="SLICE_FF.Q5"         />
     </interconnect>
   </mode>
   <mode name="LDPE_or_LDCE">
     <pb_type name="LDPE_or_LDCE" num_pb="4">
-      <input  name="D" num_pins="1"/>
+      <input  name="D"  num_pins="1"/>
       <input  name="CE" num_pins="1"/>
-      <clock  name="C" num_pins="1"/>
+      <clock  name="C"  num_pins="1"/>
       <input  name="SR" num_pins="1"/>
-      <output name="Q" num_pins="1"/>
+      <output name="Q"  num_pins="1"/>
 
       <mode name="LDPE">
         <pb_type name="LDPE" num_pb="1" blif_model=".subckt LDPE_ZINI">
-          <input  name="D" num_pins="1"/>
-          <input  name="GE" num_pins="1"/>
-          <clock  name="G" num_pins="1"/>
+          <input  name="D"   num_pins="1"/>
+          <input  name="GE"  num_pins="1"/>
+          <clock  name="G"   num_pins="1"/>
           <input  name="PRE" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
+          <output name="Q"   num_pins="1"/>
           <T_setup    value="10e-12" port="D" clock="G" />
           <T_clock_to_Q max="10e-12" port="D" clock="G" />
-
-          <delay_constant max="10e-12" in_port="G" out_port="Q" />
-          <delay_constant max="10e-12" in_port="GE" out_port="Q"/>
+          <delay_constant max="10e-12" in_port="G"   out_port="Q" />
+          <delay_constant max="10e-12" in_port="GE"  out_port="Q"/>
           <delay_constant max="10e-12" in_port="PRE" out_port="Q"/>
-
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -456,28 +449,27 @@
 	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="LDPE_or_LDCE.D" output="LDPE.D" />
-          <direct name="CE" input="LDPE_or_LDCE.CE" output="LDPE.GE" />
-          <direct name="C" input="LDPE_or_LDCE.C" output="LDPE.G" />
+          <direct name="D"  input="LDPE_or_LDCE.D"  output="LDPE.D"   />
+          <direct name="CE" input="LDPE_or_LDCE.CE" output="LDPE.GE"  />
+          <direct name="C"  input="LDPE_or_LDCE.C"  output="LDPE.G"   />
           <direct name="SR" input="LDPE_or_LDCE.SR" output="LDPE.PRE" />
-          <direct name="Q" input="LDPE.Q" output="LDPE_or_LDCE.Q" />
+          <direct name="Q"  input="LDPE.Q" output="LDPE_or_LDCE.Q"    />
         </interconnect>
       </mode>
+
       <mode name="LDCE">
         <pb_type name="LDCE" num_pb="1" blif_model=".subckt LDCE_ZINI">
-          <input  name="D" num_pins="1"/>
-          <input  name="GE" num_pins="1"/>
-          <clock  name="G" num_pins="1"/>
+          <input  name="D"   num_pins="1"/>
+          <input  name="GE"  num_pins="1"/>
+          <clock  name="G"   num_pins="1"/>
           <input  name="CLR" num_pins="1"/>
-          <output name="Q" num_pins="1"/>
+          <output name="Q"   num_pins="1"/>
           <T_setup    value="10e-12" port="D" clock="G" />
           <T_clock_to_Q max="10e-12" port="D" clock="G" />
-
-          <delay_constant max="10e-12" in_port="G" out_port="Q" />
-          <delay_constant max="10e-12" in_port="GE" out_port="Q"/>
-          <delay_constant max="10e-12" in_port="CLR" out_port="Q"/>
+          <delay_constant max="10e-12" in_port="G"   out_port="Q" />
+          <delay_constant max="10e-12" in_port="GE"  out_port="Q" />
+          <delay_constant max="10e-12" in_port="CLR" out_port="Q" />
           <metadata>
             <meta name="fasm_params">
               ZINI = ZINI
@@ -487,13 +479,12 @@
 	    <meta name="subtype">flipflop</meta>
           </metadata>
         </pb_type>
-
         <interconnect>
-          <direct name="D" input="LDPE_or_LDCE.D" output="LDCE.D" />
-          <direct name="CE" input="LDPE_or_LDCE.CE" output="LDCE.GE" />
-          <direct name="C" input="LDPE_or_LDCE.C" output="LDCE.G" />
+          <direct name="D"  input="LDPE_or_LDCE.D"  output="LDCE.D"   />
+          <direct name="CE" input="LDPE_or_LDCE.CE" output="LDCE.GE"  />
+          <direct name="C"  input="LDPE_or_LDCE.C"  output="LDCE.G"   />
           <direct name="SR" input="LDPE_or_LDCE.SR" output="LDCE.CLR" />
-          <direct name="Q" input="LDCE.Q" output="LDPE_or_LDCE.Q" />
+          <direct name="Q"  input="LDCE.Q" output="LDPE_or_LDCE.Q" />
         </interconnect>
       </mode>
       <metadata>
@@ -504,12 +495,12 @@
     </pb_type>
 
     <interconnect>
-      <direct name="CE_TO_LD" input="SLICE_FF.CE[0:3]" output="LDPE_or_LDCE.CE" />
-      <complete name="C_TO_LD"  input="SLICE_FF.CK" output="LDPE_or_LDCE.C" />
-      <direct name="SR_TO_LD" input="SLICE_FF.SR[0:3]" output="LDPE_or_LDCE.SR" />
+      <direct   name="CE_TO_LD" input="SLICE_FF.CE[0:3]" output="LDPE_or_LDCE.CE" />
+      <complete name="C_TO_LD"  input="SLICE_FF.CK"      output="LDPE_or_LDCE.C"  />
+      <direct   name="SR_TO_LD" input="SLICE_FF.SR[0:3]" output="LDPE_or_LDCE.SR" />
 
-      <direct name="D" input="SLICE_FF.D" output="LDPE_or_LDCE.D" />
-      <direct name="Q" input="LDPE_or_LDCE.Q" output="SLICE_FF.Q" />
+      <direct   name="D"        input="SLICE_FF.D"       output="LDPE_or_LDCE.D"  />
+      <direct   name="Q"        input="LDPE_or_LDCE.Q"   output="SLICE_FF.Q"      />
     </interconnect>
     <metadata>
       <meta name="fasm_features">LATCH</meta>


### PR DESCRIPTION
Makes it easier to look at.

 * Cleanup some of the additions from https://github.com/SymbiFlow/symbiflow-arch-defs/pull/789
 * Removed the unneeded values on `<direct><pack_pattern>` tags.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>