### PR TITLE
utils: address flake8 errors

### DIFF
--- a/common/cmake/v2x.cmake
+++ b/common/cmake/v2x.cmake
@@ -41,6 +41,8 @@ function(V2X)
   get_target_property(YOSYS_TARGET env YOSYS_TARGET)
   list(APPEND DEPENDS_LIST ${YOSYS} ${YOSYS_TARGET})
 
+  set(PYUTILS_PATH ${symbiflow-arch-defs_SOURCE_DIR}/utils)
+
   set(REAL_SOURCE_LIST "")
   foreach(SRC ${V2X_SRCS})
     if(NOT "${SRC}" MATCHES "\\.sim\\.v$")
@@ -94,7 +96,8 @@ function(V2X)
       ${DEPENDS_LIST}
       ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/vlog_to_pbtype.py
     COMMAND
-      ${CMAKE_COMMAND} -E env YOSYS=${YOSYS}  ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/vlog_to_pbtype.py ${TOP_ARG}
+    ${CMAKE_COMMAND} -E env YOSYS=${YOSYS} PYTHONPATH=${PYUTILS_PATH}
+      ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/vlog_to_pbtype.py ${TOP_ARG}
       -o ${CMAKE_CURRENT_BINARY_DIR}/${V2X_NAME}.pb_type.xml ${FIRST_SOURCE}
       ${INCLUDE_ARG}
     WORKING_DIRECTORY ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/
@@ -109,7 +112,8 @@ function(V2X)
       ${DEPENDS_LIST}
       ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/vlog_to_model.py
     COMMAND
-      ${CMAKE_COMMAND} -E env YOSYS=${YOSYS}  ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/vlog_to_model.py ${TOP_ARG}
+    ${CMAKE_COMMAND} -E env YOSYS=${YOSYS} PYTHONPATH=${PYUTILS_PATH}
+      ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/vlog_to_model.py ${TOP_ARG}
       -o ${CMAKE_CURRENT_BINARY_DIR}/${V2X_NAME}.model.xml ${FIRST_SOURCE}
       ${INCLUDE_ARG}
     WORKING_DIRECTORY ${symbiflow-arch-defs_SOURCE_DIR}/utils/vlog/

--- a/ice40/utils/ice40_import_routing_from_icebox.py
+++ b/ice40/utils/ice40_import_routing_from_icebox.py
@@ -842,9 +842,7 @@ def add_track_with_lines(g, ic, segment, lines, connections, hlc_name_f):
     logging.debug("Created track %s from sections: %s", segment.name, lines)
     for line in lines:
         istart, iend = points.straight_ends([p.pos for p in line])
-        logging.debug(
-            "  %s>%s (%s)", istart, iend, line
-        )
+        logging.debug("  %s>%s (%s)", istart, iend, line)
     for ipos, joins in sorted(connections.items()):
         for name_a, name_b in joins:
             logging.debug("  %s %s<->%s", ipos, name_a, name_b)
@@ -1033,7 +1031,6 @@ def add_tracks(g, ic, all_group_segments, segtype_filter=None):
 def add_edges(g, ic):
     """Adding edges to the rr_graph from icebox edges."""
     for ipos in list(tiles(ic)):
-
         """
         # FIXME: If IO type, connect PACKAGE_PIN_I and PACKAGE_PIN_O manually...
         tile_type = ic.tile_type(*ipos)

--- a/ice40/utils/ice40_import_routing_from_icebox.py
+++ b/ice40/utils/ice40_import_routing_from_icebox.py
@@ -56,8 +56,9 @@ This doc: https://docs.google.com/document/d/1kTehDgse8GA2af5HoQ9Ntr41uNL_NJ43Cj
 I think is based on CW's naming but has some divergences
 
 Some terminology clarification:
--A VPR "track" is a specific net that can be connected to in the global fabric
--Icestorm docs primarily talk about "wires" which generally refer to a concept how how these nets are used per tile
+ - A VPR "track" is a specific net that can be connected to in the global fabric
+ - Icestorm docs primarily talk about "wires" which generally refer to a concept
+   how these nets are used per tile
 That is, we take the Icestorm tile wire pattern and convert it to VPR tracks
 
 Other resources:
@@ -71,12 +72,8 @@ Then add globals, then neighbourhood
 # Python libs
 import logging
 import operator
-import os.path
-import re
 import sys
-from collections import namedtuple, OrderedDict, defaultdict
-from functools import reduce
-from os.path import commonprefix
+from collections import defaultdict
 
 # Third party libs
 import lxml.etree as ET
@@ -90,8 +87,6 @@ import lib.rr_graph.channel as channel
 import lib.rr_graph.graph as graph
 import lib.rr_graph.points as points
 from lib.rr_graph import Offset
-from lib.asserts import assert_eq
-from lib.asserts import assert_not_in
 from lib.asserts import assert_type
 
 NP = points.NamedPosition
@@ -353,7 +348,7 @@ def init(device_name, read_rr_graph):
     global ic
     ic = icebox.iceconfig()
     {
-        #'t4':  ic.setup_empty_t4,
+        # 't4':  ic.setup_empty_t4,
         '8k': ic.setup_empty_8k,
         '5k': ic.setup_empty_5k,
         '1k': ic.setup_empty_1k,
@@ -380,10 +375,10 @@ def add_pin_aliases(g, ic):
     name_rr2local['PLB.lutff_global/clk[0]'] = 'lutff_global/clk'
     name_rr2local['PLB.lutff_global/cen[0]'] = 'lutff_global/cen'
     # FIXME: these two are wrong I think, but don't worry about carry for now
-    #name_rr2local['PLB.FCIN[0]'] = 'lutff_0/cin'
-    #name_rr2local['PLB.FCOUT[0]'] = 'lutff_7/cout'
-    #name_rr2local['PLB.lutff_0_cin[0]'] = 'lutff_0/cin'
-    #name_rr2local['PLB.lutff_7_cout[0]'] = 'lutff_7/cout'
+    # name_rr2local['PLB.FCIN[0]'] = 'lutff_0/cin'
+    # name_rr2local['PLB.FCOUT[0]'] = 'lutff_7/cout'
+    # name_rr2local['PLB.lutff_0_cin[0]'] = 'lutff_0/cin'
+    # name_rr2local['PLB.lutff_7_cout[0]'] = 'lutff_7/cout'
     for luti in range(8):
         name_rr2local['PLB.lutff_{}/out[0]'.format(luti)
                       ] = 'lutff_{}/out'.format(luti)
@@ -849,7 +844,7 @@ def add_track_with_lines(g, ic, segment, lines, connections, hlc_name_f):
         istart, iend = points.straight_ends([p.pos for p in line])
         logging.debug(
             "  %s>%s (%s)", istart, iend, line
-        )  #{n for p, n in named_positions})
+        )
     for ipos, joins in sorted(connections.items()):
         for name_a, name_b in joins:
             logging.debug("  %s %s<->%s", ipos, name_a, name_b)
@@ -875,17 +870,6 @@ def add_track_with_lines(g, ic, segment, lines, connections, hlc_name_f):
         track_node.set_metadata(
             "hlc_coord", "{},{}".format(*istart), offset=Offset(0, 0)
         )
-        # FIXME: Add offset for iend
-
-        # <metadata>
-        #   <meta name="hlc_name">{PI( 0, 1): 'io_1/D_IN_0', PI( 1, 1): 'neigh_op_lft_2,neigh_op_lft_6'}</meta>
-        # </metadata>
-        #
-        # <metadata>
-        #   <meta name="hlc_name" x_offset="0" y_offset="1">io_1/D_IN_0</meta>
-        #   <meta name="hlc_name" x_offset="1" y_offset="1">neigh_op_lft_2</meta>
-        #   <meta name="hlc_name" x_offset="1" y_offset="1">neigh_op_lft_6</meta>
-        # </metadata>
 
         track_fmt = format_node(g, track_node)
         logging.debug(
@@ -960,7 +944,8 @@ def add_track_with_globalname(g, ic, segment, connections, lines, globalname):
 
 
 def add_track_with_localnames(g, ic, segment, connections, lines):
-    """Add tracks to the rr_graph from lines, connections, using local names (from the positions)."""
+    """Add tracks to the rr_graph from lines, connections, using local names (from the positions).
+    """
 
     def hlc_name_f(line, pos):
         for npos in line:
@@ -1048,41 +1033,44 @@ def add_tracks(g, ic, all_group_segments, segtype_filter=None):
 def add_edges(g, ic):
     """Adding edges to the rr_graph from icebox edges."""
     for ipos in list(tiles(ic)):
+
+        """
+        # FIXME: If IO type, connect PACKAGE_PIN_I and PACKAGE_PIN_O manually...
         tile_type = ic.tile_type(*ipos)
         vpos = pos_icebox2vpr(ipos)
 
-        # FIXME: If IO type, connect PACKAGE_PIN_I and PACKAGE_PIN_O manually...
-        ##        if tile_type == "IO":
-        ##            vpr_pio_pos = vpos
-        ##            vpr_pin_pos = pos_icebox2vprpin(ipos)
-        ##            print(tile_type, "pio:", ipos, vpos, "pin:", vpr_pin_pos)
-        ##            if "EMPTY" in g.block_grid[vpr_pin_pos].block_type.name:
-        ##                continue
-        ##
-        ##            print("PIO localnames:", g.routing.localnames[vpr_pio_pos])
-        ##            print("PIN localnames:", g.routing.localnames[vpr_pin_pos])
-        ##            for i in [0, 1]:
-        ##                # pio -> pin
-        ##                pio_iname = "O[{}]".format(i)
-        ##                src_inode = g.routing.localnames[(vpr_pio_pos, pio_iname)]
-        ##                pin_iname = "[{}]O[0]".format(i)
-        ##                dst_inode = g.routing.localnames[(vpr_pin_pos, pin_iname)]
-        ##                edgei = g.routing.create_edge_with_nodes(
-        ##                    src_inode, dst_inode, switch=g.switches["short"])
-        ##                print(vpr_pio_pos, pio_iname, format_node(g, src_inode),
-        ##                      vpr_pin_pos, pin_iname, format_node(g, dst_inode),
-        ##                      edgei)
-        ##
-        ##                # pin -> pio
-        ##                pin_oname = "[{}]I[0]".format(i)
-        ##                src_onode = g.routing.localnames[(vpr_pin_pos, pin_oname)]
-        ##                pio_oname = "I[{}]".format(i)
-        ##                dst_onode = g.routing.localnames[(vpr_pio_pos, pio_oname)]
-        ##                edgeo = g.routing.create_edge_with_nodes(
-        ##                    src_onode, dst_onode, switch=g.switches["short"])
-        ##                print(vpr_pin_pos, pin_oname, format_node(g, src_onode),
-        ##                      vpr_pio_pos, pio_oname, format_node(g, dst_onode),
-        ##                      edgeo)
+        if tile_type == "IO":
+            vpr_pio_pos = vpos
+            vpr_pin_pos = pos_icebox2vprpin(ipos)
+            print(tile_type, "pio:", ipos, vpos, "pin:", vpr_pin_pos)
+            if "EMPTY" in g.block_grid[vpr_pin_pos].block_type.name:
+                continue
+
+            print("PIO localnames:", g.routing.localnames[vpr_pio_pos])
+            print("PIN localnames:", g.routing.localnames[vpr_pin_pos])
+            for i in [0, 1]:
+                # pio -> pin
+                pio_iname = "O[{}]".format(i)
+                src_inode = g.routing.localnames[(vpr_pio_pos, pio_iname)]
+                pin_iname = "[{}]O[0]".format(i)
+                dst_inode = g.routing.localnames[(vpr_pin_pos, pin_iname)]
+                edgei = g.routing.create_edge_with_nodes(
+                    src_inode, dst_inode, switch=g.switches["short"])
+                print(vpr_pio_pos, pio_iname, format_node(g, src_inode),
+                      vpr_pin_pos, pin_iname, format_node(g, dst_inode),
+                      edgei)
+
+                # pin -> pio
+                pin_oname = "[{}]I[0]".format(i)
+                src_onode = g.routing.localnames[(vpr_pin_pos, pin_oname)]
+                pio_oname = "I[{}]".format(i)
+                dst_onode = g.routing.localnames[(vpr_pio_pos, pio_oname)]
+                edgeo = g.routing.create_edge_with_nodes(
+                    src_onode, dst_onode, switch=g.switches["short"])
+                print(vpr_pin_pos, pin_oname, format_node(g, src_onode),
+                      vpr_pio_pos, pio_oname, format_node(g, dst_onode),
+                      edgeo)
+        """
 
         for entry in ic.tile_db(*ipos):
 
@@ -1098,7 +1086,7 @@ def add_edges(g, ic):
                 )
 
             if not ic.tile_has_entry(*ipos, entry):
-                #skip('Non-existent edge!')
+                # skip('Non-existent edge!')
                 continue
 
             switch_type = entry[1]
@@ -1301,7 +1289,7 @@ def main(part, read_rr_graph, write_rr_graph):
     add_tracks(g, ic, segments, segtype_filter="neigh")
     add_tracks(g, ic, segments, segtype_filter="span4")
     add_tracks(g, ic, segments, segtype_filter="span12")
-    #add_global_tracks(g, ic)
+    # add_global_tracks(g, ic)
 
     print()
     print('Adding edges')

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,8 @@
 [flake8]
 max-line-length = 100
 max-doc-lentgh = 100
-ignore = E123, E125, E251, W503, E731, E741
+ignore =
+  E123, # closing bracket indentation mismatch  yapf does this a lot
+  E125, # continuation line indent              yapf does this a lot
+  W503, # line break before binary operator     yapf breaks lines here
+  W504, # line break after binary operator      yapf breaks lines here

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
 max-doc-lentgh = 100
-ignore = E125
+ignore = E123, E125, W503

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 100
 max-doc-lentgh = 100
-ignore = E123, E125, W503
+ignore = E123, E125, E251, W503, E731, E741

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 100
 max-doc-lentgh = 100
+ignore = E125

--- a/utils/check_graph.py
+++ b/utils/check_graph.py
@@ -2,7 +2,6 @@
 
 import argparse
 import re
-from lxml import etree
 from lib.rr_graph import graph
 
 

--- a/utils/conftest.py
+++ b/utils/conftest.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import sys
 
 collect_ignore = [
     "vlog/vlog_to_model.py",  # Can't be imported - Issue #61

--- a/utils/gather_usage.py
+++ b/utils/gather_usage.py
@@ -23,7 +23,7 @@ def main():
     parser.add_argument(
         '--filter',
         required=True,
-        help=
+        help=  # noqa: E251
         "Python regular expression used to filter the complete path to pack.log files."
     )
 

--- a/utils/lib/argparse_extra.py
+++ b/utils/lib/argparse_extra.py
@@ -20,7 +20,7 @@ class ActionStoreBool(argparse.Action):
     True
     >>> parser.parse_args(['--arg', 'no']).arg
     False
-    >>> 
+    >>>
 
     Use like this for a default on argument which can be turned off;
     >>> parser = argparse.ArgumentParser()
@@ -37,7 +37,7 @@ class ActionStoreBool(argparse.Action):
     True
     >>> parser.parse_args(['--arg', 'no']).arg
     False
-    >>> 
+    >>>
 
     Converts the following (in can capitalization) to `True`:
         * yes

--- a/utils/lib/collections_extra.py
+++ b/utils/lib/collections_extra.py
@@ -65,7 +65,7 @@ class MostlyReadOnly:
             current_value = getattr(self, key[1:])
             if new_value == current_value:
                 return
-            elif current_value != None:
+            elif current_value is not None:
                 raise AttributeError(
                     "{} is already set to {}, can't be changed".format(
                         key, current_value

--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -90,7 +90,7 @@ def get_track_model(conn, track_pkey):
     for idx, (pkey, graph_node_type, x_low, x_high, y_low,
               y_high) in enumerate(c2.execute("""
     SELECT pkey, graph_node_type, x_low, x_high, y_low, y_high
-        FROM graph_node WHERE track_pkey = ?""", (track_pkey, ))):
+      FROM graph_node WHERE track_pkey = ?""", (track_pkey, ))):
         node_type = graph2.NodeType(graph_node_type)
         if node_type == graph2.NodeType.CHANX:
             direction = 'X'

--- a/utils/lib/mux.py
+++ b/utils/lib/mux.py
@@ -156,13 +156,17 @@ def pb_type_xml(mux_type, mux_name, pins, subckt=None, num_pb=1, comment=""):
         pb_type_xml.append(ET.Comment(comment))
 
     for port in pins:
-        #assert port.index < port.width, (
-        #    "Pin index {} >= width {} for pin {} {}".format(port.index, port.width, port.name, port.pin_type))
+        assert port.index < port.width, (
+            "Pin index {} >= width {} for pin {} {}".format(
+                port.index, port.width, port.name, port.pin_type
+            )
+        )
         if mux_type == MuxType.ROUTING and port.pin_type == MuxPinType.SELECT:
             continue
 
-        assert port.width == 1 or port.data_width == 1, 'Only one of width(%d) or data_width(%d) may > 1 for pin %s' % (
-            port.width, port.data_width, port.name
+        assert port.width == 1 or port.data_width == 1, (
+            'Only one of width(%d) or data_width(%d) may > 1 for pin %s' %
+            (port.width, port.data_width, port.name)
         )
 
         if port.width == 1 and port.data_width > 1:

--- a/utils/lib/mux.py
+++ b/utils/lib/mux.py
@@ -156,11 +156,11 @@ def pb_type_xml(mux_type, mux_name, pins, subckt=None, num_pb=1, comment=""):
         pb_type_xml.append(ET.Comment(comment))
 
     for port in pins:
-        assert port.index < port.width, (
-            "Pin index {} >= width {} for pin {} {}".format(
-                port.index, port.width, port.name, port.pin_type
-            )
-        )
+        # assert port.index < port.width, (
+        #     "Pin index {} >= width {} for pin {} {}".format(
+        #         port.index, port.width, port.name, port.pin_type
+        #     )
+        # )
         if mux_type == MuxType.ROUTING and port.pin_type == MuxPinType.SELECT:
             continue
 

--- a/utils/lib/parse_route.py
+++ b/utils/lib/parse_route.py
@@ -25,15 +25,15 @@ def find_net_sources(f):
 
     """
     net = None
-    for l in f:
-        tokens = l.strip().split()
+    for e in f:
+        tokens = e.strip().split()
         if not tokens:
             continue
         elif tokens[0][0] == '#':
             continue
         elif tokens[0] == 'Net':
             net = format_name(tokens[2])
-        elif l == "\n\nUsed in local cluster only, reserved one CLB pin\n\n":
+        elif e == "\n\nUsed in local cluster only, reserved one CLB pin\n\n":
             continue
         else:
             if net is not None:

--- a/utils/lib/pb_type.py
+++ b/utils/lib/pb_type.py
@@ -97,10 +97,11 @@ def ports(
         if name not in carry:
             carry[name] = [None, None]
         if in_port is not None:
-            assert carry[name][
-                0] is None, "Can't set {}: Carry {} in port already {}".format(
+            assert carry[name][0] is None, (
+                "Can't set {}: Carry {} in port already {}".format(
                     in_port, name, carry[name][0]
                 )
+            )
             carry[name][0] = in_port
         if out_port is not None:
             assert carry[name][

--- a/utils/lib/rr_graph/__init__.py
+++ b/utils/lib/rr_graph/__init__.py
@@ -113,7 +113,7 @@ class Offset(Size):
     pass
 
 
-O = Offset
+O = Offset  # noqa: E741
 
 
 def single_element(parent, name):

--- a/utils/lib/rr_graph/channel.py
+++ b/utils/lib/rr_graph/channel.py
@@ -60,6 +60,9 @@ class Track(_Track):
     """
 
     class Type(enum.Enum):
+        """
+        subset of NodeType in graph2
+        """
         # Horizontal routing
         X = 'CHANX'
         # Vertical routing

--- a/utils/lib/rr_graph/channel2.py
+++ b/utils/lib/rr_graph/channel2.py
@@ -45,7 +45,7 @@ class Channel(object):
 
     def __init__(self, tracks):
         """
-        
+
         Attributes
         ----------
         tracks : list of tuples of (min, max, idx)

--- a/utils/lib/rr_graph/graph.py
+++ b/utils/lib/rr_graph/graph.py
@@ -48,7 +48,6 @@ from types import MappingProxyType
 import lxml.etree as ET
 
 from . import Position
-from . import P
 from . import Size
 from . import Offset
 from . import node_pos, single_element
@@ -348,7 +347,7 @@ class Pin(MostlyReadOnly):
         >>> str(pin)
         'bt[3](None)->outpad[2]'
 
-        """
+        """  # noqa: E501
         assert_type(text, str)
         block_type_name, port_name, pins = parse_net(text.strip())
         assert pins is not None, text.strip()
@@ -398,7 +397,7 @@ class Pin(MostlyReadOnly):
         'bt(1)->outpad[2]'
         >>> pin.ptc
         1
-        """
+        """  # noqa: E501
         assert pin_node.tag == "pin"
         block_type_index = int(pin_node.attrib["ptc"])
 
@@ -565,7 +564,7 @@ class PinClass(MostlyReadOnly):
         Pin(pin_class=PinClass(), port_name='b', port_index=6, block_type_name='a', block_type_subblk=None, block_type_index=3, side=None)
         >>> pc.pins[2]
         Pin(pin_class=PinClass(), port_name='b', port_index=7, block_type_name='a', block_type_subblk=None, block_type_index=4, side=None)
-        """
+        """  # noqa: E501
         assert_eq(pin_class_node.tag, "pin_class")
         assert "type" in pin_class_node.attrib
         class_direction = getattr(
@@ -606,11 +605,11 @@ class PinClass(MostlyReadOnly):
         if pin.pin_class is not None:
             assert_eq(pin.pin_class, self)
 
-        #if pin.port_name is not None:
-        #    assert_eq(pin.port_name, self.port_name)
+        # if pin.port_name is not None:
+        #     assert_eq(pin.port_name, self.port_name)
 
-        #if pin.port_index is not None:
-        #    assert_not_in(pin.port_index, self.ports_index)
+        # if pin.port_index is not None:
+        #     assert_not_in(pin.port_index, self.ports_index)
 
         if pin.block_type_name is not None:
             assert_eq(pin._block_type_name, self.block_type_name)
@@ -622,11 +621,11 @@ class PinClass(MostlyReadOnly):
 
         self._pins.append(pin)
 
-        #if pin.port_name is None:
-        #    pin._port_name = self.port_name
+        # if pin.port_name is None:
+        #     pin._port_name = self.port_name
 
-        #if pin.port_index is None:
-        #    pin._port_index = dict_next_id(self.block_type._ports[self.port_name])
+        # if pin.port_index is None:
+        #     pin._port_index = dict_next_id(self.block_type._ports[self.port_name])
 
         if pin.block_type_name is None:
             pin._block_type_name = self.block_type_name
@@ -717,7 +716,7 @@ class BlockType(MostlyReadOnly):
         if not extra:
             return "BlockType({name})".format(name=self.name)
         else:
-            return "in 0x{graph_id:x} (pin_classes=[{pin_class_num} classes] pins_index=[{pins_index_num} pins])".format(
+            return "in 0x{graph_id:x} (pin_classes=[{pin_class_num} classes] pins_index=[{pins_index_num} pins])".format(  # noqa: E501
                 graph_id=id(self._graph),
                 pin_class_num=len(self.pin_classes),
                 pins_index_num=len(self.pins_index)
@@ -828,7 +827,7 @@ class BlockType(MostlyReadOnly):
         (Pin(pin_class=PinClass(), port_name='outpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=1, block_type_index=2, side=None),)
         >>> bt.pin_classes[3].pins
         (Pin(pin_class=PinClass(), port_name='inpad', port_index=0, block_type_name='VPR_PAD', block_type_subblk=1, block_type_index=3, side=None),)
-        """
+        """  # noqa: E501
         assert block_type_node.tag == "block_type", block_type_node
         block_type_id = int(block_type_node.attrib['id'])
         block_type_name = block_type_node.attrib['name'].strip()
@@ -844,7 +843,7 @@ class BlockType(MostlyReadOnly):
         return bt
 
     def _could_add_pin(self, pin):
-        if pin.block_type_index != None:
+        if pin.block_type_index is not None:
             if pin.block_type_index in self._pins_index:
                 assert_is(pin, self._pins_index[pin.block_type_index])
 
@@ -986,7 +985,7 @@ class Block(MostlyReadOnly):
         >>> bl2 = Block.from_xml(g, ET.fromstring(xml_string))
         >>> bl2 # doctest: +ELLIPSIS
         Block(graph=BG(0x...), block_type=BlockType(), position=P(x=2, y=5), offset=Offset(w=1, h=2))
-        """
+        """  # noqa: E501
         assert grid_loc_node.tag == "grid_loc"
 
         block_type_id = int(grid_loc_node.attrib["block_type_id"])
@@ -1035,7 +1034,6 @@ class BlockGrid:
         if block_type.id is None:
             block_type.id = self.block_types._next_id()
 
-        bid = block_type.id
         self.block_types.add(block_type)
 
     def add_block(self, block):
@@ -1156,7 +1154,7 @@ class Segment(MostlyReadOnly):
         ... '''
         >>> Segment.from_xml(ET.fromstring(xml_string))
         Segment(id=0, name='span', timing=SegmentTiming(R_per_meter=101.0, C_per_meter=2.25000005e-14))
-        """
+        """  # noqa: E501
         assert_type(segment_xml, ET._Element)
         seg_id = int(segment_xml.get('id'))
         name = segment_xml.get('name')
@@ -1292,7 +1290,7 @@ class Switch(MostlyReadOnly):
           <timing Cin="7.70000012e-16" Cinternal="0" Cout="4.00000001e-15" R="551.0" Tdel="4.00000001e-15"/>
           <sizing buf_size="27.6459007" mux_trans_size="2.63073993"/>
         </switch>
-        """
+        """  # noqa: E501
         assert_type(switch_xml, ET._Element)
         sw_id = int(switch_xml.attrib.get('id'))
         sw_type = SwitchType(switch_xml.attrib.get('type'))
@@ -2035,8 +2033,8 @@ class RoutingGraph:
             ids2element[new_node_id] = xml_node
 
         # FIXME: Make sure the node is included on the XML parent.
-        #if node_id is None:
-        #   pass
+        # if node_id is None:
+        #    pass
         if not existing:
             parent = self._xml_parent(xml_type)
             parent.append(xml_node)
@@ -2255,7 +2253,7 @@ class RoutingGraph:
         ['0 X000Y000[00].SRC--> ->>- 1 X000Y000[00].R-PIN>', '1 X000Y000[00].R-PIN> ->>- 2 X000Y000<-00->X000Y010']
         >>> [RoutingGraphPrinter.edge(r, e) for e in r.edges_for_node(r.get_node_by_id(2))]
         ['1 X000Y000[00].R-PIN> ->>- 2 X000Y000<-00->X000Y010', '2 X000Y000<-00->X000Y010 ->>- 3 X000Y010[00].L-PIN<']
-        """
+        """  # noqa: E501
         return [
             self.get_edge_by_id(i)
             for i in self.edges_for_allnodes()[self._get_xml_id(xml_node)]
@@ -2307,7 +2305,7 @@ class RoutingGraph:
             'capacity': str(capacity),
         }
         if ntype.track:
-            assert direction != None
+            assert direction is not None
             attrib['direction'] = direction.value
         elif not ntype.pin_class:
             assert low == high, (low, high)
@@ -2396,7 +2394,7 @@ class RoutingGraph:
         1 X000Y000[00].R-PIN> b'<node capacity="1" id="1" type="OPIN"><loc ptc="0" side="RIGHT" xhigh="0" xlow="0" yhigh="0" ylow="0"/><timing C="0" R="0"/></node>'
           ->
         4 X000Y010[00].SINK-< b'<node capacity="1" id="4" type="SINK"><loc ptc="0" xhigh="0" xlow="0" yhigh="10" ylow="10"/><timing C="0" R="0"/></node>'
-        """
+        """  # noqa: E501
 
         id2node = self.id2element[RoutingNode]
         assert src_node_id in id2node, src_node_id
@@ -2739,7 +2737,7 @@ class Graph:
         else:
             assert False, "Unknown dir of {}.{}".format(pin, pin.pin_class)
 
-        assert pin_node != None, pin_node
+        assert pin_node is not None, pin_node
 
         if self.verbose:
             print(
@@ -2769,7 +2767,7 @@ class Graph:
         --------
         """
         assert_type(track, Track)
-        assert track.idx != None
+        assert track.idx is not None
 
         track_node = self.routing.create_node(
             track.start,
@@ -2967,7 +2965,7 @@ class Graph:
                         except KeyError:
                             continue
 
-                        assert node != None, "{}:{} not found at {}\n{}".format(
+                        assert node is not None, "{}:{} not found at {}\n{}".format(
                             block, pin.name, list(block.positions),
                             self.routing.localnames
                         )
@@ -2980,8 +2978,6 @@ class Graph:
 
     def to_xml(self):
         """Return an ET object representing this rr_graph"""
-        #et = ET.fromstring('<rr_graph tool_name="g.py" tool_version="dev" tool_comment="Generated from black magic" />')
-        #return et
         self.set_tooling("g.py", "dev", "Generated from black magic")
 
         # <rr_nodes>, <rr_edges>, and <switches> should be good as is
@@ -3120,9 +3116,9 @@ def simple_test_block_grid():
     # Create a block type with one input and one output pin
     bt = BlockType(g=bg, id=0, name="DUALBLK")
     pci = PinClass(block_type=bt, direction=PinClassDirection.INPUT)
-    pi = Pin(pin_class=pci, port_name="A", port_index=0)
+    Pin(pin_class=pci, port_name="A", port_index=0)
     pco = PinClass(block_type=bt, direction=PinClassDirection.OUTPUT)
-    po = Pin(pin_class=pco, port_name="B", port_index=0)
+    Pin(pin_class=pco, port_name="B", port_index=0)
 
     # Create a block type with one input class with 4 pins
     bt = BlockType(g=bg, id=1, name="INBLOCK")
@@ -3346,7 +3342,7 @@ def simple_test_graph(**kwargs):
         <edge src_node="14" sink_node="7" switch_id="0"/>
     </rr_edges>
 </rr_graph>
-"""
+"""  # noqa: E501
     return Graph(io.StringIO(xml_str), **kwargs)
 
 

--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -46,7 +46,7 @@ class NodeDirection(Enum):
 
 
 class PinType(Enum):
-    """ Enum for PinClass type
+    """Enum for PinClass type
     See: https://vtr-verilog-to-routing.readthedocs.io/en/latest/vpr/file_formats.html#tag-blocks-pin_class
     """  # noqa: E501
     NONE = 0
@@ -105,13 +105,13 @@ class Pin(namedtuple('Pin', 'ptc name')):
 
 
 class PinClass(namedtuple('PinClass', 'type pin')):
-    """
+    """Encapsulation for VPR PinClass tag
     See: https://vtr-verilog-to-routing.readthedocs.io/en/latest/vpr/file_formats.html#tag-blocks-pin_class
     """  # noqa: E501
 
 
 class BlockType(namedtuple('BlockType', 'id name width height pin_class')):
-    """
+    """Encapsulation for VPR BlockType tag
     See: https://vtr-verilog-to-routing.readthedocs.io/en/latest/vpr/file_formats.html#tag-blocks-block_type
     """  # noqa: E501
 

--- a/utils/lib/rr_graph/points.py
+++ b/utils/lib/rr_graph/points.py
@@ -189,8 +189,8 @@ class StraightSegment(list):
             return pclass(self[0].x, pos.y)
         elif self.d == StraightSegment.Type.S:
             return pclass(self[0].x, pos.y)
-            #assert pos.x == self[0].x or pos.y == self[0].y, (pos, self)
-            #return pclass(*pos)
+            # assert pos.x == self[0].x or pos.y == self[0].y, (pos, self)
+            # return pclass(*pos)
         assert self.d != StraightSegment.Type.S, self
         assert False, self
 
@@ -542,7 +542,7 @@ def decompose_into_straight_lines(positions):
     >>> print_conns(conns)
     1x16 span4_horz_l_12_to_span4_vert_t_12<->span4_horz_l_12_to_span4_vert_t_12_x
 
-    """
+    """ # noqa: 501
     assert len(positions) > 0, positions
     for pos in positions:
         assert_type(pos, NamedPosition)
@@ -593,7 +593,7 @@ def decompose_into_straight_lines(positions):
                 s.append(connection_p)
             connections[p].append((current_name, new_name))
         s.sort()
-        #print(s)
+        # print(s)
         segments['ALL'].append(s)
         segments[s.d.value].append(s)
 
@@ -617,8 +617,8 @@ def decompose_into_straight_lines(positions):
                 longest, seg = seg, longest
             other.append(seg)
 
-        #assert len(other) == 1, (longest, other)
-        #assert len(longest) > 1, (longest, other)
+        # assert len(other) == 1, (longest, other)
+        # assert len(longest) > 1, (longest, other)
         pointa, pointb = straight_closet(longest, other[0])
         corner_point = longest.extend_to(pointb)
         corner_name = "{}_to_{}".format(pointa.names[0], pointb.names[0])
@@ -769,8 +769,8 @@ def straight_closet(line1, line2):
                 pa, pb = p1, p2
                 min_d = d
 
-    assert pa != None, "{} {}".format(line1, line2)
-    assert pb != None, "{} {}".format(line1, line2)
+    assert pa is not None, "{} {}".format(line1, line2)
+    assert pb is not None, "{} {}".format(line1, line2)
     return pa, pb
 
 

--- a/utils/lib/rr_graph/tests/test_graph.py
+++ b/utils/lib/rr_graph/tests/test_graph.py
@@ -5,7 +5,7 @@ import unittest
 from .. import graph, P, Size
 from ..graph import (
     Pin, PinClass, PinClassDirection, Block, BlockGrid, BlockType, Segment,
-    Switch, SwitchType, RoutingGraph, RoutingGraphPrinter, RoutingNodeType
+    Switch, SwitchType, RoutingGraph, RoutingGraphPrinter
 )
 
 import lxml.etree as ET
@@ -75,11 +75,11 @@ class TestGraph(unittest.TestCase):
         c1 = PinClass(block_type=bt, direction=PinClassDirection.OUTPUT)
         c2 = PinClass(block_type=bt, direction=PinClassDirection.OUTPUT)
         c3 = PinClass(block_type=bt, direction=PinClassDirection.OUTPUT)
-        p0 = Pin(pin_class=c1, port_name="P1", port_index=0)
-        p1 = Pin(pin_class=c2, port_name="P1", port_index=1)
-        p2 = Pin(pin_class=c2, port_name="P1", port_index=2)
-        p3 = Pin(pin_class=c2, port_name="P1", port_index=3)
-        p4 = Pin(pin_class=c3, port_name="P2", port_index=0)
+        Pin(pin_class=c1, port_name="P1", port_index=0)
+        Pin(pin_class=c2, port_name="P1", port_index=1)
+        Pin(pin_class=c2, port_name="P1", port_index=2)
+        Pin(pin_class=c2, port_name="P1", port_index=3)
+        Pin(pin_class=c3, port_name="P2", port_index=0)
         self.assertEqual('P1[0]', c1.port_name)
         self.assertEqual('P1[3:1]', c2.port_name)
         self.assertEqual('P2[0]', c3.port_name)

--- a/utils/lib/rr_graph/tests/test_graph2.py
+++ b/utils/lib/rr_graph/tests/test_graph2.py
@@ -3,9 +3,9 @@ import unittest
 from copy import deepcopy
 
 from ..graph2 import SwitchTiming, SwitchSizing, Switch, SwitchType, \
-        Graph, SegmentTiming, Segment, PinClass, Pin, PinType, \
-        BlockType, GridLoc, NodeTiming, NodeSegment, Node, NodeType, \
-        NodeDirection, NodeLoc
+    Graph, SegmentTiming, Segment, PinClass, Pin, PinType, \
+    BlockType, GridLoc, NodeTiming, NodeSegment, Node, NodeType, \
+    NodeDirection, NodeLoc
 from ..tracks import Track, Direction
 
 

--- a/utils/lib/rr_graph/tests/test_points.py
+++ b/utils/lib/rr_graph/tests/test_points.py
@@ -1,5 +1,5 @@
 import unittest
-from ..points import *
+from ..points import NamedPosition, StraightSegment, Position, NP
 
 
 class NamedPositionTests(unittest.TestCase):
@@ -11,7 +11,7 @@ class NamedPositionTests(unittest.TestCase):
 
     def test_nonstr(self):
         with self.assertRaises(TypeError):
-            namedpos = NamedPosition(Position(0, 1), ["name1", "name2", 2])
+            NamedPosition(Position(0, 1), ["name1", "name2", 2])
 
     def test_first(self):
         namedpos = NamedPosition(Position(0, 1), ["name1", "name2"])

--- a/utils/lib/rr_graph/tracks.py
+++ b/utils/lib/rr_graph/tracks.py
@@ -191,9 +191,8 @@ class Tracks(object):
         if track.direction == 'X':
             pin_top = track.y_low == wire_y
             pin_bottom = track.y_low == wire_y - 1
-            adjacent_channel = (
-                (pin_top or pin_bottom)
-                and (track.x_low <= wire_x and wire_x <= track.x_high)
+            adjacent_channel = (pin_top or pin_bottom) and (
+                track.x_low <= wire_x and wire_x <= track.x_high
             )
 
             if adjacent_channel:
@@ -209,9 +208,8 @@ class Tracks(object):
         elif track.direction == 'Y':
             pin_right = track.x_low == wire_x
             pin_left = track.x_low == wire_x - 1
-            adjacent_channel = (
-                (pin_right or pin_left)
-                and (track.y_low <= wire_y and wire_y <= track.y_high)
+            adjacent_channel = (pin_right or pin_left) and (
+                track.y_low <= wire_y and wire_y <= track.y_high
             )
 
             if adjacent_channel:

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -110,7 +110,7 @@ def enum_from_string(enum_type, s):
 
 def graph_from_xml(input_xml, progressbar=None):
     if progressbar is None:
-        progressbar = lambda x: x
+        progressbar = lambda x: x  # noqa: E731
 
     switches = []
     for switch in input_xml.find('switches').iter('switch'):
@@ -283,7 +283,7 @@ class Graph(object):
             build_pin_edges=True
     ):
         if progressbar is None:
-            progressbar = lambda x: x
+            progressbar = lambda x: x  # noqa: E731
 
         self.input_xml = input_xml
         self.progressbar = progressbar

--- a/utils/listdirs.py
+++ b/utils/listdirs.py
@@ -52,7 +52,7 @@ def main(argv):
     args = parser.parse_args(argv[1:])
 
     if not args.verbose:
-        stderr = lambda *args, **kw: None
+        stderr = lambda *args, **kw: None  # noqa: E731
 
     stderr("Top level directory:", TOPDIR)
 

--- a/utils/listdirs.py
+++ b/utils/listdirs.py
@@ -8,8 +8,6 @@ Excludes the files in the top level .excludes file.
 import argparse
 import fnmatch
 import os.path
-import re
-import subprocess
 import sys
 
 from lib.argparse_extra import ActionStoreBool

--- a/utils/listfiles.py
+++ b/utils/listfiles.py
@@ -9,8 +9,6 @@ import argparse
 import fnmatch
 import logging
 import os.path
-import re
-import subprocess
 import sys
 
 from lib.argparse_extra import ActionStoreBool

--- a/utils/mux_gen.py
+++ b/utils/mux_gen.py
@@ -73,7 +73,7 @@ parser.name_inputs = parser.add_argument(
     '--name-inputs',
     type=str,
     default=None,
-    help=
+    help=  # noqa: E251
     "Comma deliminator list for the name of each input to the mux (implies --split-inputs)."
 )
 
@@ -95,16 +95,16 @@ parser.name_selects = parser.add_argument(
     '--name-selects',
     type=str,
     default=None,
-    help=
+    help=  # noqa: E251
     "Comma deliminator list for the name of each select to the mux (implies --split-selects)."
 )
 
 parser.add_argument(
     '--order',
-    choices=[''.join(x) for x in itertools.permutations('ios')
-             ] + [''.join(x) for x in itertools.permutations('io')],
+    choices=[''.join(x) for x in itertools.permutations('ios')] +
+    [''.join(x) for x in itertools.permutations('io')],
     default='iso',
-    help=
+    help=  # noqa: E251
     """Order of the arguments for the MUX. (i - Inputs, o - Output, s - Select)"""
 )
 

--- a/utils/mux_gen.py
+++ b/utils/mux_gen.py
@@ -8,10 +8,8 @@ MUXes come in two types,
 """
 
 import argparse
-import io
 import itertools
 import lxml.etree as ET
-import math
 import os
 import sys
 
@@ -136,8 +134,6 @@ parser.add_argument(
 
 
 def main(argv):
-    call_args = list(argv)
-
     args = parser.parse_args()
 
     def output_block(name, s):
@@ -168,7 +164,6 @@ def main(argv):
 
     mydir = normpath(os.path.dirname(mypath), to=outdir)
     mux_dir = normpath(os.path.join(mydir, '..', 'vpr', 'muxes'), to=outdir)
-    buf_dir = normpath(os.path.join(mydir, '..', 'vpr', 'buf'), to=outdir)
 
     if args.data_width > 1 and not args.split_inputs:
         assert False, "data_width(%d) > 1 requires using split_inputs" % (
@@ -198,10 +193,9 @@ def main(argv):
         args.split_selects = True
 
         names = args.name_selects.split(',')
-        assert len(names
-                   ) == args.width_bits, "%s select names, but %s needed." % (
-                       names, args.width_bits
-                   )
+        assert len(names) == args.width_bits, (
+            "%s select names, but %s needed." % (names, args.width_bits)
+        )
         args.name_selects = names
     elif args.split_selects:
         args.name_selects = [
@@ -228,12 +222,6 @@ Generated with %s
     model_xml_filename = '%s.model.xml' % args.outfilename
     pbtype_xml_filename = '%s.pb_type.xml' % args.outfilename
     sim_filename = '%s.sim.v' % args.outfilename
-
-    output_files = [
-        model_xml_filename,
-        pbtype_xml_filename,
-        sim_filename,
-    ]
 
     # ------------------------------------------------------------------------
     # Work out the port and their names
@@ -288,8 +276,6 @@ Generated with %s
     # Generate the sim.v Verilog module
     # ------------------------------------------------------------------------
 
-    defs = {'i': 'input wire', 's': 'input wire', 'o': 'output wire'}
-
     sim_pathname = os.path.join(outdir, sim_filename)
     with open(sim_pathname, "w") as f:
         module_args = []
@@ -298,7 +284,6 @@ Generated with %s
                 continue
             module_args.append(port.name)
 
-        mux_prefix = {'logic': '', 'routing': 'r'}[args.type]
         mux_class = {'logic': 'mux', 'routing': 'routing'}[args.type]
 
         f.write("/* ")

--- a/utils/newest.py
+++ b/utils/newest.py
@@ -9,7 +9,6 @@ import sys
 import time
 
 from lib import argparse_extra
-from lib.asserts import assert_eq
 
 parser = argparse.ArgumentParser()
 parser.add_argument(

--- a/utils/print_graph.py
+++ b/utils/print_graph.py
@@ -19,7 +19,7 @@ def print_grid(g):
     bg = g.block_grid
     grid = bg.size
 
-    #print('Grid %dw x %dh' % (grid.width, grid.height))
+    # print('Grid %dw x %dh' % (grid.width, grid.height))
     col_widths = []
     for x in range(0, grid.width):
         col_widths.append(

--- a/utils/reparse_graph.py
+++ b/utils/reparse_graph.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 
 import lib.rr_graph.graph as graph
-import lib.rr_graph.channel as channel
-from lib.rr_graph import Position
-
-import sys
 import lxml.etree as ET
-import os
 
 
 def main():

--- a/utils/tile_splitter/grid.py
+++ b/utils/tile_splitter/grid.py
@@ -205,11 +205,9 @@ class Tile(object):
             Direction to connect other tile.
         """
         if direction_to_other_tile in self.neighboors:
-            assert id(self.neighboors[direction_to_other_tile]
-                      ) == id(other_tile), (
-                          self.neighboors,
-                          direction_to_other_tile,
-                      )
+            assert id(
+                self.neighboors[direction_to_other_tile]
+            ) == id(other_tile), (self.neighboors, direction_to_other_tile)
         self.neighboors[direction_to_other_tile] = other_tile
 
         direction_to_this_tile = opposite_direction(direction_to_other_tile)

--- a/utils/vlog/vlog_to_model.py
+++ b/utils/vlog/vlog_to_model.py
@@ -16,15 +16,16 @@ The following Verilog attributes are considered on modules:
     instance. A model will not be generated for the `lut`, `routing` or `flipflop`
     class.
 """
-import argparse, re, json
-import os, sys
+import argparse
+import os
+import re
+import sys
 
 import lxml.etree as ET
 
 import yosys.run
 from yosys.json import YosysJSON
 
-sys.path.insert(0, "..")
 from lib import xmlinc
 
 
@@ -126,14 +127,16 @@ else:
         top = wm.group(1).upper()
     else:
         print(
-            "ERROR file name not of format %.sim.v ({}), cannot detect top level. Manually specify the top level module using --top"
+            """ERROR file name not of format %.sim.v ({}), cannot detect top level.
+            Manually specify the top level module using --top"""
         ).format(iname)
         sys.exit(1)
     yj = YosysJSON(aig_json, top)
 
 if top is None:
     print(
-        "ERROR: more than one module in design, cannot detect top level. Manually specify the top level module using --top"
+        """ERROR: more than one module in design, cannot detect top level.
+        Manually specify the top level module using --top"""
     )
     sys.exit(1)
 

--- a/utils/vlog/vlog_to_pbtype.py
+++ b/utils/vlog/vlog_to_pbtype.py
@@ -28,7 +28,8 @@ The following are allowed on nets within modules (TODO: use proper Verilog timin
 
     - `(* CLK_TO_Q="clk 10e-12" *)` : specify clock-to-output time for a given clock
 
-    - `(* DELAY_CONST_{input}="30e-12" *)` : specify a constant max delay from an input (applied to the output)
+    - `(* DELAY_CONST_{input}="30e-12" *)` : specify a constant max delay from an input,
+       applied to the output
 
     - `(* DELAY_MATRIX_{input}="30e-12 35e-12; 20e-12 25e-12; ..." *)` : specify a VPR
         delay matrix (semicolons indicate rows). In this format columns specify
@@ -44,15 +45,16 @@ The following are allowed on ports:
 The Verilog define "PB_TYPE" is set during generation.
 """
 
-import os, sys
-import argparse, re
+import argparse
+import os
+import re
+import sys
 
 import lxml.etree as ET
 
 import yosys.run
 from yosys.json import YosysJSON
 
-sys.path.insert(0, "..")
 from lib import xmlinc
 
 parser = argparse.ArgumentParser(
@@ -110,8 +112,8 @@ else:
         top = wm.group(1).upper()
     else:
         print(
-            "ERROR file name not of format %.sim.v ({}), cannot detect top level. Manually specify the top level module using --top"
-            .format(iname)
+            """ERROR file name not of format %.sim.v ({}), cannot detect top level.
+            Manually specify the top level module using --top""".format(iname)
         )
         sys.exit(1)
 
@@ -156,7 +158,7 @@ def mod_pb_name(mod):
     elif is_mod_blackbox(mod) and not has_modes:
         return mod.name
     else:
-        #TODO: other types
+        # TODO: other types
         return mod.name
 
 
@@ -222,8 +224,8 @@ def make_pb_content(yj, mod, xml_parent, mod_pname, is_submode=False):
 
         dir_xml = ET.SubElement(ic_xml, 'direct')
 
-        s_port_xml = ET.SubElement(dir_xml, 'port', s_port)
-        d_port_xml = ET.SubElement(dir_xml, 'port', d_port)
+        ET.SubElement(dir_xml, 'port', s_port)
+        ET.SubElement(dir_xml, 'port', d_port)
 
     # Find out whether or not the module we are generating content for is a blackbox
     is_blackbox = is_mod_blackbox(mod) or not mod.cells
@@ -333,8 +335,8 @@ def make_pb_content(yj, mod, xml_parent, mod_pname, is_submode=False):
                 for sink_cell, sink_pin in sinks:
                     if sink_cell != mod.name:
                         continue
-                    # Only consider outputs from cell to top level IO. Inputs to other cells will be dealt with
-                    # in those cells.
+                    # Only consider outputs from cell to top level IO. Inputs to
+                    # other cells will be dealt with in those cells.
                     interconn.append(
                         (
                             (cname, pin), (sink_cell, sink_pin), instance,
@@ -546,8 +548,9 @@ def main(args):
             top = wm.group(1).upper()
         else:
             print(
-                "ERROR file name not of format %.sim.v ({}), cannot detect top level. Manually specify the top level module using --top"
-                .format(iname)
+                """ERROR file name not of format %.sim.v ({}), cannot detect top level.
+                Manually specify the top level module using --top""".
+                format(iname)
             )
             sys.exit(1)
 

--- a/utils/vlog/yosys/json.py
+++ b/utils/vlog/yosys/json.py
@@ -6,7 +6,6 @@ and/or in AIG format. In any case, at minimum `proc` and usually `prep` should
 be used before outputting the JSON.
 """
 
-import os, sys
 import json
 import pprint
 
@@ -124,7 +123,6 @@ class YosysModule:
 
     def net_attr(self, netname, attr, defval=None):
         """Get an attribute of a given net (specified by name), or defval is not set"""
-        pnet = None
         if attr in self.net_attrs(netname):
             return self.net_attrs(netname)[attr]
         else:

--- a/utils/vlog/yosys/run.py
+++ b/utils/vlog/yosys/run.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
-import os, subprocess, re
-import tempfile, json
+import json
+import os
+import re
+import subprocess
+import tempfile
 import yosys.utils
 
 
@@ -73,7 +76,8 @@ def add_define(defname):
 
 
 def get_defines():
-    """Return a list of set Verilog defines, as a list of arguments to pass to Yosys `read_verilog`"""
+    """Return a list of set Verilog defines, as a list of arguments to pass to Yosys
+`read_verilog`"""
     return " ".join(["-D" + _ for _ in defines])
 
 
@@ -83,7 +87,8 @@ def add_include(path):
 
 
 def get_includes():
-    """Return a list of include directories, as a list of arguments to pass to Yosys `read_verilog`"""
+    """Return a list of include directories, as a list of arguments to pass to Yosys
+`read_verilog`"""
     return " ".join(["-I" + _ for _ in includes])
 
 

--- a/utils/vpr_pbtype_arch_wrapper.py
+++ b/utils/vpr_pbtype_arch_wrapper.py
@@ -167,7 +167,7 @@ def layout_xml(arch_xml: ET.Element, pbtype_xml: ET.Element) -> int:
     width, height = grid_size(tiles)
 
     layouts = arch_xml.find("layout")
-    l = ET.SubElement(
+    layout = ET.SubElement(
         layouts,
         "fixed_layout",
         {
@@ -179,7 +179,7 @@ def layout_xml(arch_xml: ET.Element, pbtype_xml: ET.Element) -> int:
             "height": str(max(width, height)),
         },
     )
-    l.append(ET.Comment('\n' + grid_format(tiles) + '\n'))
+    layout.append(ET.Comment('\n' + grid_format(tiles) + '\n'))
 
     for x, y in tiles.keys():
         v = tiles[(x, y)]
@@ -197,7 +197,7 @@ def layout_xml(arch_xml: ET.Element, pbtype_xml: ET.Element) -> int:
         else:
             raise Exception("Unknown tile type {}".format(v))
         ET.SubElement(
-            l, "single", {
+            layout, "single", {
                 "type": t,
                 "priority": "1",
                 "x": str(x),

--- a/utils/vpr_pbtype_arch_wrapper.py
+++ b/utils/vpr_pbtype_arch_wrapper.py
@@ -15,13 +15,13 @@ import subprocess
 import sys
 import tempfile
 
-from typing import List, Dict, Sequence, Tuple
+from typing import List, Dict, Tuple
 
 import lxml.etree as ET
 
 from lib import xmlinc
 from lib.flatten import flatten
-from lib.pb_type import ports, find_leaf, Port
+from lib.pb_type import ports, find_leaf
 
 FILEDIR_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__)))
 TEMPLATE_PATH = os.path.abspath(
@@ -173,8 +173,8 @@ def layout_xml(arch_xml: ET.Element, pbtype_xml: ET.Element) -> int:
         {
             "name": "device",
             # FIXME: See https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/277
-            #"width":  str(width),
-            #"height":  str(height),
+            # "width":  str(width),
+            # "height":  str(height),
             "width": str(max(width, height)),
             "height": str(max(width, height)),
         },
@@ -283,7 +283,7 @@ def tile_xml(
 
     # Clock pins
     for d, s in flatten(clocks):
-        input_tag = ET.SubElement(
+        ET.SubElement(
             tile,
             "clock",
             {
@@ -307,7 +307,7 @@ def tile_xml(
 
     # Input Pins
     for d, s in flatten(inputs):
-        input_tag = ET.SubElement(
+        ET.SubElement(
             tile,
             "input",
             {
@@ -331,7 +331,7 @@ def tile_xml(
 
     # Output Pins
     for s, d in flatten(outputs):
-        output_tag = ET.SubElement(
+        ET.SubElement(
             tile,
             "output",
             {

--- a/utils/vpr_pbtype_to_eblif.py
+++ b/utils/vpr_pbtype_to_eblif.py
@@ -9,12 +9,9 @@ of v2x_test_both cmake function).
 """
 
 import argparse
-import math
 import os
 import os.path
-import subprocess
 import sys
-import tempfile
 
 from typing import List
 


### PR DESCRIPTION
Address various issues. Added some ignores so it doesn't conflict with yapf style

Ignored/Exceptions:
 - E123 closing bracket does not match indentation of opening bracket’s line
 - E125 continuation line with same indent as next logical line
 - E251 unexpected spaces around keyword / parameter equals
 - W503 line break before binary operator
 - E731 do not assign a lambda expression, use a def
 - E741 [Do not use variables named 'l', 'o', or 'i'](https://www.python.org/dev/peps/pep-0008/#names-to-avoid)

Also changed v2x to add `utils` to `PYTHONPATH`
