### PR TITLE
Add testbench for ERROR_OUTPUT_LOGIC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ setup_env(
 add_conda_package(
   NAME yosys
   PROVIDES yosys
-  PACKAGE_SPEC "yosys 0.8_1059_g996d4e82 20190516_233014"
+  PACKAGE_SPEC "yosys 0.8_1161_g8d943b4c 20190531_112316"
   )
 add_conda_package(
   NAME openocd

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -1277,6 +1277,12 @@ function(ADD_FPGA_TARGET)
       SOURCES ${ADD_FPGA_TARGET_SOURCES} ${TESTBENCH}
       )
 
+    add_testbench(
+      NAME testbench_synth_${TESTBENCH_NAME}
+      ARCH ${ARCH}
+      SOURCES ${OUT_LOCAL_REL}/${TOP}_synth.v ${TESTBENCH}
+      )
+
     if(NOT ${NO_BIT_TO_V})
       add_testbench(
         NAME testbinch_${TESTBENCH_NAME}

--- a/tests/7-carry_stress/generate_carry_test.py
+++ b/tests/7-carry_stress/generate_carry_test.py
@@ -30,7 +30,7 @@ module LFSR (
     );
     parameter POLY = 1;
 
-    reg [{depth}-1:0] r;
+    reg [{depth}-1:0] r = 1;
     assign out = r;
     wire f;
     assign f = ^(POLY & ~r);

--- a/xc7/tests/common/CMakeLists.txt
+++ b/xc7/tests/common/CMakeLists.txt
@@ -1,6 +1,28 @@
 add_file_target(FILE basys3.pcf)
 add_file_target(FILE basys3.sdc)
+
 add_file_target(FILE error_output_logic.v SCANNER_TYPE verilog)
+add_file_target(FILE error_output_logic_unt.v SCANNER_TYPE verilog)
+add_file_target(FILE error_output_logic_tb.v SCANNER_TYPE verilog)
+
+add_fpga_target(
+    NAME error_output_logic_test
+    BOARD basys3
+    INPUT_IO_FILE basys3.pcf
+    SOURCES
+        error_output_logic_unt.v
+        error_output_logic.v
+    TESTBENCH_SOURCES
+        error_output_logic_tb.v
+    EXPLICIT_ADD_FILE_TARGET
+)
+
+add_dependencies(all_xc7_tests
+    testbench_error_output_logic_tb
+    testbench_synth_error_output_logic_tb
+    testbinch_error_output_logic_tb
+    )
+
 add_file_target(FILE ram_shifter.v SCANNER_TYPE verilog)
 add_file_target(FILE ram_test.v SCANNER_TYPE verilog)
 add_file_target(FILE rom_test.v SCANNER_TYPE verilog)

--- a/xc7/tests/common/error_output_logic.v
+++ b/xc7/tests/common/error_output_logic.v
@@ -129,14 +129,14 @@ module ERROR_OUTPUT_LOGIC #(
                 end
                 CR: begin
                     if(!tx_data_ready) begin
-                        tx_data <= 8'h0D;
+                        tx_data <= 8'h0D; // "\r"
                         tx_data_ready <= 1;
                         state <= LF;
                     end
                 end
                 LF: begin
                     if(!tx_data_ready) begin
-                        tx_data <= 8'h0A;
+                        tx_data <= 8'h0A; // "\n"
                         tx_data_ready <= 1;
                         state <= START;
                     end

--- a/xc7/tests/common/error_output_logic.v
+++ b/xc7/tests/common/error_output_logic.v
@@ -1,6 +1,6 @@
 module ERROR_OUTPUT_LOGIC #(
-    parameter DATA_WIDTH = 1,
-    parameter ADDR_WIDTH = 6
+    parameter [7:0] DATA_WIDTH = 1,
+    parameter [7:0] ADDR_WIDTH = 6
 ) (
     input rst,
     input clk,
@@ -25,6 +25,11 @@ module ERROR_OUTPUT_LOGIC #(
 
     reg [7:0] error_count;
     reg [7:0] output_shift;
+
+    wire [7:0] next_output_shift = output_shift + 8;
+    wire count_shift_done = next_output_shift >= 8'd16;
+    wire address_shift_done = next_output_shift >= ADDR_WIDTH;
+    wire data_shift_done = next_output_shift >= DATA_WIDTH;
 
     reg loop_ready;
     reg [7:0] latched_error_count;
@@ -54,6 +59,7 @@ module ERROR_OUTPUT_LOGIC #(
             tx_data_ready <= 0;
             tx_data <= 8'b0;
             loop_count <= 0;
+            loop_ready <= 0;
         end else begin
 
             if(error_detected) begin
@@ -112,25 +118,25 @@ module ERROR_OUTPUT_LOGIC #(
                         tx_data <= (latched_loop_count >> output_shift);
                         tx_data_ready <= 1;
 
-                        if(output_shift + 8 >= 16) begin
+                        if(count_shift_done) begin
                             output_shift <= 0;
                             loop_ready <= 0;
                             state <= CR;
                         end else begin
-                            output_shift <= output_shift + 8;
+                            output_shift <= next_output_shift;
                         end
                     end
                 end
                 CR: begin
                     if(!tx_data_ready) begin
-                        tx_data <= "\r";
+                        tx_data <= 8'h0D;
                         tx_data_ready <= 1;
                         state <= LF;
                     end
                 end
                 LF: begin
                     if(!tx_data_ready) begin
-                        tx_data <= "\n";
+                        tx_data <= 8'h0A;
                         tx_data_ready <= 1;
                         state <= START;
                     end
@@ -155,11 +161,11 @@ module ERROR_OUTPUT_LOGIC #(
                         tx_data <= (reg_error_address >> output_shift);
                         tx_data_ready <= 1;
 
-                        if(output_shift + 8 >= ADDR_WIDTH) begin
+                        if(address_shift_done) begin
                             output_shift <= 0;
                             state <= ERROR_EXPECTED_DATA;
                         end else begin
-                            output_shift <= output_shift + 8;
+                            output_shift <= next_output_shift;
                         end
                     end
                 end
@@ -168,11 +174,11 @@ module ERROR_OUTPUT_LOGIC #(
                         tx_data <= (reg_expected_data >> output_shift);
                         tx_data_ready <= 1;
 
-                        if(output_shift + 8 >= DATA_WIDTH) begin
+                        if(data_shift_done) begin
                             output_shift <= 0;
                             state <= ERROR_ACTUAL_DATA;
                         end else begin
-                            output_shift <= output_shift + 8;
+                            output_shift <= next_output_shift;
                         end
                     end
                 end
@@ -181,7 +187,7 @@ module ERROR_OUTPUT_LOGIC #(
                         tx_data <= (reg_actual_data >> output_shift);
                         tx_data_ready <= 1;
 
-                        if(output_shift + 8 >= DATA_WIDTH) begin
+                        if(data_shift_done) begin
                             state <= CR;
                             reg_error_detected <= 0;
                         end else begin

--- a/xc7/tests/common/error_output_logic_tb.v
+++ b/xc7/tests/common/error_output_logic_tb.v
@@ -1,0 +1,182 @@
+`timescale 1ns/1ps
+`default_nettype none
+
+`ifndef VCDFILE
+`define VCDFILE "testbench_error_output_logic_tb.vcd"
+`endif
+
+module test;
+
+`include "../../../library/tbassert.v"
+
+localparam ADDR_WIDTH = 10;
+localparam DATA_WIDTH = 1;
+
+reg [0:0] rst = 1'b0;
+reg [0:0] clk = 1'b0;
+
+reg [0:0] loop_complete = 1'b0;
+reg [0:0] error_detected = 1'b0;
+reg [7:0] error_state = 8'b0;
+reg [ADDR_WIDTH-1:0] error_address = {ADDR_WIDTH{1'b0}};
+reg [DATA_WIDTH-1:0] expected_data = {DATA_WIDTH{1'b0}};
+
+// Output to UART
+reg [0:0] tx_data_accepted = 1'b0;
+wire [0:0] tx_data_ready;
+wire [7:0] tx_data;
+
+// clock generation
+always #1 clk=~clk;
+
+wire [15:0] sw;
+wire [15:0] led;
+wire tx;
+wire rx;
+
+assign sw[0] = rst;
+assign sw[1] = loop_complete;
+assign sw[2] = error_detected;
+assign sw[4:3] = error_state[1:0];
+assign sw[14:5] = error_address;
+assign sw[15] = expected_data;
+assign rx = tx_data_accepted;
+
+assign tx_data = led[7:0];
+assign tx_data_ready = led[8];
+
+top unt(
+    .clk(clk),
+    .rx(rx),
+    .tx(tx),
+    .sw(sw),
+    .led(led)
+);
+
+initial begin
+    $dumpfile(`VCDFILE);
+    $dumpvars;
+#1.1 // 1
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 2
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+    rst = 1;
+#1 // 3
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 4
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+    rst = 0;
+#1 // 5
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 6 : Test simple output
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+    loop_complete = 1;
+#2 // 8
+    loop_complete = 0;
+#3 // 11
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == "L", "Check data value!");
+#1 // 12
+    tbassert(!clk, "Clock!");
+    loop_complete = 0;
+    tx_data_accepted = 1;
+#1 // 13
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 14
+    tbassert(!clk, "Clock!");
+#1 // 15
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'b0, "Check data value!");
+#4 // 19
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'b0, "Check data value!");
+#4 // 23
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'b0, "Check data value!");
+#4 // 27
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'h0D, "Check data value!");
+#4 // 31
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'h0A, "Check data value!");
+#3 // 34 : Check no extra data
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 35
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 36
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 37
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 38
+    tbassert(!clk, "Clock!");
+    error_detected = 1;
+    error_state = 8'b10;
+    error_address = 10'h3EF;
+    expected_data = 1;
+#2 // 39
+    error_detected = 0;
+#3 // 39
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == "E", "Check data value!");
+#4 // 43
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'b10, "Check error state!");
+#4 // 47
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'hEF, "Check addr[0] state!");
+#4 // 51
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'h03, "Check addr[1] state!");
+#4 // 55
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'b1, "Check expected data[0] state!");
+#4 // 59
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'b0, "Check actual data[0] state!");
+#4 // 63
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'h0D, "Check data value!");
+#4 // 67
+    tbassert(clk, "Clock!");
+    tbassert(tx_data_ready, "Data!");
+    tbassert(tx_data == 8'h0A, "Check data value!");
+#3 // 70 : Check no extra data
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 71
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 72
+    tbassert(!clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1 // 73
+    tbassert(clk, "Clock!");
+    tbassert(!tx_data_ready, "No data");
+#1  $finish;
+end
+
+endmodule

--- a/xc7/tests/common/error_output_logic_unt.v
+++ b/xc7/tests/common/error_output_logic_unt.v
@@ -24,13 +24,10 @@ ERROR_OUTPUT_LOGIC #(
     .actual_data({1'b0}),
     .tx_data_accepted(rx),
     .tx_data_ready(led[8]),
-    .tx_data(led[7:0]),
-    .count_shift_done_out(led[9]),
-    .address_shift_done_out(led[10]),
-    .data_shift_done_out(led[11])
+    .tx_data(led[7:0])
 );
 
-assign led[15:12] = sw[15:12];
+assign led[15:9] = sw[15:9];
 assign tx = sw[0];
 
 endmodule

--- a/xc7/tests/common/error_output_logic_unt.v
+++ b/xc7/tests/common/error_output_logic_unt.v
@@ -1,0 +1,36 @@
+// Until the ROI is removed, using the common basys3 structure is the easiest 
+// way to test post-PnR designs.
+// One the ROI is removed, any top level can be used, and only the clk pin
+// need be set during placement.
+module top (
+    input clk,
+    input rx,
+    output tx,
+    input [15:0] sw,
+    output [15:0] led
+);
+
+ERROR_OUTPUT_LOGIC #(
+    .ADDR_WIDTH(10),
+    .DATA_WIDTH(1)
+) unt (
+    .rst(sw[0]),
+    .clk(clk),
+    .loop_complete(sw[1]),
+    .error_detected(sw[2]),
+    .error_state(sw[4:3]),
+    .error_address(sw[14:5]),
+    .expected_data(sw[15]),
+    .actual_data({1'b0}),
+    .tx_data_accepted(rx),
+    .tx_data_ready(led[8]),
+    .tx_data(led[7:0]),
+    .count_shift_done_out(led[9]),
+    .address_shift_done_out(led[10]),
+    .data_shift_done_out(led[11])
+);
+
+assign led[15:12] = sw[15:12];
+assign tx = sw[0];
+
+endmodule


### PR DESCRIPTION
It is worth noting that none of the changes to error_output_logic.v changes synthesis, it just adds names to nets for ease of debugging.  The fix for the broken DRAM test was https://github.com/SymbiFlow/yosys/pull/29.

This PR will fail on CI until a yosys with https://github.com/SymbiFlow/yosys/pull/29 is included.