### PR TITLE
v2x: Make capitalization consistent.

### DIFF
--- a/common/cmake/xml.cmake
+++ b/common/cmake/xml.cmake
@@ -51,6 +51,7 @@ set(XML_CANONICALIZE_MERGE_FILES
   common/xml/pack-patterns.xsl
   common/xml/remove-duplicate-models.xsl
   common/xml/attribute-fixes.xsl
+  common/xml/sort-tags.xsl
   )
 
 set(XML_CANONICALIZE_DEPS "")

--- a/common/xml/convert_and_merge_composable_fpga_architecture.sh
+++ b/common/xml/convert_and_merge_composable_fpga_architecture.sh
@@ -11,4 +11,5 @@ ${XSLTPROC_CMD} ${TOP_DIR}/common/xml/identity.xsl "$@"				  | \
 	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/pack-patterns.xsl	 		- | \
 	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/remove-duplicate-models.xsl 	- | \
 	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/attribute-fixes.xsl 		- | \
+	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/sort-tags.xsl 			- | \
 	cat

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-existing-fasm-mux.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-existing-fasm-mux.golden.xml
@@ -17,6 +17,15 @@
      </meta>
         </metadata>
       </direct>
+      <mux input="COMMON_SLICE.AO5 COMMON_SLICE.AX" name="CARRY_DI0" output="CARRY4_VPR.DI0">
+        <metadata>
+          <meta name="fasm_mux">
+      COMMON_SLICE.AO5 = CARRY4.ACY0
+      COMMON_SLICE.AX = NULL
+     </meta>
+        </metadata>
+        <delay_constant in_port="COMMON_SLICE.AX" max=".105e-9" out_port="CARRY4_VPR.DI0"/>
+      </mux>
       <mux input="CARRY4_VPR.O3 CARRY4_VPR.CO_FABRIC3 COMMON_SLICE.DO6 COMMON_SLICE.DO5 COMMON_SLICE.DX" name="DFFMUX" output="SLICE_FF.D[3]">
         <metadata>
           <meta name="fasm_mux">
@@ -27,15 +36,6 @@
       CARRY4_VPR.O3 = DFFMUX.XOR
      </meta>
         </metadata>
-      </mux>
-      <mux input="COMMON_SLICE.AO5 COMMON_SLICE.AX" name="CARRY_DI0" output="CARRY4_VPR.DI0">
-        <metadata>
-          <meta name="fasm_mux">
-      COMMON_SLICE.AO5 = CARRY4.ACY0
-      COMMON_SLICE.AX = NULL
-     </meta>
-        </metadata>
-        <delay_constant in_port="COMMON_SLICE.AX" max=".105e-9" out_port="CARRY4_VPR.DI0"/>
       </mux>
     </interconnect>
   </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-fasm-mux.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-fasm-mux.golden.xml
@@ -9,7 +9,6 @@
       <output name="o"/>
     </pb_type>
     <interconnect>
-      <direct input="child.o" name="parent-o" output="parent.o"/>
       <mux input="parent.i0 parent.i1" name="mux1" output="child.i">
         <metadata>
           <meta name="fasm_mux">
@@ -19,6 +18,7 @@ parent.i1 : b1
           <meta name="fasm_name">fasm_name</meta>
         </metadata>
       </mux>
+      <direct input="child.o" name="parent-o" output="parent.o"/>
     </interconnect>
   </pb_type>
 </xml>

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-implicit-parent.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-implicit-parent.golden.xml
@@ -27,9 +27,9 @@
         <pack_pattern in_port="parent.ia2" name="A2" out_port="childa.i2"/>
         <pack_pattern in_port="parent.ia3" name="A3" out_port="childa.i2"/>
       </mux>
-      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <direct input="childa.o" name="childb-i" output="childb.i"/>
       <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
+      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <mux input="childa.o childb.o childc.o" name="output" output="parent.o1"/>
     </interconnect>
   </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-pack_patterns.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-pack_patterns.golden.xml
@@ -22,9 +22,9 @@
     <interconnect>
       <direct input="parent.ia1" name="childa-i1" output="childa.i1"/>
       <mux input="parent.ia2 parent.ia3" name="childa-input-i2" output="childa.i2"/>
-      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <direct input="childa.o" name="childb-i" output="childb.i"/>
       <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
+      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <mux input="childa.o childb.o childc.o" name="output" output="parent.o1"/>
     </interconnect>
   </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-pb_type.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-pb_type.golden.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="top" num_pb="1">
-  <pb_type blif_model=".subckt random" class="lut" name="top_inner" num_pb="1">
-    <other_tag/>
-  </pb_type>
   <pb_type name="middle" num_pb="1">
     <pb_type blif_model=".subckt random" class="lut" name="middle_inner" num_pb="1">
       <other_tag/>
     </pb_type>
+  </pb_type>
+  <pb_type blif_model=".subckt random" class="lut" name="top_inner" num_pb="1">
+    <other_tag/>
   </pb_type>
 </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/full-test.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/full-test.golden.xml
@@ -38,46 +38,46 @@
     <T_clock_to_Q clock="clk" max="10e-12" port="combb.cout"/>
   </pb_type>
   <interconnect>
-    <direct input="MULTIPLE_INSTANCE.a[3]" name="comba[3]-a" output="comba[3].a"/>
-    <direct input="MULTIPLE_INSTANCE.b[3]" name="comba[3]-b" output="comba[3].b"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[0]-cin" output="comba[0].cin"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[1]-cin" output="comba[1].cin"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[2]-cin" output="comba[2].cin"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[3]-cin" output="comba[3].cin"/>
+    <direct input="combb[3].cout" name="MULTIPLE_INSTANCE-cout" output="MULTIPLE_INSTANCE.cout"/>
+    <direct input="comba[0].sum" name="MULTIPLE_INSTANCE-sum[0]" output="MULTIPLE_INSTANCE.sum[0]"/>
+    <direct input="comba[1].sum" name="MULTIPLE_INSTANCE-sum[1]" output="MULTIPLE_INSTANCE.sum[1]"/>
+    <direct input="comba[2].sum" name="MULTIPLE_INSTANCE-sum[2]" output="MULTIPLE_INSTANCE.sum[2]"/>
     <direct input="comba[3].sum" name="MULTIPLE_INSTANCE-sum[3]" output="MULTIPLE_INSTANCE.sum[3]"/>
+    <direct input="combb[0].sum" name="MULTIPLE_INSTANCE-sum[4]" output="MULTIPLE_INSTANCE.sum[4]"/>
+    <direct input="combb[1].sum" name="MULTIPLE_INSTANCE-sum[5]" output="MULTIPLE_INSTANCE.sum[5]"/>
+    <direct input="combb[2].sum" name="MULTIPLE_INSTANCE-sum[6]" output="MULTIPLE_INSTANCE.sum[6]"/>
+    <direct input="combb[3].sum" name="MULTIPLE_INSTANCE-sum[7]" output="MULTIPLE_INSTANCE.sum[7]"/>
     <direct input="MULTIPLE_INSTANCE.a[0]" name="comba[0]-a" output="comba[0].a"/>
     <direct input="MULTIPLE_INSTANCE.b[0]" name="comba[0]-b" output="comba[0].b"/>
-    <direct input="comba[0].sum" name="MULTIPLE_INSTANCE-sum[0]" output="MULTIPLE_INSTANCE.sum[0]"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[0]-cin" output="comba[0].cin"/>
     <direct input="MULTIPLE_INSTANCE.a[1]" name="comba[1]-a" output="comba[1].a"/>
     <direct input="MULTIPLE_INSTANCE.b[1]" name="comba[1]-b" output="comba[1].b"/>
-    <direct input="comba[1].sum" name="MULTIPLE_INSTANCE-sum[1]" output="MULTIPLE_INSTANCE.sum[1]"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[1]-cin" output="comba[1].cin"/>
     <direct input="MULTIPLE_INSTANCE.a[2]" name="comba[2]-a" output="comba[2].a"/>
     <direct input="MULTIPLE_INSTANCE.b[2]" name="comba[2]-b" output="comba[2].b"/>
-    <direct input="comba[2].sum" name="MULTIPLE_INSTANCE-sum[2]" output="MULTIPLE_INSTANCE.sum[2]"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[2]-cin" output="comba[2].cin"/>
+    <direct input="MULTIPLE_INSTANCE.a[3]" name="comba[3]-a" output="comba[3].a"/>
+    <direct input="MULTIPLE_INSTANCE.b[3]" name="comba[3]-b" output="comba[3].b"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[3]-cin" output="comba[3].cin"/>
     <direct input="MULTIPLE_INSTANCE.c[0]" name="combb[0]-a" output="combb[0].a"/>
     <direct input="MULTIPLE_INSTANCE.d[0]" name="combb[0]-b" output="combb[0].b"/>
     <direct input="comba[0].cout" name="combb[0]-cin" output="combb[0].cin">
       <pack_pattern in_port="comba[0].cout" name="carry-ADDER" out_port="combb[0].cin"/>
     </direct>
-    <direct input="combb[0].sum" name="MULTIPLE_INSTANCE-sum[4]" output="MULTIPLE_INSTANCE.sum[4]"/>
     <direct input="MULTIPLE_INSTANCE.c[1]" name="combb[1]-a" output="combb[1].a"/>
     <direct input="MULTIPLE_INSTANCE.d[1]" name="combb[1]-b" output="combb[1].b"/>
     <direct input="comba[1].cout" name="combb[1]-cin" output="combb[1].cin">
       <pack_pattern in_port="comba[1].cout" name="carry-ADDER" out_port="combb[1].cin"/>
     </direct>
-    <direct input="combb[1].sum" name="MULTIPLE_INSTANCE-sum[5]" output="MULTIPLE_INSTANCE.sum[5]"/>
     <direct input="MULTIPLE_INSTANCE.c[2]" name="combb[2]-a" output="combb[2].a"/>
     <direct input="MULTIPLE_INSTANCE.d[2]" name="combb[2]-b" output="combb[2].b"/>
     <direct input="comba[2].cout" name="combb[2]-cin" output="combb[2].cin">
       <pack_pattern in_port="comba[2].cout" name="carry-ADDER" out_port="combb[2].cin"/>
     </direct>
-    <direct input="combb[2].sum" name="MULTIPLE_INSTANCE-sum[6]" output="MULTIPLE_INSTANCE.sum[6]"/>
     <direct input="MULTIPLE_INSTANCE.c[3]" name="combb[3]-a" output="combb[3].a"/>
     <direct input="MULTIPLE_INSTANCE.d[3]" name="combb[3]-b" output="combb[3].b"/>
     <direct input="comba[3].cout" name="combb[3]-cin" output="combb[3].cin">
       <pack_pattern in_port="comba[3].cout" name="carry-ADDER" out_port="combb[3].cin"/>
     </direct>
-    <direct input="combb[3].cout" name="MULTIPLE_INSTANCE-cout" output="MULTIPLE_INSTANCE.cout"/>
-    <direct input="combb[3].sum" name="MULTIPLE_INSTANCE-sum[7]" output="MULTIPLE_INSTANCE.sum[7]"/>
   </interconnect>
 </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/pack_pattern-copy-direct-ports.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/pack_pattern-copy-direct-ports.golden.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <xml>
   <interconnect>
-    <direct input="SB_FF.D" name="VPR_FF-D" output="VPR_FF.D">
-      <pack_pattern in_port="SB_FF.D" name="A" out_port="VPR_FF.D"/>
-    </direct>
     <direct input="LUTFF.FCIN" name="SB_CARRY-CI" output="SB_CARRY.CI">
       <pack_pattern in_port="LUTFF.FCIN" name="CARRYCHAIN" out_port="SB_CARRY.CI"/>
+    </direct>
+    <direct input="SB_FF.D" name="VPR_FF-D" output="VPR_FF.D">
+      <pack_pattern in_port="SB_FF.D" name="A" out_port="VPR_FF.D"/>
     </direct>
   </interconnect>
 </xml>

--- a/common/xml/convert_and_merge_composable_tests/preserve-interconnect.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/preserve-interconnect.golden.xml
@@ -25,11 +25,11 @@
         <pack_pattern in_port="parent.ia2" name="MUX1" output="childa.i2"/>
         <pack_pattern in_port="parent.ia3" name="MUX2" output="childa.i2"/>
       </mux>
+      <direct input="childa.o" name="childb-i" output="childb.i"/>
+      <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
       <direct input="childa.o" name="parent-o0" output="parent.o0">
         <pack_pattern in_port="childa.o" name="CARRY" out_port="parent.o0" output="parent.o0"/>
       </direct>
-      <direct input="childa.o" name="childb-i" output="childb.i"/>
-      <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
       <mux input="childa.o childb.o childc.o" name="output" output="parent.o1"/>
     </interconnect>
   </pb_type>

--- a/common/xml/sort-tags.xsl
+++ b/common/xml/sort-tags.xsl
@@ -1,0 +1,35 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+ <xsl:include href="identity.xsl" />
+
+ <!-- Sort <pb_type><clock> by "name" attribute -->
+ <!-- Sort <pb_type><input> by "name" attribute -->
+ <!-- Sort <pb_type><output> by "name" attribute -->
+ <xsl:template match="pb_type">
+  <xsl:copy>
+   <xsl:apply-templates select="@*"/>
+   <xsl:apply-templates select="clock">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="input">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="output">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="pb_type">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="*[not(self::clock or self::input or self::output or self::pb_type)]"/>
+  </xsl:copy>
+ </xsl:template>
+ <!-- Sort <interconnect><XXX> tags by output - direct first then muxes, finally input -->
+ <xsl:template match="interconnect">
+  <xsl:copy>
+   <xsl:apply-templates>
+    <xsl:sort select="concat(@output, name(), @input)" order="ascending"/>
+   </xsl:apply-templates>
+  </xsl:copy>
+ </xsl:template>
+
+</xsl:stylesheet>

--- a/utils/vlog/tests/clocks/dff_comb_one_clock/dff_comb_one_clock.sim.v
+++ b/utils/vlog/tests/clocks/dff_comb_one_clock/dff_comb_one_clock.sim.v
@@ -2,7 +2,7 @@
  * `input wire a` should be detected as a clock because it drives the flip
  * flop.
  */
-module block(a, b, c, d);
+module BLOCK(a, b, c, d);
 	input wire a;
 	input wire b;
 	input wire c;

--- a/utils/vlog/tests/clocks/dff_comb_one_clock/golden.model.xml
+++ b/utils/vlog/tests/clocks/dff_comb_one_clock/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a" is_clock="1" />
       <port name="b" combinational_sink_ports="d" clock="a" />

--- a/utils/vlog/tests/clocks/dff_one_clock/dff_one_clock.sim.v
+++ b/utils/vlog/tests/clocks/dff_one_clock/dff_one_clock.sim.v
@@ -2,7 +2,7 @@
  * `input wire a` should be detected as a clock because it drives the flip
  * flop.
  */
-module block(a, b, c);
+module BLOCK(a, b, c);
 	input wire a;
 	input wire b;
 	output wire c;

--- a/utils/vlog/tests/clocks/dff_one_clock/golden.model.xml
+++ b/utils/vlog/tests/clocks/dff_one_clock/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a" is_clock="1" />
       <port name="b" clock="a" />

--- a/utils/vlog/tests/clocks/dff_two_clocks/dff_two_clocks.sim.v
+++ b/utils/vlog/tests/clocks/dff_two_clocks/dff_two_clocks.sim.v
@@ -1,4 +1,4 @@
-module block(c1, c2, a, b, c, o1, o2);
+module BLOCK(c1, c2, a, b, c, o1, o2);
 	input wire c1;
 	input wire c2;
 	input wire a;

--- a/utils/vlog/tests/clocks/dff_two_clocks/golden.model.xml
+++ b/utils/vlog/tests/clocks/dff_two_clocks/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port clock="c1" combinational_sink_ports="o1" name="a"/>
       <port clock="c2 c1" combinational_sink_ports="o2 o1" name="b"/>

--- a/utils/vlog/tests/clocks/input_attr_clock/golden.model.xml
+++ b/utils/vlog/tests/clocks/input_attr_clock/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a" is_clock="1" />
       <port name="b"/>

--- a/utils/vlog/tests/clocks/input_attr_clock/input_attr_clock.sim.v
+++ b/utils/vlog/tests/clocks/input_attr_clock/input_attr_clock.sim.v
@@ -3,7 +3,7 @@
  * attribute.
  */
 (* whitebox *)
-module block(a, b, o);
+module BLOCK(a, b, o);
 	(* CLOCK *)
 	input wire a;
 	input wire b;

--- a/utils/vlog/tests/clocks/input_named_clk/golden.model.xml
+++ b/utils/vlog/tests/clocks/input_named_clk/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a"/>
       <port name="clk" is_clock="1" />

--- a/utils/vlog/tests/clocks/input_named_clk/input_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/input_named_clk/input_named_clk.sim.v
@@ -3,7 +3,7 @@
  * box module.
  */
 (* whitebox *)
-module block(clk, a, o);
+module BLOCK(clk, a, o);
 	input wire clk;
 	input wire a;
 	output wire o;

--- a/utils/vlog/tests/clocks/input_named_rdclk/golden.model.xml
+++ b/utils/vlog/tests/clocks/input_named_rdclk/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a"/>
       <port name="rdclk" is_clock="1" />

--- a/utils/vlog/tests/clocks/input_named_rdclk/input_named_rdclk.sim.v
+++ b/utils/vlog/tests/clocks/input_named_rdclk/input_named_rdclk.sim.v
@@ -3,7 +3,7 @@
  * box module.
  */
 (* whitebox *)
-module block(rdclk, a, o);
+module BLOCK(rdclk, a, o);
 	input wire rdclk;
 	input wire a;
 	output wire o;

--- a/utils/vlog/tests/clocks/multiple_inputs_named_clk/golden.model.xml
+++ b/utils/vlog/tests/clocks/multiple_inputs_named_clk/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a"/>
       <port name="b"/>

--- a/utils/vlog/tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
@@ -3,7 +3,7 @@
  * despite this being a black box module.
  */
 (* whitebox *)
-module block(a, rdclk, b, wrclk, c, o);
+module BLOCK(a, rdclk, b, wrclk, c, o);
 	input wire a;
 	input wire rdclk;
 	input wire b;

--- a/utils/vlog/tests/clocks/multiple_outputs_named_clk/golden.model.xml
+++ b/utils/vlog/tests/clocks/multiple_outputs_named_clk/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a"/>
       <port name="b"/>

--- a/utils/vlog/tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
@@ -3,7 +3,7 @@
  * despite this being a black box module.
  */
 (* whitebox *)
-module block(a, b, rdclk, o, wrclk);
+module BLOCK(a, b, rdclk, o, wrclk);
 	input wire a;
 	input wire b;
 	output wire rdclk;

--- a/utils/vlog/tests/clocks/output_attr_clock/golden.model.xml
+++ b/utils/vlog/tests/clocks/output_attr_clock/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a" />
       <port name="b"/>

--- a/utils/vlog/tests/clocks/output_attr_clock/output_attr_clock.sim.v
+++ b/utils/vlog/tests/clocks/output_attr_clock/output_attr_clock.sim.v
@@ -3,7 +3,7 @@
  * attribute.
  */
 (* whitebox *)
-module block(a, b, o);
+module BLOCK(a, b, o);
 	input wire a;
 	input wire b;
 	(* CLOCK *)

--- a/utils/vlog/tests/clocks/output_named_clk/golden.model.xml
+++ b/utils/vlog/tests/clocks/output_named_clk/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a"/>
       <port name="b" />

--- a/utils/vlog/tests/clocks/output_named_clk/output_named_clk.sim.v
+++ b/utils/vlog/tests/clocks/output_named_clk/output_named_clk.sim.v
@@ -3,7 +3,7 @@
  * box module.
  */
 (* whitebox *)
-module block(a, b, clk);
+module BLOCK(a, b, clk);
 	input wire a;
 	input wire b;
 	output wire clk;

--- a/utils/vlog/tests/clocks/output_named_rdclk/golden.model.xml
+++ b/utils/vlog/tests/clocks/output_named_rdclk/golden.model.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <models>
-  <model name="block">
+  <model name="BLOCK">
     <input_ports>
       <port name="a"/>
       <port name="b"/>

--- a/utils/vlog/tests/clocks/output_named_rdclk/output_named_rdclk.sim.v
+++ b/utils/vlog/tests/clocks/output_named_rdclk/output_named_rdclk.sim.v
@@ -3,7 +3,7 @@
  * box module.
  */
 (* whitebox *)
-module block(a, b, rdclk);
+module BLOCK(a, b, rdclk);
 	input wire a;
 	input wire b;
 	output wire rdclk;

--- a/utils/vlog/tests/dsp_combinational/dsp_combinational.sim.v
+++ b/utils/vlog/tests/dsp_combinational/dsp_combinational.sim.v
@@ -1,7 +1,7 @@
 `ifndef DSP_COMB
 `define DSP_COMB
 (* whitebox *)
-module dsp_combinational (
+module DSP_COMBINATIONAL (
 	a, b, m,
 	out
 );

--- a/utils/vlog/tests/dsp_combinational/golden.model.xml
+++ b/utils/vlog/tests/dsp_combinational/golden.model.xml
@@ -1,6 +1,6 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-no-internal-paths -->
-  <model name="dsp_combinational">
+  <model name="DSP_COMBINATIONAL">
     <input_ports>
       <port name="a" combinational_sink_ports="out"/>
       <port name="b" combinational_sink_ports="out"/>

--- a/utils/vlog/tests/dsp_combinational/golden.pb_type.xml
+++ b/utils/vlog/tests/dsp_combinational/golden.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="dsp_combinational" blif_model=".subckt dsp_combinational" num_pb="1">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="DSP_COMBINATIONAL" blif_model=".subckt DSP_COMBINATIONAL" num_pb="1">
   <input name="a" num_pins="32"/>
   <input name="b" num_pins="32"/>
   <input name="m" num_pins="1"/>

--- a/utils/vlog/tests/dsp_in_registered/dsp_in_registered.sim.v
+++ b/utils/vlog/tests/dsp_in_registered/dsp_in_registered.sim.v
@@ -2,7 +2,7 @@
 `include "../dsp_combinational/dsp_combinational.sim.v"
 
 /* DSP Block with register on all inputs */
-module dsp_in_registered (clk, a, b, m, out);
+module DSP_IN_REGISTERED (clk, a, b, m, out);
 	localparam DATA_WIDTH = 64;
 
 	input wire clk;
@@ -18,11 +18,11 @@ module dsp_in_registered (clk, a, b, m, out);
 
 	genvar i;
 	for (i=0; i<DATA_WIDTH/2; i=i+1) begin: dffs_gen
-		dff q_a_ff(.d(a[i]), .q(q_a[i]), .clk(clk));
-		dff q_b_ff(.d(b[i]), .q(q_b[i]), .clk(clk));
+		DFF q_a_ff(.d(a[i]), .q(q_a[i]), .clk(clk));
+		DFF q_b_ff(.d(b[i]), .q(q_b[i]), .clk(clk));
 	end
-	dff m_ff(.d(m), .q(q_m), .clk(clk));
+	DFF m_ff(.d(m), .q(q_m), .clk(clk));
 
 	/* Combinational Logic */
-	dsp_combinational comb (.a(q_a), .b(q_b), .m(q_m), .out(out));
+	DSP_COMBINATIONAL comb (.a(q_a), .b(q_b), .m(q_m), .out(out));
 endmodule

--- a/utils/vlog/tests/dsp_in_registered/golden.model.xml
+++ b/utils/vlog/tests/dsp_in_registered/golden.model.xml
@@ -1,7 +1,7 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../fig42-dff/dff.model.xml" xpointer="xpointer(models/child::node())"/>
-  <model name="dsp_in_registered">
+  <model name="DSP_IN_REGISTERED">
     <input_ports>
       <port clock="clk" combinational_sink_ports="out" name="a"/>
       <port clock="clk" combinational_sink_ports="out" name="b"/>

--- a/utils/vlog/tests/dsp_inout_registered/dsp_inout_registered.sim.v
+++ b/utils/vlog/tests/dsp_inout_registered/dsp_inout_registered.sim.v
@@ -2,7 +2,7 @@
 `include "../dsp_combinational/dsp_combinational.sim.v"
 
 /* DSP Block with register on both the inputs and the output */
-module dsp_inout_registered (clk, a, b, m, out);
+module DSP_INOUT_REGISTERED (clk, a, b, m, out);
 	localparam DATA_WIDTH = 64;
 
 	input wire clk;
@@ -18,20 +18,20 @@ module dsp_inout_registered (clk, a, b, m, out);
 
 	genvar i;
 	for (i=0; i<DATA_WIDTH/2; i=i+1) begin: input_dffs_gen
-		dff q_a_ff(.d(a[i]), .q(q_a[i]), .clk(clk));
-		dff q_b_ff(.d(b[i]), .q(q_b[i]), .clk(clk));
+		DFF q_a_ff(.d(a[i]), .q(q_a[i]), .clk(clk));
+		DFF q_b_ff(.d(b[i]), .q(q_b[i]), .clk(clk));
 	end
-	dff m_ff(.d(m), .q(q_m), .clk(clk));
+	DFF m_ff(.d(m), .q(q_m), .clk(clk));
 
 	/* Combinational logic */
 	wire [DATA_WIDTH-1:0] c_out;
-	dsp_combinational comb (.a(q_a), .b(q_b), .m(q_m), .out(c_out));
+	DSP_COMBINATIONAL comb (.a(q_a), .b(q_b), .m(q_m), .out(c_out));
 
 	/* Output register */
 	wire [DATA_WIDTH-1:0] q_out;
 	genvar j;
 	for (j=0; j<DATA_WIDTH; j=j+1) begin: output_dffs_gen
-		dff q_out_ff(.d(c_out[j]), .q(q_out[j]), .clk(clk));
+		DFF q_out_ff(.d(c_out[j]), .q(q_out[j]), .clk(clk));
 	end
 
 	assign out = q_out;

--- a/utils/vlog/tests/dsp_inout_registered/golden.model.xml
+++ b/utils/vlog/tests/dsp_inout_registered/golden.model.xml
@@ -2,7 +2,7 @@
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../fig42-dff/dff.model.xml" xpointer="xpointer(models/child::node())"/>
   <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#mixed-sequential-combinational-block -->
-  <model name="dsp_inout_registered">
+  <model name="DSP_INOUT_REGISTERED">
     <input_ports>
       <port name="a" combinational_sink_ports="out" clock="clk"/>
       <port name="b" combinational_sink_ports="out" clock="clk"/>

--- a/utils/vlog/tests/dsp_inout_registered_dualclk/dsp_inout_registered_dualclk.sim.v
+++ b/utils/vlog/tests/dsp_inout_registered_dualclk/dsp_inout_registered_dualclk.sim.v
@@ -2,7 +2,7 @@
 `include "../dsp_combinational/dsp_combinational.sim.v"
 
 /* DSP Block with register on both the inputs and the output, which use different clocks */
-module dsp_inout_registered_dualclk (iclk, oclk, a, b, m, out);
+module DSP_INOUT_REGISTERED_DUALCLK (iclk, oclk, a, b, m, out);
 	localparam DATA_WIDTH = 64;
 
 	input wire iclk;
@@ -19,20 +19,20 @@ module dsp_inout_registered_dualclk (iclk, oclk, a, b, m, out);
 
 	genvar i;
 	for (i=0; i<DATA_WIDTH/2; i=i+1) begin: input_dffs_gen
-		dff q_a_ff(.d(a[i]), .q(q_a[i]), .clk(iclk));
-		dff q_b_ff(.d(b[i]), .q(q_b[i]), .clk(iclk));
+		DFF q_a_ff(.d(a[i]), .q(q_a[i]), .clk(iclk));
+		DFF q_b_ff(.d(b[i]), .q(q_b[i]), .clk(iclk));
 	end
-	dff m_ff(.d(m), .q(q_m), .clk(iclk));
+	DFF m_ff(.d(m), .q(q_m), .clk(iclk));
 
 	/* Combinational logic */
 	wire [DATA_WIDTH-1:0] c_out;
-	dsp_combinational comb (.a(q_a), .b(q_b), .m(q_m), .out(c_out));
+	DSP_COMBINATIONAL comb (.a(q_a), .b(q_b), .m(q_m), .out(c_out));
 
 	/* Output register on oclk */
 	wire [DATA_WIDTH-1:0] q_out;
 	genvar j;
 	for (j=0; j<DATA_WIDTH; j=j+1) begin: output_dffs_gen
-		dff q_out_ff(.d(c_out[j]), .q(q_out[j]), .clk(oclk));
+		DFF q_out_ff(.d(c_out[j]), .q(q_out[j]), .clk(oclk));
 	end
 
 	assign out = q_out;

--- a/utils/vlog/tests/dsp_inout_registered_dualclk/golden.model.xml
+++ b/utils/vlog/tests/dsp_inout_registered_dualclk/golden.model.xml
@@ -1,7 +1,7 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../fig42-dff/dff.model.xml" xpointer="xpointer(models/child::node())"/>
-  <model name="dsp_inout_registered_dualclk">
+  <model name="DSP_INOUT_REGISTERED_DUALCLK">
     <input_ports>
       <port clock="oclk iclk" combinational_sink_ports="out" name="a"/>
       <port clock="oclk iclk" combinational_sink_ports="out" name="b"/>

--- a/utils/vlog/tests/dsp_modes/dsp_modes.sim.v
+++ b/utils/vlog/tests/dsp_modes/dsp_modes.sim.v
@@ -3,7 +3,7 @@
 
 /* DSP Block with register on both the inputs and the output */
 (* MODES="REGISTERED_NONE; REGISTERED_IN; REGISTERED_OUT; REGISTERED_INOUT; REGISTERED_PARTIAL" *)
-module dsp_modes (clk, a, b, m, out);
+module DSP_MODES (clk, a, b, m, out);
 	localparam DATA_WIDTH = 64;
 
 	parameter MODE = "REGISTERED_INOUT";
@@ -17,16 +17,16 @@ module dsp_modes (clk, a, b, m, out);
 	/* Register modes */
 	generate
 		if (MODE == "REGISTERED_NONE") begin
-			dsp_combinational dsp_int_comb (.clk(clk), .a(a), .b(b), .m(m), .out(out));
+			DSP_COMBINATIONAL dsp_int_comb (.clk(clk), .a(a), .b(b), .m(m), .out(out));
 		end if (MODE == "REGISTERED_INOUT") begin
-			dsp_inout_registered dsp_int_regio (.clk(clk), .a(a), .b(b), .m(m), .out(out));
-/* FIXME: dsp_(in|out)_registered is currently disabled.
+			DSP_INOUT_REGISTERED dsp_int_regio (.clk(clk), .a(a), .b(b), .m(m), .out(out));
+/* FIXME: DSP_(IN|OUT)_REGISTERED is currently disabled.
 		end if (MODE == "REGISTERED_IN") begin
-			dsp_in_registered dsp_int_regi (.clk(clk), .a(a), .b(b), .m(m), .out(out));
+			DSP_IN_REGISTERED dsp_int_regi (.clk(clk), .a(a), .b(b), .m(m), .out(out));
 		end if (MODE == "REGISTERED_OUT") begin
-			dsp_out_registered dsp_int_rego (.clk(clk), .a(a), .b(b), .m(m), .out(out));
+			DSP_OUT_REGISTERED dsp_int_rego (.clk(clk), .a(a), .b(b), .m(m), .out(out));
 		end if (MODE == "REGISTERED_PARTIAL") begin
-			dsp_partial_registered dsp_int_part (.clk(clk), .a(a), .b(b), .m(m), .out(out));
+			DSP_PARTIAL_REGISTERED dsp_int_part (.clk(clk), .a(a), .b(b), .m(m), .out(out));
 */
 		end
 	endgenerate

--- a/utils/vlog/tests/dsp_modes/golden.model.xml
+++ b/utils/vlog/tests/dsp_modes/golden.model.xml
@@ -1,7 +1,7 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../dsp_inout_registered/dsp_inout_registered.model.xml" xpointer="xpointer(models/child::node())"/>
-  <model name="dsp_modes">
+  <model name="DSP_MODES">
     <input_ports>
       <port clock="clk" combinational_sink_ports="out" name="a"/>
       <port clock="clk" combinational_sink_ports="out" name="b"/>

--- a/utils/vlog/tests/dsp_out_registered/dsp_out_registered.sim.v
+++ b/utils/vlog/tests/dsp_out_registered/dsp_out_registered.sim.v
@@ -2,7 +2,7 @@
 `include "../dsp_combinational/dsp_combinational.sim.v"
 
 /* DSP Block with register on the output */
-module dsp_out_registered (clk, a, b, m, out);
+module DSP_OUT_REGISTERED (clk, a, b, m, out);
 	localparam DATA_WIDTH = 64;
 
 	input wire clk;
@@ -13,13 +13,13 @@ module dsp_out_registered (clk, a, b, m, out);
 
 	/* Combinational logic */
 	wire [DATA_WIDTH-1:0] c_out;
-	dsp_combinational comb (.a(a), .b(b), .m(m), .out(c_out));
+	DSP_COMBINATIONAL comb (.a(a), .b(b), .m(m), .out(c_out));
 
 	/* Output register on clk */
 	wire [DATA_WIDTH-1:0] q_out;
 	genvar j;
 	for (j=0; j<DATA_WIDTH; j=j+1) begin: output_dffs_gen
-		dff q_out_ff(.d(c_out[j]), .q(q_out[j]), .clk(clk));
+		DFF q_out_ff(.d(c_out[j]), .q(q_out[j]), .clk(clk));
 	end
 
 	assign out = q_out;

--- a/utils/vlog/tests/dsp_out_registered/golden.pb_type.xml
+++ b/utils/vlog/tests/dsp_out_registered/golden.pb_type.xml
@@ -5,10 +5,10 @@
   <clock name="clk" num_pins="1"/>
   <input name="m" num_pins="1"/>
   <output name="out" num_pins="64"/>
-  <pb_type blif_model=".subckt dsp_combinational" name="dsp_combinational" num_pb="1">
+  <pb_type blif_model=".subckt DSP_COMBINATIONAL" name="dsp_combinational" num_pb="1">
     <xi:include href="../dsp_combinational/dsp_combinational.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
   </pb_type>
-  <pb_type blif_model=".subckt dff" name="dff" num_pb="64">
+  <pb_type blif_model=".subckt DFF" name="dff" num_pb="64">
     <xi:include href="../fig42-dff/dff.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
   </pb_type>
   <interconnect>

--- a/utils/vlog/tests/dsp_partial_registered/dsp_partial_registered.sim.v
+++ b/utils/vlog/tests/dsp_partial_registered/dsp_partial_registered.sim.v
@@ -2,7 +2,7 @@
 `include "../dsp_combinational/dsp_combinational.sim.v"
 
 /* DSP Block with register on only some inputs */
-module dsp_partial_registered (clk, a, b, m, out);
+module DSP_PARTIAL_REGISTERED (clk, a, b, m, out);
 	localparam DATA_WIDTH = 64;
 
 	input wire clk;
@@ -17,10 +17,10 @@ module dsp_partial_registered (clk, a, b, m, out);
 
 	genvar i;
 	for (i=0; i<DATA_WIDTH/2; i=i+1) begin: dffs_gen
-		dff q_a_ff(.d(a[i]), .q(q_a[i]), .clk(clk));
-		dff q_b_ff(.d(b[i]), .q(q_b[i]), .clk(clk));
+		DFF q_a_ff(.d(a[i]), .q(q_a[i]), .clk(clk));
+		DFF q_b_ff(.d(b[i]), .q(q_b[i]), .clk(clk));
 	end
 
 	/* Combinational Logic */
-	dsp_combinational comb (.a(q_a), .b(q_b), .m(m), .out(out));
+	DSP_COMBINATIONAL comb (.a(q_a), .b(q_b), .m(m), .out(out));
 endmodule

--- a/utils/vlog/tests/dsp_partial_registered/golden.model.xml
+++ b/utils/vlog/tests/dsp_partial_registered/golden.model.xml
@@ -2,7 +2,7 @@
   <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#mixed-sequential-combinational-block -->
   <xi:include href="../dsp_combinational/dsp_combinational.model.xml" xpointer="xpointer(models/child::node())"/>
   <xi:include href="../fig42-dff/dff.model.xml" xpointer="xpointer(models/child::node())"/>
-  <model name="dsp_partial_registered">
+  <model name="DSP_PARTIAL_REGISTERED">
     <input_ports>
       <port name="a" combinational_sink_ports="out" clock="clk"/>
       <port name="b" combinational_sink_ports="out" clock="clk"/>

--- a/utils/vlog/tests/fig41-full-adder/adder.sim.v
+++ b/utils/vlog/tests/fig41-full-adder/adder.sim.v
@@ -1,5 +1,5 @@
 (* whitebox *)
-module adder (
+module ADDER (
 	a, b, cin,
 	sum, cout
 );
@@ -40,4 +40,3 @@ module adder (
 	endspecify
 `endif
 endmodule
-

--- a/utils/vlog/tests/fig41-full-adder/golden.model.xml
+++ b/utils/vlog/tests/fig41-full-adder/golden.model.xml
@@ -1,6 +1,6 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-no-internal-paths -->
-  <model name="adder">
+  <model name="ADDER">
     <input_ports>
       <port name="a" combinational_sink_ports="cout sum"/>
       <port name="b" combinational_sink_ports="cout sum"/>

--- a/utils/vlog/tests/fig41-full-adder/golden.pb_type.xml
+++ b/utils/vlog/tests/fig41-full-adder/golden.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="adder" blif_model=".subckt adder" num_pb="1">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="ADDER" blif_model=".subckt adder" num_pb="1">
   <input name="a" num_pins="1"/>
   <input name="b" num_pins="1"/>
   <input name="cin" num_pins="1"/>

--- a/utils/vlog/tests/fig41-full-adder/golden.pb_type.xml
+++ b/utils/vlog/tests/fig41-full-adder/golden.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="ADDER" blif_model=".subckt adder" num_pb="1">
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="ADDER" blif_model=".subckt ADDER" num_pb="1">
   <input name="a" num_pins="1"/>
   <input name="b" num_pins="1"/>
   <input name="cin" num_pins="1"/>

--- a/utils/vlog/tests/fig42-dff/dff.sim.v
+++ b/utils/vlog/tests/fig42-dff/dff.sim.v
@@ -1,5 +1,5 @@
 (* whitebox *)
-module dff (d, clk, q);
+module DFF (d, clk, q);
 	input wire d;
 	input wire clk;
 	output reg q;

--- a/utils/vlog/tests/fig42-dff/golden.model.xml
+++ b/utils/vlog/tests/fig42-dff/golden.model.xml
@@ -1,6 +1,6 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-no-internal-paths -->
-  <model name="dff">
+  <model name="DFF">
     <input_ports>
       <port name="clk" is_clock="1"/>
       <port name="d" clock="clk"/>

--- a/utils/vlog/tests/multiple_instance/golden.pb_type.xml
+++ b/utils/vlog/tests/multiple_instance/golden.pb_type.xml
@@ -1,166 +1,209 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="MULTIPLE_INSTANCE" num_pb="1">
-  <input name="a" num_pins="4"/>
-  <input name="b" num_pins="4"/>
-  <input name="c" num_pins="4"/>
-  <input name="cin" num_pins="1"/>
-  <input name="d" num_pins="4"/>
-  <output name="cout" num_pins="1"/>
-  <output name="sum" num_pins="8"/>
-  <pb_type blif_model=".subckt adder" name="comba" num_pb="4">
-    <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
-  </pb_type>
-  <pb_type blif_model=".subckt adder" name="combb" num_pb="4">
+  <input  name="a"    num_pins="4"/>
+  <!-- FIXME: Current hack to work around lack of carry -->
+  <output name="a2b"  num_pins="4"/>
+  <input  name="b"    num_pins="4"/>
+  <input  name="c"    num_pins="4"/>
+  <!-- FIXME: cin/cout should be marked as carry -->
+  <input  name="cin"  num_pins="4"/>
+  <output name="cout" num_pins="4"/>
+  <input  name="d"    num_pins="4"/>
+  <output name="sum"  num_pins="8"/>
+  <pb_type blif_model=".subckt ADDER" name="adder" num_pb="8">
     <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
   </pb_type>
   <interconnect>
+
+    <!-- 1st - a+b -> sum -->
     <direct>
-      <port name="a[3]" type="input"/>
-      <port from="comba[3]" name="a" type="output"/>
+      <port                 name="a[0]"   type="input"  />
+      <port from="adder[2]" name="a"      type="output" />
     </direct>
     <direct>
-      <port name="b[3]" type="input"/>
-      <port from="comba[3]" name="b" type="output"/>
+      <port                 name="b[0]"   type="input"  />
+      <port from="adder[2]" name="b"      type="output" />
     </direct>
     <direct>
-      <port name="cin" type="input"/>
-      <port from="comba[0]" name="cin" type="output"/>
+      <port from="adder[2]" name="sum"    type="input"  />
+      <port                 name="sum[0]" type="output" />
+    </direct>
+
+    <!-- 2nd - a+b -> sum -->
+    <direct>
+      <port                 name="a[1]"   type="input"  />
+      <port from="adder[4]" name="a"      type="output" />
     </direct>
     <direct>
-      <port name="cin" type="input"/>
-      <port from="comba[1]" name="cin" type="output"/>
+      <port                 name="b[1]"   type="input"  />
+      <port from="adder[4]" name="b"      type="output" />
     </direct>
     <direct>
-      <port name="cin" type="input"/>
-      <port from="comba[2]" name="cin" type="output"/>
+      <port from="adder[4]" name="sum"    type="input"  />
+      <port                 name="sum[1]" type="output" />
+    </direct>
+
+    <!-- 3rd - a+b -> sum -->
+    <direct>
+      <port                 name="a[2]"   type="input"/>
+      <port from="adder[6]" name="a"      type="output"/>
     </direct>
     <direct>
-      <port name="cin" type="input"/>
-      <port from="comba[3]" name="cin" type="output"/>
+      <port                 name="b[2]"   type="input"/>
+      <port from="adder[6]" name="b"      type="output"/>
     </direct>
     <direct>
-      <port from="comba[3]" name="sum" type="input"/>
-      <port name="sum[3]" type="output"/>
+      <port from="adder[6]" name="sum"    type="input"/>
+      <port                 name="sum[2]" type="output"/>
+    </direct>
+
+    <!-- 4th - a+b -> sum -->
+    <direct>
+      <port                 name="a[3]"   type="input"  />
+      <port from="adder[0]" name="a"      type="output" />
     </direct>
     <direct>
-      <port name="a[0]" type="input"/>
-      <port from="comba[0]" name="a" type="output"/>
+      <port                 name="b[3]"   type="input"  />
+      <port from="adder[0]" name="b"      type="output" />
     </direct>
     <direct>
-      <port name="b[0]" type="input"/>
-      <port from="comba[0]" name="b" type="output"/>
+      <port from="adder[0]" name="sum"    type="input"  />
+      <port                 name="sum[3]" type="output" />
+    </direct>
+
+    <!-- 1st - c+d -> sum -->
+    <direct>
+      <port                 name="c[0]"   type="input"/>
+      <port from="adder[3]" name="a"      type="output"/>
     </direct>
     <direct>
-      <port from="comba[0]" name="sum" type="input"/>
-      <port name="sum[0]" type="output"/>
+      <port                 name="d[0]"   type="input"/>
+      <port from="adder[3]" name="b"      type="output"/>
     </direct>
     <direct>
-      <port name="a[1]" type="input"/>
-      <port from="comba[1]" name="a" type="output"/>
+      <port from="adder[3]" name="sum"    type="input"/>
+      <port                 name="sum[4]" type="output"/>
+    </direct>
+
+    <!-- 2nd - c+d -> sum -->
+    <direct>
+      <port                 name="c[1]"   type="input"/>
+      <port from="adder[5]" name="a"      type="output"/>
     </direct>
     <direct>
-      <port name="b[1]" type="input"/>
-      <port from="comba[1]" name="b" type="output"/>
+      <port                 name="d[1]"   type="input"/>
+      <port from="adder[5]" name="b"      type="output"/>
     </direct>
     <direct>
-      <port from="comba[1]" name="sum" type="input"/>
-      <port name="sum[1]" type="output"/>
+      <port from="adder[5]" name="sum"    type="input"/>
+      <port                 name="sum[5]" type="output"/>
+    </direct>
+
+    <!-- 3rd - c+d -> sum -->
+    <direct>
+      <port                 name="c[2]"   type="input"/>
+      <port from="adder[7]" name="a"      type="output"/>
     </direct>
     <direct>
-      <port name="a[2]" type="input"/>
-      <port from="comba[2]" name="a" type="output"/>
+      <port                 name="d[2]"   type="input"/>
+      <port from="adder[7]" name="b"      type="output"/>
     </direct>
     <direct>
-      <port name="b[2]" type="input"/>
-      <port from="comba[2]" name="b" type="output"/>
+      <port from="adder[7]" name="sum"    type="input"/>
+      <port                 name="sum[6]" type="output"/>
+    </direct>
+
+    <!-- 4th - c+d -> sum -->
+    <direct>
+      <port                 name="c[3]"   type="input"/>
+      <port from="adder[1]" name="a"      type="output"/>
     </direct>
     <direct>
-      <port from="comba[2]" name="sum" type="input"/>
-      <port name="sum[2]" type="output"/>
+      <port                 name="d[3]"   type="input"/>
+      <port from="adder[1]" name="b"      type="output"/>
     </direct>
     <direct>
-      <port name="c[0]" type="input"/>
-      <port from="combb[0]" name="a" type="output"/>
+      <port from="adder[1]" name="sum"    type="input"/>
+      <port                 name="sum[7]" type="output"/>
+    </direct>
+
+    <!-- Carry chains -->
+
+    <!-- FIXME: Hack until carries work -->
+    <direct>
+      <port from="adder[2]" name="cout"   type="input"  />
+      <port                 name="a2b[0]" type="output" />
     </direct>
     <direct>
-      <port name="d[0]" type="input"/>
-      <port from="combb[0]" name="b" type="output"/>
+      <port from="adder[4]" name="cout"   type="input"  />
+      <port                 name="a2b[1]" type="output" />
     </direct>
     <direct>
-      <port from="comba[0]" name="cout" type="input"/>
-      <port from="combb[0]" name="cin" type="output"/>
-      <pack_pattern name="ADDER" type="carry">
-        <port from="comba[0]" name="cout" type="input"/>
-        <port from="combb[0]" name="cin" type="output"/>
-      </pack_pattern>
+      <port from="adder[6]" name="cout"   type="input"  />
+      <port                 name="a2b[2]" type="output" />
     </direct>
     <direct>
-      <port from="combb[0]" name="sum" type="input"/>
-      <port name="sum[4]" type="output"/>
+      <port from="adder[0]" name="cout"    type="input"  />
+      <port                 name="a2b[3]"  type="output" />
+    </direct>
+
+
+    <!-- cin -> 1st a+b -> 1st c+d -> cout -->
+    <direct>
+      <port                 name="cin[0]"  type="input"  />
+      <port from="adder[2]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port name="c[1]" type="input"/>
-      <port from="combb[1]" name="a" type="output"/>
+      <port from="adder[2]" name="cout"    type="input"  />
+      <port from="adder[3]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port name="d[1]" type="input"/>
-      <port from="combb[1]" name="b" type="output"/>
+      <port from="adder[3]" name="cout"    type="input"  />
+      <port                 name="cout[0]" type="output" />
+    </direct>
+
+    <!-- cin -> 2nd a+b -> 2nd c+d -> cout -->
+    <direct>
+      <port                 name="cin[1]"  type="input"  />
+      <port from="adder[4]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port from="comba[1]" name="cout" type="input"/>
-      <port from="combb[1]" name="cin" type="output"/>
-      <pack_pattern name="ADDER" type="carry">
-        <port from="comba[1]" name="cout" type="input"/>
-        <port from="combb[1]" name="cin" type="output"/>
-      </pack_pattern>
+      <port from="adder[4]" name="cout"    type="input"  />
+      <port from="adder[5]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port from="combb[1]" name="sum" type="input"/>
-      <port name="sum[5]" type="output"/>
+      <port from="adder[5]" name="cout"    type="input"  />
+      <port                 name="cout[1]" type="output" />
+    </direct>
+
+    <!-- cin -> 3rd a+b -> 3rd c+d -> cout -->
+    <direct>
+      <port                 name="cin[2]"  type="input"  />
+      <port from="adder[6]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port name="c[2]" type="input"/>
-      <port from="combb[2]" name="a" type="output"/>
+      <port from="adder[6]" name="cout"    type="input"  />
+      <port from="adder[7]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port name="d[2]" type="input"/>
-      <port from="combb[2]" name="b" type="output"/>
+      <port from="adder[7]" name="cout"    type="input"  />
+      <port                 name="cout[2]" type="output" />
+    </direct>
+
+    <!-- cin -> 4th a+b -> 4th c+d -> cout -->
+    <direct>
+      <port                 name="cin[3]"  type="input"  />
+      <port from="adder[0]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port from="comba[2]" name="cout" type="input"/>
-      <port from="combb[2]" name="cin" type="output"/>
-      <pack_pattern name="ADDER" type="carry">
-        <port from="comba[2]" name="cout" type="input"/>
-        <port from="combb[2]" name="cin" type="output"/>
-      </pack_pattern>
+      <port from="adder[0]" name="cout"    type="input"  />
+      <port from="adder[1]" name="cin"     type="output" />
     </direct>
     <direct>
-      <port from="combb[2]" name="sum" type="input"/>
-      <port name="sum[6]" type="output"/>
+      <port from="adder[1]" name="cout"    type="input"  />
+      <port                 name="cout[3]" type="output" />
     </direct>
-    <direct>
-      <port name="c[3]" type="input"/>
-      <port from="combb[3]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="d[3]" type="input"/>
-      <port from="combb[3]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port from="comba[3]" name="cout" type="input"/>
-      <port from="combb[3]" name="cin" type="output"/>
-      <pack_pattern name="ADDER" type="carry">
-        <port from="comba[3]" name="cout" type="input"/>
-        <port from="combb[3]" name="cin" type="output"/>
-      </pack_pattern>
-    </direct>
-    <direct>
-      <port from="combb[3]" name="cout" type="input"/>
-      <port name="cout" type="output"/>
-    </direct>
-    <direct>
-      <port from="combb[3]" name="sum" type="input"/>
-      <port name="sum[7]" type="output"/>
-    </direct>
+
+
   </interconnect>
 </pb_type>

--- a/utils/vlog/tests/multiple_instance/golden.pb_type.xml
+++ b/utils/vlog/tests/multiple_instance/golden.pb_type.xml
@@ -1,1293 +1,166 @@
 <?xml version='1.0' encoding='utf-8'?>
-<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="multiple_instance" num_pb="1">
-  <input  name="a"    num_pins="64"/>
-  <input  name="b"    num_pins="64"/>
-  <input  name="cin"  num_pins="64"/>
-  <output name="cout" num_pins="64"/>
-  <output name="sum"  num_pins="64"/>
-  <pb_type blif_model=".subckt adder" name="adder" num_pb="64">
-    <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())" />
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="MULTIPLE_INSTANCE" num_pb="1">
+  <input name="a" num_pins="4"/>
+  <input name="b" num_pins="4"/>
+  <input name="c" num_pins="4"/>
+  <input name="cin" num_pins="1"/>
+  <input name="d" num_pins="4"/>
+  <output name="cout" num_pins="1"/>
+  <output name="sum" num_pins="8"/>
+  <pb_type blif_model=".subckt adder" name="comba" num_pb="4">
+    <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
+  </pb_type>
+  <pb_type blif_model=".subckt adder" name="combb" num_pb="4">
+    <xi:include href="../fig41-full-adder/adder.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
   </pb_type>
   <interconnect>
     <direct>
-      <port name="a[0]" type="input"/>
-      <port from="adder[0]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[0]" type="input"/>
-      <port from="adder[0]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[0]" type="input"/>
-      <port from="adder[0]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[0]" name="cout" type="input"/>
-      <port name="cout[0]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[0]" name="sum" type="input"/>
-      <port name="sum[0]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[10]" type="input"/>
-      <port from="adder[1]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[10]" type="input"/>
-      <port from="adder[1]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[10]" type="input"/>
-      <port from="adder[1]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[1]" name="cout" type="input"/>
-      <port name="cout[10]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[1]" name="sum" type="input"/>
-      <port name="sum[10]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[11]" type="input"/>
-      <port from="adder[2]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[11]" type="input"/>
-      <port from="adder[2]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[11]" type="input"/>
-      <port from="adder[2]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[2]" name="cout" type="input"/>
-      <port name="cout[11]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[2]" name="sum" type="input"/>
-      <port name="sum[11]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[12]" type="input"/>
-      <port from="adder[3]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[12]" type="input"/>
-      <port from="adder[3]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[12]" type="input"/>
-      <port from="adder[3]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[3]" name="cout" type="input"/>
-      <port name="cout[12]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[3]" name="sum" type="input"/>
-      <port name="sum[12]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[13]" type="input"/>
-      <port from="adder[4]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[13]" type="input"/>
-      <port from="adder[4]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[13]" type="input"/>
-      <port from="adder[4]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[4]" name="cout" type="input"/>
-      <port name="cout[13]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[4]" name="sum" type="input"/>
-      <port name="sum[13]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[14]" type="input"/>
-      <port from="adder[5]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[14]" type="input"/>
-      <port from="adder[5]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[14]" type="input"/>
-      <port from="adder[5]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[5]" name="cout" type="input"/>
-      <port name="cout[14]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[5]" name="sum" type="input"/>
-      <port name="sum[14]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[15]" type="input"/>
-      <port from="adder[6]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[15]" type="input"/>
-      <port from="adder[6]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[15]" type="input"/>
-      <port from="adder[6]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[6]" name="cout" type="input"/>
-      <port name="cout[15]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[6]" name="sum" type="input"/>
-      <port name="sum[15]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[16]" type="input"/>
-      <port from="adder[7]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[16]" type="input"/>
-      <port from="adder[7]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[16]" type="input"/>
-      <port from="adder[7]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[7]" name="cout" type="input"/>
-      <port name="cout[16]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[7]" name="sum" type="input"/>
-      <port name="sum[16]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[17]" type="input"/>
-      <port from="adder[8]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[17]" type="input"/>
-      <port from="adder[8]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[17]" type="input"/>
-      <port from="adder[8]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[8]" name="cout" type="input"/>
-      <port name="cout[17]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[8]" name="sum" type="input"/>
-      <port name="sum[17]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[18]" type="input"/>
-      <port from="adder[9]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[18]" type="input"/>
-      <port from="adder[9]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[18]" type="input"/>
-      <port from="adder[9]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[9]" name="cout" type="input"/>
-      <port name="cout[18]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[9]" name="sum" type="input"/>
-      <port name="sum[18]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[19]" type="input"/>
-      <port from="adder[10]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[19]" type="input"/>
-      <port from="adder[10]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[19]" type="input"/>
-      <port from="adder[10]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[10]" name="cout" type="input"/>
-      <port name="cout[19]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[10]" name="sum" type="input"/>
-      <port name="sum[19]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[1]" type="input"/>
-      <port from="adder[11]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[1]" type="input"/>
-      <port from="adder[11]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[1]" type="input"/>
-      <port from="adder[11]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[11]" name="cout" type="input"/>
-      <port name="cout[1]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[11]" name="sum" type="input"/>
-      <port name="sum[1]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[20]" type="input"/>
-      <port from="adder[12]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[20]" type="input"/>
-      <port from="adder[12]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[20]" type="input"/>
-      <port from="adder[12]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[12]" name="cout" type="input"/>
-      <port name="cout[20]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[12]" name="sum" type="input"/>
-      <port name="sum[20]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[21]" type="input"/>
-      <port from="adder[13]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[21]" type="input"/>
-      <port from="adder[13]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[21]" type="input"/>
-      <port from="adder[13]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[13]" name="cout" type="input"/>
-      <port name="cout[21]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[13]" name="sum" type="input"/>
-      <port name="sum[21]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[22]" type="input"/>
-      <port from="adder[14]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[22]" type="input"/>
-      <port from="adder[14]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[22]" type="input"/>
-      <port from="adder[14]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[14]" name="cout" type="input"/>
-      <port name="cout[22]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[14]" name="sum" type="input"/>
-      <port name="sum[22]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[23]" type="input"/>
-      <port from="adder[15]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[23]" type="input"/>
-      <port from="adder[15]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[23]" type="input"/>
-      <port from="adder[15]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[15]" name="cout" type="input"/>
-      <port name="cout[23]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[15]" name="sum" type="input"/>
-      <port name="sum[23]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[24]" type="input"/>
-      <port from="adder[16]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[24]" type="input"/>
-      <port from="adder[16]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[24]" type="input"/>
-      <port from="adder[16]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[16]" name="cout" type="input"/>
-      <port name="cout[24]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[16]" name="sum" type="input"/>
-      <port name="sum[24]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[25]" type="input"/>
-      <port from="adder[17]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[25]" type="input"/>
-      <port from="adder[17]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[25]" type="input"/>
-      <port from="adder[17]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[17]" name="cout" type="input"/>
-      <port name="cout[25]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[17]" name="sum" type="input"/>
-      <port name="sum[25]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[26]" type="input"/>
-      <port from="adder[18]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[26]" type="input"/>
-      <port from="adder[18]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[26]" type="input"/>
-      <port from="adder[18]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[18]" name="cout" type="input"/>
-      <port name="cout[26]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[18]" name="sum" type="input"/>
-      <port name="sum[26]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[27]" type="input"/>
-      <port from="adder[19]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[27]" type="input"/>
-      <port from="adder[19]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[27]" type="input"/>
-      <port from="adder[19]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[19]" name="cout" type="input"/>
-      <port name="cout[27]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[19]" name="sum" type="input"/>
-      <port name="sum[27]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[28]" type="input"/>
-      <port from="adder[20]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[28]" type="input"/>
-      <port from="adder[20]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[28]" type="input"/>
-      <port from="adder[20]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[20]" name="cout" type="input"/>
-      <port name="cout[28]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[20]" name="sum" type="input"/>
-      <port name="sum[28]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[29]" type="input"/>
-      <port from="adder[21]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[29]" type="input"/>
-      <port from="adder[21]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[29]" type="input"/>
-      <port from="adder[21]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[21]" name="cout" type="input"/>
-      <port name="cout[29]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[21]" name="sum" type="input"/>
-      <port name="sum[29]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[2]" type="input"/>
-      <port from="adder[22]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[2]" type="input"/>
-      <port from="adder[22]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[2]" type="input"/>
-      <port from="adder[22]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[22]" name="cout" type="input"/>
-      <port name="cout[2]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[22]" name="sum" type="input"/>
-      <port name="sum[2]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[30]" type="input"/>
-      <port from="adder[23]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[30]" type="input"/>
-      <port from="adder[23]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[30]" type="input"/>
-      <port from="adder[23]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[23]" name="cout" type="input"/>
-      <port name="cout[30]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[23]" name="sum" type="input"/>
-      <port name="sum[30]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[31]" type="input"/>
-      <port from="adder[24]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[31]" type="input"/>
-      <port from="adder[24]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[31]" type="input"/>
-      <port from="adder[24]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[24]" name="cout" type="input"/>
-      <port name="cout[31]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[24]" name="sum" type="input"/>
-      <port name="sum[31]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[32]" type="input"/>
-      <port from="adder[25]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[32]" type="input"/>
-      <port from="adder[25]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[32]" type="input"/>
-      <port from="adder[25]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[25]" name="cout" type="input"/>
-      <port name="cout[32]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[25]" name="sum" type="input"/>
-      <port name="sum[32]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[33]" type="input"/>
-      <port from="adder[26]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[33]" type="input"/>
-      <port from="adder[26]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[33]" type="input"/>
-      <port from="adder[26]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[26]" name="cout" type="input"/>
-      <port name="cout[33]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[26]" name="sum" type="input"/>
-      <port name="sum[33]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[34]" type="input"/>
-      <port from="adder[27]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[34]" type="input"/>
-      <port from="adder[27]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[34]" type="input"/>
-      <port from="adder[27]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[27]" name="cout" type="input"/>
-      <port name="cout[34]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[27]" name="sum" type="input"/>
-      <port name="sum[34]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[35]" type="input"/>
-      <port from="adder[28]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[35]" type="input"/>
-      <port from="adder[28]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[35]" type="input"/>
-      <port from="adder[28]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[28]" name="cout" type="input"/>
-      <port name="cout[35]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[28]" name="sum" type="input"/>
-      <port name="sum[35]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[36]" type="input"/>
-      <port from="adder[29]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[36]" type="input"/>
-      <port from="adder[29]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[36]" type="input"/>
-      <port from="adder[29]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[29]" name="cout" type="input"/>
-      <port name="cout[36]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[29]" name="sum" type="input"/>
-      <port name="sum[36]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[37]" type="input"/>
-      <port from="adder[30]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[37]" type="input"/>
-      <port from="adder[30]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[37]" type="input"/>
-      <port from="adder[30]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[30]" name="cout" type="input"/>
-      <port name="cout[37]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[30]" name="sum" type="input"/>
-      <port name="sum[37]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[38]" type="input"/>
-      <port from="adder[31]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[38]" type="input"/>
-      <port from="adder[31]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[38]" type="input"/>
-      <port from="adder[31]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[31]" name="cout" type="input"/>
-      <port name="cout[38]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[31]" name="sum" type="input"/>
-      <port name="sum[38]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[39]" type="input"/>
-      <port from="adder[32]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[39]" type="input"/>
-      <port from="adder[32]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[39]" type="input"/>
-      <port from="adder[32]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[32]" name="cout" type="input"/>
-      <port name="cout[39]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[32]" name="sum" type="input"/>
-      <port name="sum[39]" type="output"/>
-    </direct>
-    <direct>
       <port name="a[3]" type="input"/>
-      <port from="adder[33]" name="a" type="output"/>
+      <port from="comba[3]" name="a" type="output"/>
     </direct>
     <direct>
       <port name="b[3]" type="input"/>
-      <port from="adder[33]" name="b" type="output"/>
+      <port from="comba[3]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="cin[3]" type="input"/>
-      <port from="adder[33]" name="cin" type="output"/>
+      <port name="cin" type="input"/>
+      <port from="comba[0]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[33]" name="cout" type="input"/>
-      <port name="cout[3]" type="output"/>
+      <port name="cin" type="input"/>
+      <port from="comba[1]" name="cin" type="output"/>
     </direct>
     <direct>
-      <port from="adder[33]" name="sum" type="input"/>
+      <port name="cin" type="input"/>
+      <port from="comba[2]" name="cin" type="output"/>
+    </direct>
+    <direct>
+      <port name="cin" type="input"/>
+      <port from="comba[3]" name="cin" type="output"/>
+    </direct>
+    <direct>
+      <port from="comba[3]" name="sum" type="input"/>
       <port name="sum[3]" type="output"/>
     </direct>
     <direct>
-      <port name="a[40]" type="input"/>
-      <port from="adder[34]" name="a" type="output"/>
+      <port name="a[0]" type="input"/>
+      <port from="comba[0]" name="a" type="output"/>
     </direct>
     <direct>
-      <port name="b[40]" type="input"/>
-      <port from="adder[34]" name="b" type="output"/>
+      <port name="b[0]" type="input"/>
+      <port from="comba[0]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="cin[40]" type="input"/>
-      <port from="adder[34]" name="cin" type="output"/>
+      <port from="comba[0]" name="sum" type="input"/>
+      <port name="sum[0]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[34]" name="cout" type="input"/>
-      <port name="cout[40]" type="output"/>
+      <port name="a[1]" type="input"/>
+      <port from="comba[1]" name="a" type="output"/>
     </direct>
     <direct>
-      <port from="adder[34]" name="sum" type="input"/>
-      <port name="sum[40]" type="output"/>
+      <port name="b[1]" type="input"/>
+      <port from="comba[1]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="a[41]" type="input"/>
-      <port from="adder[35]" name="a" type="output"/>
+      <port from="comba[1]" name="sum" type="input"/>
+      <port name="sum[1]" type="output"/>
     </direct>
     <direct>
-      <port name="b[41]" type="input"/>
-      <port from="adder[35]" name="b" type="output"/>
+      <port name="a[2]" type="input"/>
+      <port from="comba[2]" name="a" type="output"/>
     </direct>
     <direct>
-      <port name="cin[41]" type="input"/>
-      <port from="adder[35]" name="cin" type="output"/>
+      <port name="b[2]" type="input"/>
+      <port from="comba[2]" name="b" type="output"/>
     </direct>
     <direct>
-      <port from="adder[35]" name="cout" type="input"/>
-      <port name="cout[41]" type="output"/>
+      <port from="comba[2]" name="sum" type="input"/>
+      <port name="sum[2]" type="output"/>
     </direct>
     <direct>
-      <port from="adder[35]" name="sum" type="input"/>
-      <port name="sum[41]" type="output"/>
+      <port name="c[0]" type="input"/>
+      <port from="combb[0]" name="a" type="output"/>
     </direct>
     <direct>
-      <port name="a[42]" type="input"/>
-      <port from="adder[36]" name="a" type="output"/>
+      <port name="d[0]" type="input"/>
+      <port from="combb[0]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="b[42]" type="input"/>
-      <port from="adder[36]" name="b" type="output"/>
+      <port from="comba[0]" name="cout" type="input"/>
+      <port from="combb[0]" name="cin" type="output"/>
+      <pack_pattern name="ADDER" type="carry">
+        <port from="comba[0]" name="cout" type="input"/>
+        <port from="combb[0]" name="cin" type="output"/>
+      </pack_pattern>
     </direct>
     <direct>
-      <port name="cin[42]" type="input"/>
-      <port from="adder[36]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[36]" name="cout" type="input"/>
-      <port name="cout[42]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[36]" name="sum" type="input"/>
-      <port name="sum[42]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[43]" type="input"/>
-      <port from="adder[37]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[43]" type="input"/>
-      <port from="adder[37]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[43]" type="input"/>
-      <port from="adder[37]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[37]" name="cout" type="input"/>
-      <port name="cout[43]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[37]" name="sum" type="input"/>
-      <port name="sum[43]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[44]" type="input"/>
-      <port from="adder[38]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[44]" type="input"/>
-      <port from="adder[38]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[44]" type="input"/>
-      <port from="adder[38]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[38]" name="cout" type="input"/>
-      <port name="cout[44]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[38]" name="sum" type="input"/>
-      <port name="sum[44]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[45]" type="input"/>
-      <port from="adder[39]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[45]" type="input"/>
-      <port from="adder[39]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[45]" type="input"/>
-      <port from="adder[39]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[39]" name="cout" type="input"/>
-      <port name="cout[45]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[39]" name="sum" type="input"/>
-      <port name="sum[45]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[46]" type="input"/>
-      <port from="adder[40]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[46]" type="input"/>
-      <port from="adder[40]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[46]" type="input"/>
-      <port from="adder[40]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[40]" name="cout" type="input"/>
-      <port name="cout[46]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[40]" name="sum" type="input"/>
-      <port name="sum[46]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[47]" type="input"/>
-      <port from="adder[41]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[47]" type="input"/>
-      <port from="adder[41]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[47]" type="input"/>
-      <port from="adder[41]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[41]" name="cout" type="input"/>
-      <port name="cout[47]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[41]" name="sum" type="input"/>
-      <port name="sum[47]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[48]" type="input"/>
-      <port from="adder[42]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[48]" type="input"/>
-      <port from="adder[42]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[48]" type="input"/>
-      <port from="adder[42]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[42]" name="cout" type="input"/>
-      <port name="cout[48]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[42]" name="sum" type="input"/>
-      <port name="sum[48]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[49]" type="input"/>
-      <port from="adder[43]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[49]" type="input"/>
-      <port from="adder[43]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[49]" type="input"/>
-      <port from="adder[43]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[43]" name="cout" type="input"/>
-      <port name="cout[49]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[43]" name="sum" type="input"/>
-      <port name="sum[49]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[4]" type="input"/>
-      <port from="adder[44]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[4]" type="input"/>
-      <port from="adder[44]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[4]" type="input"/>
-      <port from="adder[44]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[44]" name="cout" type="input"/>
-      <port name="cout[4]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[44]" name="sum" type="input"/>
+      <port from="combb[0]" name="sum" type="input"/>
       <port name="sum[4]" type="output"/>
     </direct>
     <direct>
-      <port name="a[50]" type="input"/>
-      <port from="adder[45]" name="a" type="output"/>
+      <port name="c[1]" type="input"/>
+      <port from="combb[1]" name="a" type="output"/>
     </direct>
     <direct>
-      <port name="b[50]" type="input"/>
-      <port from="adder[45]" name="b" type="output"/>
+      <port name="d[1]" type="input"/>
+      <port from="combb[1]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="cin[50]" type="input"/>
-      <port from="adder[45]" name="cin" type="output"/>
+      <port from="comba[1]" name="cout" type="input"/>
+      <port from="combb[1]" name="cin" type="output"/>
+      <pack_pattern name="ADDER" type="carry">
+        <port from="comba[1]" name="cout" type="input"/>
+        <port from="combb[1]" name="cin" type="output"/>
+      </pack_pattern>
     </direct>
     <direct>
-      <port from="adder[45]" name="cout" type="input"/>
-      <port name="cout[50]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[45]" name="sum" type="input"/>
-      <port name="sum[50]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[51]" type="input"/>
-      <port from="adder[46]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[51]" type="input"/>
-      <port from="adder[46]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[51]" type="input"/>
-      <port from="adder[46]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[46]" name="cout" type="input"/>
-      <port name="cout[51]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[46]" name="sum" type="input"/>
-      <port name="sum[51]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[52]" type="input"/>
-      <port from="adder[47]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[52]" type="input"/>
-      <port from="adder[47]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[52]" type="input"/>
-      <port from="adder[47]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[47]" name="cout" type="input"/>
-      <port name="cout[52]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[47]" name="sum" type="input"/>
-      <port name="sum[52]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[53]" type="input"/>
-      <port from="adder[48]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[53]" type="input"/>
-      <port from="adder[48]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[53]" type="input"/>
-      <port from="adder[48]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[48]" name="cout" type="input"/>
-      <port name="cout[53]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[48]" name="sum" type="input"/>
-      <port name="sum[53]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[54]" type="input"/>
-      <port from="adder[49]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[54]" type="input"/>
-      <port from="adder[49]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[54]" type="input"/>
-      <port from="adder[49]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[49]" name="cout" type="input"/>
-      <port name="cout[54]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[49]" name="sum" type="input"/>
-      <port name="sum[54]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[55]" type="input"/>
-      <port from="adder[50]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[55]" type="input"/>
-      <port from="adder[50]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[55]" type="input"/>
-      <port from="adder[50]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[50]" name="cout" type="input"/>
-      <port name="cout[55]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[50]" name="sum" type="input"/>
-      <port name="sum[55]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[56]" type="input"/>
-      <port from="adder[51]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[56]" type="input"/>
-      <port from="adder[51]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[56]" type="input"/>
-      <port from="adder[51]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[51]" name="cout" type="input"/>
-      <port name="cout[56]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[51]" name="sum" type="input"/>
-      <port name="sum[56]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[57]" type="input"/>
-      <port from="adder[52]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[57]" type="input"/>
-      <port from="adder[52]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[57]" type="input"/>
-      <port from="adder[52]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[52]" name="cout" type="input"/>
-      <port name="cout[57]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[52]" name="sum" type="input"/>
-      <port name="sum[57]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[58]" type="input"/>
-      <port from="adder[53]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[58]" type="input"/>
-      <port from="adder[53]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[58]" type="input"/>
-      <port from="adder[53]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[53]" name="cout" type="input"/>
-      <port name="cout[58]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[53]" name="sum" type="input"/>
-      <port name="sum[58]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[59]" type="input"/>
-      <port from="adder[54]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[59]" type="input"/>
-      <port from="adder[54]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[59]" type="input"/>
-      <port from="adder[54]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[54]" name="cout" type="input"/>
-      <port name="cout[59]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[54]" name="sum" type="input"/>
-      <port name="sum[59]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[5]" type="input"/>
-      <port from="adder[55]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[5]" type="input"/>
-      <port from="adder[55]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[5]" type="input"/>
-      <port from="adder[55]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[55]" name="cout" type="input"/>
-      <port name="cout[5]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[55]" name="sum" type="input"/>
+      <port from="combb[1]" name="sum" type="input"/>
       <port name="sum[5]" type="output"/>
     </direct>
     <direct>
-      <port name="a[60]" type="input"/>
-      <port from="adder[56]" name="a" type="output"/>
+      <port name="c[2]" type="input"/>
+      <port from="combb[2]" name="a" type="output"/>
     </direct>
     <direct>
-      <port name="b[60]" type="input"/>
-      <port from="adder[56]" name="b" type="output"/>
+      <port name="d[2]" type="input"/>
+      <port from="combb[2]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="cin[60]" type="input"/>
-      <port from="adder[56]" name="cin" type="output"/>
+      <port from="comba[2]" name="cout" type="input"/>
+      <port from="combb[2]" name="cin" type="output"/>
+      <pack_pattern name="ADDER" type="carry">
+        <port from="comba[2]" name="cout" type="input"/>
+        <port from="combb[2]" name="cin" type="output"/>
+      </pack_pattern>
     </direct>
     <direct>
-      <port from="adder[56]" name="cout" type="input"/>
-      <port name="cout[60]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[56]" name="sum" type="input"/>
-      <port name="sum[60]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[61]" type="input"/>
-      <port from="adder[57]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[61]" type="input"/>
-      <port from="adder[57]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[61]" type="input"/>
-      <port from="adder[57]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[57]" name="cout" type="input"/>
-      <port name="cout[61]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[57]" name="sum" type="input"/>
-      <port name="sum[61]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[62]" type="input"/>
-      <port from="adder[58]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[62]" type="input"/>
-      <port from="adder[58]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[62]" type="input"/>
-      <port from="adder[58]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[58]" name="cout" type="input"/>
-      <port name="cout[62]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[58]" name="sum" type="input"/>
-      <port name="sum[62]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[63]" type="input"/>
-      <port from="adder[59]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[63]" type="input"/>
-      <port from="adder[59]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[63]" type="input"/>
-      <port from="adder[59]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[59]" name="cout" type="input"/>
-      <port name="cout[63]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[59]" name="sum" type="input"/>
-      <port name="sum[63]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[6]" type="input"/>
-      <port from="adder[60]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[6]" type="input"/>
-      <port from="adder[60]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[6]" type="input"/>
-      <port from="adder[60]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[60]" name="cout" type="input"/>
-      <port name="cout[6]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[60]" name="sum" type="input"/>
+      <port from="combb[2]" name="sum" type="input"/>
       <port name="sum[6]" type="output"/>
     </direct>
     <direct>
-      <port name="a[7]" type="input"/>
-      <port from="adder[61]" name="a" type="output"/>
+      <port name="c[3]" type="input"/>
+      <port from="combb[3]" name="a" type="output"/>
     </direct>
     <direct>
-      <port name="b[7]" type="input"/>
-      <port from="adder[61]" name="b" type="output"/>
+      <port name="d[3]" type="input"/>
+      <port from="combb[3]" name="b" type="output"/>
     </direct>
     <direct>
-      <port name="cin[7]" type="input"/>
-      <port from="adder[61]" name="cin" type="output"/>
+      <port from="comba[3]" name="cout" type="input"/>
+      <port from="combb[3]" name="cin" type="output"/>
+      <pack_pattern name="ADDER" type="carry">
+        <port from="comba[3]" name="cout" type="input"/>
+        <port from="combb[3]" name="cin" type="output"/>
+      </pack_pattern>
     </direct>
     <direct>
-      <port from="adder[61]" name="cout" type="input"/>
-      <port name="cout[7]" type="output"/>
+      <port from="combb[3]" name="cout" type="input"/>
+      <port name="cout" type="output"/>
     </direct>
     <direct>
-      <port from="adder[61]" name="sum" type="input"/>
+      <port from="combb[3]" name="sum" type="input"/>
       <port name="sum[7]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[8]" type="input"/>
-      <port from="adder[62]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[8]" type="input"/>
-      <port from="adder[62]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[8]" type="input"/>
-      <port from="adder[62]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[62]" name="cout" type="input"/>
-      <port name="cout[8]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[62]" name="sum" type="input"/>
-      <port name="sum[8]" type="output"/>
-    </direct>
-    <direct>
-      <port name="a[9]" type="input"/>
-      <port from="adder[63]" name="a" type="output"/>
-    </direct>
-    <direct>
-      <port name="b[9]" type="input"/>
-      <port from="adder[63]" name="b" type="output"/>
-    </direct>
-    <direct>
-      <port name="cin[9]" type="input"/>
-      <port from="adder[63]" name="cin" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[63]" name="cout" type="input"/>
-      <port name="cout[9]" type="output"/>
-    </direct>
-    <direct>
-      <port from="adder[63]" name="sum" type="input"/>
-      <port name="sum[9]" type="output"/>
     </direct>
   </interconnect>
 </pb_type>

--- a/utils/vlog/tests/multiple_instance/multiple_instance.sim.v
+++ b/utils/vlog/tests/multiple_instance/multiple_instance.sim.v
@@ -1,16 +1,29 @@
 `include "../fig41-full-adder/adder.sim.v"
-module multiple_instance (a, b, cin, cout, sum);
-	localparam DATA_WIDTH = 64;
+module MULTIPLE_INSTANCE (a, b, c, d, cin, cout, sum);
+	localparam DATA_WIDTH = 4;
 
 	input wire [DATA_WIDTH-1:0] a;
 	input wire [DATA_WIDTH-1:0] b;
-	input wire [DATA_WIDTH-1:0] cin;
-	output wire [DATA_WIDTH-1:0] cout;
-	output wire [DATA_WIDTH-1:0] sum;
+	input wire [DATA_WIDTH-1:0] c;
+	input wire [DATA_WIDTH-1:0] d;
+	input wire cin;
+	output wire cout;
+	output wire [DATA_WIDTH*2-1:0] sum;
+
+	wire [DATA_WIDTH-1:0] a2b;
 
 	genvar i;
-	for(i=0; i<DATA_WIDTH; i=i+1) begin:gentest
-		adder comb (.a(a[i]), .b(b[i]), .cin(cin[i]), .cout(cout[i]), .sum(sum[i]));
+	for(i=0; i<DATA_WIDTH; i=i+1) begin
+		ADDER comba (.a(a[i]), .b(b[i]), .cin(cin), .cout(a2b[i]), .sum(sum[i]));
+	end
+
+	genvar j;
+	for(j=0; j<DATA_WIDTH; j=j+1) begin
+		if ( j < DATA_WIDTH-1 ) begin
+			ADDER combb (.a(c[j]), .b(d[j]), .cin(a2b[j]), .sum(sum[DATA_WIDTH+j]));
+		end else begin
+			ADDER combb (.a(c[j]), .b(d[j]), .cin(a2b[j]), .cout(cout), .sum(sum[DATA_WIDTH+j]));
+		end
 	end
 
 endmodule

--- a/utils/vlog/tests/multiple_instance/multiple_instance.sim.v
+++ b/utils/vlog/tests/multiple_instance/multiple_instance.sim.v
@@ -1,29 +1,33 @@
 `include "../fig41-full-adder/adder.sim.v"
-module MULTIPLE_INSTANCE (a, b, c, d, cin, cout, sum);
+module MULTIPLE_INSTANCE (a, b, c, d, cin, cout, sum, a2b);
 	localparam DATA_WIDTH = 4;
 
-	input wire [DATA_WIDTH-1:0] a;
-	input wire [DATA_WIDTH-1:0] b;
-	input wire [DATA_WIDTH-1:0] c;
-	input wire [DATA_WIDTH-1:0] d;
-	input wire cin;
-	output wire cout;
+	input  wire [DATA_WIDTH-1:0] a;
+	input  wire [DATA_WIDTH-1:0] b;
+	input  wire [DATA_WIDTH-1:0] c;
+	input  wire [DATA_WIDTH-1:0] d;
 	output wire [DATA_WIDTH*2-1:0] sum;
 
-	wire [DATA_WIDTH-1:0] a2b;
+	input  wire [DATA_WIDTH-1:0] cin;
+	output wire [DATA_WIDTH-1:0] cout;
+
+	/* FIXME: Once carry works make this an internal only wire */
+	output wire [DATA_WIDTH-1:0] a2b;
 
 	genvar i;
+	/* n = 0..DATA_WIDTH
+	 *
+	 *       cin[n]
+	 *        ↓
+	 *   a[n] + b[n] → sum[n]
+	 *        ↓
+	 *   c[n] + d[n] → sum[4+n]
+	 *        ↓
+	 *      cout[n]
+	 */
 	for(i=0; i<DATA_WIDTH; i=i+1) begin
-		ADDER comba (.a(a[i]), .b(b[i]), .cin(cin), .cout(a2b[i]), .sum(sum[i]));
-	end
-
-	genvar j;
-	for(j=0; j<DATA_WIDTH; j=j+1) begin
-		if ( j < DATA_WIDTH-1 ) begin
-			ADDER combb (.a(c[j]), .b(d[j]), .cin(a2b[j]), .sum(sum[DATA_WIDTH+j]));
-		end else begin
-			ADDER combb (.a(c[j]), .b(d[j]), .cin(a2b[j]), .cout(cout), .sum(sum[DATA_WIDTH+j]));
-		end
+		ADDER comb_apb (.a(a[i]), .b(b[i]), .cin(cin[i]), .cout(a2b[i]),  .sum(sum[i]));
+		ADDER comb_cpd (.a(c[i]), .b(d[i]), .cin(a2b[i]), .cout(cout[i]), .sum(sum[DATA_WIDTH+i]));
 	end
 
 endmodule

--- a/utils/vlog/tests/simple_pll/golden.model.xml
+++ b/utils/vlog/tests/simple_pll/golden.model.xml
@@ -1,5 +1,5 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
-  <model name="simple_pll">
+  <model name="SIMPLE_PLL">
     <input_ports>
       <port name="in_clock" is_clock="1"/>
     </input_ports>

--- a/utils/vlog/tests/simple_pll/simple_pll.sim.v
+++ b/utils/vlog/tests/simple_pll/simple_pll.sim.v
@@ -1,5 +1,5 @@
 /* Simple model of a PLL which divides the input block by 64 */
-module simple_pll (in_clock, out_clock);
+module SIMPLE_PLL (in_clock, out_clock);
 
 	input wire in_clock;
 

--- a/utils/vlog/tests/v2x_tests.cmake
+++ b/utils/vlog/tests/v2x_tests.cmake
@@ -35,10 +35,20 @@ function(V2X_TEST_GENERIC)
   # pb_type checking
   set(GOLDEN_XML golden.${TYPE}.xml)
   add_file_target(FILE ${GOLDEN_XML} SCANNER_TYPE xml)
-  xml_canonicalize_merge(NAME ${NAME}_${TYPE}_golden_sort FILE ${GOLDEN_XML} OUTPUT ${NAME}.${TYPE}.golden.xml)
+  xml_canonicalize_merge(
+    NAME ${NAME}_${TYPE}_golden_sort
+    FILE ${GOLDEN_XML}
+    OUTPUT ${NAME}.${TYPE}.golden.xml
+    EXTRA_ARGUMENTS "-param" "strip_comments" "1"
+    )
 
   set(ACTUAL_XML ${NAME}.${TYPE}.xml)
-  xml_canonicalize_merge(NAME ${NAME}_${TYPE}_actual_sort FILE ${ACTUAL_XML} OUTPUT ${NAME}.${TYPE}.actual.xml)
+  xml_canonicalize_merge(
+    NAME ${NAME}_${TYPE}_actual_sort
+    FILE ${ACTUAL_XML}
+    OUTPUT ${NAME}.${TYPE}.actual.xml
+    EXTRA_ARGUMENTS "-param" "strip_comments" "1"
+    )
 
   diff(NAME ${NAME}_${TYPE}_diff GOLDEN ${NAME}.${TYPE}.golden.xml ACTUAL ${NAME}.${TYPE}.actual.xml)
 

--- a/utils/vlog/vlog_to_model.py
+++ b/utils/vlog/vlog_to_model.py
@@ -118,25 +118,32 @@ if args.includes:
 
 aig_json = yosys.run.vlog_to_json(args.infiles, flatten=True, aig=True)
 
+top = None
 if args.top is not None:
-    yj = YosysJSON(aig_json, args.top)
-    top = yj.top
+    top = args.top.upper()
 else:
-    wm = re.match(r"([A-Za-z0-9_]+)\.sim\.v", iname)
-    if wm:
-        top = wm.group(1).upper()
+    yj = YosysJSON(aig_json)
+    if yj.top is not None:
+        top = yj.top
     else:
-        print(
-            """ERROR file name not of format %.sim.v ({}), cannot detect top level.
-            Manually specify the top level module using --top"""
-        ).format(iname)
-        sys.exit(1)
-    yj = YosysJSON(aig_json, top)
+        wm = re.match(r"([A-Za-z0-9_]+)\.sim\.v", iname)
+        if wm:
+            top = wm.group(1).upper()
+        else:
+            print(
+                """\
+ERROR file name not of format %.sim.v ({}), cannot detect top level.
+Manually specify the top level module using --top"""
+            ).format(iname)
+            sys.exit(1)
 
+assert top is not None
+yj = YosysJSON(aig_json, top)
 if top is None:
     print(
-        """ERROR: more than one module in design, cannot detect top level.
-        Manually specify the top level module using --top"""
+        """\
+ERROR: more than one module in design, cannot detect top level.
+Manually specify the top level module using --top"""
     )
     sys.exit(1)
 

--- a/utils/vlog/vlog_to_model.py
+++ b/utils/vlog/vlog_to_model.py
@@ -188,6 +188,8 @@ if len(deps_files) > 0:
 else:
     # Is a leaf model
     topname = tmod.attr("MODEL_NAME", top)
+    assert topname == topname.upper(
+    ), "Leaf model names should be all uppercase!"
     modclass = tmod.attr("CLASS", "")
 
     if modclass not in ("lut", "routing", "flipflop"):

--- a/utils/vlog/vlog_to_pbtype.py
+++ b/utils/vlog/vlog_to_pbtype.py
@@ -57,7 +57,6 @@ from yosys.json import YosysJSON
 
 from lib import xmlinc
 
-
 INVALID_INSTANCE = -1
 
 
@@ -400,8 +399,19 @@ def make_pb_type(yj, mod):
     # will be included by another one
     pb_xml_attrs["num_pb"] = "1"
     pb_type_xml = ET.Element(
-        "pb_type", pb_xml_attrs, nsmap={'xi': xmlinc.xi_url}
+        "pb_type", {
+            "num_pb": "1",
+            "name": mod_pname
+        },
+        nsmap={'xi': xmlinc.xi_url}
     )
+
+    if 'blif_model' in pb_attrs:
+        ET.SubElement(pb_type_xml, "blif_model",
+                      {}).text = pb_attrs["blif_model"]
+    if 'class' in pb_attrs:
+        ET.SubElement(pb_type_xml, "pb_class", {}).text = pb_attrs["class"]
+
     # Process IOs
     clocks = yosys.run.list_clocks(args.infiles, mod.name)
     for name, width, bits, iodir in mod.ports:

--- a/utils/vlog/vlog_to_pbtype.py
+++ b/utils/vlog/vlog_to_pbtype.py
@@ -57,67 +57,6 @@ from yosys.json import YosysJSON
 
 from lib import xmlinc
 
-parser = argparse.ArgumentParser(
-    description=__doc__.strip(), formatter_class=argparse.RawTextHelpFormatter
-)
-parser.add_argument(
-    'infiles',
-    metavar='input.v',
-    type=str,
-    nargs='+',
-    help="""\
-One or more Verilog input files, that will be passed to Yosys internally.
-They should be enough to generate a flattened representation of the model,
-so that paths through the model can be determined.
-"""
-)
-parser.add_argument(
-    '--top',
-    help="""\
-Top level module, will usually be automatically determined from the file name
-%.sim.v
-"""
-)
-parser.add_argument(
-    '--includes',
-    help="""\
-Command seperate list of include directories.
-""",
-    default=""
-)
-parser.add_argument('-o', help="""\
-Output filename, default 'model.xml'
-""")
-
-args = parser.parse_args()
-iname = os.path.basename(args.infiles[0])
-
-outfile = "pb_type.xml"
-if "o" in args and args.o is not None:
-    outfile = args.o
-
-yosys.run.add_define("PB_TYPE")
-if args.includes:
-    for include in args.includes.split(','):
-        yosys.run.add_include(include)
-
-vjson = yosys.run.vlog_to_json(args.infiles, flatten=False, aig=False)
-yj = YosysJSON(vjson)
-
-if args.top is not None:
-    top = args.top
-else:
-    wm = re.match(r"([A-Za-z0-9_]+)\.sim\.v", iname)
-    if wm:
-        top = wm.group(1).upper()
-    else:
-        print(
-            """ERROR file name not of format %.sim.v ({}), cannot detect top level.
-            Manually specify the top level module using --top""".format(iname)
-        )
-        sys.exit(1)
-
-tmod = yj.module(top)
 
 INVALID_INSTANCE = -1
 
@@ -528,7 +467,7 @@ parser.add_argument(
     type=argparse.FileType('w'),
     default="pb_type.xml",
     help="""\
-Output filename, default 'model.xml'
+Output filename.
 """
 )
 

--- a/utils/vlog/vlog_to_pbtype.py
+++ b/utils/vlog/vlog_to_pbtype.py
@@ -365,6 +365,8 @@ def make_pb_type(yj, mod):
     if modes is not None:
         modes = modes.split(";")
     mod_pname = mod_pb_name(mod)
+    assert mod_pname == mod_pname.upper(
+    ), "pb_type name should be all uppercase. {}".format(mod_pname)
 
     pb_xml_attrs = dict()
     pb_xml_attrs["name"] = mod_pname
@@ -375,6 +377,9 @@ def make_pb_type(yj, mod):
     print("is_blackbox", is_blackbox, "has_modes?", has_modes)
 
     # Process type and class of module
+    model_name = mod.attr("MODEL_NAME", mod.name)
+    assert model_name == model_name.upper(
+    ), "Model name should be uppercase. {}".format(model_name)
     mod_cls = mod.CLASS
     if mod_cls is not None:
         if mod_cls == "lut":
@@ -392,8 +397,7 @@ def make_pb_type(yj, mod):
         else:
             assert False, "unknown class {}".format(mod_cls)
     elif is_blackbox and not has_modes:
-        pb_xml_attrs["blif_model"
-                     ] = ".subckt " + mod.attr("MODEL_NAME", mod.name)
+        pb_xml_attrs["blif_model"] = ".subckt " + model_name
 
     # set num_pb to 1, it will be updated if this pb_type
     # will be included by another one
@@ -502,6 +506,9 @@ def main(args):
                 format(iname)
             )
             sys.exit(1)
+
+    assert top == top.upper(
+    ), "Top module name should be all uppercase. {}".format(top)
 
     tmod = yj.module(top)
 

--- a/utils/vpr_pbtype_arch_wrapper.py
+++ b/utils/vpr_pbtype_arch_wrapper.py
@@ -237,7 +237,7 @@ def tile_xml(
     dirpath = os.path.dirname(outfile)
     xmlinc.include_xml(
         tile,
-        os.path.join(dirpath, "{}.pb_type.xml".format(name)),
+        os.path.join(dirpath, "{}.pb_type.xml".format(name.lower())),
         outfile,
     )
 
@@ -429,7 +429,7 @@ def main(args):
     models = arch_root.find("models")
     xmlinc.include_xml(
         models,
-        os.path.join(dirpath, "{}.model.xml".format(tname)),
+        os.path.join(dirpath, "{}.model.xml".format(tname.lower())),
         outfile,
         xptr="xpointer(models/child::node())",
     )


### PR DESCRIPTION
This pull request is extracted from https://github.com/SymbiFlow/symbiflow-arch-defs/pull/703

 * Modules are named in all `UPPER_CASE`.
 * Instances are named in `lower_case`.

Examples;
```verilog
/**
 * These modules do **not** produce anything in the output unless
 * something in the top module uses it.
 */
module MODULE_TYPE_A (...);
	// ...
endmodule

/**
 * This module includes another module, but still doesn't produce
 * anything unless something in the top module uses it.
 */
module MODULE_TYPE_B (...);
	MODULE_TYPE_A object_1 (...);
	MODULE_TYPE_A object_2 (...);
endmodule

module top(...);
	MODULE_TYPE_A top_level_object_1 (...);
	MODULE_TYPE_B top_level_object_2 (...);
endmodule
```

This means that a "bare" `<pb_type>` is always going to have an upper case name. While `<pb_type>` inside other `<pb_type>`s objects will have lower case names. This means that includes will always need to override the name values.
```xml
<pb_type name="UPPER_CASE">
	<pb_type name="inner_object_a">
		<xi:include href="XXXX.xml" xpointer="xpointer(pb_type/child::node())" />
	</pb_type>
	<pb_type name="inner_object_b">
		<xi:include href="XXXX.xml" xpointer="xpointer(pb_type/child::node())" />
	</pb_type>
</pb_type>
```