### PR TITLE
xml: Provide better sort order (sort by name) of XML output

### DIFF
--- a/common/cmake/xml.cmake
+++ b/common/cmake/xml.cmake
@@ -51,6 +51,7 @@ set(XML_CANONICALIZE_MERGE_FILES
   common/xml/pack-patterns.xsl
   common/xml/remove-duplicate-models.xsl
   common/xml/attribute-fixes.xsl
+  common/xml/sort-tags.xsl
   )
 
 set(XML_CANONICALIZE_DEPS "")

--- a/common/xml/convert_and_merge_composable_fpga_architecture.sh
+++ b/common/xml/convert_and_merge_composable_fpga_architecture.sh
@@ -11,4 +11,5 @@ ${XSLTPROC_CMD} ${TOP_DIR}/common/xml/identity.xsl "$@"				  | \
 	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/pack-patterns.xsl	 		- | \
 	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/remove-duplicate-models.xsl 	- | \
 	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/attribute-fixes.xsl 		- | \
+	${XSLTPROC_CMD} ${TOP_DIR}/common/xml/sort-tags.xsl 			- | \
 	cat

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-existing-fasm-mux.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-existing-fasm-mux.golden.xml
@@ -17,6 +17,15 @@
      </meta>
         </metadata>
       </direct>
+      <mux input="COMMON_SLICE.AO5 COMMON_SLICE.AX" name="CARRY_DI0" output="CARRY4_VPR.DI0">
+        <metadata>
+          <meta name="fasm_mux">
+      COMMON_SLICE.AO5 = CARRY4.ACY0
+      COMMON_SLICE.AX = NULL
+     </meta>
+        </metadata>
+        <delay_constant in_port="COMMON_SLICE.AX" max=".105e-9" out_port="CARRY4_VPR.DI0"/>
+      </mux>
       <mux input="CARRY4_VPR.O3 CARRY4_VPR.CO_FABRIC3 COMMON_SLICE.DO6 COMMON_SLICE.DO5 COMMON_SLICE.DX" name="DFFMUX" output="SLICE_FF.D[3]">
         <metadata>
           <meta name="fasm_mux">
@@ -27,15 +36,6 @@
       CARRY4_VPR.O3 = DFFMUX.XOR
      </meta>
         </metadata>
-      </mux>
-      <mux input="COMMON_SLICE.AO5 COMMON_SLICE.AX" name="CARRY_DI0" output="CARRY4_VPR.DI0">
-        <metadata>
-          <meta name="fasm_mux">
-      COMMON_SLICE.AO5 = CARRY4.ACY0
-      COMMON_SLICE.AX = NULL
-     </meta>
-        </metadata>
-        <delay_constant in_port="COMMON_SLICE.AX" max=".105e-9" out_port="CARRY4_VPR.DI0"/>
       </mux>
     </interconnect>
   </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-fasm-mux.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-fasm-mux.golden.xml
@@ -9,7 +9,6 @@
       <output name="o"/>
     </pb_type>
     <interconnect>
-      <direct input="child.o" name="parent-o" output="parent.o"/>
       <mux input="parent.i0 parent.i1" name="mux1" output="child.i">
         <metadata>
           <meta name="fasm_mux">
@@ -19,6 +18,7 @@ parent.i1 : b1
           <meta name="fasm_name">fasm_name</meta>
         </metadata>
       </mux>
+      <direct input="child.o" name="parent-o" output="parent.o"/>
     </interconnect>
   </pb_type>
 </xml>

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-implicit-parent.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-implicit-parent.golden.xml
@@ -27,9 +27,9 @@
         <pack_pattern in_port="parent.ia2" name="A2" out_port="childa.i2"/>
         <pack_pattern in_port="parent.ia3" name="A3" out_port="childa.i2"/>
       </mux>
-      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <direct input="childa.o" name="childb-i" output="childb.i"/>
       <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
+      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <mux input="childa.o childb.o childc.o" name="output" output="parent.o1"/>
     </interconnect>
   </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-interconnect-pack_patterns.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-interconnect-pack_patterns.golden.xml
@@ -22,9 +22,9 @@
     <interconnect>
       <direct input="parent.ia1" name="childa-i1" output="childa.i1"/>
       <mux input="parent.ia2 parent.ia3" name="childa-input-i2" output="childa.i2"/>
-      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <direct input="childa.o" name="childb-i" output="childb.i"/>
       <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
+      <direct input="childa.o" name="parent-o0" output="parent.o0"/>
       <mux input="childa.o childb.o childc.o" name="output" output="parent.o1"/>
     </interconnect>
   </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-pb_type.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-pb_type.golden.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="top" num_pb="1">
-  <pb_type blif_model=".subckt random" class="lut" name="top_inner" num_pb="1">
-    <other_tag/>
-  </pb_type>
   <pb_type name="middle" num_pb="1">
     <pb_type blif_model=".subckt random" class="lut" name="middle_inner" num_pb="1">
       <other_tag/>
     </pb_type>
+  </pb_type>
+  <pb_type blif_model=".subckt random" class="lut" name="top_inner" num_pb="1">
+    <other_tag/>
   </pb_type>
 </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/full-test.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/full-test.golden.xml
@@ -38,46 +38,46 @@
     <T_clock_to_Q clock="clk" max="10e-12" port="combb.cout"/>
   </pb_type>
   <interconnect>
-    <direct input="MULTIPLE_INSTANCE.a[3]" name="comba[3]-a" output="comba[3].a"/>
-    <direct input="MULTIPLE_INSTANCE.b[3]" name="comba[3]-b" output="comba[3].b"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[0]-cin" output="comba[0].cin"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[1]-cin" output="comba[1].cin"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[2]-cin" output="comba[2].cin"/>
-    <direct input="MULTIPLE_INSTANCE.cin" name="comba[3]-cin" output="comba[3].cin"/>
+    <direct input="combb[3].cout" name="MULTIPLE_INSTANCE-cout" output="MULTIPLE_INSTANCE.cout"/>
+    <direct input="comba[0].sum" name="MULTIPLE_INSTANCE-sum[0]" output="MULTIPLE_INSTANCE.sum[0]"/>
+    <direct input="comba[1].sum" name="MULTIPLE_INSTANCE-sum[1]" output="MULTIPLE_INSTANCE.sum[1]"/>
+    <direct input="comba[2].sum" name="MULTIPLE_INSTANCE-sum[2]" output="MULTIPLE_INSTANCE.sum[2]"/>
     <direct input="comba[3].sum" name="MULTIPLE_INSTANCE-sum[3]" output="MULTIPLE_INSTANCE.sum[3]"/>
+    <direct input="combb[0].sum" name="MULTIPLE_INSTANCE-sum[4]" output="MULTIPLE_INSTANCE.sum[4]"/>
+    <direct input="combb[1].sum" name="MULTIPLE_INSTANCE-sum[5]" output="MULTIPLE_INSTANCE.sum[5]"/>
+    <direct input="combb[2].sum" name="MULTIPLE_INSTANCE-sum[6]" output="MULTIPLE_INSTANCE.sum[6]"/>
+    <direct input="combb[3].sum" name="MULTIPLE_INSTANCE-sum[7]" output="MULTIPLE_INSTANCE.sum[7]"/>
     <direct input="MULTIPLE_INSTANCE.a[0]" name="comba[0]-a" output="comba[0].a"/>
     <direct input="MULTIPLE_INSTANCE.b[0]" name="comba[0]-b" output="comba[0].b"/>
-    <direct input="comba[0].sum" name="MULTIPLE_INSTANCE-sum[0]" output="MULTIPLE_INSTANCE.sum[0]"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[0]-cin" output="comba[0].cin"/>
     <direct input="MULTIPLE_INSTANCE.a[1]" name="comba[1]-a" output="comba[1].a"/>
     <direct input="MULTIPLE_INSTANCE.b[1]" name="comba[1]-b" output="comba[1].b"/>
-    <direct input="comba[1].sum" name="MULTIPLE_INSTANCE-sum[1]" output="MULTIPLE_INSTANCE.sum[1]"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[1]-cin" output="comba[1].cin"/>
     <direct input="MULTIPLE_INSTANCE.a[2]" name="comba[2]-a" output="comba[2].a"/>
     <direct input="MULTIPLE_INSTANCE.b[2]" name="comba[2]-b" output="comba[2].b"/>
-    <direct input="comba[2].sum" name="MULTIPLE_INSTANCE-sum[2]" output="MULTIPLE_INSTANCE.sum[2]"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[2]-cin" output="comba[2].cin"/>
+    <direct input="MULTIPLE_INSTANCE.a[3]" name="comba[3]-a" output="comba[3].a"/>
+    <direct input="MULTIPLE_INSTANCE.b[3]" name="comba[3]-b" output="comba[3].b"/>
+    <direct input="MULTIPLE_INSTANCE.cin" name="comba[3]-cin" output="comba[3].cin"/>
     <direct input="MULTIPLE_INSTANCE.c[0]" name="combb[0]-a" output="combb[0].a"/>
     <direct input="MULTIPLE_INSTANCE.d[0]" name="combb[0]-b" output="combb[0].b"/>
     <direct input="comba[0].cout" name="combb[0]-cin" output="combb[0].cin">
       <pack_pattern in_port="comba[0].cout" name="carry-ADDER" out_port="combb[0].cin"/>
     </direct>
-    <direct input="combb[0].sum" name="MULTIPLE_INSTANCE-sum[4]" output="MULTIPLE_INSTANCE.sum[4]"/>
     <direct input="MULTIPLE_INSTANCE.c[1]" name="combb[1]-a" output="combb[1].a"/>
     <direct input="MULTIPLE_INSTANCE.d[1]" name="combb[1]-b" output="combb[1].b"/>
     <direct input="comba[1].cout" name="combb[1]-cin" output="combb[1].cin">
       <pack_pattern in_port="comba[1].cout" name="carry-ADDER" out_port="combb[1].cin"/>
     </direct>
-    <direct input="combb[1].sum" name="MULTIPLE_INSTANCE-sum[5]" output="MULTIPLE_INSTANCE.sum[5]"/>
     <direct input="MULTIPLE_INSTANCE.c[2]" name="combb[2]-a" output="combb[2].a"/>
     <direct input="MULTIPLE_INSTANCE.d[2]" name="combb[2]-b" output="combb[2].b"/>
     <direct input="comba[2].cout" name="combb[2]-cin" output="combb[2].cin">
       <pack_pattern in_port="comba[2].cout" name="carry-ADDER" out_port="combb[2].cin"/>
     </direct>
-    <direct input="combb[2].sum" name="MULTIPLE_INSTANCE-sum[6]" output="MULTIPLE_INSTANCE.sum[6]"/>
     <direct input="MULTIPLE_INSTANCE.c[3]" name="combb[3]-a" output="combb[3].a"/>
     <direct input="MULTIPLE_INSTANCE.d[3]" name="combb[3]-b" output="combb[3].b"/>
     <direct input="comba[3].cout" name="combb[3]-cin" output="combb[3].cin">
       <pack_pattern in_port="comba[3].cout" name="carry-ADDER" out_port="combb[3].cin"/>
     </direct>
-    <direct input="combb[3].cout" name="MULTIPLE_INSTANCE-cout" output="MULTIPLE_INSTANCE.cout"/>
-    <direct input="combb[3].sum" name="MULTIPLE_INSTANCE-sum[7]" output="MULTIPLE_INSTANCE.sum[7]"/>
   </interconnect>
 </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/pack_pattern-copy-direct-ports.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/pack_pattern-copy-direct-ports.golden.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <xml>
   <interconnect>
-    <direct input="SB_FF.D" name="VPR_FF-D" output="VPR_FF.D">
-      <pack_pattern in_port="SB_FF.D" name="A" out_port="VPR_FF.D"/>
-    </direct>
     <direct input="LUTFF.FCIN" name="SB_CARRY-CI" output="SB_CARRY.CI">
       <pack_pattern in_port="LUTFF.FCIN" name="CARRYCHAIN" out_port="SB_CARRY.CI"/>
+    </direct>
+    <direct input="SB_FF.D" name="VPR_FF-D" output="VPR_FF.D">
+      <pack_pattern in_port="SB_FF.D" name="A" out_port="VPR_FF.D"/>
     </direct>
   </interconnect>
 </xml>

--- a/common/xml/convert_and_merge_composable_tests/preserve-interconnect.golden.xml
+++ b/common/xml/convert_and_merge_composable_tests/preserve-interconnect.golden.xml
@@ -25,11 +25,11 @@
         <pack_pattern in_port="parent.ia2" name="MUX1" output="childa.i2"/>
         <pack_pattern in_port="parent.ia3" name="MUX2" output="childa.i2"/>
       </mux>
+      <direct input="childa.o" name="childb-i" output="childb.i"/>
+      <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
       <direct input="childa.o" name="parent-o0" output="parent.o0">
         <pack_pattern in_port="childa.o" name="CARRY" out_port="parent.o0" output="parent.o0"/>
       </direct>
-      <direct input="childa.o" name="childb-i" output="childb.i"/>
-      <mux input="childa.o childb.o" name="childc-input" output="childc.i"/>
       <mux input="childa.o childb.o childc.o" name="output" output="parent.o1"/>
     </interconnect>
   </pb_type>

--- a/common/xml/sort-tags.xsl
+++ b/common/xml/sort-tags.xsl
@@ -1,0 +1,35 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+ <xsl:include href="identity.xsl" />
+
+ <!-- Sort <pb_type><clock> by "name" attribute -->
+ <!-- Sort <pb_type><input> by "name" attribute -->
+ <!-- Sort <pb_type><output> by "name" attribute -->
+ <xsl:template match="pb_type">
+  <xsl:copy>
+   <xsl:apply-templates select="@*"/>
+   <xsl:apply-templates select="clock">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="input">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="output">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="pb_type">
+    <xsl:sort select="@name" order="ascending"/>
+   </xsl:apply-templates>
+   <xsl:apply-templates select="*[not(self::clock or self::input or self::output or self::pb_type)]"/>
+  </xsl:copy>
+ </xsl:template>
+ <!-- Sort <interconnect><XXX> tags by output - direct first then muxes, finally input -->
+ <xsl:template match="interconnect">
+  <xsl:copy>
+   <xsl:apply-templates>
+    <xsl:sort select="concat(@output, name(), @input)" order="ascending"/>
+   </xsl:apply-templates>
+  </xsl:copy>
+ </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
```xml
<pb_type>
 <clocks by name/>
 <inputs by name/>
 <outputs by name/>
 <pb_type by name>
   ...
 </pb_type>
 <interconnect>
  <direct|mux by output>
 </interconnect>
</pb_type>
```

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>