### PR TITLE
rr_graph: removing dummy tracks/channels from routing graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 7.0.5_7352_g22c2cadd5 20190607_105733"
+  PACKAGE_SPEC "vtr 7.0.5_7423_g43cfd5baf 20190618_143837"
   )
 add_conda_package(
   NAME libxslt

--- a/ice40/utils/ice40_generate_routing.py
+++ b/ice40/utils/ice40_generate_routing.py
@@ -92,7 +92,6 @@ if True:
     ])
     plb_tracks.extend([
         # Span 4 Vertical
-        Track(name="sp04_v----", type="space", aliases=()),
         Track(name="sp04_v[00]", type="span4", aliases=(               "sp4_v_b[1]",  )),
         Track(name="sp04_v[01]", type="span4", aliases=(               "sp4_v_b[0]",  )),
         Track(name="sp04_v[02]", type="span4", aliases=(               "sp4_v_b[3]",  )),
@@ -154,7 +153,6 @@ if True:
         Track(name="sp04_v[58]", type="span4", aliases=("sp4_v_t[46]",                )),
         Track(name="sp04_v[59]", type="span4", aliases=("sp4_v_t[47]",                )),
         # Span 4 Right Vertical
-        Track(name="sp04_rv----", type="space", aliases=()),
         Track(name="sp04_rv[00]", type="span4", aliases=("sp4_r_v_b[0]",  )),
         Track(name="sp04_rv[01]", type="span4", aliases=("sp4_r_v_b[1]",  )),
         Track(name="sp04_rv[02]", type="span4", aliases=("sp4_r_v_b[2]",  )),
@@ -204,7 +202,6 @@ if True:
         Track(name="sp04_rv[46]", type="span4", aliases=("sp4_r_v_b[46]", )),
         Track(name="sp04_rv[47]", type="span4", aliases=("sp4_r_v_b[47]", )),
         # Span 12 Vertical
-        Track(name="sp12_v----", type="space", aliases=()),
         Track(name="sp12_v[00]", type="span12", aliases=(                "sp12_v_b[1]",  )),
         Track(name="sp12_v[01]", type="span12", aliases=(                "sp12_v_b[0]",  )),
         Track(name="sp12_v[02]", type="span12", aliases=("sp12_v_t[0]",  "sp12_v_b[3]",  )),
@@ -232,7 +229,6 @@ if True:
         Track(name="sp12_v[24]", type="span12", aliases=("sp12_v_t[22]",                 )),
         Track(name="sp12_v[25]", type="span12", aliases=("sp12_v_t[23]",                 )),
         # Span 4 Horizontal
-        Track(name="sp04_h----", type="space", aliases=()),
         Track(name="sp04_h[00]", type="span4", aliases=(               "sp4_h_r[1]",  )),
         Track(name="sp04_h[01]", type="span4", aliases=(               "sp4_h_r[0]",  )),
         Track(name="sp04_h[02]", type="span4", aliases=(               "sp4_h_r[3]",  )),
@@ -294,7 +290,6 @@ if True:
         Track(name="sp04_h[58]", type="span4", aliases=("sp4_h_l[46]",                )),
         Track(name="sp04_h[59]", type="span4", aliases=("sp4_h_l[47]",                )),
         # Span 12 Horizontal
-        Track(name="sp12_h----", type="space", aliases=()),
         Track(name="sp12_h[00]", type="span12", aliases=(                "sp12_h_r[1]",  )),
         Track(name="sp12_h[01]", type="span12", aliases=(                "sp12_h_r[0]",  )),
         Track(name="sp12_h[02]", type="span12", aliases=("sp12_h_l[0]",  "sp12_h_r[3]",  )),
@@ -334,7 +329,6 @@ if True:
     #span4_vert_t_{12,13,14,15}
     io_tracks = [
         Track(name="fabout", type="local", aliases=("fabout[0]", )),
-        Track(name="sp4_h----", type="space", aliases=()),
         Track(name="sp4_h[00]", type="span4", aliases=(                    "span4_horz_r[0]",  )),
         Track(name="sp4_h[01]", type="span4", aliases=(                    "span4_horz_r[1]",  )),
         Track(name="sp4_h[02]", type="span4", aliases=(                    "span4_horz_r[2]",  )),
@@ -355,7 +349,6 @@ if True:
         Track(name="sp4_h[17]", type="span4", aliases=("span4_horz_l[13]",                     )),
         Track(name="sp4_h[18]", type="span4", aliases=("span4_horz_l[14]",                     )),
         Track(name="sp4_h[19]", type="span4", aliases=("span4_horz_l[15]",                     )),
-        Track(name="sp4_v----", type="space", aliases=()),
         Track(name="sp4_v[00]", type="span4", aliases=(                    "span4_vert_t[0]",  )),
         Track(name="sp4_v[01]", type="span4", aliases=(                    "span4_vert_t[1]",  )),
         Track(name="sp4_v[02]", type="span4", aliases=(                    "span4_vert_t[2]",  )),
@@ -380,9 +373,6 @@ if True:
 
     #span4_horz_{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47}
     io_tracks.extend([
-        Track(name="sp4_v_term---", type="space", aliases=()),
-        Track(name="sp4_h_term---", type="space", aliases=()),
-    ])
     for i in range(0, 48):
         io_tracks.extend([
             Track(name="sp4_v_term[%02i]" % i, type="span4", aliases=("span4_vert[%s]" % i, "sp4_v_t[%s]" % i, "sp4_v_b[%s]" % i)),
@@ -390,10 +380,6 @@ if True:
         ])
 
     #span12_horz_{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23}
-    io_tracks.extend([
-        Track(name="sp12_v_term---", type="space", aliases=()),
-        Track(name="sp12_h_term---", type="space", aliases=()),
-    ])
     for i in range(0, 24):
         io_tracks.extend([
             Track(name="sp12_v_term[%02i]" % i, type="span12", aliases=("span12_vert[%s]" % i, "sp12_v_t[%s]" % i, "sp12_v_b[%s]" % i)),
@@ -449,9 +435,7 @@ mappings.append(("FCOUT[0]", CompassDir.N, "FCIN[0]"))
 
 
 def segment_type(g, d):
-    if d.type == "space":
-        s_type = g.segments["dummy"]
-    elif d.type == 'span4':
+    if d.type == 'span4':
         s_type = g.segments["span4"]
     elif d.type == 'span12':
         s_type = g.segments["span12"]
@@ -537,7 +521,6 @@ def create_tracks(g, verbose=False):
     # Internal Block wires
     #############################################################################
     segment_global = g.segments["global"]
-    segment_dummy = g.segments["dummy"]
     segment_local = g.segments["local"]
 
     for block in g.block_grid:
@@ -567,13 +550,6 @@ def create_tracks(g, verbose=False):
             print("{} - {}".format(block, g_n))
 
             g.routing.localnames.add(begin, g_n, _track_node)
-
-        # Padding ------------------------------------------------
-        track, _track_node = g.create_xy_track(
-            begin, end, segment_dummy, typeh=type_y, direction=bi_dir
-        )
-        print()
-        # --------------------------------------------------------
 
         if tname == "PLB":
             tracks = plb_tracks

--- a/ice40/utils/ice40_generate_routing.py
+++ b/ice40/utils/ice40_generate_routing.py
@@ -372,7 +372,6 @@ if True:
     ]
 
     #span4_horz_{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47}
-    io_tracks.extend([
     for i in range(0, 48):
         io_tracks.extend([
             Track(name="sp4_v_term[%02i]" % i, type="span4", aliases=("span4_vert[%s]" % i, "sp4_v_t[%s]" % i, "sp4_v_b[%s]" % i)),

--- a/ice40/utils/ice40_import_routing_from_icebox.py
+++ b/ice40/utils/ice40_import_routing_from_icebox.py
@@ -527,36 +527,9 @@ def add_pin_aliases(g, ic):
                 g.routing.localnames.add(vpos, localname, node)
 
 
-def add_dummy_tracks(g, ic):
-    """Add a single dummy track to every channel."""
-    dummy = g.segments["dummy"]
-    for x in range(-2, ic.max_x + 2):
-        istart = PositionIcebox(x, 0)
-        iend = PositionIcebox(x, ic.max_y)
-        track, track_node = g.create_xy_track(
-            pos_icebox2vpr(istart),
-            pos_icebox2vpr(iend),
-            segment=dummy,
-            direction=channel.Track.Direction.BI,
-            capacity=0
-        )
-    for y in range(-2, ic.max_y + 2):
-        istart = PositionIcebox(0, y)
-        iend = PositionIcebox(ic.max_x, y)
-        track, track_node = g.create_xy_track(
-            pos_icebox2vpr(istart),
-            pos_icebox2vpr(iend),
-            segment=dummy,
-            direction=channel.Track.Direction.BI,
-            capacity=0
-        )
-
-
 # FIXME: Currently unused.
 def add_global_tracks(g, ic):
     """Add the global tracks to every channel."""
-    add_dummy_tracks(g, ic)
-
     GLOBAL_SPINE_ROW = ic.max_x // 2
     GLOBAL_BUF = "GLOBAL_BUFFER_OUTPUT"
     padin_db = ic.padin_pio_db()
@@ -989,8 +962,6 @@ def add_track_with_localnames(g, ic, segment, connections, lines):
 
 def add_tracks(g, ic, all_group_segments, segtype_filter=None):
     """Adding tracks from icebox segment groups."""
-    add_dummy_tracks(g, ic)
-
     for group in sorted(all_group_segments):
         positions = {}
         for x, y, netname in group:
@@ -1294,11 +1265,6 @@ def main(part, read_rr_graph, write_rr_graph):
     add_edges(g, ic)
     print()
     print_nodes_edges(g)
-    print()
-    print('Padding channels')
-    print('=' * 80)
-    dummy_segment = g.segments['dummy']
-    g.pad_channels(dummy_segment.id)
     print()
     print('Saving')
     open(write_rr_graph, 'w').write(

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -259,11 +259,7 @@ def create_track_rr_graph(
     print('{} Importing alive tracks'.format(now()))
     import_tracks(conn, alive_tracks, node_mapping, graph, segment_id)
 
-    print(
-        'original {} final {}'.format(
-            num_channels, len(alive_tracks)
-        )
-    )
+    print('original {} final {}'.format(num_channels, len(alive_tracks)))
 
 
 def add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles):

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -243,44 +243,6 @@ FROM
         )
 
 
-def import_dummy_tracks(conn, graph, segment_id):
-    cur = conn.cursor()
-
-    num_dummy = 0
-    for (graph_node_pkey, track_pkey, graph_node_type, x_low, x_high, y_low,
-         y_high, ptc) in cur.execute(
-             """
-    SELECT pkey, track_pkey, graph_node_type, x_low, x_high, y_low, y_high, ptc FROM
-        graph_node WHERE (graph_node_type = ? or graph_node_type = ?) and capacity = 0;""",
-             (graph2.NodeType.CHANX.value, graph2.NodeType.CHANY.value)):
-
-        node_type = graph2.NodeType(graph_node_type)
-
-        if node_type == graph2.NodeType.CHANX:
-            direction = 'X'
-            x_low = x_low
-        elif node_type == graph2.NodeType.CHANY:
-            direction = 'Y'
-            y_low = y_low
-        else:
-            assert False, node_type
-
-        track = tracks.Track(
-            direction=direction,
-            x_low=x_low,
-            x_high=x_high,
-            y_low=y_low,
-            y_high=y_high,
-        )
-
-        graph.add_track(
-            track=track, segment_id=segment_id, capacity=0, ptc=ptc
-        )
-        num_dummy += 1
-
-    return num_dummy
-
-
 def create_track_rr_graph(
         conn, graph, node_mapping, use_roi, roi, synth_tiles, segment_id
 ):
@@ -297,12 +259,9 @@ def create_track_rr_graph(
     print('{} Importing alive tracks'.format(now()))
     import_tracks(conn, alive_tracks, node_mapping, graph, segment_id)
 
-    print('{} Importing dummy tracks'.format(now()))
-    num_dummy = import_dummy_tracks(conn, graph, segment_id)
-
     print(
-        'original {} final {} dummy {}'.format(
-            num_channels, len(alive_tracks), num_dummy
+        'original {} final {}'.format(
+            num_channels, len(alive_tracks)
         )
     )
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR removes dummy tracks in the routing graph, both for ice40 and xc7.
It fixes https://github.com/SymbiFlow/symbiflow-arch-defs/issues/829, but it can be merged after conda VTR includes the following patch: https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/648.