### PR TITLE
cmake: update VTR and add new command line options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 7.0.5_7423_g43cfd5baf 20190618_143837"
+  PACKAGE_SPEC "vtr 7.0.5_7452_g893663cd9 20190626_102931"
   )
 add_conda_package(
   NAME libxslt

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -922,10 +922,12 @@ function(ADD_FPGA_TARGET)
     set(VPR_ARCH_ARGS "")
   endif()
 
+  set(OUT_NOISY_WARNINGS ${OUT_LOCAL}/noisy_warnings.log)
   separate_arguments(
     VPR_BASE_ARGS_LIST UNIX_COMMAND "${VPR_BASE_ARGS}"
     )
   list(APPEND VPR_BASE_ARGS_LIST --route_chan_width ${ROUTE_CHAN_WIDTH})
+  list(APPEND VPR_BASE_ARGS_LIST --suppress_warnings ${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R)
   separate_arguments(
     VPR_EXTRA_ARGS_LIST UNIX_COMMAND "${VPR_EXTRA_ARGS}"
     )

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -922,17 +922,19 @@ function(ADD_FPGA_TARGET)
     set(VPR_ARCH_ARGS "")
   endif()
 
-  set(OUT_NOISY_WARNINGS ${OUT_LOCAL}/noisy_warnings.log)
   separate_arguments(
     VPR_BASE_ARGS_LIST UNIX_COMMAND "${VPR_BASE_ARGS}"
     )
   list(APPEND VPR_BASE_ARGS_LIST --route_chan_width ${ROUTE_CHAN_WIDTH})
-  list(APPEND VPR_BASE_ARGS_LIST --suppress_warnings ${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R)
   separate_arguments(
     VPR_EXTRA_ARGS_LIST UNIX_COMMAND "${VPR_EXTRA_ARGS}"
     )
+
+  # Setting noisy warnings log file if needed.
+  set(OUT_NOISY_WARNINGS ${OUT_LOCAL}/noisy_warnings.log)
+  string(CONFIGURE ${VPR_ARCH_ARGS} VPR_ARCH_ARGS_EXPANDED)
   separate_arguments(
-    VPR_ARCH_ARGS_LIST UNIX_COMMAND "${VPR_ARCH_ARGS}"
+    VPR_ARCH_ARGS_LIST UNIX_COMMAND "${VPR_ARCH_ARGS_EXPANDED}"
     )
 
   if(NOT "${ADD_FPGA_TARGET_SDC_FILE}" STREQUAL "")

--- a/ice40/icestorm.cmake
+++ b/ice40/icestorm.cmake
@@ -78,12 +78,12 @@ function(icestorm_setup)
     ARCH ice40
     YOSYS_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/ice40/yosys/synth.tcl
     DEVICE_FULL_TEMPLATE \${DEVICE}-\${PACKAGE}
-    VPR_ARCH_ARGS
-      --clock_modeling route
-      --allow_unrelated_clustering off
-      --target_ext_pin_util 0.7
-      --router_init_wirelength_abort_threshold 2
-      --congested_routing_iteration_threshold 0.8
+    VPR_ARCH_ARGS "\
+      --clock_modeling route \
+      --allow_unrelated_clustering off \
+      --target_ext_pin_util 0.7 \
+      --router_init_wirelength_abort_threshold 2 \
+      --congested_routing_iteration_threshold 0.8"
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/ice40/utils/ice40_import_routing_from_icebox.py
     RR_PATCH_CMD "\${QUIET_CMD} \${CMAKE_COMMAND} -E env ${PYPATH_ARG} \

--- a/testarch/CMakeLists.txt
+++ b/testarch/CMakeLists.txt
@@ -6,9 +6,9 @@ define_arch(
   ARCH testarch
   YOSYS_SCRIPT ${symbiflow-arch-defs_SOURCE_DIR}/testarch/yosys/synth.tcl
   DEVICE_FULL_TEMPLATE \${DEVICE}
-  VPR_ARCH_ARGS
-    --router_init_wirelength_abort_threshold 20
-    --place_algorithm bounding_box
+  VPR_ARCH_ARGS " \
+    --router_init_wirelength_abort_threshold 20 \
+    --place_algorithm bounding_box"
   RR_PATCH_TOOL
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/testarch_graph.py
   RR_PATCH_CMD "\${CMAKE_COMMAND} -E env PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils

--- a/testarch/CMakeLists.txt
+++ b/testarch/CMakeLists.txt
@@ -8,6 +8,7 @@ define_arch(
   DEVICE_FULL_TEMPLATE \${DEVICE}
   VPR_ARCH_ARGS
     --router_init_wirelength_abort_threshold 20
+    --place_algorithm bounding_box
   RR_PATCH_TOOL
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/testarch_graph.py
   RR_PATCH_CMD "\${CMAKE_COMMAND} -E env PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -18,16 +18,17 @@ function(ADD_XC7_ARCH_DEFINE)
     YOSYS_SCRIPT ${YOSYS_SCRIPT}
     DEVICE_FULL_TEMPLATE \${DEVICE}-\${PACKAGE}
     CELLS_SIM ${YOSYS_DATADIR}/xilinx/cells_sim.v ${symbiflow-arch-defs_SOURCE_DIR}/xc7/techmap/cells_sim.v
-    VPR_ARCH_ARGS
-      --clock_modeling route
-      --place_algorithm bounding_box
-      --enable_timing_computations off
-      --allow_unrelated_clustering on
-      --clustering_pin_feasibility_filter off
-      --disable_check_route on
-      --strict_checks off
-      --allow_dangling_combinational_nodes on
-      --disable_errors check_unbuffered_edges:check_route
+    VPR_ARCH_ARGS "\
+      --clock_modeling route \
+      --place_algorithm bounding_box \
+      --enable_timing_computations off \
+      --allow_unrelated_clustering on \
+      --clustering_pin_feasibility_filter off \
+      --disable_check_route on \
+      --strict_checks off \
+      --allow_dangling_combinational_nodes on \
+      --disable_errors check_unbuffered_edges:check_route \
+      --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R"
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -26,6 +26,8 @@ function(ADD_XC7_ARCH_DEFINE)
       --clustering_pin_feasibility_filter off
       --disable_check_route on
       --strict_checks off
+      --allow_dangling_combinational_nodes on
+      --disable_errors check_unbuffered_edges:check_route
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the option to allow dangling combinational nodes to xc7.

CI will fail as the option is not yet in the conda package. Once it is added I will re-run kokoro and merge if green.