### PR TITLE
rr_graph: adding bb place algorithm when creating rr_graph virt

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -448,6 +448,7 @@ function(DEFINE_DEVICE)
         ${QUIET_CMD} ${VPR} ${DEVICE_MERGED_FILE}
         --device ${DEVICE_FULL}
         ${symbiflow-arch-defs_SOURCE_DIR}/common/wire.eblif
+        --place_algorithm bounding_box
         --route_chan_width 6
         --echo_file on
         --min_route_chan_width_hint 1


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds the `bounding_box` place algorithm option when creating the virtual rr_graph.

After analyzing why [this VPR patch was needed](https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/664) (issue described [here](https://github.com/SymbiFlow/vtr-verilog-to-routing/issues/76)), I've noticed that the error showed up at the `virtaul_rr_graph` generation moment because the placer was using the `timing_driven` algorithm which, presumably, produces an error if timing information is not correctly provided to the architecture.

[Here there is the code](https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/4cfe982a6051e5bfe5c19ee1676b9baaa3fbec40/vpr/src/place/place.cpp#L3499-L3514) that produces the error: if `timing_driven` algorithm is set (which is by default), the `virtual_rr_graph` creation will end up in [this error](https://github.com/verilog-to-routing/vtr-verilog-to-routing/blob/4cfe982a6051e5bfe5c19ee1676b9baaa3fbec40/vpr/src/place/place.cpp#L3510).

This addition will allow us to close https://github.com/SymbiFlow/vtr-verilog-to-routing/issues/76 without the need to merge a very specific patch to upstream VtR.