### PR TITLE
Revise rr_graph schema

### DIFF
--- a/common/xml/routing_resource.xsd
+++ b/common/xml/routing_resource.xsd
@@ -16,12 +16,12 @@
   </xs:complexType>
 
   <xs:complexType name="x_list">
-    <xs:attribute name="index" type="xs:int" use="required"/>
+    <xs:attribute name="index" type="xs:unsignedInt" use="required"/>
     <xs:attribute name="info" type="xs:int" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="y_list">
-    <xs:attribute name="index" type="xs:int" use="required"/>
+    <xs:attribute name="index" type="xs:unsignedInt" use="required"/>
     <xs:attribute name="info" type="xs:int" use="required"/>
   </xs:complexType>
 
@@ -36,37 +36,37 @@
   </xs:simpleType>
 
   <xs:complexType name="timing">
-    <xs:attribute name="R" type="xs:double"/>
-    <xs:attribute name="Cin" type="xs:double"/>
-    <xs:attribute name="Cinternal" type="xs:double"/>
-    <xs:attribute name="Cout" type="xs:double"/>
-    <xs:attribute name="Tdel" type="xs:double"/>
+    <xs:attribute name="R" type="xs:float"/>
+    <xs:attribute name="Cin" type="xs:float"/>
+    <xs:attribute name="Cinternal" type="xs:float"/>
+    <xs:attribute name="Cout" type="xs:float"/>
+    <xs:attribute name="Tdel" type="xs:float"/>
   </xs:complexType>
 
   <xs:complexType name="sizing">
-    <xs:attribute name="mux_trans_size" type="xs:double" use="required"/>
-    <xs:attribute name="buf_size" type="xs:double" use="required"/>
+    <xs:attribute name="mux_trans_size" type="xs:float" use="required"/>
+    <xs:attribute name="buf_size" type="xs:float" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="switch">
-    <xs:choice maxOccurs="unbounded">
-      <xs:element name="timing" type="timing"/>
+    <xs:all>
+      <xs:element name="timing" type="timing" minOccurs="0"/>
       <xs:element name="sizing" type="sizing"/>
-    </xs:choice>
+    </xs:all>
     <xs:attribute name="id" type="xs:int" use="required"/>
     <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="type" type="switch_type"/>
   </xs:complexType>
 
   <xs:complexType name="segment_timing">
-    <xs:attribute name="R_per_meter" type="xs:double"/>
-    <xs:attribute name="C_per_meter" type="xs:double"/>
+    <xs:attribute name="R_per_meter" type="xs:float"/>
+    <xs:attribute name="C_per_meter" type="xs:float"/>
   </xs:complexType>
 
   <xs:complexType name="segment">
-    <xs:sequence>
-      <xs:element name="timing" type="segment_timing" maxOccurs="unbounded"/>
-    </xs:sequence>
+    <xs:all>
+      <xs:element name="timing" type="segment_timing" minOccurs="0"/>
+    </xs:all>
     <xs:attribute name="id" type="xs:int" use="required"/>
     <xs:attribute name="name" type="xs:string" use="required"/>
   </xs:complexType>
@@ -90,8 +90,6 @@
     <xs:simpleContent>
       <xs:extension base="xs:string">
         <xs:attribute name="name" type="xs:string" use="required"/>
-	<xs:attribute name="x_offset" type="xs:int"/>
-	<xs:attribute name="y_offset" type="xs:int"/>
       </xs:extension>
     </xs:simpleContent>
   </xs:complexType>
@@ -166,8 +164,8 @@
   </xs:complexType>
 
   <xs:complexType name="node_timing">
-    <xs:attribute name="R" type="xs:double" use="required"/>
-    <xs:attribute name="C" type="xs:double" use="required"/>
+    <xs:attribute name="R" type="xs:float" use="required"/>
+    <xs:attribute name="C" type="xs:float" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="node_segment">
@@ -175,34 +173,34 @@
   </xs:complexType>
 
   <xs:complexType name="node">
-    <xs:choice maxOccurs="unbounded">
+    <xs:all>
       <xs:element name="loc" type="node_loc"/>
-      <xs:element name="timing" type="node_timing"/>
-      <xs:element name="segment" type="node_segment"/>
-      <xs:element name="metadata" type="metadata"/>
-    </xs:choice>
-    <xs:attribute name="id" type="xs:int" use="required"/>
+      <xs:element name="timing" type="node_timing" minOccurs="0"/>
+      <xs:element name="segment" type="node_segment" minOccurs="0"/>
+      <xs:element name="metadata" type="metadata" minOccurs="0"/>
+    </xs:all>
+    <xs:attribute name="id" type="xs:unsignedInt" use="required"/>
     <xs:attribute name="type" type="node_type" use="required"/>
     <xs:attribute name="direction" type="node_direction"/>
-    <xs:attribute name="capacity" type="xs:int" use="required"/>
+    <xs:attribute name="capacity" type="xs:unsignedInt" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="edge">
-    <xs:choice minOccurs="0" maxOccurs="unbounded">
-      <xs:element name="metadata" type="metadata"/>
-    </xs:choice>
-    <xs:attribute name="id" type="xs:int"/>
-    <xs:attribute name="src_node" type="xs:int" use="required"/>
-    <xs:attribute name="sink_node" type="xs:int" use="required"/>
-    <xs:attribute name="switch_id" type="xs:int" use="required"/>
+    <xs:all>
+      <xs:element name="metadata" type="metadata" minOccurs="0"/>
+    </xs:all>
+    <xs:attribute name="id" type="xs:unsignedInt"/>
+    <xs:attribute name="src_node" type="xs:unsignedInt" use="required"/>
+    <xs:attribute name="sink_node" type="xs:unsignedInt" use="required"/>
+    <xs:attribute name="switch_id" type="xs:unsignedInt" use="required"/>
   </xs:complexType>
 
   <xs:complexType name="channels">
-    <xs:choice maxOccurs="unbounded">
+    <xs:sequence>
       <xs:element name="channel" type="channel"/>
-      <xs:element name="x_list" type="x_list"/>
-      <xs:element name="y_list" type="y_list"/>
-    </xs:choice>
+      <xs:element name="x_list" type="x_list" maxOccurs="unbounded"/>
+      <xs:element name="y_list" type="y_list" maxOccurs="unbounded"/>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:complexType name="switches">
@@ -241,18 +239,37 @@
     </xs:choice>
   </xs:complexType>
 
+  <xs:complexType name="bin_nodes">
+    <xs:attribute name="file" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="connection_box">
+    <xs:attribute name="id" type="xs:int"/>
+    <xs:attribute name="name" type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="connection_boxes">
+    <xs:sequence>
+      <xs:element name="connection_box" type="connection_box" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="x_dim" type="xs:int"/>
+    <xs:attribute name="y_dim" type="xs:int"/>
+    <xs:attribute name="num_boxes" type="xs:int"/>
+  </xs:complexType>
+
   <xs:element name="rr_graph">
     <xs:complexType>
-      <xs:choice maxOccurs="unbounded">
+      <xs:all>
+        <xs:element name="binary_nodes_and_edges" type="bin_nodes" minOccurs="0"/>
+        <xs:element name="connection_boxes" type="connection_boxes" minOccurs="0"/>
         <xs:element name="channels" type="channels"/>
         <xs:element name="switches" type="switches"/>
         <xs:element name="segments" type="segments"/>
         <xs:element name="block_types" type="block_types"/>
         <xs:element name="grid" type="grid_locs"/>
         <xs:element name="rr_nodes" type="rr_nodes"/>
-
         <xs:element name="rr_edges" type="rr_edges"/>
-      </xs:choice>
+      </xs:all>
 
       <xs:attribute name="tool_name" type="xs:string"/>
       <xs:attribute name="tool_version" type="xs:string"/>

--- a/utils/lib/rr_graph/graph.py
+++ b/utils/lib/rr_graph/graph.py
@@ -1766,9 +1766,6 @@ def _set_metadata(parent_node, key, value, offset=None):
         metadata = ET.SubElement(parent_node, "metadata")
 
     attribs = [("name", key)]
-    if offset:
-        attribs.append(("x_offset", str(offset.width)))
-        attribs.append(("y_offset", str(offset.height)))
 
     metanode = None
     for node in metadata.iterfind("./meta"):


### PR DESCRIPTION
This:
- Converts all `xs:double` types to `xs:float` in accordance with VPR's usage.
- Converts fields for some of the index types from `xs:int` to `xs:unsignedInt`. Not all are converted because `-1` is a special value in some fields such as node segment_ids.
- Deletes `x_offset` and `y_offset` attributes from metadata.
- Converts `xs:choice`s to `xs:all` where applicable. `xs:choice` does not imply existence of all elements inside it, but we need that behavior in some places like the top-level tag.
