### PR TITLE
Fix unconnected CARRY4 inputs in fasm2bels

### DIFF
--- a/xc7/fasm2bels/clb_models.py
+++ b/xc7/fasm2bels/clb_models.py
@@ -669,18 +669,18 @@ def process_slice(top, s):
 
         if site.has_feature('PRECYINIT.AX'):
             site.add_sink(bel, 'CYINIT', 'AX')
-            bel.unused_connections.add('CI')
+            bel.connections['CI'] = 0
 
         elif site.has_feature('PRECYINIT.C0'):
             bel.connections['CYINIT'] = 0
-            bel.unused_connections.add('CI')
+            bel.connections['CI'] = 0
 
         elif site.has_feature('PRECYINIT.C1'):
             bel.connections['CYINIT'] = 1
-            bel.unused_connections.add('CI')
+            bel.connections['CI'] = 0
 
         elif site.has_feature('PRECYINIT.CIN'):
-            bel.unused_connections.add('CYINIT')
+            bel.connections['CYINIT'] = 0
             site.add_sink(bel, 'CI', 'CIN')
 
         else:


### PR DESCRIPTION
Unused CIN or CYINIT of a CARRY4 was left unconnected. This caused Yosys simulation to crash and caused Icarus to produce Xs. This happened eg, on autosim target in xc7/tests/counter design.

This PR ties those inputs to const 0 when unused which fixes the problem.