### PR TITLE
Enable Yosys abc9 pass.

### DIFF
--- a/tests/7-carry_stress/generate_carry_test.py
+++ b/tests/7-carry_stress/generate_carry_test.py
@@ -35,7 +35,7 @@ module LFSR (
     wire f;
     assign f = ^(POLY & ~r);
     always @( posedge clk)
-      r <= {{r[{depth}-1:1], ~f}};
+      r <= {{r[{depth}-2:0], ~f}};
 endmodule"""
 
 

--- a/tests/7-carry_stress/generate_carry_test.py
+++ b/tests/7-carry_stress/generate_carry_test.py
@@ -28,7 +28,7 @@ module LFSR (
     input clk,
     output [{depth}-1:0] out
     );
-    parameter POLY = 1;
+    parameter POLY = 1'b101;
 
     reg [{depth}-1:0] r = 1;
     assign out = r;

--- a/xc7/yosys/synth.tcl
+++ b/xc7/yosys/synth.tcl
@@ -2,7 +2,7 @@ yosys -import
 
 # -flatten is used to ensure that the output eblif has only one module.
 # Some of symbiflow expects eblifs with only one module.
-synth_xilinx -vpr -flatten -nosrl
+synth_xilinx -vpr -flatten -nosrl -abc9
 
 write_verilog $::env(OUT_SYNTH_V).premap.v
 


### PR DESCRIPTION
This dramatically improves the synthesis result from a timing
perspective.