### PR TITLE
SRL32 timings

### DIFF
--- a/xc7/bels.json
+++ b/xc7/bels.json
@@ -121,22 +121,14 @@
                 ["LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
         },
         "SRLC32E_VPR":{
-            "ASRL":{
-                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
-                "instance": "SLICEM/A6LUT SLICEM"
-            },
-            "BSRL":{
-                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
-                "instance": "SLICEM/B6LUT SLICEM"
-            },
-            "CSRL":{
-                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
-                "instance": "SLICEM/C6LUT SLICEM"
-            },
-            "DSRL":{
-                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
-                "instance": "SLICEM/D6LUT SLICEM"
-            }
+            "ASRL":
+                ["LUT_OR_MEM6SHFREG.SLICEM", "LUT_OR_MEM6SHFREG.SLICEM/A6LUT", "LUT_OR_MEM6LRAM.SLICEM/A6LUT"],
+            "BSRL":
+                ["LUT_OR_MEM6SHFREG.SLICEM", "LUT_OR_MEM6SHFREG.SLICEM/B6LUT", "LUT_OR_MEM6LRAM.SLICEM/B6LUT"],
+            "CSRL":
+                ["LUT_OR_MEM6SHFREG.SLICEM", "LUT_OR_MEM6SHFREG.SLICEM/C6LUT", "LUT_OR_MEM6LRAM.SLICEM/C6LUT"],
+            "DSRL":
+                ["LUT_OR_MEM6SHFREG.SLICEM", "LUT_OR_MEM6SHFREG.SLICEM/D6LUT", "LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
         },
         "F7AMUX":{
             "SLICEM_MODES":

--- a/xc7/bels.json
+++ b/xc7/bels.json
@@ -120,6 +120,24 @@
             "D_DRAM128":
                 ["LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
         },
+        "SRLC32E_VPR":{
+            "ASRL":{
+                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
+                "instance": "SLICEM/A6LUT SLICEM"
+            },
+            "BSRL":{
+                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
+                "instance": "SLICEM/B6LUT SLICEM"
+            },
+            "CSRL":{
+                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
+                "instance": "SLICEM/C6LUT SLICEM"
+            },
+            "DSRL":{
+                "celltype": "LUT_OR_MEM6SHFREG LUT_OR_MEM6LRAM",
+                "instance": "SLICEM/D6LUT SLICEM"
+            }
+        },
         "F7AMUX":{
             "SLICEM_MODES":
                 ["SELMUX2_1.SLICEM/F7AMUX"],

--- a/xc7/primitives/slicem/srl/srlc32e_vpr.model.xml
+++ b/xc7/primitives/slicem/srl/srlc32e_vpr.model.xml
@@ -4,11 +4,12 @@
   <input_ports>
    <port name="CLK" is_clock="1"/>
    <port name="CE" clock="CLK"/>
-   <port name="A" clock="CLK"/>
+   <port name="A" combinational_sink_ports="Q"/>
    <port name="D" clock="CLK"/>
   </input_ports>
   <output_ports>
-   <port name="Q" clock="CLK"/>
+   <!-- <port name="Q" clock="CLK"/> -->
+   <port name="Q"/>
    <port name="Q31" clock="CLK"/>
   </output_ports>
  </model>

--- a/xc7/primitives/slicem/srl/srlc32e_vpr.pb_type.xml
+++ b/xc7/primitives/slicem/srl/srlc32e_vpr.pb_type.xml
@@ -11,6 +11,8 @@
   <T_setup port="D" clock="CLK" value="{setup_CLK_DI1}"/>
   <T_hold port="D" clock="CLK" value="{hold_CLK_DI1}"/>
 
+  <!-- Physically inputs A2-A6 of a LUT in SRL32 mode are used. Hence
+       timings for those inputs are selected here -->      
   <delay_matrix type="min" in_port="A" out_port="Q">
     {iopath_A2_O6}
     {iopath_A3_O6}

--- a/xc7/primitives/slicem/srl/srlc32e_vpr.pb_type.xml
+++ b/xc7/primitives/slicem/srl/srlc32e_vpr.pb_type.xml
@@ -6,12 +6,29 @@
   <output name="Q" num_pins="1"/>
   <output name="Q31" num_pins="1"/>
 
-  <T_setup port="CE" clock="CLK" value="1e-11"/>
-  <T_setup port="A" clock="CLK" value="1e-11"/>
-  <T_setup port="D" clock="CLK" value="1e-11"/>
+  <T_setup port="CE" clock="CLK" value="{setup_CLK_WE}"/>
+  <T_hold port="CE" clock="CLK" value="{hold_CLK_WE}"/>
+  <T_setup port="D" clock="CLK" value="{setup_CLK_DI1}"/>
+  <T_hold port="D" clock="CLK" value="{hold_CLK_DI1}"/>
 
-  <T_clock_to_Q port="Q" clock="CLK" max="1e-11"/>
-  <T_clock_to_Q port="Q31" clock="CLK" max="1e-11"/>
+  <delay_matrix type="min" in_port="A" out_port="Q">
+    {iopath_A2_O6}
+    {iopath_A3_O6}
+    {iopath_A4_O6}
+    {iopath_A5_O6}
+    {iopath_A6_O6}
+  </delay_matrix>
+
+  <delay_matrix type="max" in_port="A" out_port="Q">
+    {iopath_A2_O6}
+    {iopath_A3_O6}
+    {iopath_A4_O6}
+    {iopath_A5_O6}
+    {iopath_A6_O6}
+  </delay_matrix>
+
+  <!-- <T_clock_to_Q port="Q" clock="CLK" max="{iopath_CLK_O6}"/> -->
+  <T_clock_to_Q port="Q31" clock="CLK" max="{iopath_CLK_MC31}"/>
 
   <metadata>
     <meta name="fasm_params">


### PR DESCRIPTION
This PR adds timings to SRL32 definitions. It also fixes a bug in `update_arch_timings.py` which caused hold times to be imported incorrectly.

Due to lack of support of a particular timing model structure in VPR (see https://github.com/SymbiFlow/symbiflow-arch-defs/issues/958) the output Q is treated as combinational and dependent on A inputs.