### PR TITLE
Fixes "git checkout" typo to "git clone"

### DIFF
--- a/xc7/README.md
+++ b/xc7/README.md
@@ -30,7 +30,7 @@ Additional targets are best explored via tab completion.
 Full example for buttons:
 
 ```
-git checkout https://github.com/SymbiFlow/symbiflow-arch-defs.git
+git clone https://github.com/SymbiFlow/symbiflow-arch-defs.git
 cd symbiflow-arch-defs
 make env
 cd build


### PR DESCRIPTION
The git checkout should be git clone. 