### PR TITLE
Add place delay and lookahead caching.

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -382,6 +382,9 @@ function(DEFINE_DEVICE)
   #   ARCH <arch>
   #   DEVICE_TYPE <device_type>
   #   PACKAGES <list of packages>
+  #   [CACHE_PLACE_DELAY]
+  #   [CACHE_LOOKAHEAD]
+  #   [CACHE_ARGS <args>]
   #   )
   # ~~~
   #
@@ -393,9 +396,23 @@ function(DEFINE_DEVICE)
   #
   # In order to use a device with ADD_FPGA_TARGET, the property
   # ${PACKAGE}_PINMAP on target <device> must be set.
-  set(options)
+  #
+  # To prevent VPR from recomputing the place delay matrix and/or lookahead,
+  # CACHE_PLACE_DELAY and CACHE_LOOKAHEAD options may be specified.
+  #
+  # If either are specified, CACHE_ARGS must be supplied with the relevant
+  # VPR arguments needed to emit the correct place delay and lookahead outputs.
+  # It is not required that the all arguments match the DEFINE_ARCH.VPR_ARCH_ARGS
+  # as it may be advantagous to increase routing effort for the placement delay
+  # matrix computation (e.g. lower astar_fac, etc).
+  #
+  # At a minimum, the --route_chan_width argument must be supplied.
+  #
+  # WARNING: Using a different place delay or lookahead algorithm will result
+  # in an invalid cache.
+  set(options CACHE_LOOKAHEAD CACHE_PLACE_DELAY)
   set(oneValueArgs DEVICE ARCH DEVICE_TYPE PACKAGES)
-  set(multiValueArgs RR_PATCH_DEPS RR_PATCH_EXTRA_ARGS)
+  set(multiValueArgs RR_PATCH_DEPS RR_PATCH_EXTRA_ARGS CACHE_ARGS)
   cmake_parse_arguments(
     DEFINE_DEVICE
     "${options}"
@@ -443,6 +460,10 @@ function(DEFINE_DEVICE)
       rr_graph_${DEVICE}_${PACKAGE}.rr_graph.virt${RR_GRAPH_EXT})
     set(OUT_RRXML_REAL_FILENAME
       rr_graph_${DEVICE}_${PACKAGE}.rr_graph.real${RR_GRAPH_EXT})
+    set(LOOKAHEAD_FILENAME
+      rr_graph_${DEVICE}_${PACKAGE}.lookahead.bin)
+    set(PLACE_DELAY_FILENAME
+      rr_graph_${DEVICE}_${PACKAGE}.place_delay.bin)
     set(OUT_RRXML_REAL_LINT_FILENAME rr_graph_${DEVICE}_${PACKAGE}.rr_graph.real.lint.html)
     set(OUT_RRXML_VIRT ${CMAKE_CURRENT_BINARY_DIR}/${OUT_RRXML_VIRT_FILENAME})
     set(OUT_RRXML_REAL ${CMAKE_CURRENT_BINARY_DIR}/${OUT_RRXML_REAL_FILENAME})
@@ -532,6 +553,79 @@ function(DEFINE_DEVICE)
         FILE ${OUT_RRXML_REAL}
         SCHEMA ${ROUTING_SCHEMA}
         )
+    endif()
+
+    if(${DEFINE_DEVICE_CACHE_LOOKAHEAD} OR ${DEFINE_DEVICE_CACHE_PLACE_DELAY})
+      # Generate lookahead and place delay lookup caches
+      set(DEPS)
+      append_file_dependency(DEPS ${OUT_RRXML_REAL_FILENAME})
+      append_file_dependency(DEPS ${VIRT_DEVICE_MERGED_FILE})
+
+      set(OUTPUTS)
+      set(ARGS)
+      if(${DEFINE_DEVICE_CACHE_LOOKAHEAD})
+          list(APPEND OUTPUTS ${LOOKAHEAD_FILENAME})
+          list(APPEND ARGS --write_router_lookahead ${LOOKAHEAD_FILENAME})
+      endif()
+      if(${DEFINE_DEVICE_CACHE_PLACE_DELAY})
+          list(APPEND OUTPUTS ${PLACE_DELAY_FILENAME})
+          list(APPEND ARGS --write_placement_delay_lookup ${PLACE_DELAY_FILENAME})
+      endif()
+
+      add_custom_command(
+        OUTPUT ${OUTPUTS}
+        DEPENDS
+            ${symbiflow-arch-defs_SOURCE_DIR}/common/wire.eblif
+            ${VPR} ${VPR_TARGET}
+            ${QUIET_CMD} ${QUIET_CMD_TARGET}
+            ${DEFINE_DEVICE_DEVICE_TYPE}
+            ${DEPS}
+        COMMAND
+            ${QUIET_CMD} ${VPR} ${DEVICE_MERGED_FILE}
+            --device ${DEVICE_FULL}
+            ${symbiflow-arch-defs_SOURCE_DIR}/common/wire.eblif
+            --read_rr_graph ${OUT_RRXML_REAL}
+            --outfile_prefix ${DEVICE}_${PACKAGE}_cache
+            --pack
+            --place
+            ${ARGS}
+            ${DEFINE_DEVICE_CACHE_ARGS}
+        COMMAND
+            ${CMAKE_COMMAND} -E copy vpr_stdout.log
+              rr_graph_${DEVICE}_${PACKAGE}.cache.out
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      )
+
+      if(${DEFINE_DEVICE_CACHE_LOOKAHEAD})
+        add_file_target(FILE ${LOOKAHEAD_FILENAME} GENERATED)
+      endif()
+      if(${DEFINE_DEVICE_CACHE_PLACE_DELAY})
+        add_file_target(FILE ${PLACE_DELAY_FILENAME} GENERATED)
+
+        if(${DEFINE_DEVICE_CACHE_LOOKAHEAD})
+            get_file_target(LOOKAHEAD_TARGET ${LOOKAHEAD_FILENAME})
+            get_file_target(PLACE_DELAY_TARGET ${PLACE_DELAY_FILENAME})
+
+            # Linearize target dependency.
+            add_dependencies(${PLACE_DELAY_TARGET} ${LOOKAHEAD_TARGET})
+        endif()
+      endif()
+
+      set_target_properties(
+        ${DEFINE_DEVICE_DEVICE}
+        PROPERTIES
+          ${PACKAGE}_HAS_PLACE_DELAY_CACHE ${DEFINE_DEVICE_CACHE_PLACE_DELAY}
+          ${PACKAGE}_HAS_LOOKAHEAD_CACHE ${DEFINE_DEVICE_CACHE_LOOKAHEAD}
+          ${PACKAGE}_LOOKAHEAD_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${LOOKAHEAD_FILENAME}
+          ${PACKAGE}_PLACE_DELAY_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${PLACE_DELAY_FILENAME}
+      )
+    else()
+      set_target_properties(
+        ${DEFINE_DEVICE_DEVICE}
+        PROPERTIES
+          ${PACKAGE}_HAS_PLACE_DELAY_CACHE FALSE
+          ${PACKAGE}_HAS_LOOKAHEAD_CACHE FALSE
+      )
     endif()
 
     # Define dummy boards.  PROG_TOOL is set to false to disallow programming.
@@ -958,6 +1052,32 @@ function(ADD_FPGA_TARGET)
     ${VPR_EXTRA_ARGS_LIST}
     ${SDC_ARG}
   )
+
+  get_target_property_required(
+    USE_LOOKAHEAD_CACHE ${DEVICE} ${PACKAGE}_HAS_LOOKAHEAD_CACHE
+  )
+  if(${USE_LOOKAHEAD_CACHE})
+    # If lookahead is cached, use the cache instead of recomputing lookaheads.
+    get_target_property_required(
+      LOOKAHEAD_FILE ${DEVICE} ${PACKAGE}_LOOKAHEAD_FILE
+      )
+    append_file_dependency(VPR_DEPS ${LOOKAHEAD_FILE})
+    get_file_location(LOOKAHEAD_LOCATION ${LOOKAHEAD_FILE})
+    list(APPEND VPR_CMD --read_router_lookahead ${LOOKAHEAD_LOCATION})
+  endif()
+
+  get_target_property_required(
+    USE_PLACE_DELAY_CACHE ${DEVICE} ${PACKAGE}_HAS_PLACE_DELAY_CACHE
+  )
+  if(${USE_PLACE_DELAY_CACHE})
+    get_target_property_required(
+      PLACE_DELAY_FILE ${DEVICE} ${PACKAGE}_PLACE_DELAY_FILE
+      )
+    append_file_dependency(VPR_DEPS ${PLACE_DELAY_FILE})
+    get_file_location(PLACE_DELAY_LOCATION ${PLACE_DELAY_FILE})
+    list(APPEND VPR_CMD --read_placement_delay_lookup ${PLACE_DELAY_LOCATION})
+  endif()
+
   list(APPEND VPR_DEPS ${VPR} ${VPR_TARGET} ${QUIET_CMD} ${QUIET_CMD_TARGET})
   append_file_dependency(VPR_DEPS ${OUT_EBLIF_REL})
 

--- a/ice40/devices/CMakeLists.txt
+++ b/ice40/devices/CMakeLists.txt
@@ -18,6 +18,14 @@ function(DEFINE_ICE40_DEVICE)
     ARCH ice40
     DEVICE_TYPE ${DEFINE_ICE40_DEVICE_DEVICE_TYPE}
     PACKAGES ${DEFINE_ICE40_DEVICE_PACKAGES}
+    CACHE_PLACE_DELAY
+    CACHE_ARGS
+      --route_chan_width 100
+      --clock_modeling route
+      --allow_unrelated_clustering off
+      --target_ext_pin_util 0.7
+      --router_init_wirelength_abort_threshold 2
+      --congested_routing_iteration_threshold 0.8
   )
 
   add_icebox_layouts(


### PR DESCRIPTION
 - Enable ice40 place delay caching.
 - xc7 place delay and lookahead caching will be enabled in a future commit.