### PR TITLE
Effectively zero out ice40 routing delays to make costs sane.

### DIFF
--- a/ice40/devices/top-routing-virt/arch.xml
+++ b/ice40/devices/top-routing-virt/arch.xml
@@ -87,8 +87,8 @@
  </device>
 
  <switchlist>
-  <switch type="mux"    name="routing" R="1" Cin=".77e-15" Cout="4e-15" Cinternal="0" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
-  <switch type="mux"    name="buffer"  R="2" Cin=".77e-15" Cout="4e-15" Cinternal="0" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+  <switch type="mux"    name="routing" R="1e-12" Cin=".77e-15" Cout="4e-15" Cinternal="0" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
+  <switch type="mux"    name="buffer"  R="2e-12" Cin=".77e-15" Cout="4e-15" Cinternal="0" Tdel="58e-12" mux_trans_size="2.630740" buf_size="27.645901"/>
   <switch type="short"  name="short" R="0" Cin="0" Cout="0" Tdel="0" />
   <switch type="buffer" name="driver" Cin="0" Cout="0" R="0" Tdel="0" buf_size="0" />
 <!--
@@ -100,52 +100,52 @@
 
  <segmentlist>
   <!-- Global networks -->
-  <segment name="fabout" length="1" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="fabout" length="1" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1</sb>
    <cb type="pattern">0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="tile_global" length="1" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="tile_global" length="1" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1</sb>
    <cb type="pattern">0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_0" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_0" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_1" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_1" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_2" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_2" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_3" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_3" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_4" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_4" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_5" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_5" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_6" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_6" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
   </segment>
-  <segment name="glb_netwk_7" length="100" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb_netwk_7" length="100" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0</cb>
    <mux name="buffer"/>
@@ -153,7 +153,7 @@
 
   <!-- Span 12 vertical   tracks -->
   <!-- Span 12 horizontal tracks -->
-  <segment name="span12" length="12" freq="50.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="span12" length="12" freq="50.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1 1</sb>
    <cb type="pattern">1 1 1 1 1 1 1 1 1 1 1 1</cb>
    <mux name="routing"/>
@@ -161,34 +161,34 @@
 
   <!-- Span 4 vertical   tracks -->
   <!-- Span 4 horizontal tracks -->
-  <segment name="span4" length="4" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="span4" length="4" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">1 1 1 1 1</sb>
    <cb type="pattern">1 1 1 1</cb>
    <mux name="buffer"/>
   </segment>
 
-  <segment name="glb2local" length="1" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="glb2local" length="1" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">0 1</sb>
    <cb type="pattern">1</cb>
    <mux name="buffer"/>
   </segment>
 
   <!-- Local tracks -->
-  <segment name="local" length="1" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="local" length="1" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">0 1</sb>
    <cb type="pattern">1</cb>
    <mux name="buffer"/>
   </segment>
 
   <!-- Neighbourhood tracks -->
-  <segment name="neigh" length="2" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="neigh" length="2" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">0 0 0</sb>
    <cb type="pattern">1 1</cb>
    <mux name="buffer"/>
   </segment>
 
   <!-- Dummy tracks -->
-  <segment name="dummy" length="1" freq="1.000000" type="unidir" Rmetal="101" Cmetal="22.5e-15">
+  <segment name="dummy" length="1" freq="1.000000" type="unidir" Rmetal="1e-12" Cmetal="22.5e-15">
    <sb type="pattern">0 0</sb>
    <cb type="pattern">0</cb>
    <mux name="buffer"/>

--- a/utils/lib/rr_graph/graph.py
+++ b/utils/lib/rr_graph/graph.py
@@ -2337,7 +2337,7 @@ class RoutingGraph:
             if ntype.track:
                 # Seems to confuse VPR when 0
                 # XXX: consider requiring the user to give instead of defaulting
-                timing = RoutingNodeTiming(R=1, C=1)
+                timing = RoutingNodeTiming(R=1e-9, C=1e-9)
             else:
                 timing = RoutingNodeTiming(R=0, C=0)
         assert len(timing) == 2
@@ -2391,7 +2391,7 @@ class RoutingGraph:
         TypeError: RoutingNodeType.SOURCE -> RoutingNodeType.CHANX not valid, Only SOURCE -> OPIN is valid
         0 X000Y000[00].SRC--> b'<node id="0" type="SOURCE" capacity="1"><loc xlow="0" ylow="0" xhigh="0" yhigh="0" ptc="0"/><timing R="0" C="0"/></node>'
           ->
-        2 X000Y000<-00->X000Y010 b'<node id="2" type="CHANX" capacity="1" direction="BI_DIR"><loc xlow="0" ylow="0" xhigh="0" yhigh="10" ptc="0"/><timing R="1" C="1"/><segment segment_id="0"/></node>'
+        2 X000Y000<-00->X000Y010 b'<node id="2" type="CHANX" capacity="1" direction="BI_DIR"><loc xlow="0" ylow="0" xhigh="0" yhigh="10" ptc="0"/><timing R="1e-09" C="1e-09"/><segment segment_id="0"/></node>'
         >>> r.create_edge_with_ids(1, 4, sw)
         Traceback (most recent call last):
           ...


### PR DESCRIPTION
While these new values are still wrong, the delay values are more
reasonable (e.g. 1-100 ns) instead of 1e9 seconds, etc.