### PR TITLE
Add INPINFEED, OUTPINFEED segment annotations and IPIN connection boxes.

### DIFF
--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -269,6 +269,7 @@ CREATE TABLE graph_node(
   pkey INTEGER PRIMARY KEY,
   graph_node_type INT,
   track_pkey INT,
+  connection_box_wire_pkey INT,
   node_pkey INT,
   x_low INT,
   x_high INT,
@@ -278,6 +279,7 @@ CREATE TABLE graph_node(
   capacity INT,
   capacitance REAL,
   resistance REAL,
+  FOREIGN KEY(connection_box_wire_pkey) REFERENCES wire(pkey),
   FOREIGN KEY(track_pkey) REFERENCES track(pkey),
   FOREIGN KEY(node_pkey) REFERENCES node(pkey)
 );

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -473,6 +473,7 @@ WHERE pkey IN (
 
             # This node does not exist, create it now
             write_cur = self.conn.cursor()
+
             write_cur.execute("INSERT INTO track DEFAULT VALUES")
             new_track_pkey = write_cur.lastrowid
 
@@ -510,6 +511,15 @@ FROM graph_node WHERE pkey = ?""", (
                 )
             )
             site_pin_graph_node_pkey = write_cur.lastrowid
+
+            write_cur.execute(
+                """
+UPDATE wire SET site_pin_graph_node_pkey = ?
+WHERE pkey = ?""", (
+                    site_pin_graph_node_pkey,
+                    wire_pkey,
+                )
+            )
 
             write_cur.connection.commit()
 
@@ -1212,6 +1222,389 @@ def verify_channels(conn, alive_tracks):
             ptcs[ptc] = graph_node_pkey
 
 
+def set_pin_connection(
+        conn, write_cur, pin_graph_node_pkey, forward, graph_node_pkey, tracks
+):
+    """ Sets pin connection box location canonical location.
+
+    Tracks that are a part of the pinfeed also get this location.
+
+    """
+    cur = conn.cursor()
+    cur2 = conn.cursor()
+    cur.execute(
+        """SELECT node_pkey, graph_node_type FROM graph_node WHERE pkey = ?""",
+        (pin_graph_node_pkey, )
+    )
+    pin_node_pkey, graph_node_type = cur.fetchone()
+
+    source_wires = []
+    cur.execute(
+        """SELECT pkey FROM wire WHERE node_pkey = (
+        SELECT node_pkey FROM graph_node WHERE pkey = ?
+        )""", (graph_node_pkey, )
+    )
+    for (wire_pkey, ) in cur:
+        if forward:
+            cur2.execute(
+                """SELECT count() FROM pip_in_tile WHERE src_wire_in_tile_pkey = (
+                SELECT wire_in_tile_pkey FROM wire WHERE pkey = ?
+                )""", (wire_pkey, )
+            )
+        else:
+            cur2.execute(
+                """SELECT count() FROM pip_in_tile WHERE dest_wire_in_tile_pkey = (
+                SELECT wire_in_tile_pkey FROM wire WHERE pkey = ?
+                )""", (wire_pkey, )
+            )
+
+        has_pip = cur2.fetchone()[0]
+        if has_pip:
+            source_wires.append(wire_pkey)
+
+    assert len(source_wires) <= 1
+
+    if len(source_wires) == 1:
+        cur.execute(
+            "SELECT phy_tile_pkey FROM wire WHERE pkey = ?",
+            (source_wires[0], )
+        )
+        phy_tile_pkey = cur.fetchone()[0]
+        for track_pkey in tracks:
+            write_cur.execute(
+                "UPDATE track SET canon_phy_tile_pkey = ? WHERE pkey = ?", (
+                    phy_tile_pkey,
+                    track_pkey,
+                )
+            )
+
+        if not forward:
+            assert NodeType(graph_node_type) == NodeType.IPIN
+            source_wire_pkey = source_wires[0]
+            write_cur.execute(
+                """
+UPDATE graph_node SET connection_box_wire_pkey = ? WHERE pkey = ?
+            """, (
+                    source_wire_pkey,
+                    pin_graph_node_pkey,
+                )
+            )
+
+
+def walk_and_mark_segment(
+        conn, write_cur, graph_node_pkey, forward, segment_pkey, unknown_pkey,
+        pin_graph_node_pkey, tracks
+):
+    """ Recursive function to walk along a node and mark segments.
+
+    This algorithm is used for marking INPINFEED and OUTPINFEED on nodes
+    starting from an IPIN or OPIN edge.
+
+    In addition, the canonical location of the connection box IPIN/OPIN nodes
+    is the canonical location of the routing interface.  For example, the
+    CLBLL_R tile is located to the right of the INT_R tile.  The routing
+    lookahead routes to the INT_R (e.g. a x-1 of the CLBLL_R).  So the
+    canonical location of the CLBLL_R IPIN is the INT_R tile, not the CLBLL_R
+    tile.
+
+    """
+    cur = conn.cursor()
+
+    # Update track segment's to segment_pkey (e.g. INPINFEED or OUTPINFEED).
+    cur.execute(
+        """SELECT graph_node_type FROM graph_node WHERE pkey = ?""",
+        (graph_node_pkey, )
+    )
+    graph_node_type = NodeType(cur.fetchone()[0])
+    if graph_node_type in [NodeType.CHANX, NodeType.CHANY]:
+        cur.execute(
+            "SELECT track_pkey FROM graph_node WHERE pkey = ?",
+            (graph_node_pkey, )
+        )
+        track_pkey = cur.fetchone()[0]
+        assert track_pkey is not None
+
+        cur.execute(
+            "SELECT segment_pkey FROM track WHERE pkey = ?", (track_pkey, )
+        )
+        old_segment_pkey = cur.fetchone()[0]
+        if old_segment_pkey == unknown_pkey or old_segment_pkey is None:
+            tracks.append(track_pkey)
+            write_cur.execute(
+                "UPDATE track SET segment_pkey = ? WHERE pkey = ?", (
+                    segment_pkey,
+                    track_pkey,
+                )
+            )
+
+    # Traverse to the next graph node.
+    if forward:
+        cur.execute(
+            """
+SELECT dest_graph_node_pkey FROM graph_edge WHERE src_graph_node_pkey = ?
+""", (graph_node_pkey, )
+        )
+        next_nodes = cur.fetchall()
+    else:
+        cur.execute(
+            """
+SELECT src_graph_node_pkey FROM graph_edge WHERE dest_graph_node_pkey = ?
+""", (graph_node_pkey, )
+        )
+        next_nodes = cur.fetchall()
+
+    next_node = None
+    if len(next_nodes) == 1:
+        # This is a simple edge, keep walking.
+        next_node = next_nodes[0][0]
+    elif not forward:
+        # Some nodes simply lead to GND/VCC tieoff pins, these should not
+        # stop the walk, as they are not relevant to connection box.
+        next_non_tieoff_nodes = []
+        for (next_graph_node_pkey, ) in next_nodes:
+            cur.execute(
+                """
+SELECT count() FROM constant_sources WHERE
+    vcc_track_pkey = (SELECT track_pkey FROM graph_node WHERE pkey = ?)
+OR
+    gnd_track_pkey = (SELECT track_pkey FROM graph_node WHERE pkey = ?)
+    """, (
+                    next_graph_node_pkey,
+                    next_graph_node_pkey,
+                )
+            )
+            if cur.fetchone()[0] == 0:
+                next_non_tieoff_nodes.append(next_graph_node_pkey)
+
+        if len(next_non_tieoff_nodes) == 1:
+            next_node = next_non_tieoff_nodes[0]
+
+    if next_node is not None:
+        # If there is a next node, keep walking
+        walk_and_mark_segment(
+            conn, write_cur, next_node, forward, segment_pkey, unknown_pkey,
+            pin_graph_node_pkey, tracks
+        )
+    else:
+        # There is not a next node, update the connection box of the IPIN/OPIN
+        # the walk was started from.
+        set_pin_connection(
+            conn=conn,
+            write_cur=write_cur,
+            pin_graph_node_pkey=pin_graph_node_pkey,
+            forward=forward,
+            graph_node_pkey=graph_node_pkey,
+            tracks=tracks
+        )
+
+
+def active_graph_node(conn, graph_node_pkey, forward):
+    """ Returns true if an edge in the specified direction exists. """
+    cur = conn.cursor()
+
+    if forward:
+        cur.execute(
+            """
+SELECT count(*) FROM graph_edge WHERE src_graph_node_pkey = ? LIMIT 1
+            """, (graph_node_pkey, )
+        )
+    else:
+        cur.execute(
+            """
+SELECT count(*) FROM graph_edge WHERE dest_graph_node_pkey = ? LIMIT 1
+            """, (graph_node_pkey, )
+        )
+
+    return cur.fetchone()[0] > 0
+
+
+def annotate_pin_feeds(conn):
+    """ Identifies and annotates pin feed channels.
+
+    Some channels are simply paths from IPIN's or OPIN's.  Set
+    pin_classification to either IPIN_FEED or OPIN_FEED.  During track creation
+    if these nodes are not given a specific segment, they will be assigned as
+    INPINFEED or OUTPINFEED.
+    """
+    write_cur = conn.cursor()
+    cur = conn.cursor()
+
+    cur.execute("SELECT pkey FROM segment WHERE name = ?", ("unknown", ))
+    unknown_pkey = cur.fetchone()[0]
+
+    cur.execute("SELECT pkey FROM segment WHERE name = ?", ("INPINFEED", ))
+    inpinfeed_pkey = cur.fetchone()[0]
+
+    cur.execute("SELECT pkey FROM segment WHERE name = ?", ("OUTPINFEED", ))
+    outpinfeed_pkey = cur.fetchone()[0]
+
+    write_cur.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+
+    # Walk from OPIN's first.
+    for (graph_node_pkey, node_pkey) in cur.execute("""
+SELECT graph_node.pkey, graph_node.node_pkey
+FROM graph_node
+WHERE graph_node.graph_node_type = ?
+        """, (NodeType.OPIN.value, )):
+        if not active_graph_node(conn, graph_node_pkey, forward=True):
+            continue
+
+        walk_and_mark_segment(
+            conn,
+            write_cur,
+            graph_node_pkey,
+            forward=True,
+            segment_pkey=outpinfeed_pkey,
+            unknown_pkey=unknown_pkey,
+            pin_graph_node_pkey=graph_node_pkey,
+            tracks=list(),
+        )
+
+    # Walk from IPIN's next.
+    for (graph_node_pkey, ) in cur.execute("""
+SELECT graph_node.pkey
+FROM graph_node
+WHERE graph_node.graph_node_type = ?
+        """, (NodeType.IPIN.value, )):
+
+        if not active_graph_node(conn, graph_node_pkey, forward=False):
+            continue
+
+        walk_and_mark_segment(
+            conn,
+            write_cur,
+            graph_node_pkey,
+            forward=False,
+            segment_pkey=inpinfeed_pkey,
+            unknown_pkey=unknown_pkey,
+            pin_graph_node_pkey=graph_node_pkey,
+            tracks=list(),
+        )
+
+    write_cur.execute("""COMMIT TRANSACTION;""")
+
+
+def set_track_canonical_loc(conn):
+    """ For each track, compute a canonical location.
+
+    This canonical location should be consisent across instances of the track
+    type.  For example, a 6 length NW should always have a canonical location
+    at the SE corner of the the track.
+
+    For bidirection wires (generally long segments), use a consisent
+    canonilization.
+    """
+
+    write_cur = conn.cursor()
+    cur = conn.cursor()
+    cur2 = conn.cursor()
+    cur3 = conn.cursor()
+
+    write_cur.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+
+    cur.execute("SELECT pkey FROM track WHERE alive")
+    tracks = cur.fetchall()
+    for (track_pkey, ) in progressbar_utils.progressbar(tracks):
+        source_wires = []
+        for (wire_pkey, ) in cur2.execute("""
+SELECT pkey FROM wire WHERE node_pkey IN (
+    SELECT pkey FROM node WHERE track_pkey = ?
+    )""", (track_pkey, )):
+            cur3.execute(
+                """
+SELECT count(*)
+FROM pip_in_tile
+WHERE
+    dest_wire_in_tile_pkey = (SELECT wire_in_tile_pkey FROM wire WHERE pkey = ?)
+LIMIT 1
+    """, (wire_pkey, )
+            )
+            pips_to_wire = cur3.fetchone()[0]
+            if pips_to_wire > 0:
+                cur3.execute(
+                    """
+SELECT grid_x, grid_y FROM phy_tile WHERE pkey = (
+    SELECT phy_tile_pkey FROM wire WHERE pkey = ?
+                    )""", (wire_pkey, )
+                )
+                grid_x, grid_y = cur3.fetchone()
+                source_wires.append(((grid_x, grid_y), wire_pkey))
+
+        if len(source_wires) > 0:
+            source_wire_pkey = min(source_wires, key=lambda x: x[0])[1]
+            write_cur.execute(
+                """
+UPDATE track
+SET canon_phy_tile_pkey = (SELECT phy_tile_pkey FROM wire WHERE pkey = ?)
+WHERE pkey = ?
+            """, (source_wire_pkey, track_pkey)
+            )
+
+    write_cur.execute("""COMMIT TRANSACTION;""")
+
+
+def compute_segment_lengths(conn):
+    """ Determine segment lengths used for cost normalization. """
+    cur = conn.cursor()
+    cur2 = conn.cursor()
+    cur3 = conn.cursor()
+    cur4 = conn.cursor()
+
+    write_cur = conn.cursor()
+
+    write_cur.execute("""BEGIN EXCLUSIVE TRANSACTION;""")
+
+    for (segment_pkey, ) in cur.execute("SELECT pkey FROM segment"):
+        segment_length = 1
+
+        # Get all tracks with this segment
+        for (track_pkey, src_phy_tile_pkey) in cur2.execute("""
+SELECT pkey, canon_phy_tile_pkey FROM track
+WHERE
+    canon_phy_tile_pkey IS NOT NULL
+AND
+    segment_pkey = ?
+        """, (segment_pkey, )):
+            cur4.execute(
+                "SELECT grid_x, grid_y FROM phy_tile WHERE pkey = ?",
+                (src_phy_tile_pkey, )
+            )
+            src_x, src_y = cur4.fetchone()
+
+            # Get tiles downstream of this track.
+            for (dest_phy_tile_pkey, ) in cur3.execute("""
+SELECT DISTINCT canon_phy_tile_pkey FROM track WHERE pkey IN (
+    SELECT track_pkey FROM graph_node WHERE pkey IN (
+        SELECT dest_graph_node_pkey FROM graph_edge WHERE src_graph_node_pkey = (
+            SELECT pkey FROM graph_node WHERE track_pkey = ?
+        )
+    )
+) AND canon_phy_tile_pkey IS NOT NULL
+            """, (track_pkey, )):
+                if src_phy_tile_pkey == dest_phy_tile_pkey:
+                    continue
+
+                cur4.execute(
+                    "SELECT grid_x, grid_y FROM phy_tile WHERE pkey = ?",
+                    (dest_phy_tile_pkey, )
+                )
+                dest_x, dest_y = cur4.fetchone()
+
+                segment_length = max(
+                    segment_length,
+                    abs(dest_x - src_x) + abs(dest_y - src_y)
+                )
+
+        write_cur.execute(
+            "UPDATE segment SET length = ? WHERE pkey = ?", (
+                segment_length,
+                segment_pkey,
+            )
+        )
+
+    write_cur.execute("""COMMIT TRANSACTION;""")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1376,6 +1769,9 @@ def main():
         write_cur.execute(
             """CREATE INDEX dest_node_index ON graph_edge(dest_graph_node_pkey);"""
         )
+        write_cur.execute(
+            """CREATE INDEX node_track_index ON node(track_pkey);"""
+        )
         write_cur.connection.commit()
 
         print('{} Indices created, marking track liveness'.format(now()))
@@ -1384,6 +1780,15 @@ def main():
         mark_track_liveness(
             conn, pool, input_only_nodes, output_only_nodes, alive_tracks
         )
+
+        print('{} Set track canonical loc'.format(now()))
+        set_track_canonical_loc(conn)
+
+        print('{} Annotate pin feeds'.format(now()))
+        annotate_pin_feeds(conn)
+
+        print('{} Compute segment lengths'.format(now()))
+        compute_segment_lengths(conn)
 
         print(
             '{} Flushing database back to file "{}"'.format(


### PR DESCRIPTION
These changes are required to support connection box lookahead.

- INPINFEED/OUTPINFEED's are annotated by propigating out from IPIN's
  and OPIN's.  These segments are typically uninteresting to the router,
  as they have no decisions, but soley exist for timing reasons.
- IPIN connection boxes provide the canonical routing locations based on
  their connection to the routing interface (e.g. INT_L location versus
  CLBLL_L location).