### PR TITLE
Use ninja build system.

### DIFF
--- a/.github/kokoro/continuous-docs.cfg
+++ b/.github/kokoro/continuous-docs.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/continuous-ice40.cfg
+++ b/.github/kokoro/continuous-ice40.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/continuous-testarch.cfg
+++ b/.github/kokoro/continuous-testarch.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/continuous-tests.cfg
+++ b/.github/kokoro/continuous-tests.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/continuous-xc7.cfg
+++ b/.github/kokoro/continuous-xc7.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/kokoro-cfg.py
+++ b/.github/kokoro/kokoro-cfg.py
@@ -19,6 +19,11 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
+    regex: "**/pack.log"
+    regex: "**/place.log"
+    regex: "**/route.log"
+    regex: "**/*_qor.csv"
     strip_prefix: "github/symbiflow-arch-defs-%(kokoro_type)s-%(arch)s/"
   }
 }

--- a/.github/kokoro/presubmit-docs.cfg
+++ b/.github/kokoro/presubmit-docs.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/presubmit-ice40.cfg
+++ b/.github/kokoro/presubmit-ice40.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/presubmit-testarch.cfg
+++ b/.github/kokoro/presubmit-testarch.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/presubmit-tests.cfg
+++ b/.github/kokoro/presubmit-tests.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/presubmit-xc7.cfg
+++ b/.github/kokoro/presubmit-xc7.cfg
@@ -13,6 +13,7 @@ action {
     # File types
     regex: "**/*result*.xml"
     regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -36,6 +36,11 @@ sudo apt-get install -y \
         python3-virtualenv \
         python3-yaml \
         virtualenv \
+        ninja-build \
+
+if [ -z "${BUILD_TOOL}" ]; then
+    export BUILD_TOOL=make
+fi
 
 echo "----------------------------------------"
 
@@ -54,7 +59,7 @@ echo "----------------------------------------"
 	echo
 	echo " Setting up basic conda environment"
 	echo "----------------------------------------"
-	make all_conda
+	${BUILD_TOOL} all_conda
 
 	echo
 	echo " Output information about conda environment"

--- a/.github/kokoro/xc7.sh
+++ b/.github/kokoro/xc7.sh
@@ -3,6 +3,8 @@
 SCRIPT_SRC="$(realpath ${BASH_SOURCE[0]})"
 SCRIPT_DIR="$(dirname "${SCRIPT_SRC}")"
 
+export CMAKE_FLAGS=-GNinja
+export BUILD_TOOL=ninja
 source ${SCRIPT_DIR}/common.sh
 
 echo
@@ -12,9 +14,7 @@ echo "----------------------------------------"
 (
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
-	export MAKE_ARGS="-j${MAX_CORES} --output-sync=target"
-	# Run as many tests as we can.  Rerun individually on failure.
-	make -k ${MAKE_ARGS} all_xc7 || make all_xc7
-	make print_qor > xc7_qor.csv
+	ninja -j${MAX_CORES} all_xc7
+	ninja print_qor > xc7_qor.csv
 )
 echo "----------------------------------------"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 env:
 	git submodule init
 	git submodule update --init --recursive
-	mkdir -p build && cd build && cmake ..
+	mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
 
 build/Makefile:
 	make env


### PR DESCRIPTION
Unclear why, but using ninja might help with the flakyness we've been seeing on the large VMs.  It may also speed up builds too.  As a side affect, ninja logs can be used to easily profiler the build times (see https://buildbloat.neocities.org/)