### PR TITLE
Yosys: cells property should not return internal cells

### DIFF
--- a/utils/vlog/yosys/json.py
+++ b/utils/vlog/yosys/json.py
@@ -51,6 +51,8 @@ class YosysModule:
         """
         clist = []
         for cell, cdata in sorted(self.data["cells"].items()):
+            if cdata["type"].startswith('$'):
+                continue
             clist.append((cell, cdata["type"]))
         return clist
 


### PR DESCRIPTION
Comment says that the cell property does not include Yosys internal cells, but the code is not filtering them.