### PR TITLE
Add buttons_arty target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,8 @@ add_custom_target(all_xc7_route_tests)
 
 if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
 add_dependencies(all_xc7_route_tests
-    all_dummy_artix7_xc7a50t-arty_test_route
+    all_dummy_artix7_xc7a50t-arty-swbut_test_route
+    all_dummy_artix7_xc7a50t-arty-uart_test_route
     all_dummy_artix7_xc7a50t-basys3_test_route
     )
 endif()
@@ -224,7 +225,8 @@ endif()
 add_custom_target(all_xc7_demos)
 if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
 add_dependencies(all_xc7_demos
-    all_arty_bin
+    all_arty-swbut_bin
+    all_arty-uart_bin
     all_basys3_bin
     # TODO(#548) Zybo targets not currently working, so removed from all target.
     #all_zybo_bin

--- a/xc7/archs/artix7/devices/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_xc7_device_define(
   ARCH artix7
-  DEVICES xc7a50t-basys3 xc7a50t-arty
-  PARTS xc7a35tcpg236-1 xc7a35tcsg324-1
+  DEVICES xc7a50t-basys3 xc7a50t-arty xc7a50t-arty-swbut
+  PARTS xc7a35tcpg236-1 xc7a35tcsg324-1 xc7a35tcsg324-1
 )

--- a/xc7/archs/artix7/devices/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_xc7_device_define(
   ARCH artix7
-  DEVICES xc7a50t-basys3 xc7a50t-arty xc7a50t-arty-swbut
+  DEVICES xc7a50t-basys3 xc7a50t-arty-uart xc7a50t-arty-swbut
   PARTS xc7a35tcpg236-1 xc7a35tcsg324-1 xc7a35tcsg324-1
 )

--- a/xc7/archs/artix7/devices/xc7a50t-arty-swbut-roi-virt/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/xc7a50t-arty-swbut-roi-virt/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_xc7_device_define_type(
+  ARCH artix7
+  DEVICE xc7a50t-arty-swbut
+  ROI_PART xc7a35tcsg324-1
+  ROI_DIR ${PRJXRAY_DB_DIR}/artix7/harness/arty-a7/swbut
+  TILE_TYPES SLICEL SLICEM BRAM_L
+  NAME arty-swbut
+)

--- a/xc7/archs/artix7/devices/xc7a50t-arty-uart-roi-virt/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/xc7a50t-arty-uart-roi-virt/CMakeLists.txt
@@ -4,5 +4,5 @@ add_xc7_device_define_type(
   ROI_PART xc7a35tcsg324-1
   ROI_DIR ${PRJXRAY_DB_DIR}/artix7/harness/arty-a7/uart
   TILE_TYPES SLICEL SLICEM BRAM_L
-  NAME arty
+  NAME arty-uart
 )

--- a/xc7/archs/artix7/devices/xc7a50t-arty-uart-roi-virt/CMakeLists.txt
+++ b/xc7/archs/artix7/devices/xc7a50t-arty-uart-roi-virt/CMakeLists.txt
@@ -1,9 +1,8 @@
 add_xc7_device_define_type(
   ARCH artix7
-  DEVICE xc7a50t-arty
+  DEVICE xc7a50t-arty-uart
   ROI_PART xc7a35tcsg324-1
   ROI_DIR ${PRJXRAY_DB_DIR}/artix7/harness/arty-a7/uart
   TILE_TYPES SLICEL SLICEM BRAM_L
   NAME arty
 )
-

--- a/xc7/boards.cmake
+++ b/xc7/boards.cmake
@@ -10,6 +10,14 @@ define_board(
 )
 
 define_board(
+  BOARD arty-swbut
+  DEVICE xc7a50t-arty-swbut
+  PACKAGE test
+  PROG_TOOL ${OPENOCD_TARGET}
+  PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
+)
+
+define_board(
   BOARD arty
   DEVICE xc7a50t-arty
   PACKAGE test

--- a/xc7/boards.cmake
+++ b/xc7/boards.cmake
@@ -18,9 +18,11 @@ define_board(
 )
 
 define_board(
-  BOARD arty
-  DEVICE xc7a50t-arty
+  BOARD arty-uart
+  DEVICE xc7a50t-arty-uart
   PACKAGE test
+  PROG_TOOL ${OPENOCD_TARGET}
+  PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
 )
 
 # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/344

--- a/xc7/tests/buttons/CMakeLists.txt
+++ b/xc7/tests/buttons/CMakeLists.txt
@@ -1,4 +1,11 @@
 add_fpga_target(
+  NAME buttons_arty
+  BOARD arty-swbut
+  SOURCES buttons_arty.v
+  INPUT_IO_FILE arty.pcf
+  )
+
+ add_fpga_target(
   NAME buttons_basys3
   BOARD basys3
   SOURCES buttons_basys3.v

--- a/xc7/tests/buttons/arty.pcf
+++ b/xc7/tests/buttons/arty.pcf
@@ -1,0 +1,20 @@
+# in[7:0] corresponds to {BTN3-0, SW3-0} in arty
+set_io in[0] A8
+set_io in[1] C11
+set_io in[2] C10
+set_io in[3] A10
+set_io in[4] D9
+set_io in[5] C9
+set_io in[6] B9
+set_io in[7] B8
+
+# out[7:0] corresponds to {LD7-0} in arty.
+# only green components of RGB leds
+set_io out[0] F6
+set_io out[1] J4
+set_io out[2] J2
+set_io out[3] H6
+set_io out[4] H5
+set_io out[5] J5
+set_io out[6] T9
+set_io out[7] T10

--- a/xc7/tests/buttons/buttons_arty.v
+++ b/xc7/tests/buttons/buttons_arty.v
@@ -1,0 +1,6 @@
+module top(
+	input [7:0] in,
+	output [7:0] out
+);
+  assign out = in;
+endmodule

--- a/xc7/tests/counter/CMakeLists.txt
+++ b/xc7/tests/counter/CMakeLists.txt
@@ -27,4 +27,4 @@ add_fpga_target(
   BOARD arty-uart
   SOURCES counter_arty.v
   INPUT_IO_FILE arty.pcf
-  )
+)

--- a/xc7/tests/counter/CMakeLists.txt
+++ b/xc7/tests/counter/CMakeLists.txt
@@ -24,7 +24,7 @@ add_vivado_target(
 
 add_fpga_target_boards(
   NAME counter
-  BOARDS arty
+  BOARDS arty-uart
   SOURCES counter_arty.v
   IMPLICIT_INPUT_IO_FILES
   )

--- a/xc7/tests/counter/CMakeLists.txt
+++ b/xc7/tests/counter/CMakeLists.txt
@@ -26,5 +26,5 @@ add_fpga_target_boards(
   NAME counter
   BOARDS arty-uart
   SOURCES counter_arty.v
-  IMPLICIT_INPUT_IO_FILES
+  INPUT_IO_FILE arty.pcf
   )

--- a/xc7/tests/counter/CMakeLists.txt
+++ b/xc7/tests/counter/CMakeLists.txt
@@ -22,9 +22,9 @@ add_vivado_target(
     CLOCK_PERIODS 10.0
     )
 
-add_fpga_target_boards(
-  NAME counter
-  BOARDS arty-uart
+add_fpga_target(
+  NAME counter_arty
+  BOARD arty-uart
   SOURCES counter_arty.v
   INPUT_IO_FILE arty.pcf
   )

--- a/xc7/tests/uart_loopback/CMakeLists.txt
+++ b/xc7/tests/uart_loopback/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_fpga_target_boards(
-  NAME uart_loopback
-  BOARDS arty-uart
+add_fpga_target(
+  NAME uart_loopback_arty
+  BOARD arty-uart
   SOURCES uart_loopback.v
   INPUT_IO_FILE arty.pcf
   )

--- a/xc7/tests/uart_loopback/CMakeLists.txt
+++ b/xc7/tests/uart_loopback/CMakeLists.txt
@@ -2,5 +2,5 @@ add_fpga_target_boards(
   NAME uart_loopback
   BOARDS arty-uart
   SOURCES uart_loopback.v
-  IMPLICIT_INPUT_IO_FILES
+  INPUT_IO_FILE arty.pcf
   )

--- a/xc7/tests/uart_loopback/CMakeLists.txt
+++ b/xc7/tests/uart_loopback/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_fpga_target_boards(
   NAME uart_loopback
-  BOARDS arty
+  BOARDS arty-uart
   SOURCES uart_loopback.v
   IMPLICIT_INPUT_IO_FILES
   )


### PR DESCRIPTION
This adds an `arty-swbut` board(separate from `arty`, which uses `uart` harness) which uses the `swbut` harness of Arty, and adds a case to `xc7/tests/buttons` so that `make buttons_arty_prog` works on HW.