### PR TITLE
[xc7] Fixes for SRL and LUT-RAM

### DIFF
--- a/tests/9-scalable_proc/utils/rom_generator.py
+++ b/tests/9-scalable_proc/utils/rom_generator.py
@@ -115,7 +115,7 @@ RAM64X1D #
 )
 dram_{row}_{col}
 (
-.WCLK   (1'b0),
+.WCLK   (CLK),
 .WE     (1'b0), .D(1'b0),
 .DPRA0  (1'b0), .DPRA1(1'b0), .DPRA2(1'b0),
 .DPRA3  (1'b0), .DPRA4(1'b0), .DPRA5(1'b0),

--- a/xc7/bels.json
+++ b/xc7/bels.json
@@ -90,7 +90,17 @@
             "D_DRAM":
                 ["LUT_OR_MEM5LRAM.SLICEM/D5LUT"]
         },
-        "DPRAM32": {
+        "DPRAM32_O6": {
+            "A_DRAM":
+                ["LUT_OR_MEM5LRAM.SLICEM/A5LUT"],
+            "B_DRAM":
+                ["LUT_OR_MEM5LRAM.SLICEM/B5LUT"],
+            "C_DRAM":
+                ["LUT_OR_MEM5LRAM.SLICEM/C5LUT"],
+            "D_DRAM":
+                ["LUT_OR_MEM5LRAM.SLICEM/D5LUT"]
+        },
+        "DPRAM32_O5": {
             "A_DRAM":
                 ["LUT_OR_MEM5LRAM.SLICEM/A5LUT"],
             "B_DRAM":

--- a/xc7/fasm2bels/clb_models.py
+++ b/xc7/fasm2bels/clb_models.py
@@ -1069,7 +1069,9 @@ def process_slice(top, s):
 
     ff5_bels = {}
     for lut in 'ABCD':
-        if site.has_feature('{}OUTMUX.{}5Q'.format(lut, lut)):
+        if site.has_feature('{}OUTMUX.{}5Q'.format(lut, lut)) or \
+                site.has_feature('{}5FFMUX.IN_A'.format(lut)) or \
+                site.has_feature('{}5FFMUX.IN_B'.format(lut)):
             # 5FF in use, emit
             name, clk, ce, sr, init = ff_bel(site, lut, ff5=True)
             ff5 = Bel(name, "{}5_{}".format(lut, name))

--- a/xc7/fasm2bels/clb_models.py
+++ b/xc7/fasm2bels/clb_models.py
@@ -54,7 +54,7 @@ def get_srl32_init(features, tile_name, slice_name, srl):
 
 
 def create_srl32(site, srl):
-    bel = Bel('SRLC32E', srl + 'SRL', priority=3)
+    bel = Bel('SRLC32E', srl + 'SRL', priority=2)
     bel.set_bel(srl + '6LUT')
 
     site.add_sink(bel, 'CLK', 'CLK')
@@ -91,7 +91,7 @@ def create_srl16(site, srl, srl_type, part):
 
     assert part == '5' or part == '6'
 
-    bel = Bel(srl_type, srl + part + 'SRL', priority=3)
+    bel = Bel(srl_type, srl + part + 'SRL', priority=2)
     bel.set_bel(srl + part + 'LUT')
 
     site.add_sink(bel, 'CLK', 'CLK')
@@ -115,8 +115,10 @@ def decode_dram(site):
     Returns dictionary of lut position (e.g. 'A') to lut mode.
     """
     lut_ram = {}
+    lut_small = {}
     for lut in 'ABCD':
         lut_ram[lut] = site.has_feature('{}LUT.RAM'.format(lut))
+        lut_small[lut] = site.has_feature('{}LUT.SMALL'.format(lut))
 
     di = {}
     for lut in 'ABC':
@@ -167,47 +169,54 @@ def decode_dram(site):
 
         return lut_modes
 
-    # Remaining modes:
-    # RAM32X1S, RAM32X1D, RAM64X1S, RAM64X1D
+    all_ram = all(lut_ram[lut] for lut in 'ABCD')
+    all_small = all(lut_small[lut] for lut in 'ABCD')
 
-    remaining = set('ABCD')
+    if all_ram and not all_small:
+        return {'D': 'RAM64M'}
+    elif all_ram and all_small:
+        return {'D': 'RAM32M'}
+    else:
+        # Remaining modes:
+        # RAM32X1S, RAM32X1D, RAM64X1S, RAM64X1D
+        remaining = set('ABCD')
 
-    for lut in 'AC':
-        if lut_ram[lut] and di[lut]:
-            remaining.remove(lut)
-
-            if site.has_feature('{}LUT.SMALL'.format(lut)):
-                lut_modes[lut] = 'RAM32X2S'
-            else:
-                lut_modes[lut] = 'RAM64X1S'
-
-    for lut in 'BD':
-        if not lut_ram[lut]:
-            continue
-
-        minus_one = chr(ord(lut) - 1)
-        if minus_one in remaining:
-            if lut_ram[minus_one]:
+        for lut in 'AC':
+            if lut_ram[lut] and di[lut]:
                 remaining.remove(lut)
-                remaining.remove(minus_one)
-                if site.has_feature('{}LUT.SMALL'.format(lut)):
-                    lut_modes[lut] = 'RAM32X1D'
-                    lut_modes[minus_one] = 'RAM32X1D'
+
+                if lut_small[lut]:
+                    lut_modes[lut] = 'RAM32X1S'
                 else:
-                    lut_modes[lut] = 'RAM64X1D'
-                    lut_modes[minus_one] = 'RAM64X1D'
+                    lut_modes[lut] = 'RAM64X1S'
 
-        if lut in remaining:
-            remaining.remove(lut)
-            if site.has_feature('{}LUT.SMALL'.format(lut)):
-                lut_modes[lut] = 'RAM32X2S'
-            else:
-                lut_modes[lut] = 'RAM64X1S'
+        for lut in 'BD':
+            if not lut_ram[lut]:
+                continue
 
-    for lut in remaining:
-        lut_modes[lut] = 'LUT'
+            minus_one = chr(ord(lut) - 1)
+            if minus_one in remaining:
+                if lut_ram[minus_one]:
+                    remaining.remove(lut)
+                    remaining.remove(minus_one)
+                    if lut_small[lut]:
+                        lut_modes[lut] = 'RAM32X1D'
+                        lut_modes[minus_one] = 'RAM32X1D'
+                    else:
+                        lut_modes[lut] = 'RAM64X1D'
+                        lut_modes[minus_one] = 'RAM64X1D'
 
-    return lut_modes
+            if lut in remaining:
+                remaining.remove(lut)
+                if lut_small[lut]:
+                    lut_modes[lut] = 'RAM32X1S'
+                else:
+                    lut_modes[lut] = 'RAM64X1S'
+
+        for lut in remaining:
+            lut_modes[lut] = 'LUT'
+
+        return lut_modes
 
 
 def ff_bel(site, lut, ff5):
@@ -286,6 +295,8 @@ def cleanup_carry4(top, site):
             # No outputs in use, remove entire BEL
             top.remove_bel(site, carry4)
         else:
+            pass
+            """
             for idx in range(4):
                 if not o_in_use[idx] and not co_in_use[idx]:
                     sink_wire_pkey = site.remove_internal_sink(
@@ -299,6 +310,7 @@ def cleanup_carry4(top, site):
                     )
                     if sink_wire_pkey is not None:
                         top.remove_sink(sink_wire_pkey)
+            """
 
 
 def cleanup_srl(top, site):
@@ -364,6 +376,24 @@ def cleanup_slice(top, site):
 
     # Cleanup SRL stuff
     cleanup_srl(top, site)
+
+
+def munge_ram32m_init(init):
+    """ RAM32M INIT is interleaved, while the underlying data is not.
+
+    INIT[::2] = INIT[:32]
+    INIT[1::2] = INIT[32:]
+
+    """
+
+    bits = init.replace("64'b", "")[::-1]
+    assert len(bits) == 64
+
+    out_init = ['0' for _ in range(64)]
+    out_init[::2] = bits[:32]
+    out_init[1::2] = bits[32:]
+
+    return "64'b{}".format(''.join(out_init[::-1]))
 
 
 def process_slice(top, s):
@@ -441,6 +471,7 @@ def process_slice(top, s):
 
     luts = {}
     srls = {}
+
     # Add BELs for LUTs/RAMs
     if not site.has_feature('DLUT.RAM'):
         for row in 'ABCD':
@@ -646,8 +677,64 @@ def process_slice(top, s):
             del lut_modes['B']
             del lut_modes['C']
             del lut_modes['D']
+        elif lut_modes['D'] == 'RAM64M':
+            del lut_modes['D']
+
+            ram64m = Bel('RAM64M', name='RAM64M', priority=3)
+
+            site.add_sink(ram64m, 'WE', WE)
+            site.add_sink(ram64m, 'WCLK', "CLK")
+
+            for lut in 'ABCD':
+                site.add_sink(ram64m, 'DI' + lut, lut + "I")
+                for idx in range(6):
+                    site.add_sink(
+                        ram64m, 'ADDR{}[{}]'.format(lut, idx),
+                        "{}{}".format(lut, idx + 1)
+                    )
+
+                site.add_internal_source(ram64m, 'DO' + lut, lut + "O6")
+
+                ram64m.parameters['INIT_' + lut] = get_lut_init(
+                    s, aparts[0], aparts[1], lut
+                )
+
+            site.add_bel(ram64m)
+        elif lut_modes['D'] == 'RAM32M':
+            del lut_modes['D']
+
+            ram32m = Bel('RAM32M', name='RAM32M', priority=3)
+
+            site.add_sink(ram32m, 'WE', WE)
+            site.add_sink(ram32m, 'WCLK', "CLK")
+
+            for lut in 'ABCD':
+                site.add_sink(ram32m, 'DI{}[1]'.format(lut), lut + "X")
+                site.add_internal_source(
+                    ram32m, 'DO{}[1]'.format(lut), lut + "O6"
+                )
+
+                site.add_sink(ram32m, 'DI{}[0]'.format(lut), lut + "I")
+                site.add_internal_source(
+                    ram32m, 'DO{}[0]'.format(lut), lut + "O5"
+                )
+
+                for idx in range(5):
+                    site.add_sink(
+                        ram32m, 'ADDR{}[{}]'.format(lut, idx),
+                        "{}{}".format(lut, idx + 1)
+                    )
+
+                ram32m.parameters['INIT_' + lut] = munge_ram32m_init(
+                    get_lut_init(s, aparts[0], aparts[1], lut)
+                )
+
+            site.add_bel(ram32m)
 
         for priority, lut in zip([4, 3], 'BD'):
+            if lut not in lut_modes:
+                continue
+
             minus_one = chr(ord(lut) - 1)
 
             if lut_modes[lut] == 'RAM64X1D':
@@ -688,34 +775,48 @@ def process_slice(top, s):
                 del lut_modes[lut]
                 del lut_modes[minus_one]
             elif lut_modes[lut] == 'RAM32X1D':
-                ram32 = Bel(
-                    'RAM32X1D',
-                    name='RAM32X1D_' + minus_one + lut,
-                    priority=priority
-                )
+                ram32 = [
+                    Bel(
+                        'RAM32X1D',
+                        name='RAM32X1D_{}_{}'.format(lut, idx),
+                        priority=priority
+                    ) for idx in range(2)
+                ]
 
-                site.add_sink(ram32, 'WE', WE)
-                site.add_sink(ram32, 'WCLK', "CLK")
-                site.add_sink(ram32, 'D', lut + "I")
+                for idx in range(2):
+                    site.add_sink(ram32[idx], 'WE', WE)
+                    site.add_sink(ram32[idx], 'WCLK', "CLK")
+                    for aidx in range(5):
+                        site.add_sink(
+                            ram32[idx], 'A{}'.format(aidx),
+                            "{}{}".format(lut, aidx + 1)
+                        )
+                        site.add_sink(
+                            ram32[idx], 'DPRA{}'.format(aidx),
+                            "{}{}".format(minus_one, aidx + 1)
+                        )
 
-                for idx in range(5):
-                    site.add_sink(
-                        ram32, 'A{}'.format(idx), "{}{}".format(lut, idx + 1)
-                    )
-                    site.add_sink(
-                        ram32, 'DPRA{}'.format(idx),
-                        "{}{}".format(minus_one, idx + 1)
-                    )
+                site.add_sink(ram32[0], 'D', lut + "X")
+                site.add_internal_source(ram32[0], 'SPO', lut + "O6")
+                site.add_internal_source(ram32[0], 'DPO', minus_one + "O6")
+                ram32[0].set_bel('{}6LUT'.format(lut))
 
-                site.add_internal_source(ram32, 'SPO', lut + "O6")
-                site.add_internal_source(ram32, 'DPO', minus_one + "O6")
+                site.add_sink(ram32[1], 'D', lut + "I")
+                site.add_internal_source(ram32[1], 'SPO', lut + "O5")
+                site.add_internal_source(ram32[1], 'DPO', minus_one + "O5")
+                ram32[1].set_bel('{}5LUT'.format(lut))
 
-                ram32.parameters['INIT'] = get_lut_init(
-                    s, aparts[0], aparts[1], lut
-                )
+                lut_init = get_lut_init(s, aparts[0], aparts[1], lut)
                 other_init = get_lut_init(s, aparts[0], aparts[1], minus_one)
+                assert lut_init == other_init
 
-                site.add_bel(ram32)
+                bits = lut_init.replace("64'b", "")
+                assert len(bits) == 64
+                ram32[0].parameters['INIT'] = "32'b{}".format(bits[:32])
+                ram32[1].parameters['INIT'] = "32'b{}".format(bits[32:])
+
+                site.add_bel(ram32[0])
+                site.add_bel(ram32[1])
 
                 del lut_modes[lut]
                 del lut_modes[minus_one]
@@ -751,27 +852,41 @@ def process_slice(top, s):
                 )
 
                 site.add_bel(ram64)
-            elif lut_modes[lut] == 'RAM32X2S':
-                ram32 = Bel(
-                    'RAM32X1S', name='RAM32X1S_' + lut, priority=priority
-                )
+            elif lut_modes[lut] == 'RAM32X1S':
+                ram32 = [
+                    Bel(
+                        'RAM32X1S',
+                        name='RAM32X1S_{}_{}'.format(lut, idx),
+                        priority=priority
+                    ) for idx in range(2)
+                ]
 
-                site.add_sink(ram32, 'WE', WE)
-                site.add_sink(ram32, 'WCLK', "CLK")
-                site.add_sink(ram32, 'D', lut + "I")
+                for idx in range(2):
+                    site.add_sink(ram32[idx], 'WE', WE)
+                    site.add_sink(ram32[idx], 'WCLK', "CLK")
+                    for aidx in range(5):
+                        site.add_sink(
+                            ram32[idx], 'A{}'.format(aidx),
+                            "{}{}".format(lut, aidx + 1)
+                        )
 
-                for idx in range(5):
-                    site.add_sink(
-                        ram32, 'A{}'.format(idx), "{}{}".format(lut, idx + 1)
-                    )
-
+                site.add_sink(ram32[0], 'D', lut + "X")
                 site.add_internal_source(ram32, 'O', lut + "O6")
+                ram32[0].set_bel('{}6LUT'.format(lut))
 
-                ram32.parameters['INIT'] = get_lut_init(
-                    s, aparts[0], aparts[1], lut
-                )
+                site.add_sink(ram32[1], 'D', lut + "I")
+                site.add_internal_source(ram32, 'O', lut + "O5")
+                ram32[1].set_bel('{}5LUT'.format(lut))
 
-                site.add_bel(ram32)
+                lut_init = get_lut_init(s, aparts[0], aparts[1], lut)
+
+                bits = lut_init.replace("64'b", "")
+                assert len(bits) == 64
+                ram32[0].parameters['INIT'] = "32'b{}".format(bits[:32])
+                ram32[1].parameters['INIT'] = "32'b{}".format(bits[32:])
+
+                site.add_bel(ram32[0])
+                site.add_bel(ram32[1])
             else:
                 assert False, lut_modes[lut]
 

--- a/xc7/fasm2bels/verilog_modeling.py
+++ b/xc7/fasm2bels/verilog_modeling.py
@@ -762,8 +762,8 @@ class Site(object):
             source name provided to Site.add_internal_source earlier.
 
         """
-        assert source not in self.sources
-        assert internal_source in self.internal_sources
+        assert source not in self.sources, source
+        assert internal_source in self.internal_sources, internal_source
 
         self.outputs[source] = internal_source
         self.sources[source] = self.internal_sources[internal_source]

--- a/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/d_dram.pb_type.xml
@@ -38,27 +38,44 @@
    </interconnect>
  </mode>
  <mode name="32_SINGLE_PORT">
-   <xi:include href="dpram32.pb_type.xml" />
+   <pb_type name="DPRAM32_O6" num_pb="1" blif_model=".subckt DPRAM32">
+    <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])" />
+    <metadata>
+     <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/metadata/child::node())" />
+     <meta name="fasm_params">
+      INIT[63:32] = INIT_00
+     </meta>
+    </metadata>
+   </pb_type>
+   <pb_type name="DPRAM32_O5" num_pb="1" blif_model=".subckt DPRAM32">
+    <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])" />
+    <metadata>
+     <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/metadata/child::node())" />
+     <meta name="fasm_params">
+      INIT[31:0] = INIT_00
+     </meta>
+    </metadata>
+   </pb_type>
    <interconnect>
      <!-- upper -->
-     <direct name="CLK_U" input="D_DRAM.CLK" output="DPRAM32[1].CLK" />
-     <direct name="A_U" input="D_DRAM.A[4:0]" output="DPRAM32[1].A[4:0]" />
-     <direct name="WA_U" input="D_DRAM.A[4:0]" output="DPRAM32[1].WA[4:0]" />
-     <direct name="DI2" input="D_DRAM.DI2" output="DPRAM32[1].DI" />
-     <direct name="WE_U" input="D_DRAM.WE" output="DPRAM32[1].WE" />
+     <direct name="CLK_U" input="D_DRAM.CLK" output="DPRAM32_O6.CLK" />
+     <direct name="A_U" input="D_DRAM.A[4:0]" output="DPRAM32_O6.A[4:0]" />
+     <direct name="WA_U" input="D_DRAM.A[4:0]" output="DPRAM32_O6.WA[4:0]" />
+     <direct name="DI2" input="D_DRAM.DI2" output="DPRAM32_O6.DI" />
+     <direct name="WE_U" input="D_DRAM.WE" output="DPRAM32_O6.WE" />
 
-     <direct name="O6" input="DPRAM32[1].O" output="D_DRAM.O6" />
-     <direct name="SO6" input="DPRAM32[1].O" output="D_DRAM.SO6_32" />
+     <direct name="O6" input="DPRAM32_O6.O" output="D_DRAM.O6" />
+     <direct name="SO6" input="DPRAM32_O6.O" output="D_DRAM.SO6_32" />
 
      <!-- lower -->
-     <direct name="CLK_L" input="D_DRAM.CLK" output="DPRAM32[0].CLK" />
-     <direct name="A_L" input="D_DRAM.A[4:0]" output="DPRAM32[0].A[4:0]" />
-     <direct name="WA_L" input="D_DRAM.A[4:0]" output="DPRAM32[0].WA[4:0]" />
-     <direct name="DI" input="D_DRAM.DI1" output="DPRAM32[0].DI" />
-     <direct name="WE_L" input="D_DRAM.WE" output="DPRAM32[0].WE" />
+     <direct name="CLK_L" input="D_DRAM.CLK" output="DPRAM32_O5.CLK" />
+     <direct name="A_L" input="D_DRAM.A[4:0]" output="DPRAM32_O5.A[4:0]" />
+     <direct name="WA_L" input="D_DRAM.A[4:0]" output="DPRAM32_O5.WA[4:0]" />
+     <direct name="DI" input="D_DRAM.DI1" output="DPRAM32_O5.DI" />
+     <direct name="WE_L" input="D_DRAM.WE" output="DPRAM32_O5.WE" />
 
-     <direct name="O5" input="DPRAM32[0].O" output="D_DRAM.O5" />
-     <direct name="SO5" input="DPRAM32[0].O" output="D_DRAM.SO5_32" />
+     <direct name="O5" input="DPRAM32_O5.O" output="D_DRAM.O5" />
+     <direct name="SO5" input="DPRAM32_O5.O" output="D_DRAM.SO5_32" />
    </interconnect>
  </mode>
 

--- a/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
@@ -1,4 +1,4 @@
-<pb_type name="DPRAM32" num_pb="2" blif_model=".subckt DPRAM32">
+<pb_type name="DPRAM32" num_pb="1" blif_model=".subckt DPRAM32">
   <clock  name="CLK" num_pins="1" />
 
   <!-- A1 - Read port -->
@@ -30,9 +30,6 @@
   <T_clock_to_Q   max="10e-12" port="DI"    clock="CLK"  />
   <delay_constant max="10e-12" in_port="DI" out_port="O" />
   <metadata>
-    <meta name="fasm_params">
-      INIT[31:0] = INIT_00
-    </meta>
     <meta name="fasm_features">
       RAM
       SMALL

--- a/xc7/primitives/slicem/Ndram/ntemplate.N_dram.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/ntemplate.N_dram.pb_type.xml
@@ -46,27 +46,44 @@
     </metadata>
   </mode>
   <mode name="32_DUAL_PORT">
-    <xi:include href="dpram32.pb_type.xml" />
+    <pb_type name="DPRAM32_O6" num_pb="1" blif_model=".subckt DPRAM32">
+     <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])" />
+     <metadata>
+      <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/metadata/child::node())" />
+      <meta name="fasm_params">
+       INIT[63:32] = INIT_00
+      </meta>
+     </metadata>
+    </pb_type>
+    <pb_type name="DPRAM32_O5" num_pb="1" blif_model=".subckt DPRAM32">
+     <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/child::node()[local-name()!='metadata'])" />
+     <metadata>
+      <xi:include href="dpram32.pb_type.xml" xpointer="xpointer(pb_type/metadata/child::node())" />
+      <meta name="fasm_params">
+       INIT[31:0] = INIT_00
+      </meta>
+     </metadata>
+    </pb_type>
     <interconnect>
       <!-- upper -->
-      <direct name="CLK_U" input="{N}_DRAM.CLK"     output="DPRAM32[1].CLK"     />
-      <direct name="A_U"   input="{N}_DRAM.A[4:0]"  output="DPRAM32[1].A[4:0]"  />
-      <direct name="WA_U"  input="{N}_DRAM.WA[4:0]" output="DPRAM32[1].WA[4:0]" />
-      <direct name="DI2"   input="{N}_DRAM.DI2"     output="DPRAM32[1].DI"      />
-      <direct name="WE_U"  input="{N}_DRAM.WE"      output="DPRAM32[1].WE"      />
+      <direct name="CLK_U" input="{N}_DRAM.CLK"     output="DPRAM32_O6.CLK"     />
+      <direct name="A_U"   input="{N}_DRAM.A[4:0]"  output="DPRAM32_O6.A[4:0]"  />
+      <direct name="WA_U"  input="{N}_DRAM.WA[4:0]" output="DPRAM32_O6.WA[4:0]" />
+      <direct name="DI2"   input="{N}_DRAM.DI2"     output="DPRAM32_O6.DI"      />
+      <direct name="WE_U"  input="{N}_DRAM.WE"      output="DPRAM32_O6.WE"      />
 
-      <direct name="O6"    input="DPRAM32[1].O"     output="{N}_DRAM.O6"        />
-      <direct name="DO6"   input="DPRAM32[1].O"     output="{N}_DRAM.DO6_32"    />
+      <direct name="O6"    input="DPRAM32_O6.O"     output="{N}_DRAM.O6"        />
+      <direct name="DO6"   input="DPRAM32_O6.O"     output="{N}_DRAM.DO6_32"    />
 
       <!-- lower -->
-      <direct name="CLK_L" input="{N}_DRAM.CLK"     output="DPRAM32[0].CLK"     />
-      <direct name="A_L"   input="{N}_DRAM.A[4:0]"  output="DPRAM32[0].A[4:0]"  />
-      <direct name="WA_L"  input="{N}_DRAM.WA[4:0]" output="DPRAM32[0].WA[4:0]" />
-      <direct name="DI"    input="{N}_DRAM.DI1"     output="DPRAM32[0].DI"      />
-      <direct name="WE_L"  input="{N}_DRAM.WE"      output="DPRAM32[0].WE"      />
+      <direct name="CLK_L" input="{N}_DRAM.CLK"     output="DPRAM32_O5.CLK"     />
+      <direct name="A_L"   input="{N}_DRAM.A[4:0]"  output="DPRAM32_O5.A[4:0]"  />
+      <direct name="WA_L"  input="{N}_DRAM.WA[4:0]" output="DPRAM32_O5.WA[4:0]" />
+      <direct name="DI"    input="{N}_DRAM.DI1"     output="DPRAM32_O5.DI"      />
+      <direct name="WE_L"  input="{N}_DRAM.WE"      output="DPRAM32_O5.WE"      />
 
-      <direct name="O5"    input="DPRAM32[0].O"     output="{N}_DRAM.O5"        />
-      <direct name="DO5"   input="DPRAM32[0].O"     output="{N}_DRAM.DO5_32"    />
+      <direct name="O5"    input="DPRAM32_O5.O"     output="{N}_DRAM.O5"        />
+      <direct name="DO5"   input="DPRAM32_O5.O"     output="{N}_DRAM.DO5_32"    />
     </interconnect>
     <metadata>
       <meta name="fasm_prefix">{N}LUT</meta>

--- a/xc7/primitives/slicem/slicem.pb_type.xml
+++ b/xc7/primitives/slicem/slicem.pb_type.xml
@@ -251,7 +251,8 @@
         <direct name="SLICEM_MODES.D4_to_D_SRL.A4" input="SLICEM_MODES.D4" output="DSRL.A4"/>
         <direct name="SLICEM_MODES.D5_to_D_SRL.A5" input="SLICEM_MODES.D5" output="DSRL.A5"/>
         <direct name="SLICEM_MODES.D6_to_D_SRL.A6" input="SLICEM_MODES.D6" output="DSRL.A6"/>
-        <direct name="SLICEM_MODES.DI_to_D_SRL.DI1" input="SLICEM_MODES.DI" output="DSRL.DI1"/>
+        <direct name="SLICEM_MODES.DI_to_D_SRL.DI1_SRL32" input="SLICEM_MODES.DI" output="DSRL.DI1_SRL32"/>
+        <direct name="SLICEM_MODES.DI_to_D_SRL.DI1_SRL16" input="SLICEM_MODES.DI" output="DSRL.DI1_SRL16"/>
         <direct name="SLICEM_MODES.DX_to_D_SRL.DI2" input="SLICEM_MODES.DX" output="DSRL.DI2"/>
         <direct name="D_SRL.O5_to_SLICEM_MODES.DO5" input="DSRL.O5" output="SLICEM_MODES.DO5"/>
         <direct name="D_SRL.O6_to_SLICEM_MODES.DO6" input="DSRL.O6" output="SLICEM_MODES.DO6"/>
@@ -261,73 +262,89 @@
         <direct name="SLICEM_MODES.WE_to_WE_MUX.WE" input="SLICEM_MODES.WE" output="WE_MUX.WE"/>
 
         <!-- ADI1MUX -->
-        <mux name="ADI1MUX" input="BSRL.MC31 SLICEM_MODES.AI" output="ASRL.DI1">
+        <mux name="ADI1MUX32" input="BSRL.MC31_SRL32 SLICEM_MODES.AI" output="ASRL.DI1_SRL32">
           <metadata>
             <meta name="fasm_mux">
-              BSRL.MC31 = DI1MUX.BDI1_BMC31
+              BSRL.MC31_SRL32 = DI1MUX.BDI1_BMC31
               SLICEM_MODES.AI = DI1MUX.AI
             </meta>
           </metadata>
-        </mux>       
- 
+          <pack_pattern name="SRL32_x2" in_port="BSRL.MC31_SRL32" out_port="ASRL.DI1_SRL32" />
+          <pack_pattern name="SRL32_x3" in_port="BSRL.MC31_SRL32" out_port="ASRL.DI1_SRL32" />
+          <pack_pattern name="SRL32_x4" in_port="BSRL.MC31_SRL32" out_port="ASRL.DI1_SRL32" />
+        </mux>
+
         <!-- BDI1MUX -->
-        <mux name="BDI1MUX" input="CSRL.MC31 SLICEM_MODES.BI" output="BSRL.DI1">
+        <mux name="BDI1MUX32" input="CSRL.MC31_SRL32 SLICEM_MODES.BI" output="BSRL.DI1_SRL32">
           <metadata>
             <meta name="fasm_mux">
-              CSRL.MC31 = DI1MUX.DI_CMC31
+              CSRL.MC31_SRL32 = DI1MUX.DI_CMC31
               SLICEM_MODES.BI = DI1MUX.BI
             </meta>
           </metadata>
-        </mux>       
-        
+          <pack_pattern name="SRL32_x3" in_port="CSRL.MC31_SRL32" out_port="BSRL.DI1_SRL32" />
+          <pack_pattern name="SRL32_x4" in_port="CSRL.MC31_SRL32" out_port="BSRL.DI1_SRL32" />
+        </mux>
+
         <!-- CDI1MUX -->
-        <mux name="CDI1MUX" input="DSRL.MC31 SLICEM_MODES.CI" output="CSRL.DI1">
+        <mux name="CDI1MUX32" input="DSRL.MC31_SRL32 SLICEM_MODES.CI" output="CSRL.DI1_SRL32">
           <metadata>
             <meta name="fasm_mux">
-              DSRL.MC31 = DI1MUX.DI_DMC31
+              DSRL.MC31_SRL32 = DI1MUX.DI_DMC31
               SLICEM_MODES.CI = DI1MUX.CI
             </meta>
           </metadata>
-        </mux>       
+          <pack_pattern name="SRL32_x4" in_port="DSRL.MC31_SRL32" out_port="CSRL.DI1_SRL32" />
+        </mux>
+
+        <mux name="ADI1MUX16" input="BSRL.MC31_SRL16 SLICEM_MODES.AI" output="ASRL.DI1_SRL16">
+          <metadata>
+            <meta name="fasm_mux">
+              BSRL.MC31_SRL16 = DI1MUX.BDI1_BMC31
+              SLICEM_MODES.AI = DI1MUX.AI
+            </meta>
+          </metadata>
+        </mux>
+
+        <!-- BDI1MUX -->
+        <mux name="BDI1MUX16" input="CSRL.MC31_SRL16 SLICEM_MODES.BI" output="BSRL.DI1_SRL16">
+          <metadata>
+            <meta name="fasm_mux">
+              CSRL.MC31_SRL16 = DI1MUX.DI_CMC31
+              SLICEM_MODES.BI = DI1MUX.BI
+            </meta>
+          </metadata>
+        </mux>
+
+        <!-- CDI1MUX -->
+        <mux name="CDI1MUX16" input="DSRL.MC31_SRL16 SLICEM_MODES.CI" output="CSRL.DI1_SRL16">
+          <metadata>
+            <meta name="fasm_mux">
+              DSRL.MC31_SRL16 = DI1MUX.DI_DMC31
+              SLICEM_MODES.CI = DI1MUX.CI
+            </meta>
+          </metadata>
+        </mux>
 
         <!-- AMC31 -->
         <direct name="ASRL.MC31_to_SLICEM_MODES.AMC31" input="ASRL.MC31" output="SLICEM_MODES.AMC31"/>
 
         <!-- F7AMUX inputs -->
-        <direct name="F7AMUX_I0" input="BSRL.O6"   output="F7AMUX.I0">
-          <pack_pattern in_port="BSRL.O6" name="SRL_x2" out_port="F7AMUX.I0"/>
-          <pack_pattern in_port="BSRL.O6" name="SRL_x3" out_port="F7AMUX.I0"/>
-          <pack_pattern in_port="BSRL.O6" name="SRL_x4" out_port="F7AMUX.I0"/> 
-        </direct>
-        <direct name="F7AMUX_I1" input="ASRL.O6"   output="F7AMUX.I1">
-          <pack_pattern in_port="ASRL.O6" name="SRL_x2" out_port="F7AMUX.I1"/>
-          <pack_pattern in_port="ASRL.O6" name="SRL_x4" out_port="F7AMUX.I1"/>
-        </direct>
+        <direct name="F7AMUX_I0" input="BSRL.O6"   output="F7AMUX.I0"/>
+        <direct name="F7AMUX_I1" input="ASRL.O6"   output="F7AMUX.I1"/>
 
         <direct name="F7AMUX_S"  input="SLICEM_MODES.AX" output="F7AMUX.S" />
 
         <!-- F7BMUX inputs -->
-        <direct name="F7BMUX_I0" input="DSRL.O6"   output="F7BMUX.I0">
-          <pack_pattern in_port="DSRL.O6" name="SRL_x2" out_port="F7BMUX.I0"/>
-          <pack_pattern in_port="DSRL.O6" name="SRL_x3" out_port="F7BMUX.I0"/>
-          <pack_pattern in_port="DSRL.O6" name="SRL_x4" out_port="F7BMUX.I0"/>
-        </direct>
-        <direct name="F7BMUX_I1" input="CSRL.O6"   output="F7BMUX.I1">
-          <pack_pattern in_port="CSRL.O6" name="SRL_x2" out_port="F7BMUX.I1"/>
-          <pack_pattern in_port="CSRL.O6" name="SRL_x3" out_port="F7BMUX.I1"/>
-          <pack_pattern in_port="CSRL.O6" name="SRL_x4" out_port="F7BMUX.I1"/>
-        </direct>
+        <direct name="F7BMUX_I0" input="DSRL.O6"   output="F7BMUX.I0"/>
+        <direct name="F7BMUX_I1" input="CSRL.O6"   output="F7BMUX.I1"/>
 
         <direct name="F7BMUX_S"  input="SLICEM_MODES.CX" output="F7BMUX.S" />
 
         <!-- F8MUX inputs -->
         <direct name="F8MUX_I0"  input="F7BMUX.O"  output="F8MUX.I0">
-          <pack_pattern in_port="F7BMUX.O" name="SRL_x3" out_port="F8MUX.I0"/>
-          <pack_pattern in_port="F7BMUX.O" name="SRL_x4" out_port="F8MUX.I0"/>
         </direct>
         <direct name="F8MUX_I1"  input="F7AMUX.O"  output="F8MUX.I1">
-          <pack_pattern in_port="F7AMUX.O" name="SRL_x3" out_port="F8MUX.I1"/>
-          <pack_pattern in_port="F7AMUX.O" name="SRL_x4" out_port="F8MUX.I1"/>
         </direct>
 
         <direct name="F8MUX_S"   input="SLICEM_MODES.BX" output="F8MUX.S" />
@@ -779,7 +796,7 @@
         <mux name="F7BMUX_O"   input="F7BMUX.O DRAM_2_OUTPUT_STUB.SPO_OUT" output="SLICEM_MODES.F7BMUX_O" />
       </interconnect>
 
-      
+
       <!-- The DLUT must be in RAM-mode for any of the RAM's to work.
            As a corollary, a DRAM requires the clock, so only turn on the
            DRAM if the clock is also connected.
@@ -855,7 +872,7 @@
     <direct name="F7AMUX_O" input="SLICEM_MODES.F7AMUX_O"   output="COMMON_SLICE.F7AMUX_O" />
     <direct name="F7BMUX_O" input="SLICEM_MODES.F7BMUX_O"   output="COMMON_SLICE.F7BMUX_O" />
     <direct name="F8MUX_O"  input="SLICEM_MODES.F8MUX_O"    output="COMMON_SLICE.F8MUX_O" />
-    
+
     <direct name="SLICEM_MODES.AMC31_to_SLICEM.AMC31" input="SLICEM_MODES.AMC31" output="COMMON_SLICE.AMC31"/>
 
     <!-- A-DX inputs -->

--- a/xc7/primitives/slicem/srl/a_srl.pb_type.xml
+++ b/xc7/primitives/slicem/srl/a_srl.pb_type.xml
@@ -11,7 +11,8 @@
   <input  name="A4" num_pins="1"/>
   <input  name="A5" num_pins="1"/>
   <input  name="A6" num_pins="1"/>
-  <input  name="DI1" num_pins="1"/>
+  <input  name="DI1_SRL16" num_pins="1"/>
+  <input  name="DI1_SRL32" num_pins="1"/>
   <input  name="DI2" num_pins="1"/>
   <output name="O5" num_pins="1"/>
   <output name="O6" num_pins="1"/>
@@ -22,16 +23,13 @@
     <interconnect>
       <direct name="CLK" input="ASRL.CLK" output="SRLC32E_VPR.CLK"/>
       <direct name="WE" input="ASRL.WE" output="SRLC32E_VPR.CE"/>
-      <direct name="DI1" input="ASRL.DI1" output="SRLC32E_VPR.D"/>
+      <direct name="DI1" input="ASRL.DI1_SRL32" output="SRLC32E_VPR.D"/>
       <direct name="A2" input="ASRL.A2" output="SRLC32E_VPR.A[0]"/>
       <direct name="A3" input="ASRL.A3" output="SRLC32E_VPR.A[1]"/>
       <direct name="A4" input="ASRL.A4" output="SRLC32E_VPR.A[2]"/>
       <direct name="A5" input="ASRL.A5" output="SRLC32E_VPR.A[3]"/>
       <direct name="A6" input="ASRL.A6" output="SRLC32E_VPR.A[4]"/>
-      <direct name="O6" input="SRLC32E_VPR.Q" output="ASRL.O6">
-        <pack_pattern out_port="ASRL.O6" name="SRL_x2" in_port="SRLC32E_VPR.Q"/>
-        <pack_pattern out_port="ASRL.O6" name="SRL_x4" in_port="SRLC32E_VPR.Q"/>
-      </direct>
+      <direct name="O6" input="SRLC32E_VPR.Q" output="ASRL.O6"/>
       <direct name="MC31" input="SRLC32E_VPR.Q31" output="ASRL.MC31"/>
     </interconnect>
   </mode>
@@ -42,7 +40,7 @@
     <interconnect>
       <direct name="CLK_0" input="ASRL.CLK" output="SRLC16E_VPR_0.CLK"/>
       <direct name="WE_0" input="ASRL.WE" output="SRLC16E_VPR_0.CE"/>
-      <direct name="DI1" input="ASRL.DI1" output="SRLC16E_VPR_0.D"/>
+      <direct name="DI1" input="ASRL.DI1_SRL16" output="SRLC16E_VPR_0.D"/>
       <direct name="A2_0" input="ASRL.A2" output="SRLC16E_VPR_0.A0"/>
       <direct name="A3_0" input="ASRL.A3" output="SRLC16E_VPR_0.A1"/>
       <direct name="A4_0" input="ASRL.A4" output="SRLC16E_VPR_0.A2"/>

--- a/xc7/primitives/slicem/srl/ntemplate.N_srl.pb_type.xml
+++ b/xc7/primitives/slicem/srl/ntemplate.N_srl.pb_type.xml
@@ -10,29 +10,31 @@
   <input  name="A4" num_pins="1"/>
   <input  name="A5" num_pins="1"/>
   <input  name="A6" num_pins="1"/>
-  <input  name="DI1" num_pins="1"/>
+    <!-- Note that because SRL32 has a pack pattern, it must root to
+      one block.  If DI1 connects to both SRL32 and SRL16, it roots to two
+      blocks.
+   -->
+  <input  name="DI1_SRL32" num_pins="1"/>
+  <input  name="DI1_SRL16" num_pins="1"/>
   <input  name="DI2" num_pins="1"/>
   <output name="O5" num_pins="1"/>
   <output name="O6" num_pins="1"/>
-  <output name="MC31" num_pins="1"/>
+  <output name="MC31_SRL16" num_pins="1"/>
+  <output name="MC31_SRL32" num_pins="1"/>
 
   <mode name="SRL32">
     <xi:include href="srlc32e_vpr.pb_type.xml" />
     <interconnect>
       <direct name="CLK" input="{N}SRL.CLK" output="SRLC32E_VPR.CLK"/>
       <direct name="WE" input="{N}SRL.WE" output="SRLC32E_VPR.CE"/>
-      <direct name="DI1" input="{N}SRL.DI1" output="SRLC32E_VPR.D"/>
+      <direct name="DI1" input="{N}SRL.DI1_SRL32" output="SRLC32E_VPR.D" />
       <direct name="A2" input="{N}SRL.A2" output="SRLC32E_VPR.A[0]"/>
       <direct name="A3" input="{N}SRL.A3" output="SRLC32E_VPR.A[1]"/>
       <direct name="A4" input="{N}SRL.A4" output="SRLC32E_VPR.A[2]"/>
       <direct name="A5" input="{N}SRL.A5" output="SRLC32E_VPR.A[3]"/>
       <direct name="A6" input="{N}SRL.A6" output="SRLC32E_VPR.A[4]"/>
-      <direct name="O6" input="SRLC32E_VPR.Q" output="{N}SRL.O6">
-        <pack_pattern out_port="{N}SRL.O6" name="SRL_x2" in_port="SRLC32E_VPR.Q"/>
-        <pack_pattern out_port="{N}SRL.O6" name="SRL_x3" in_port="SRLC32E_VPR.Q"/>
-        <pack_pattern out_port="{N}SRL.O6" name="SRL_x4" in_port="SRLC32E_VPR.Q"/>
-      </direct>
-      <direct name="MC31" input="SRLC32E_VPR.Q31" output="{N}SRL.MC31"/>
+      <direct name="O6" input="SRLC32E_VPR.Q" output="{N}SRL.O6" />
+      <direct name="MC31" input="SRLC32E_VPR.Q31" output="{N}SRL.MC31_SRL32" />
     </interconnect>
   </mode>
 
@@ -42,7 +44,7 @@
     <interconnect>
       <direct name="CLK_0" input="{N}SRL.CLK" output="SRLC16E_VPR_0.CLK"/>
       <direct name="WE_0" input="{N}SRL.WE" output="SRLC16E_VPR_0.CE"/>
-      <direct name="DI1" input="{N}SRL.DI1" output="SRLC16E_VPR_0.D"/>
+      <direct name="DI1" input="{N}SRL.DI1_SRL16" output="SRLC16E_VPR_0.D"/>
       <direct name="A2_0" input="{N}SRL.A2" output="SRLC16E_VPR_0.A0"/>
       <direct name="A3_0" input="{N}SRL.A3" output="SRLC16E_VPR_0.A1"/>
       <direct name="A4_0" input="{N}SRL.A4" output="SRLC16E_VPR_0.A2"/>
@@ -57,7 +59,7 @@
       <direct name="A4_1" input="{N}SRL.A4" output="SRLC16E_VPR_1.A2"/>
       <direct name="A5_1" input="{N}SRL.A5" output="SRLC16E_VPR_1.A3"/>
       <direct name="O6" input="SRLC16E_VPR_1.Q" output="{N}SRL.O6"/>
-      <direct name="MC31" input="SRLC16E_VPR_1.Q15" output="{N}SRL.MC31"/>
+      <direct name="MC31" input="SRLC16E_VPR_1.Q15" output="{N}SRL.MC31_SRL16"/>
     </interconnect>
   </mode>
 

--- a/xc7/techmap/cells_map.v
+++ b/xc7/techmap/cells_map.v
@@ -595,8 +595,18 @@ module RAM32M (
     wire [1:0] DOB_TO_STUB;
     wire [1:0] DOA_TO_STUB;
 
+function [31:0] every_other_bit_32;
+   input [63:0] in;
+   input         odd;
+   integer       i;
+   for (i = 0; i < 32; i = i + 1) begin
+      every_other_bit_32[i] = in[i * 2 + odd];
+   end
+endfunction
+
+
     DPRAM32 #(
-        .INIT_00(INIT_A[63:32]),
+        .INIT_00(every_other_bit_32(INIT_A, 1'b1)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_a1 (
          .DI(DIA[1]),
@@ -608,7 +618,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_A[31:0]),
+        .INIT_00(every_other_bit_32(INIT_A, 1'b0)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_a0 (
          .DI(DIA[0]),
@@ -620,7 +630,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_B[63:32]),
+        .INIT_00(every_other_bit_32(INIT_B, 1'b1)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_b1 (
          .DI(DIB[1]),
@@ -632,7 +642,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_B[31:0]),
+        .INIT_00(every_other_bit_32(INIT_B, 1'b0)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_b0 (
          .DI(DIB[0]),
@@ -644,7 +654,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_C[63:32]),
+        .INIT_00(every_other_bit_32(INIT_C, 1'b1)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_c1 (
          .DI(DIC[1]),
@@ -656,7 +666,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_C[31:0]),
+        .INIT_00(every_other_bit_32(INIT_C, 1'b0)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_c0 (
          .DI(DIC[0]),
@@ -668,7 +678,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_D[63:32]),
+        .INIT_00(every_other_bit_32(INIT_D, 1'b1)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_d1 (
          .DI(DID[1]),
@@ -680,7 +690,7 @@ module RAM32M (
     );
 
     DPRAM32 #(
-        .INIT_00(INIT_D[31:0]),
+        .INIT_00(every_other_bit_32(INIT_D, 0)),
         .IS_WCLK_INVERTED(IS_WCLK_INVERTED)
     ) ram_d0 (
          .DI(DID[0]),

--- a/xc7/tests/dram_test/CMakeLists.txt
+++ b/xc7/tests/dram_test/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND SOURCES ../common/error_output_logic.v ../common/ram_test.v)
 get_target_property_required(DEVICE basys3 DEVICE)
 get_target_property_required(ARCH ${DEVICE} ARCH)
 
-foreach(type 64x1d 32m 64m)
+foreach(type 32x1d 64x1d 32m 64m)
   add_file_target(FILE dram_test_${type}.v SCANNER_TYPE verilog)
   add_fpga_target(
     NAME dram_test_${type}

--- a/xc7/tests/dram_test/dram_test_64m.v
+++ b/xc7/tests/dram_test/dram_test_64m.v
@@ -38,7 +38,8 @@ module top (
 
     wire [5:0] write_address;
     wire [5:0] read_address;
-    wire [2:0] read_data;
+    wire [2:0] read_data_unreg;
+    reg [2:0] read_data = 3'b0;
     wire [2:0] write_data;
     wire write_enable;
 
@@ -93,9 +94,9 @@ module top (
         .ADDRB(read_address),
         .ADDRA(read_address),
 
-        .DOC(read_data[2]),
-        .DOB(read_data[1]),
-        .DOA(read_data[0]),
+        .DOC(read_data_unreg[2]),
+        .DOB(read_data_unreg[1]),
+        .DOA(read_data_unreg[0]),
 
         .DIC(write_data[2]),
         .DIB(write_data[1]),
@@ -103,6 +104,10 @@ module top (
 
         .WE(write_enable)
     );
+
+    always @(posedge clk) begin
+        read_data <= read_data_unreg;
+    end
 
     ERROR_OUTPUT_LOGIC #(
         .DATA_WIDTH(3),

--- a/xc7/tests/srl/srl32_chain/basys3_top.v
+++ b/xc7/tests/srl/srl32_chain/basys3_top.v
@@ -55,7 +55,7 @@ generate for(i=0; i<4; i=i+1) begin
                     (i==1) ?   "SLICE_X2Y101" :
                     (i==2) ?   "SLICE_X2Y102" : "SLICE_X2Y103";
 
-  srl_shift_tester #(.SRL_LENGTH(32 * (i+1))) tester
+  srl_shift_tester #(.FIXED_DELAY(32*(i+1)-1), .SRL_LENGTH(32 * (i+1))) tester
   (
   .clk      (clk),
   .rst      (rst),


### PR DESCRIPTION
These fixes were identified via fasm2v differences between VPR and Vivado or errors during Vivado.