### PR TITLE
Add FASM features for DI1MUX's to ensure that ADI1 connection is valid.

### DIFF
--- a/xc7/primitives/slicem/slicem.pb_type.xml
+++ b/xc7/primitives/slicem/slicem.pb_type.xml
@@ -265,8 +265,8 @@
         <mux name="ADI1MUX32" input="BSRL.MC31_SRL32 SLICEM_MODES.AI" output="ASRL.DI1_SRL32">
           <metadata>
             <meta name="fasm_mux">
-              BSRL.MC31_SRL32 = DI1MUX.BDI1_BMC31
-              SLICEM_MODES.AI = DI1MUX.AI
+              BSRL.MC31_SRL32 = ALUT.DI1MUX.BDI1_BMC31
+              SLICEM_MODES.AI = ALUT.DI1MUX.AI
             </meta>
           </metadata>
           <pack_pattern name="SRL32_x2" in_port="BSRL.MC31_SRL32" out_port="ASRL.DI1_SRL32" />
@@ -278,8 +278,8 @@
         <mux name="BDI1MUX32" input="CSRL.MC31_SRL32 SLICEM_MODES.BI" output="BSRL.DI1_SRL32">
           <metadata>
             <meta name="fasm_mux">
-              CSRL.MC31_SRL32 = DI1MUX.DI_CMC31
-              SLICEM_MODES.BI = DI1MUX.BI
+              CSRL.MC31_SRL32 = BLUT.DI1MUX.DI_CMC31
+              SLICEM_MODES.BI = BLUT.DI1MUX.BI
             </meta>
           </metadata>
           <pack_pattern name="SRL32_x3" in_port="CSRL.MC31_SRL32" out_port="BSRL.DI1_SRL32" />
@@ -290,8 +290,8 @@
         <mux name="CDI1MUX32" input="DSRL.MC31_SRL32 SLICEM_MODES.CI" output="CSRL.DI1_SRL32">
           <metadata>
             <meta name="fasm_mux">
-              DSRL.MC31_SRL32 = DI1MUX.DI_DMC31
-              SLICEM_MODES.CI = DI1MUX.CI
+              DSRL.MC31_SRL32 = CLUT.DI1MUX.DI_DMC31
+              SLICEM_MODES.CI = CLUT.DI1MUX.CI
             </meta>
           </metadata>
           <pack_pattern name="SRL32_x4" in_port="DSRL.MC31_SRL32" out_port="CSRL.DI1_SRL32" />
@@ -300,8 +300,8 @@
         <mux name="ADI1MUX16" input="BSRL.MC31_SRL16 SLICEM_MODES.AI" output="ASRL.DI1_SRL16">
           <metadata>
             <meta name="fasm_mux">
-              BSRL.MC31_SRL16 = DI1MUX.BDI1_BMC31
-              SLICEM_MODES.AI = DI1MUX.AI
+              BSRL.MC31_SRL16 = ALUT.DI1MUX.BDI1_BMC31
+              SLICEM_MODES.AI = ALUT.DI1MUX.AI
             </meta>
           </metadata>
         </mux>
@@ -310,8 +310,8 @@
         <mux name="BDI1MUX16" input="CSRL.MC31_SRL16 SLICEM_MODES.BI" output="BSRL.DI1_SRL16">
           <metadata>
             <meta name="fasm_mux">
-              CSRL.MC31_SRL16 = DI1MUX.DI_CMC31
-              SLICEM_MODES.BI = DI1MUX.BI
+              CSRL.MC31_SRL16 = BLUT.DI1MUX.DI_CMC31
+              SLICEM_MODES.BI = BLUT.DI1MUX.BI
             </meta>
           </metadata>
         </mux>
@@ -320,8 +320,8 @@
         <mux name="CDI1MUX16" input="DSRL.MC31_SRL16 SLICEM_MODES.CI" output="CSRL.DI1_SRL16">
           <metadata>
             <meta name="fasm_mux">
-              DSRL.MC31_SRL16 = DI1MUX.DI_DMC31
-              SLICEM_MODES.CI = DI1MUX.CI
+              DSRL.MC31_SRL16 = CLUT.DI1MUX.DI_DMC31
+              SLICEM_MODES.CI = CLUT.DI1MUX.CI
             </meta>
           </metadata>
         </mux>
@@ -466,26 +466,31 @@
         <mux name="CDI1MUX" input="SLICEM_MODES.DI SLICEM_MODES.CI" output="C_DRAM.DI1">
           <metadata>
             <meta name="fasm_mux">
-              SLICEM_MODES.DI = NULL
-              SLICEM_MODES.CI = DI1MUX.CI
+              SLICEM_MODES.DI = CLUT.DI1MUX.DI_DMC31
+              SLICEM_MODES.CI = CLUT.DI1MUX.CI
             </meta>
           </metadata>
         </mux>
         <mux name="BDI1MUX" input="SLICEM_MODES.DI SLICEM_MODES.BI" output="B_DRAM.DI1">
           <metadata>
             <meta name="fasm_mux">
-              SLICEM_MODES.DI = NULL
-              SLICEM_MODES.BI = DI1MUX.BI
+              SLICEM_MODES.DI = BLUT.DI1MUX.DI_CMC31
+              SLICEM_MODES.BI = BLUT.DI1MUX.BI
             </meta>
           </metadata>
         </mux>
-        <!-- TODO: ensure BLUT.DI1MUX is set correctly for SLICEM_MODES.DI/BI -->
+        <!-- TODO: ensure BLUT.DI1MUX is set correctly for SLICEM_MODES.DI/BI
+
+          For now, the FASM features are emitted to ensure that the mux
+          is set correctly, and it there is a mux conflict it will arise
+          during fasm2frames.
+        -->
         <mux name="ADI1MUX" input="SLICEM_MODES.DI SLICEM_MODES.BI SLICEM_MODES.AI" output="A_DRAM.DI1">
           <metadata>
             <meta name="fasm_mux">
-              SLICEM_MODES.DI = NULL
-              SLICEM_MODES.BI = NULL
-              SLICEM_MODES.AI = DI1MUX.AI
+              SLICEM_MODES.DI = ALUT.DI1MUX.BDI1_BMC31,BLUT.DI1MUX.DI_CMC31
+              SLICEM_MODES.BI = ALUT.DI1MUX.BDI1_BMC31,BLUT.DI1MUX.BI
+              SLICEM_MODES.AI = ALUT.DI1MUX.AI
             </meta>
           </metadata>
         </mux>


### PR DESCRIPTION
An error will result if the ADI1 connection does not match the BDI1
connection.

Does requires `genfasm` fix, tracked https://github.com/SymbiFlow/vtr-verilog-to-routing/issues/280 .  Plan is to update VTR with this change after https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1017 is merged, (FYI @acomodi)