### PR TITLE
Refactor tracks to cache neighboor computation.

### DIFF
--- a/testarch/utils/testarch_graph.py
+++ b/testarch/utils/testarch_graph.py
@@ -157,8 +157,8 @@ def create_global_constant_tracks(graph, mux, short, grid_width, grid_height):
                     pin_map[pin_side] = pin_node
 
                 made_connection = False
-                for idx, pin_dir in tracks.get_tracks_for_wire_at_coord(
-                    (loc.x, loc.y)):
+                for pin_dir, idx in tracks.get_tracks_for_wire_at_coord(
+                    (loc.x, loc.y)).items():
                     if pin_dir in pin_map:
                         made_connection = True
                         graph.add_edge(

--- a/utils/lib/rr_graph/tests/test_tracks.py
+++ b/utils/lib/rr_graph/tests/test_tracks.py
@@ -67,7 +67,5 @@ class TracksTests(unittest.TestCase):
 
     def test_get_tracks(self):
 
-        dirs = [d for d in self.trks.get_tracks_for_wire_at_coord((1, 1))]
-        self.assertEqual(
-            sorted(dirs), [(0, Direction.RIGHT), (1, Direction.TOP)]
-        )
+        dirs = self.trks.get_tracks_for_wire_at_coord((1, 1))
+        self.assertEqual(dirs, {Direction.RIGHT: 0, Direction.TOP: 1})

--- a/utils/lib/rr_graph/tracks.py
+++ b/utils/lib/rr_graph/tracks.py
@@ -158,6 +158,8 @@ class Tracks(object):
         self.tracks = tracks
         self.track_connections = track_connections
 
+        self.track_cache = {}
+
     def verify_tracks(self):
         """ Verify that all tracks are connected to all other tracks. """
         track_connections = {}
@@ -225,16 +227,37 @@ class Tracks(object):
             assert False, track
 
     def get_tracks_for_wire_at_coord(self, coord):
-        """Returns which track indicies and direction a wire at a coord can
-        be connected too.
+        """Returns map of direction to track indicies for valid connections.
+
+        There may be multiple connections to tracks at a particular coordinate,
+        this method only returns a possible connection in each direction to
+        this track.
+
+        Parameters
+        ----------
+        coord : (int, int)
+            Coordinate to attach to track
+
+        Returns
+        -------
+        dict(Direction -> int)
+            Dictionary of pin direction to track index.
+
         """
 
-        wire_x, wire_y = coord
+        if coord in self.track_cache:
+            return self.track_cache[coord]
+        else:
+            wire_x, wire_y = coord
 
-        for idx, track in enumerate(self.tracks):
-            pin_dir = self.is_wire_adjacent_to_track(idx, coord)
-            if pin_dir != Direction.NO_SIDE:
-                yield (idx, pin_dir)
+            conns = {}
+            for idx, track in enumerate(self.tracks):
+                pin_dir = self.is_wire_adjacent_to_track(idx, coord)
+                if pin_dir != Direction.NO_SIDE:
+                    conns[pin_dir] = idx
+
+            self.track_cache[coord] = conns
+            return conns
 
 
 def main():

--- a/xc7/utils/prjxray_assign_tile_pin_direction.py
+++ b/xc7/utils/prjxray_assign_tile_pin_direction.py
@@ -283,8 +283,9 @@ WHERE
 
                 tracks_model = channel_wires_to_tracks[track_pkey]
                 available_pins = set(
-                    pin_dir for _, pin_dir in tracks_model.
-                    get_tracks_for_wire_at_coord((grid_x, grid_y))
+                    tracks_model.get_tracks_for_wire_at_coord(
+                        (grid_x, grid_y)
+                    ).keys()
                 )
 
                 edge_assignments[(tile_type, wire)].append(available_pins)
@@ -293,8 +294,9 @@ WHERE
                     tracks_model = channel_wires_to_tracks[
                         const_tracks[constant]]
                     available_pins = set(
-                        pin_dir for _, pin_dir in tracks_model.
-                        get_tracks_for_wire_at_coord((grid_x, grid_y))
+                        tracks_model.get_tracks_for_wire_at_coord(
+                            (grid_x, grid_y)
+                        ).keys()
                     )
                     edge_assignments[(tile_type, wire)].append(available_pins)
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -619,15 +619,16 @@ AND
         if self.tracks and other_connector.tracks:
             tracks_model, graph_nodes = self.tracks
             idx1 = None
-            for idx1, _ in tracks_model.get_tracks_for_wire_at_coord(loc):
+            for idx1 in tracks_model.get_tracks_for_wire_at_coord(loc
+                                                                  ).values():
                 break
 
             assert idx1 is not None
 
             other_tracks_model, other_graph_nodes = other_connector.tracks
             idx2 = None
-            for idx2, _ in other_tracks_model.get_tracks_for_wire_at_coord(loc
-                                                                           ):
+            for idx2 in other_tracks_model.get_tracks_for_wire_at_coord(
+                    loc).values():
                 break
 
             assert idx2 is not None
@@ -642,8 +643,8 @@ AND
             assert self.pins.site_pin_direction == SitePinDirection.OUT
 
             tracks_model, graph_nodes = other_connector.tracks
-            for idx, pin_dir in tracks_model.get_tracks_for_wire_at_coord(
-                    grid_types.GridLoc(self.pins.x, self.pins.y)):
+            for pin_dir, idx in tracks_model.get_tracks_for_wire_at_coord(
+                    grid_types.GridLoc(self.pins.x, self.pins.y)).items():
                 if pin_dir in self.pins.edge_map:
                     # Site pin -> Interconnect is modelled as:
                     #
@@ -665,9 +666,9 @@ AND
             assert other_connector.pins.site_pin_direction == SitePinDirection.IN
 
             tracks_model, graph_nodes = self.tracks
-            for idx, pin_dir in tracks_model.get_tracks_for_wire_at_coord(
+            for pin_dir, idx in tracks_model.get_tracks_for_wire_at_coord(
                     grid_types.GridLoc(other_connector.pins.x,
-                                       other_connector.pins.y)):
+                                       other_connector.pins.y)).items():
                 if pin_dir in other_connector.pins.edge_map:
                     # Interconnect -> Site pin is modelled as:
                     #

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -1125,12 +1125,13 @@ FROM
 
         for wire_pkey, grid_x, grid_y in wires:
             connections = list(
-                tracks_model.get_tracks_for_wire_at_coord((grid_x, grid_y))
+                tracks_model.get_tracks_for_wire_at_coord((grid_x,
+                                                           grid_y)).values()
             )
             assert len(connections) > 0, (
                 connections, wire_pkey, track_pkey, grid_x, grid_y, node
             )
-            graph_node_pkey = track_graph_node_pkey[connections[0][0]]
+            graph_node_pkey = track_graph_node_pkey[connections[0]]
 
             wire_to_graph[wire_pkey] = graph_node_pkey
 

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -429,7 +429,9 @@ WHERE
             tracks_model, track_nodes = get_track_model(conn, track_pkey)
 
             option = list(
-                tracks_model.get_tracks_for_wire_at_coord(synth_tile['loc'])
+                tracks_model.get_tracks_for_wire_at_coord(
+                    tuple(synth_tile['loc'])
+                ).values()
             )
             assert len(option) > 0, (pin, len(option))
 
@@ -448,7 +450,7 @@ WHERE
             else:
                 assert False, pin
 
-            track_node = track_nodes[option[0][0]]
+            track_node = track_nodes[option[0]]
             assert track_node in node_mapping, (track_node, track_pkey)
             pin_name = graph.create_pin_name_from_tile_type_and_pin(
                 tile_type, wire


### PR DESCRIPTION
During edge creation, get_tracks_for_wire_at_coord gets called enough
times that caching the result is a good memory <-> CPU trade off.

Part of prjxray_create_edge scaling work to reach full 50T in reasonable time.