### PR TITLE
Initial support for RIOB33M routing

### DIFF
--- a/xc7/boards.cmake
+++ b/xc7/boards.cmake
@@ -10,6 +10,14 @@ define_board(
 )
 
 define_board(
+  BOARD basys3-x1y0
+  DEVICE xc7a50t
+  PACKAGE test
+  PROG_TOOL ${OPENOCD_TARGET}
+  PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
+)
+
+define_board(
   BOARD arty-swbut
   DEVICE xc7a50t-arty-swbut
   PACKAGE test

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -272,6 +272,7 @@ function(PROJECT_XRAY_ARCH)
 
   if(NOT "${PROJECT_XRAY_ARCH_GRAPH_LIMIT}" STREQUAL "")
     set(ROI_ARG_FOR_CREATE_EDGES --graph_limit ${PROJECT_XRAY_ARCH_GRAPH_LIMIT})
+    set(ROI_ARG --graph_limit ${PROJECT_XRAY_ARCH_GRAPH_LIMIT})
   endif()
 
 

--- a/xc7/tests/buttons/CMakeLists.txt
+++ b/xc7/tests/buttons/CMakeLists.txt
@@ -18,3 +18,11 @@ add_fpga_target(
   SOURCES buttons_zybo.v
   INPUT_IO_FILE zybo.pcf
   )
+
+add_fpga_target(
+  NAME buttons_basys3_x1y0
+  BOARD basys3-x1y0
+  SOURCES buttons_basys3_x1y0.v
+  INPUT_IO_FILE basys3_x1y0.pcf
+  )
+

--- a/xc7/tests/buttons/basys3_x1y0.pcf
+++ b/xc7/tests/buttons/basys3_x1y0.pcf
@@ -1,0 +1,2 @@
+set_io in V2
+set_io out V3

--- a/xc7/tests/buttons/buttons_basys3_x1y0.v
+++ b/xc7/tests/buttons/buttons_basys3_x1y0.v
@@ -1,0 +1,8 @@
+module top(
+	input in,
+	output out
+);
+
+assign out = in;
+
+endmodule

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -401,6 +401,11 @@ def main():
     parser.add_argument('--device', required=True)
     parser.add_argument('--synth_tiles', required=False)
     parser.add_argument('--connection_database', required=True)
+    parser.add_argument(
+        '--graph_limit',
+        help=
+        'Limit grid to specified dimensions in semicolor x_min,y_min,x_max,y_max',
+    )
 
     args = parser.parse_args()
 
@@ -476,6 +481,15 @@ def main():
         for _, tile_info in synth_tiles['tiles'].items():
             assert tuple(tile_info['loc']) not in synth_loc_map
             synth_loc_map[tuple(tile_info['loc'])] = tile_info
+    elif args.graph_limit:
+        x_min, y_min, x_max, y_max = map(int, args.graph_limit.split(','))
+        roi = Roi(
+            db=db,
+            x1=x_min,
+            y1=y_min,
+            x2=x_max,
+            y2=y_max,
+        )
 
     with DatabaseCache(args.connection_database, read_only=True) as conn:
         c = conn.cursor()

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -342,8 +342,10 @@ def get_tiles(conn, g, roi, synth_loc_map, synth_tile_map, tile_types):
         VPR tile type at this grid location.
     grid_x, grid_y : int
         Grid coordinate of tile
-    fasm_tile_prefix : str
-        FASM prefix for this tile.
+    metadata_function : function that takes lxml.Element
+        Function for attaching metadata tags to <single> elements.
+        Function must be supplied, but doesn't need to add metadata if not
+        required.
 
     """
     c = conn.cursor()
@@ -490,8 +492,7 @@ def main():
     parser.add_argument('--connection_database', required=True)
     parser.add_argument(
         '--graph_limit',
-        help=
-        'Limit grid to specified dimensions in semicolor x_min,y_min,x_max,y_max',
+        help='Limit grid to specified dimensions in x_min,y_min,x_max,y_max',
     )
 
     args = parser.parse_args()
@@ -608,7 +609,7 @@ def main():
             }
         )
 
-        for vpr_tile_type, grid_x, grid_y, meta_fun in get_tiles(
+        for vpr_tile_type, grid_x, grid_y, metadata_function in get_tiles(
                 conn=conn,
                 g=g,
                 roi=roi,
@@ -624,7 +625,7 @@ def main():
                     'y': str(grid_y),
                 }
             )
-            meta_fun(single_xml)
+            metadata_function(single_xml)
 
         switchlist_xml = ET.SubElement(arch_xml, 'switchlist')
 

--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -54,8 +54,7 @@ def main():
     )
     parser.add_argument(
         '--graph_limit',
-        help=
-        'Limit grid to specified dimensions in semicolor x_min,y_min,x_max,y_max',
+        help='Limit grid to specified dimensions in x_min,y_min,x_max,y_max',
     )
 
     args = parser.parse_args()

--- a/xc7/utils/prjxray_create_pinmap_csv.py
+++ b/xc7/utils/prjxray_create_pinmap_csv.py
@@ -9,7 +9,8 @@ import sqlite3
 
 def get_vpr_coords_from_site_name(conn, site_name):
     cur = conn.cursor()
-    cur.execute("""
+    cur.execute(
+        """
 SELECT DISTINCT tile.grid_x, tile.grid_y
 FROM site_instance
 INNER JOIN wire_in_tile

--- a/xc7/utils/prjxray_create_pinmap_csv.py
+++ b/xc7/utils/prjxray_create_pinmap_csv.py
@@ -1,0 +1,70 @@
+#! /usr/bin/env python3
+""" Tool generate a pin map CSV from channels.db and a *_package_pins.csv for pin placement. """
+from __future__ import print_function
+import argparse
+import sys
+import csv
+import sqlite3
+
+
+def get_vpr_coords_from_tile_name(conn, tile_name):
+    cur = conn.cursor()
+    loc = tile_name.split('_')[-1]
+    cur.execute(
+        """
+        SELECT grid_x, grid_y FROM tile
+          WHERE phy_tile_pkey =
+            (SELECT pkey FROM phy_tile WHERE name like "%IOI%_" || ?);
+        """, (loc, )
+    )
+    return cur.fetchone()
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Creates a pin map CSV.')
+    parser.add_argument(
+        "--output",
+        type=argparse.FileType('w'),
+        default=sys.stdout,
+        help='The output pin map CSV file'
+    )
+    parser.add_argument(
+        '--connection_database',
+        help='Database of fabric connectivity',
+        required=True
+    )
+    parser.add_argument(
+        "--package_pins",
+        type=argparse.FileType('r'),
+        required=True,
+        help='Map listing relationship between pads and sites.',
+    )
+
+    args = parser.parse_args()
+
+    fieldnames = [
+        'name', 'x', 'y', 'z', 'is_clock', 'is_input', 'is_output', 'iob'
+    ]
+    writer = csv.DictWriter(args.output, fieldnames=fieldnames)
+
+    writer.writeheader()
+    with sqlite3.connect(args.connection_database) as conn:
+        for l in csv.DictReader(args.package_pins):
+            loc = get_vpr_coords_from_tile_name(conn, l['tile'])
+            if loc is not None:
+                writer.writerow(
+                    dict(
+                        name=l['pin'],
+                        x=loc[0],
+                        y=loc[1],
+                        z=0,
+                        is_clock=1,
+                        is_input=1,
+                        is_output=1,
+                        iob=l['site'],
+                    )
+                )
+
+
+if __name__ == '__main__':
+    main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -36,7 +36,6 @@ import datetime
 import re
 import functools
 import pickle
-import lxml.etree
 
 from prjxray_db_cache import DatabaseCache
 
@@ -802,8 +801,7 @@ def main():
     )
     parser.add_argument(
         '--graph_limit',
-        help=
-        'Limit grid to specified dimensions in semicolor x_min,y_min,x_max,y_max',
+        help='Limit grid to specified dimensions in x_min,y_min,x_max,y_max',
     )
 
     args = parser.parse_args()

--- a/xc7/utils/prjxray_tile_import.py
+++ b/xc7/utils/prjxray_tile_import.py
@@ -939,7 +939,7 @@ FROM wire_in_tile
 INNER JOIN site
 ON site.pkey = wire_in_tile.site_pkey
 WHERE
-    tile_type_pkey = ?
+    wire_in_tile.tile_type_pkey = ?
 GROUP BY site.site_type_pkey, wire_in_tile.phy_tile_type_pkey
 ORDER BY wire_in_tile.phy_tile_type_pkey;""", (tile_type_pkey, )
     )


### PR DESCRIPTION
This PR will hopefully add support for routing to RIOB33M pins.

Approximate work:
 - [x] Have `prjxray_form_channels` generate database with split RIOB33M tiles
 - [x] Have `prjxray_assign_pin_direction` generate pin directions for new IO PAD tiles
 - [x] Have `prjxray_create_edges` generate graph_nodes and graph_edges for new IO PAD tiles
 - [x] Have initial RIOPAD_M tile
 - [x] Update CMake flow to handle lack of synth_tiles
 - [x] Add CMake option to generate partial routing graph for debugging ease
 - [x] Add lower right CMT device/device type that includes RIOPAD_M tile type
 - [x] Verify prjxray_routing_import completes with RIOPAD_M in arch
 - [x] Verify routing graph connects RIOPAD_M IPIN/OPINs to arch
 - [x] Integrate pinmap.csv tool from @HackerFoo to generate valid IO placement constraints
 - [x] Merge RIOB33M tile into RIOPAD_M
 - [x] Update prjxray_import_tile to handle merged tiles and within tile connections
 - [x] Hack VPR to new search coordinates
 - [x] Verify VPR routes between RIOPAD_M
 - [x] Verify that constant network is integrated
 - [x] Integrate new "fasm_placeholders" features to emit valid FASM prefixes for IOB and IOI sites.
 - [ ] Have VPR that integrates lookahead fix that works with existing ROI and https://github.com/SymbiFlow/vtr-verilog-to-routing/pull/285
 - [x] Add fixed FASM features as needed to emit required FASM features.