### PR TITLE
Support for PLLE2_ADV for fasm2bels.

### DIFF
--- a/xc7/fasm2bels/clb_models.py
+++ b/xc7/fasm2bels/clb_models.py
@@ -1,4 +1,3 @@
-import fasm
 from .verilog_modeling import Bel, Site
 
 

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -4,6 +4,7 @@ from .verilog_modeling import Bel, Site
 
 # =============================================================================
 
+
 def get_pll_site(db, grid, tile, site):
     """ Return the prjxray.tile.Site object for the given PLL site. """
     gridinfo = grid.gridinfo_at_tilename(tile)
@@ -44,7 +45,10 @@ def process_pll(conn, top, tile_name, features):
         return
 
     # Create the site
-    site = Site(pll_features, get_pll_site(top.db, top.grid, tile=tile_name, site='PLLE2_ADV'))
+    site = Site(
+        pll_features,
+        get_pll_site(top.db, top.grid, tile=tile_name, site='PLLE2_ADV')
+    )
 
     # If the PLL is not used then skip the rest
     if not site.has_feature("IN_USE"):
@@ -82,11 +86,15 @@ def process_pll(conn, top, tile_name, features):
         if site.has_feature('CLK{}_CLKOUT1_OUTPUT_ENABLE'.format(clkout)):
 
             # Add output source
-            site.add_source(pll, 'CLK'+clkout, 'CLK'+clkout)
+            site.add_source(pll, 'CLK' + clkout, 'CLK' + clkout)
 
             # Calculate the divider and duty cycle
-            high_time = decode_multi_bit_feature(features, 'CLK{}_CLKOUT1_HIGH_TIME'.format(clkout))
-            low_time  = decode_multi_bit_feature(features, 'CLK{}_CLKOUT1_LOW_TIME'.format(clkout))
+            high_time = decode_multi_bit_feature(
+                features, 'CLK{}_CLKOUT1_HIGH_TIME'.format(clkout)
+            )
+            low_time = decode_multi_bit_feature(
+                features, 'CLK{}_CLKOUT1_LOW_TIME'.format(clkout)
+            )
 
             divider = high_time + low_time
             duty = high_time / (low_time + high_time)
@@ -99,33 +107,41 @@ def process_pll(conn, top, tile_name, features):
                 pll.parameters['CLKFBOUT_MULT'] = divider
             else:
                 pll.parameters['CLK{}_DIVIDE'.format(clkout)] = divider
-                pll.parameters['CLK{}_DUTY_CYCLE'.format(clkout)] = "{0:.3f}".format(duty)
+                pll.parameters['CLK{}_DUTY_CYCLE'.format(clkout)
+                               ] = "{0:.3f}".format(duty)
 
             # Phase shift
-            delay = decode_multi_bit_feature(features, 'CLK{}_CLKOUT2_DELAY_TIME'.format(clkout))
-            phase = decode_multi_bit_feature(features, 'CLK{}_CLKOUT1_PHASE_MUX'.format(clkout))
-            
+            delay = decode_multi_bit_feature(
+                features, 'CLK{}_CLKOUT2_DELAY_TIME'.format(clkout)
+            )
+            phase = decode_multi_bit_feature(
+                features, 'CLK{}_CLKOUT1_PHASE_MUX'.format(clkout)
+            )
+
             phase = float(delay) + phase / 8.0  # Delay in VCO cycles
             phase = 360.0 * phase / divider  # Phase of CLK in degrees
 
             if clkout == 'FBOUT':
                 pll.parameters['CLKFBOUT_PHASE'] = "{0:.3f}".format(phase)
             else:
-                pll.parameters['CLK{}_PHASE'.format(clkout)] = "{0:.3f}".format(phase)
- 
+                pll.parameters['CLK{}_PHASE'.format(clkout)
+                               ] = "{0:.3f}".format(phase)
+
     # Input clock divider
     high_time = decode_multi_bit_feature(features, 'DIVCLK_DIVCLK_HIGH_TIME')
-    low_time  = decode_multi_bit_feature(features, 'DIVCLK_DIVCLK_LOW_TIME')
+    low_time = decode_multi_bit_feature(features, 'DIVCLK_DIVCLK_LOW_TIME')
 
     divider = high_time + low_time
-    
+
     if site.has_feature('DIVCLK_DIVCLK_NO_COUNT'):
         divider = 1
 
     pll.parameters['DIVCLK_DIVIDE'] = divider
 
     # Startup wait
-    pll.parameters['STARTUP_WAIT'] = '"TRUE"' if site.has_feature('STARTUP_WAIT') else '"FALSE"'
+    pll.parameters['STARTUP_WAIT'] = '"TRUE"' if site.has_feature(
+        'STARTUP_WAIT'
+    ) else '"FALSE"'
 
     # Compensation  TODO: Other modes
     if site.has_feature('COMPENSATION.INTERNAL'):
@@ -142,4 +158,3 @@ def process_pll(conn, top, tile_name, features):
     # Add the bel and site
     site.add_bel(pll)
     top.add_site(site)
-

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -1,5 +1,4 @@
 import fasm
-from .connection_db_utils import create_maybe_get_wire
 from .verilog_modeling import Bel, Site
 
 # =============================================================================

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -96,7 +96,12 @@ def process_pll(conn, top, tile_name, features):
                 features, 'CLK{}_CLKOUT1_LOW_TIME'.format(clkout)
             )
 
-            divider = high_time + low_time
+            if decode_multi_bit_feature(features,
+                                        'CLK{}_CLKOUT2_EDGE'.format(clkout)):
+                high_time += 0.5
+                low_time = max(0, low_time - 0.5)
+
+            divider = int(high_time + low_time)
             duty = high_time / (low_time + high_time)
 
             if site.has_feature('CLK{}_CLKOUT2_NO_COUNT'.format(clkout)):

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -1,0 +1,145 @@
+import fasm
+from .connection_db_utils import create_maybe_get_wire
+from .verilog_modeling import Bel, Site
+
+# =============================================================================
+
+def get_pll_site(db, grid, tile, site):
+    """ Return the prjxray.tile.Site object for the given PLL site. """
+    gridinfo = grid.gridinfo_at_tilename(tile)
+    tile_type = db.get_tile_type(gridinfo.tile_type)
+
+    sites = list(tile_type.get_instance_sites(gridinfo))
+    assert len(sites) == 1, sites
+
+    return sites[0]
+
+
+def decode_multi_bit_feature(features, target_feature):
+    """
+    Decodes a "multi-bit" fasm feature. If not present returns 0.
+    """
+    value = 0
+
+    for f in features:
+        last_part = f.feature.split('.')[-1]
+        if last_part.startswith(target_feature):
+            for canon_f in fasm.canonical_features(f):
+                if canon_f.start is None:
+                    value |= 1
+                else:
+                    value |= (1 << canon_f.start)
+
+    return value
+
+
+def process_pll(conn, top, tile_name, features):
+    """
+    Processes the PLL site
+    """
+
+    # Filter only PLL related features
+    pll_features = [f for f in features if 'PLLE2.' in f.feature]
+    if len(pll_features) == 0:
+        return
+
+    # Create the site
+    site = Site(pll_features, get_pll_site(top.db, top.grid, tile=tile_name, site='PLLE2_ADV'))
+
+    # If the PLL is not used then skip the rest
+    if not site.has_feature("IN_USE"):
+        return
+
+    # Create the PLLE2_ADV bel and add its ports
+    pll = Bel('PLLE2_ADV')
+
+    for i in range(6):
+        site.add_sink(pll, 'DADDR[{}]'.format(i), 'DADDR{}'.format(i))
+
+    for i in range(15):
+        site.add_sink(pll, 'DI[{}]'.format(i), 'DI{}'.format(i))
+
+    site.add_sink(pll, 'DCLK', 'DCLK')
+    site.add_sink(pll, 'DEN', 'DEN')
+    site.add_sink(pll, 'DWE', 'DWE')
+    site.add_sink(pll, 'CLKIN1', 'CLKIN1')
+    site.add_sink(pll, 'CLKIN2', 'CLKIN2')
+    site.add_sink(pll, 'CLKINSEL', 'CLKINSEL')
+    site.add_sink(pll, 'CLKFBIN', 'CLKFBIN')
+    site.add_sink(pll, 'RST', 'RST')
+    site.add_sink(pll, 'PWRDWN', 'PWRDWN')
+
+    site.add_source(pll, 'DRDY', 'DRDY')
+    site.add_source(pll, 'LOCKED', 'LOCKED')
+
+    for i in range(15):
+        site.add_source(pll, 'DO[{}]'.format(i), 'DO{}'.format(i))
+
+    # Process clock outputs
+    clkouts = ['FBOUT'] + ['OUT{}'.format(i) for i in range(6)]
+
+    for clkout in clkouts:
+        if site.has_feature('CLK{}_CLKOUT1_OUTPUT_ENABLE'.format(clkout)):
+
+            # Add output source
+            site.add_source(pll, 'CLK'+clkout, 'CLK'+clkout)
+
+            # Calculate the divider and duty cycle
+            high_time = decode_multi_bit_feature(features, 'CLK{}_CLKOUT1_HIGH_TIME'.format(clkout))
+            low_time  = decode_multi_bit_feature(features, 'CLK{}_CLKOUT1_LOW_TIME'.format(clkout))
+
+            divider = high_time + low_time
+            duty = high_time / (low_time + high_time)
+
+            if site.has_feature('CLK{}_CLKOUT2_NO_COUNT'.format(clkout)):
+                divider = 1
+                duty = 0.5
+
+            if clkout == 'FBOUT':
+                pll.parameters['CLKFBOUT_MULT'] = divider
+            else:
+                pll.parameters['CLK{}_DIVIDE'.format(clkout)] = divider
+                pll.parameters['CLK{}_DUTY_CYCLE'.format(clkout)] = "{0:.3f}".format(duty)
+
+            # Phase shift
+            delay = decode_multi_bit_feature(features, 'CLK{}_CLKOUT2_DELAY_TIME'.format(clkout))
+            phase = decode_multi_bit_feature(features, 'CLK{}_CLKOUT1_PHASE_MUX'.format(clkout))
+            
+            phase = float(delay) + phase / 8.0  # Delay in VCO cycles
+            phase = 360.0 * phase / divider  # Phase of CLK in degrees
+
+            if clkout == 'FBOUT':
+                pll.parameters['CLKFBOUT_PHASE'] = "{0:.3f}".format(phase)
+            else:
+                pll.parameters['CLK{}_PHASE'.format(clkout)] = "{0:.3f}".format(phase)
+ 
+    # Input clock divider
+    high_time = decode_multi_bit_feature(features, 'DIVCLK_DIVCLK_HIGH_TIME')
+    low_time  = decode_multi_bit_feature(features, 'DIVCLK_DIVCLK_LOW_TIME')
+
+    divider = high_time + low_time
+    
+    if site.has_feature('DIVCLK_DIVCLK_NO_COUNT'):
+        divider = 1
+
+    pll.parameters['DIVCLK_DIVIDE'] = divider
+
+    # Startup wait
+    pll.parameters['STARTUP_WAIT'] = '"TRUE"' if site.has_feature('STARTUP_WAIT') else '"FALSE"'
+
+    # Compensation  TODO: Other modes
+    if site.has_feature('COMPENSATION.INTERNAL'):
+        pll.parameters['COMPENSATION'] = '"INTERNAL"'
+
+    # Built-in inverters
+    pll.parameters['IS_CLKINSEL_INVERTED'] =\
+        "1'b1" if site.has_feature('INV_CLKINSEL') else "1'b0"
+    pll.parameters['IS_PWRDWN_INVERTED'] =\
+        "1'b1" if site.has_feature('ZINV_PWRDWN') else "1'b0"
+    pll.parameters['IS_RST_INVERTED'] =\
+        "1'b1" if site.has_feature('ZINV_RST') else "1'b0"
+
+    # Add the bel and site
+    site.add_bel(pll)
+    top.add_site(site)
+

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -3,6 +3,52 @@ from .verilog_modeling import Bel, Site
 
 # =============================================================================
 
+# A lookup table for content of the TABLE register to get the BANDWIDTH
+# setting. Values taken from XAPP888 reference design.
+PLL_BANDWIDTH_LOOKUP = {
+
+    # LOW
+    0b0010111100: "LOW",
+    0b0010011100: "LOW",
+    0b0010110100: "LOW",
+    0b0010010100: "LOW",
+    0b0010100100: "LOW",
+    0b0010111000: "LOW",
+    0b0010000100: "LOW",
+    0b0010011000: "LOW",
+    0b0010101000: "LOW",
+    0b0010110000: "LOW",
+    0b0010001000: "LOW",
+    0b0011110000: "LOW",
+    0b0010010000: "LOW",
+
+    # OPTIMIZED and HIGH are the same
+    0b0011011100: "OPTIMIZED",
+    0b0101111100: "OPTIMIZED",
+    0b0111111100: "OPTIMIZED",
+    0b0111101100: "OPTIMIZED",
+    0b1101011100: "OPTIMIZED",
+    0b1110101100: "OPTIMIZED",
+    0b1110110100: "OPTIMIZED",
+    0b1111110100: "OPTIMIZED",
+    0b1111011100: "OPTIMIZED",
+    0b1111101100: "OPTIMIZED",
+    0b1111110100: "OPTIMIZED",
+    0b1111001100: "OPTIMIZED",
+    0b1110010100: "OPTIMIZED",
+    0b1111010100: "OPTIMIZED",
+    0b0111011000: "OPTIMIZED",
+    0b0101110000: "OPTIMIZED",
+    0b1100000100: "OPTIMIZED",
+    0b0100001000: "OPTIMIZED",
+    0b0010100000: "OPTIMIZED",
+    0b0011010000: "OPTIMIZED",
+    0b0010100000: "OPTIMIZED",
+    0b0100110000: "OPTIMIZED",
+    0b0010010000: "OPTIMIZED",
+}
+
+# =============================================================================
 
 def get_pll_site(db, grid, tile, site):
     """ Return the prjxray.tile.Site object for the given PLL site. """
@@ -146,6 +192,12 @@ def process_pll(conn, top, tile_name, features):
     pll.parameters['STARTUP_WAIT'] = '"TRUE"' if site.has_feature(
         'STARTUP_WAIT'
     ) else '"FALSE"'
+
+    # Bandwidth
+    table = decode_multi_bit_feature(features, 'TABLE')
+    if table in PLL_BANDWIDTH_LOOKUP:
+        pll.parameters['BANDWIDTH'] =\
+            '"{}"'.format(PLL_BANDWIDTH_LOOKUP[table])
 
     # Compensation  TODO: Other modes
     if site.has_feature('COMPENSATION.INTERNAL'):

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -199,9 +199,11 @@ def process_pll(conn, top, tile_name, features):
         pll.parameters['BANDWIDTH'] =\
             '"{}"'.format(PLL_BANDWIDTH_LOOKUP[table])
 
-    # Compensation  TODO: Other modes
+    # Compensation  TODO: Probably need to rework database tags for those.
     if site.has_feature('COMPENSATION.INTERNAL'):
         pll.parameters['COMPENSATION'] = '"INTERNAL"'
+    elif site.has_feature('COMPENSATION.BUF_IN_OR_EXTERNAL_OR_ZHOLD_CLKIN_BUF'):
+        pll.parameters['COMPENSATION'] = '"BUF_IN"'
 
     # Built-in inverters
     pll.parameters['IS_CLKINSEL_INVERTED'] =\

--- a/xc7/fasm2bels/cmt_models.py
+++ b/xc7/fasm2bels/cmt_models.py
@@ -1,4 +1,3 @@
-import fasm
 from .verilog_modeling import Bel, Site
 
 # =============================================================================
@@ -20,7 +19,7 @@ PLL_BANDWIDTH_LOOKUP = {
     0b0010110000: "LOW",
     0b0010001000: "LOW",
     0b0011110000: "LOW",
-    0b0010010000: "LOW",
+    # 0b0010010000: "LOW",  # Overlaps with one of "OPTIMIZED"
 
     # OPTIMIZED and HIGH are the same
     0b0011011100: "OPTIMIZED",

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -30,6 +30,7 @@ from prjxray import fasm_disassembler
 from prjxray import bitstream
 import prjxray.db
 
+from .cmt_models import process_pll
 from .bram_models import process_bram
 from .clb_models import process_clb
 from .clk_models import process_hrow, process_bufg
@@ -81,6 +82,8 @@ PROCESS_TILE = {
     'HCLK_CMT_L': null_process,
     'BRAM_L': process_bram,
     'BRAM_R': process_bram,
+    'CMT_TOP_R_UPPER_T': process_pll,
+    'CMT_TOP_R_LOWER_B': process_pll,
 }
 
 

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -83,7 +83,7 @@ PROCESS_TILE = {
     'BRAM_L': process_bram,
     'BRAM_R': process_bram,
     'CMT_TOP_R_UPPER_T': process_pll,
-    'CMT_TOP_R_LOWER_B': process_pll,
+    'CMT_TOP_L_UPPER_T': process_pll,
 }
 
 

--- a/xc7/fasm2bels/iob_models.py
+++ b/xc7/fasm2bels/iob_models.py
@@ -61,30 +61,6 @@ def get_iob_site(db, grid, tile, site):
     return iob_site, iologic_tile, ilogic_site, ologic_site
 
 
-def has_feature_with_part(site, part):
-    """
-    Returns True when a given site has a feature which contains a particular
-    part.
-    """
-    for feature in site.set_features:
-        parts = feature.split(".")
-        if part in parts:
-            return True
-
-    return False
-
-
-def has_feature_containing(site, substr):
-    """
-    Returns True when a given site has a feature which contains a given substring.
-    """
-    for feature in site.set_features:
-        if substr in feature:
-            return True
-
-    return False
-
-
 def append_obuf_iostandard_params(
         top, site, bel, possible_iostandards, slew="SLOW"
 ):
@@ -172,7 +148,7 @@ def process_iob(top, iob):
     iostd_slew = {}
     iostd_in = set()
 
-    for feature in site.set_features:
+    for feature in site.features:
         parts = feature.split(".")
 
         if "DRIVE" in parts:
@@ -212,14 +188,14 @@ def process_iob(top, iob):
                 ))
 
     # Buffer direction
-    is_input = has_feature_with_part(site, "IN") or has_feature_with_part(
-        site, "IN_ONLY"
+    is_input = site.has_feature_with_part("IN") or site.has_feature_with_part(
+        "IN_ONLY"
     )
-    is_inout = has_feature_with_part(site, "IN") and has_feature_with_part(
-        site, "DRIVE"
+    is_inout = site.has_feature_with_part("IN") and site.has_feature_with_part(
+        "DRIVE"
     )
-    is_output = not has_feature_with_part(site, "IN") and \
-        has_feature_with_part(site, "DRIVE")
+    is_output = not site.has_feature_with_part("IN") and \
+        site.has_feature_with_part("DRIVE")
 
     # Sanity check. Can be only one or neither of them
     assert (is_input + is_inout + is_output) <= 1
@@ -291,7 +267,7 @@ def process_iob(top, iob):
         # called O, so it is in fact correct.
         site.add_sink(bel, bel_pin='I', sink='O')
 
-        slew = "FAST" if has_feature_containing(site, "SLEW.FAST") else "SLOW"
+        slew = "FAST" if site.has_feature_containing("SLEW.FAST") else "SLOW"
         append_obuf_iostandard_params(top, site, bel, iostd_out, slew)
 
         site.add_site(bel)
@@ -308,7 +284,7 @@ def process_iob(top, iob):
         # is called O, so it is in fact correct.
         site.add_sink(bel, bel_pin='I', sink='O')
 
-        slew = "FAST" if has_feature_containing(site, "SLEW.FAST") else "SLOW"
+        slew = "FAST" if site.has_feature_containing("SLEW.FAST") else "SLOW"
         append_obuf_iostandard_params(top, site, bel, iostd_out, slew)
 
         site.add_bel(bel)

--- a/xc7/fasm2bels/make_routes.py
+++ b/xc7/fasm2bels/make_routes.py
@@ -602,8 +602,9 @@ SELECT name, site_pin_pkey FROM wire_in_tile WHERE pkey = (
     # There does not appear to be an upstream connection, handle it.
     if allow_orphan_sinks:
         print(
-            '// ERROR, failed to find source for node = {}'.
-            format(sink_node_pkey)
+            '// ERROR, failed to find source for node = {} ({}/{})'.format(
+                sink_node_pkey, tile_name, wire_name
+            )
         )
     else:
         assert False, (sink_node_pkey, tile_name, wire_name, sink_wire_pkey)

--- a/xc7/fasm2bels/make_routes.py
+++ b/xc7/fasm2bels/make_routes.py
@@ -485,6 +485,13 @@ def expand_sink(
             )
 
             if upstream_sink_wire_pkey in net_map:
+                if DEBUG:
+                    print(
+                        '// {}/{} is connected to net via wire_pkey {}'.format(
+                            tile_name, wire_name, upstream_sink_wire_pkey
+                        )
+                    )
+
                 for net in net_map[upstream_sink_wire_pkey]:
                     nets[net].add_node(
                         conn=conn,
@@ -514,6 +521,13 @@ SELECT name, site_pin_pkey FROM wire_in_tile WHERE pkey = (
         site_pin, direction = c.fetchone()
 
         if direction == 'OUT':
+            if DEBUG:
+                print(
+                    '// {}/{} is connected to const'.format(
+                        tile_name, wire_name
+                    )
+                )
+
             if site_pin == 'HARD1':
                 nets[ONE_NET].add_node(
                     conn, net_map, sink_node_pkey, parent_node_pkey=ONE_NET


### PR DESCRIPTION
This PR adds support for the PLLE2_ADV decoding to fasm2bels. Requires https://github.com/SymbiFlow/prjxray/pull/1077 to work correctly (routing decoding issues).

The decoding of COMPENSATION parameter may require improvement as the relation between fasm tags and this parameter is somewhat unclear.
