### PR TITLE
Routing import memory optimizations

### DIFF
--- a/testarch/utils/testarch_graph.py
+++ b/testarch/utils/testarch_graph.py
@@ -4,7 +4,6 @@ from lib.rr_graph import graph2
 from lib.rr_graph import tracks
 from lib.rr_graph import points
 import lib.rr_graph_xml.graph2 as xml_graph2
-from lib.rr_graph_xml.utils import read_xml_file
 
 
 # bi-directional channels
@@ -336,9 +335,8 @@ def rebuild_graph(fn, fn_out, rcw=6, verbose=False):
     """
 
     print('Importing input g')
-    input_rr_graph = read_xml_file(fn)
     xml_graph = xml_graph2.Graph(
-        input_rr_graph,
+        fn,
         output_file_name=fn_out,
     )
 
@@ -371,10 +369,16 @@ def rebuild_graph(fn, fn_out, rcw=6, verbose=False):
     connect_tracks_to_tracks(graph, switch=mux, verbose=verbose)
     print("Completed rebuild")
 
+    xml_graph.root_attrib["tool_version"] = "dev"
+    xml_graph.root_attrib["tool_comment"] = "Generated from black magic"
+
+    channels_obj = graph.create_channels(pad_segment=graph.segments[0].id)
+
     xml_graph.serialize_to_xml(
-        tool_version="dev",
-        tool_comment="Generated from black magic",
-        pad_segment=graph.segments[0].id,
+        channels_obj=channels_obj,
+        connection_box_obj=None,
+        nodes_obj=graph.nodes,
+        edges_obj=graph.edges
     )
 
 

--- a/utils/lib/perf_utils.py
+++ b/utils/lib/perf_utils.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Utilities related to performance measurement.
+"""
+import time
+
+# =============================================================================
+
+
+def get_memory_usage():
+    """
+    Returns memory usage of the current process in GB.
+    WORKS ONLY ON A LINUX SYSTEM.
+    """
+
+    status = None
+    result = {'peak': 0.0, 'rss': 0.0}
+
+    try:
+        # This will only work on systems with a /proc file system
+        # (like Linux).
+        status = open('/proc/self/status')
+        for line in status:
+            parts = line.split()
+            key = parts[0][2:-1].lower()
+            if key in result:
+                result[key] = int(parts[1]) / (1024*1024)
+
+    finally:
+
+        if status is not None:
+            status.close()
+
+    return result
+
+
+# =============================================================================
+
+
+class MemoryLog(object):
+    """
+    Memory usage logging helper class.
+
+    Create object of the MemoryLog type, provide it with the log file name.
+    Then at each important point of the script call its "checkpoint" method.
+    """
+
+    def __init__(self, file_name):
+        self.fp = open(file_name, "w")
+        self.t0 = time.time()
+        self._write("Time [s], Label, Peak [GB], RSS [GB]\n")
+
+    def _write(self, s):
+        self.fp.write(s)
+        self.fp.flush()
+
+    def checkpoint(self, label):
+        mem = get_memory_usage()
+        self._write("{:.1f}, {}, {:.2f}, {:.2f}\n".format(time.time() - self.t0, label, mem["peak"], mem["rss"]))
+

--- a/utils/lib/perf_utils.py
+++ b/utils/lib/perf_utils.py
@@ -24,7 +24,7 @@ def get_memory_usage():
             parts = line.split()
             key = parts[0][2:-1].lower()
             if key in result:
-                result[key] = int(parts[1]) / (1024*1024)
+                result[key] = int(parts[1]) / (1024 * 1024)
 
     finally:
 
@@ -56,5 +56,8 @@ class MemoryLog(object):
 
     def checkpoint(self, label):
         mem = get_memory_usage()
-        self._write("{:.1f}, {}, {:.2f}, {:.2f}\n".format(time.time() - self.t0, label, mem["peak"], mem["rss"]))
-
+        self._write(
+            "{:.1f}, {}, {:.2f}, {:.2f}\n".format(
+                time.time() - self.t0, label, mem["peak"], mem["rss"]
+            )
+        )

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -145,7 +145,7 @@ def graph_from_xml(input_file_name, progressbar=None):
             )
 
             pins = []
-           
+
         # Block type
         if path == "rr_graph/block_types" and element.tag == "block_type":
             block_types.append(
@@ -162,7 +162,8 @@ def graph_from_xml(input_file_name, progressbar=None):
 
         # Grid
         if path == "rr_graph/grid" and element.tag == "grid_loc":
-            grid.append(graph2.GridLoc(
+            grid.append(
+                graph2.GridLoc(
                     x=int(element.attrib['x']),
                     y=int(element.attrib['y']),
                     block_type_id=int(element.attrib['block_type_id']),
@@ -198,7 +199,9 @@ def graph_from_xml(input_file_name, progressbar=None):
 
         # Node
         if path == "rr_graph/rr_nodes" and element.tag == "node":
-            node_type = enum_from_string(graph2.NodeType, element.attrib['type'])
+            node_type = enum_from_string(
+                graph2.NodeType, element.attrib['type']
+            )
 
             if node_type in [graph2.NodeType.SOURCE, graph2.NodeType.SINK,
                              graph2.NodeType.OPIN, graph2.NodeType.IPIN]:
@@ -288,7 +291,7 @@ class Graph(object):
         Writes beginning of an XML tag. If term=True then terminates it
         immediately.
         """
-        s  = "<{}".format(tag)
+        s = "<{}".format(tag)
         s += "".join([' {}="{}"'.format(k, str(v)) for k, v in attrib.items()])
         if value and term:
             s += ">{}</{}>".format(value, tag)
@@ -315,13 +318,11 @@ class Graph(object):
         """
         self._begin_xml_tag(tag, attrib, value, True)
 
-
     def _write_xml_header(self):
         """
         Writes the RR graph XML header.
         """
         self._begin_xml_tag("rr_graph", self.root_attrib)
-
 
     def _write_channels(self, channels):
         """
@@ -340,10 +341,12 @@ class Graph(object):
 
         for l in channels.x_list:
             self._write_xml_tag("x_list", {"index": l.index, "info": l.info})
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
         for l in channels.y_list:
             self._write_xml_tag("y_list", {"index": l.index, "info": l.info})
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
 
@@ -361,10 +364,10 @@ class Graph(object):
 
         for idx, box in enumerate(connection_box.boxes):
             self._write_xml_tag("connection_box", {"id": idx, "name": box})
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
-
 
     def _write_nodes(self, nodes):
         """ Serialize list of Node objects to XML.
@@ -390,7 +393,6 @@ class Graph(object):
 
             self._begin_xml_tag("node", attrib)
 
-
             attrib = {
                 "xlow": node.loc.x_low,
                 "xhigh": node.loc.x_high,
@@ -400,10 +402,9 @@ class Graph(object):
             }
 
             if node.loc.side is not None:
-               attrib["side"] = node.loc.side.name
+                attrib["side"] = node.loc.side.name
 
             self._write_xml_tag("loc", attrib)
-
 
             if node.timing is not None:
                 attrib = {
@@ -415,16 +416,13 @@ class Graph(object):
             if node.metadata is not None and len(node.metadata) > 0:
                 self._begin_xml_tag("metadata")
                 for m in node.metadata:
-                    self._write_xml_tag("meta", {"name": m.name}, m.value)                    
+                    self._write_xml_tag("meta", {"name": m.name}, m.value)
 
                 self._end_xml_tag()
-          
-            if node.segment is not None:
-                attrib = {
-                    "segment_id": node.segment.segment_id
-                }
-                self._write_xml_tag("segment", attrib)
 
+            if node.segment is not None:
+                attrib = {"segment_id": node.segment.segment_id}
+                self._write_xml_tag("segment", attrib)
 
             if node.connection_box is not None:
                 attrib = {
@@ -434,7 +432,6 @@ class Graph(object):
                 }
                 self._write_xml_tag("connection_box", attrib)
 
-
             if node.canonical_loc is not None:
                 attrib = {
                     "x": node.canonical_loc.x,
@@ -443,10 +440,10 @@ class Graph(object):
                 self._write_xml_tag("canonical_loc", attrib)
 
             self._end_xml_tag()
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
-
 
     def _write_edges(self, edges):
         """ Serialize list of edge tuples objects to XML.
@@ -483,7 +480,6 @@ class Graph(object):
 
         self._end_xml_tag()
 
-
     def _write_switches(self):
         """
         Writes the RR graph switches.
@@ -505,9 +501,9 @@ class Graph(object):
                     "Cout": switch.timing.c_out,
                     "Tdel": switch.timing.t_del,
                 }
-                
+
                 if VPR_HAS_C_INTERNAL_SUPPORT:
-                    attrib["Cinternal"] = switch.timing.c_internal 
+                    attrib["Cinternal"] = switch.timing.c_internal
 
                 self._write_xml_tag("timing", attrib)
 
@@ -519,10 +515,10 @@ class Graph(object):
                 self._write_xml_tag("sizing", attrib)
 
             self._end_xml_tag()
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
-
 
     def _write_segments(self):
         """
@@ -545,10 +541,10 @@ class Graph(object):
                 self._write_xml_tag("segment", attrib)
 
             self._end_xml_tag()
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
-
 
     def _write_block_types(self):
         """
@@ -566,22 +562,25 @@ class Graph(object):
             self._begin_xml_tag("block_type", attrib)
 
             for pin_class in blk.pin_class:
-                self._begin_xml_tag("pin_class",
-                    {"type": pin_class.type.name.upper()})
+                self._begin_xml_tag(
+                    "pin_class", {"type": pin_class.type.name.upper()}
+                )
 
                 for pin in pin_class.pin:
                     self._write_xml_tag("pin", {"ptc": pin.ptc}, pin.name)
-                    if DEBUG >= 2: break
+                    if DEBUG >= 2:
+                        break
 
                 self._end_xml_tag()
-                if DEBUG >= 2: break
+                if DEBUG >= 2:
+                    break
 
             self._end_xml_tag()
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
 
-    
     def _write_grid(self):
         """
         Writes the RR graph grid.
@@ -597,18 +596,14 @@ class Graph(object):
                 "height_offset": loc.height_offset,
             }
             self._write_xml_tag("grid_loc", attrib)
-            if DEBUG >= 2: break
+            if DEBUG >= 2:
+                break
 
         self._end_xml_tag()
 
-
     def serialize_to_xml(
-        self,
-        channels_obj,
-        connection_box_obj,
-        nodes_obj,
-        edges_obj
-        ):
+            self, channels_obj, connection_box_obj, nodes_obj, edges_obj
+    ):
         """
         Writes the routing graph to the XML file.
         """
@@ -636,7 +631,6 @@ class Graph(object):
 
             # Write footer
             self._end_xml_tag()
-
 
     def add_switch(self, switch):
         """ Add switch into graph model.

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -619,7 +619,9 @@ class Graph(object):
             self._write_xml_header()
 
             self._write_channels(channels_obj)
-            self._write_connection_box(connection_box_obj)
+
+            if connection_box_obj is not None:
+                self._write_connection_box(connection_box_obj)
 
             self._write_switches()
             self._write_segments()

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -538,7 +538,7 @@ class Graph(object):
                     "R_per_meter": segment.timing.r_per_meter,
                     "C_per_meter": segment.timing.c_per_meter,
                 }
-                self._write_xml_tag("segment", attrib)
+                self._write_xml_tag("timing", attrib)
 
             self._end_xml_tag()
             if DEBUG >= 2:

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -162,9 +162,7 @@ def load_io_sites(db_root, part, pcf):
 
 
 def load_net_list(conn, rr_graph_file, route_file):
-    xml_graph = xml_graph2.Graph(
-        read_xml_file(rr_graph_file), build_pin_edges=False
-    )
+    xml_graph = xml_graph2.Graph(rr_graph_file, build_pin_edges=False)
     graph = xml_graph.graph
 
     net_map = {}

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -36,9 +36,7 @@ import datetime
 import re
 import functools
 import pickle
-import time
 
-from lib.perf_utils import MemoryLog
 import sqlite3
 
 now = datetime.datetime.now
@@ -1003,10 +1001,6 @@ def main():
 
     args = parser.parse_args()
 
-    # Initialize the memory log
-    memlog = MemoryLog(args.write_rr_graph + ".memory.log")
-    memlog.checkpoint("Initial")
-
     db = prjxray.db.Database(args.db_root)
     populate_hclk_cmt_tiles(db)
 
@@ -1040,26 +1034,19 @@ def main():
         roi = None
         synth_tiles = None
 
-    memlog.checkpoint("Synth tiles read")
-
     xml_graph = xml_graph2.Graph(
         input_file_name=args.read_rr_graph,
         progressbar=progressbar_utils.progressbar,
         output_file_name=args.write_rr_graph,
     )
 
-    memlog.checkpoint("Graph loaded")
-
     graph = xml_graph.graph
 
     if synth_tiles is None:
         synth_tiles = find_constant_network(graph)
 
-
     with sqlite3.connect("file:{}?mode=ro".format(args.connection_database),
                          uri=True) as conn:
-
-        memlog.checkpoint("Connected to the SQL db")
 
         populate_bufg_rebuf_map(conn)
 
@@ -1109,12 +1096,10 @@ FROM
 
         print('{} Creating connection box list'.format(now()))
         connection_box_map = create_connection_boxes(conn, graph)
-        memlog.checkpoint("Connection box list created")
 
         # Match site pins rr nodes with graph_node's in the connection_database.
         print('{} Importing graph nodes'.format(now()))
         import_graph_nodes(conn, graph, node_mapping, connection_box_map)
-        memlog.checkpoint("Graph nodes imported")
 
         # Walk all track graph nodes and add them.
         print('{} Creating tracks'.format(now()))
@@ -1122,24 +1107,20 @@ FROM
         create_track_rr_graph(
             conn, graph, node_mapping, use_roi, roi, synth_tiles, segment_id
         )
-        memlog.checkpoint("Tracks created")
 
         # Set of (src, sink, switch_id) tuples that pip edges have been sent to
         # VPR.  VPR cannot handle duplicate paths with the same switch id.
         if use_roi:
             print('{} Adding synthetic edges'.format(now()))
             add_synthetic_edges(conn, graph, node_mapping, grid, synth_tiles)
-            memlog.checkpoint("Synthetic edges added")
 
         print('{} Creating channels.'.format(now()))
         channels_obj = create_channels(conn)
-        memlog.checkpoint("Channels created")
 
         x_dim, y_dim = phy_grid_dims(conn)
         connection_box_obj = graph.create_connection_box_object(
             x_dim=x_dim, y_dim=y_dim
         )
-        memlog.checkpoint("Connection box obj. created")
 
         print('{} Serializing to disk.'.format(now()))
         xml_graph.serialize_to_xml(
@@ -1148,13 +1129,12 @@ FROM
             nodes_obj=yield_nodes(xml_graph.graph.nodes),
             edges_obj=import_graph_edges(conn, graph, node_mapping),
         )
-        memlog.checkpoint("Graph written to disk")
 
         print('{} Writing node map.'.format(now()))
         with open(args.write_rr_node_map, 'wb') as f:
             pickle.dump(node_mapping, f)
         print('{} Done writing node map.'.format(now()))
-        memlog.checkpoint("Node map written to disk")
+
 
 if __name__ == '__main__':
     main()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -523,7 +523,8 @@ def import_tracks(conn, alive_tracks, node_mapping, graph, default_segment_id):
     cur = conn.cursor()
     cur2 = conn.cursor()
     for (graph_node_pkey, track_pkey, graph_node_type, x_low, x_high, y_low,
-         y_high, ptc, capacitance, resistance) in progressbar_utils.progressbar(cur.execute("""
+         y_high, ptc, capacitance,
+         resistance) in progressbar_utils.progressbar(cur.execute("""
 SELECT
     pkey,
     track_pkey,
@@ -983,7 +984,7 @@ def memory_usage():
             parts = line.split()
             key = parts[0][2:-1].lower()
             if key in result:
-                result[key] = int(parts[1]) / (1024*1024)
+                result[key] = int(parts[1]) / (1024 * 1024)
     finally:
         if status is not None:
             status.close()
@@ -1060,7 +1061,7 @@ def main():
         synth_tiles = None
 
     memlog.checkpoint("Synth tiles read")
-    
+
     xml_graph = xml_graph2.Graph(
         input_file_name=args.read_rr_graph,
         progressbar=progressbar_utils.progressbar,
@@ -1074,8 +1075,10 @@ def main():
     if synth_tiles is None:
         synth_tiles = find_constant_network(graph)
 
+
 #    with DatabaseCache(args.connection_database, True) as conn:
-    with sqlite3.connect("file:{}?mode=ro".format(args.connection_database), uri=True) as conn:
+    with sqlite3.connect("file:{}?mode=ro".format(args.connection_database),
+                         uri=True) as conn:
 
         memlog.checkpoint("Connected to the SQL db")
 
@@ -1161,10 +1164,10 @@ FROM
 
         print('{} Serializing to disk.'.format(now()))
         xml_graph.serialize_to_xml(
-                channels_obj=channels_obj,
-                connection_box_obj=connection_box_obj,
-                nodes_obj=yield_nodes(xml_graph.graph.nodes),
-                edges_obj=import_graph_edges(conn, graph, node_mapping),
+            channels_obj=channels_obj,
+            connection_box_obj=connection_box_obj,
+            nodes_obj=yield_nodes(xml_graph.graph.nodes),
+            edges_obj=import_graph_edges(conn, graph, node_mapping),
         )
         memlog.checkpoint("Graph written to disk")
 

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -39,7 +39,6 @@ import pickle
 import time
 
 from lib.perf_utils import MemoryLog
-#from prjxray_db_cache import DatabaseCache
 import sqlite3
 
 now = datetime.datetime.now
@@ -972,25 +971,6 @@ def find_constant_network(graph):
     return synth_tiles
 
 
-def memory_usage():
-    """Memory usage of the current process in GB."""
-    status = None
-    result = {'peak': 0, 'rss': 0}
-    try:
-        # This will only work on systems with a /proc file system
-        # (like Linux).
-        status = open('/proc/self/status')
-        for line in status:
-            parts = line.split()
-            key = parts[0][2:-1].lower()
-            if key in result:
-                result[key] = int(parts[1]) / (1024 * 1024)
-    finally:
-        if status is not None:
-            status.close()
-    return result
-
-
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -1076,7 +1056,6 @@ def main():
         synth_tiles = find_constant_network(graph)
 
 
-#    with DatabaseCache(args.connection_database, True) as conn:
     with sqlite3.connect("file:{}?mode=ro".format(args.connection_database),
                          uri=True) as conn:
 

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -1078,8 +1078,8 @@ def main():
     mem_log.write("04: {}\n".format(str(memory_usage())))
     mem_log.flush()
 
-    tool_version = input_rr_graph.getroot().attrib['tool_version']
-    tool_comment = input_rr_graph.getroot().attrib['tool_comment']
+    tool_version = "version" #input_rr_graph.getroot().attrib['tool_version']
+    tool_comment = "comment" #input_rr_graph.getroot().attrib['tool_comment']
 
     sql_log = open("sql_trace.log", "w")
     sql_t0  = time.time()
@@ -1188,18 +1188,25 @@ FROM
         )
 
         print('{} Serializing to disk.'.format(now()))
-        with xml_graph:
-            xml_graph.start_serialize_to_xml(
-                tool_version=tool_version,
-                tool_comment=tool_comment,
+        xml_graph.serialize_to_xml(
                 channels_obj=channels_obj,
                 connection_box_obj=connection_box_obj,
-            )
+                tool_version=tool_version,
+                tool_comment=tool_comment,
+        )
 
-            xml_graph.serialize_nodes(yield_nodes(xml_graph.graph.nodes))
-            xml_graph.serialize_edges(
-                import_graph_edges(conn, graph, node_mapping)
-            )
+#        with xml_graph:
+#            xml_graph.start_serialize_to_xml(
+#                tool_version=tool_version,
+#                tool_comment=tool_comment,
+#                channels_obj=channels_obj,
+#                connection_box_obj=connection_box_obj,
+#            )
+#
+#            xml_graph.serialize_nodes(yield_nodes(xml_graph.graph.nodes))
+#            xml_graph.serialize_edges(
+#                import_graph_edges(conn, graph, node_mapping)
+#            )
 
         mem_log.write("11: {}\n".format(str(memory_usage())))
         mem_log.flush()

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -285,16 +285,16 @@ def check_feature(feature):
 
         return ' '.join(features)
 
-#    m = HCLK_OUT.fullmatch(feature_path[-1])
-#    if m:
-#        return ' '.join(
-#            (
-#                feature,
-#                find_hclk_cmt_hclk_feature(
-#                    feature_path[0], m.group(1), m.group(2)
-#                )
-#            )
-#        )
+    m = HCLK_OUT.fullmatch(feature_path[-1])
+    if m:
+        return ' '.join(
+            (
+                feature,
+                find_hclk_cmt_hclk_feature(
+                    feature_path[0], m.group(1), m.group(2)
+                )
+            )
+        )
 
     m = CASCOUT_REGEX.fullmatch(feature_path[-2])
     if m:


### PR DESCRIPTION
This PR adds optimizations to the `prjxray_routing_import.py` functionality allowing to significantly reduce its memory footprint. 

Before the optimization import of routing for the whole 50T rr graph took **18.5 GB** and **336 sec**. Once they are applied it takes only **3.6 GB** and **397 sec** (the db read from a HDD drive).

The optimizations include:

- Removal of loading of the whole rr graph to memory at once in favor of parsing it iteratively. Also the data is not stored in ET.Element objects which are pretty memory consuming.
- Refactored rr graph serialization so the data is directly written into the XML file rather than being stored in ET.Element objects and then serialized.
- Removal of SQL database cache. The database is read from the file directly.

This PR also adds a memory usage logging utility script.
