### PR TITLE
Sort rr node ids by geometric neighbors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,10 @@ add_conda_pip(
   NAME gitpython
   NO_EXE
 )
+add_conda_pip(
+  NAME hilbertcurve
+  NO_EXE
+)
 
 get_target_property_required(PYTHON3 env PYTHON3)
 get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)

--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -257,6 +257,7 @@ class Graph(object):
 
         self.tracks = []
         self.nodes = nodes
+        self.nodes.sort(key=lambda node: node.id)
         self.edges = []
 
         self.connection_boxes = []
@@ -293,12 +294,6 @@ class Graph(object):
         # Create mapping from grid locations and pins to nodes.
         for idx, node in enumerate(self.nodes):
             assert node.id == idx, (idx, node)
-            assert node.type in (
-                NodeType.IPIN,
-                NodeType.OPIN,
-                NodeType.SOURCE,
-                NodeType.SINK,
-            ), node
 
             if node.type in (
                     NodeType.IPIN,

--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -714,3 +714,6 @@ class Graph(object):
 
     def get_switch_id(self, switch_name):
         return self.switch_name_map[switch_name]
+
+    def sort_nodes(self):
+        self.nodes.sort(key=lambda node: node.id)

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -369,7 +369,7 @@ class Graph(object):
 
         self._end_xml_tag()
 
-    def _write_nodes(self, nodes):
+    def _write_nodes(self, nodes, node_remap):
         """ Serialize list of Node objects to XML.
 
         Note that this method is extremely hot, len(nodes) is order 1-10 million.
@@ -383,7 +383,7 @@ class Graph(object):
 
         for node in nodes:
             attrib = {
-                "id": node.id,
+                "id": node_remap(node.id),
                 "type": node.type.name,
                 "capacity": node.capacity
             }
@@ -445,7 +445,7 @@ class Graph(object):
 
         self._end_xml_tag()
 
-    def _write_edges(self, edges):
+    def _write_edges(self, edges, node_remap):
         """ Serialize list of edge tuples objects to XML.
 
         edge tuples are (src_node(int), sink_node(int), switch_id(int), metadata(NodeMetadata)).
@@ -462,8 +462,8 @@ class Graph(object):
 
         for src_node, sink_node, switch_id, metadata in edges:
             attrib = {
-                "src_node": src_node,
-                "sink_node": sink_node,
+                "src_node": node_remap(src_node),
+                "sink_node": node_remap(sink_node),
                 "switch_id": switch_id,
             }
 
@@ -602,7 +602,12 @@ class Graph(object):
         self._end_xml_tag()
 
     def serialize_to_xml(
-            self, channels_obj, connection_box_obj, nodes_obj, edges_obj
+            self,
+            channels_obj,
+            connection_box_obj,
+            nodes_obj,
+            edges_obj,
+            node_remap=lambda x: x
     ):
         """
         Writes the routing graph to the XML file.
@@ -628,8 +633,8 @@ class Graph(object):
             self._write_block_types()
             self._write_grid()
 
-            self._write_nodes(nodes_obj)
-            self._write_edges(edges_obj)
+            self._write_nodes(nodes_obj, node_remap)
+            self._write_edges(edges_obj, node_remap)
 
             # Write footer
             self._end_xml_tag()

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -41,7 +41,6 @@ from .verilog_modeling import Module
 from .net_map import create_net_list
 
 import lib.rr_graph_xml.graph2 as xml_graph2
-from lib.rr_graph_xml.utils import read_xml_file
 from lib.parse_pcf import parse_simple_pcf
 import eblif
 
@@ -162,9 +161,13 @@ def load_io_sites(db_root, part, pcf):
 
 
 def load_net_list(conn, rr_graph_file, route_file):
-    xml_graph = xml_graph2.Graph(rr_graph_file, build_pin_edges=False)
+    xml_graph = xml_graph2.Graph(
+        rr_graph_file,
+        build_pin_edges=False,
+        rebase_nodes=False,
+        filter_nodes=False,
+    )
     graph = xml_graph.graph
-    graph.sort_nodes()
 
     net_map = {}
     with open(route_file) as f:

--- a/xc7/fasm2bels/fasm2bels.py
+++ b/xc7/fasm2bels/fasm2bels.py
@@ -164,6 +164,7 @@ def load_io_sites(db_root, part, pcf):
 def load_net_list(conn, rr_graph_file, route_file):
     xml_graph = xml_graph2.Graph(rr_graph_file, build_pin_edges=False)
     graph = xml_graph.graph
+    graph.sort_nodes()
 
     net_map = {}
     with open(route_file) as f:

--- a/xc7/fasm2bels/net_map.py
+++ b/xc7/fasm2bels/net_map.py
@@ -28,6 +28,7 @@ def create_net_list(conn, graph, route_file):
 
     for net, node in find_net_sources(route_file):
         graph_node = graph.nodes[node.inode]
+        assert graph_node.id == node.inode
         assert graph_node.loc.x_low == node.x_low
         assert graph_node.loc.x_high == node.x_high
         assert graph_node.loc.y_low == node.y_low

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -75,7 +75,7 @@ function(ADD_XC7_ARCH_DEFINE)
         \${PYTHON3} -mfasm2bels \
         \${BIT_TO_V_EXTRA_ARGS} \
         --db_root ${PRJXRAY_DB_DIR}/${ARCH} \
-        --rr_graph \${OUT_RRXML_VIRT_LOCATION} \
+        --rr_graph \${OUT_RRXML_REAL_LOCATION} \
         --route \${OUT_ROUTE} \
         --iostandard_defs \${OUT_EBLIF}.iostandard.json \
         --bitread $<TARGET_FILE:bitread> \

--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -392,7 +392,7 @@ function(PROJECT_XRAY_PREPARE_DATABASE)
     --connection_database ${CMAKE_CURRENT_BINARY_DIR}/${CHANNELS}
     DEPENDS
     ${FORM_CHANNELS}
-    ${DEPS} ${DEPS2} simplejson progressbar2 intervaltree
+    ${DEPS} ${DEPS2} simplejson progressbar2 intervaltree hilbertcurve
     ${PYTHON3} ${PYTHON3_TARGET}
     )
 


### PR DESCRIPTION
- This PR introduces rr node re-sorting based on a Hilbert curve, which
  is a space filing curve.  This change dramatically speeds up expansion
  in the lookahead for the full 50T graph (3600 -> 600 seconds).

  It should also accelerate routing in general on graphs, but this has
  not been tested.
