### PR TITLE
Fix the order segments via an OrderedDict and add CCIO segments.

### DIFF
--- a/xc7/utils/prjxray_create_edges.py
+++ b/xc7/utils/prjxray_create_edges.py
@@ -61,7 +61,7 @@ def main():
 
     now = datetime.datetime.now
     print("{}: Creating edges".format(now()))
-    create_edges(args)
+    ccio_sites = create_edges(args)
     print("{}: Done with edges".format(now()))
 
     with sqlite3.connect(args.connection_database) as conn:
@@ -74,7 +74,7 @@ def main():
         set_track_canonical_loc(conn)
 
         print('{} Annotate pin feeds'.format(now()))
-        annotate_pin_feeds(conn)
+        annotate_pin_feeds(conn, ccio_sites)
 
         print('{} Compute segment lengths'.format(now()))
         compute_segment_lengths(conn)

--- a/xc7/utils/prjxray_define_segments.py
+++ b/xc7/utils/prjxray_define_segments.py
@@ -4,6 +4,7 @@
 import argparse
 from prjxray.db import Database
 import re
+from collections import OrderedDict
 
 
 def add_segment_wires(db, tile, wires, segments):
@@ -66,20 +67,24 @@ def get_segments(db):
     """
     wires = set()
 
-    segments = {
-        'INPINFEED': set(),
-        'CLKFEED': set(),
-        'OUTPINFEED': set(),
-        'BRAM_CASCADE': set(),
-        'BUFG_CASCADE': set(),
-        'GCLK': set(),
-        'HCLK_CK_IN': set(),
-        'BRAM_IMUX': set(),
-        'HCLK_COLUMNS': set(),
-        'HCLK_ROWS': set(),
-        'HCLK_ROW_TO_COLUMN': set(),
-        'CCIO_CLK_IN': set(),
-    }
+    segments = OrderedDict()
+
+    for segment in [
+            'INPINFEED',
+            'CLKFEED',
+            'OUTPINFEED',
+            'BRAM_CASCADE',
+            'BUFG_CASCADE',
+            'GCLK',
+            'HCLK_CK_IN',
+            'BRAM_IMUX',
+            'HCLK_COLUMNS',
+            'HCLK_ROWS',
+            'HCLK_ROW_TO_COLUMN',
+            'CCIO_OUTPINFEED',
+            'CCIO_CLK_IN',
+    ]:
+        segments[segment] = set()
 
     for tile in ['INT_L', 'INT_R']:
         add_segment_wires(db, tile, wires, segments)


### PR DESCRIPTION
 - The lookahead expansion is currently driven based on the order of segments,
   so to ensure consistent behavior, the order of segments should be fixed
   rather than simply based on the hash order.
 - CCIO wires are fairly special (dedicated routing to BUFG, etc), and
   should be handled specially.  By defining a segment for CCIO IPINs
   (rather than the generic OUTPINFEED) this ensures they get full
   characterization.