### PR TITLE
xc7: fix dram timings and models

### DIFF
--- a/xc7/bels.json
+++ b/xc7/bels.json
@@ -92,43 +92,43 @@
         },
         "DPRAM32_O6": {
             "A_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/A5LUT"],
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/A5LUT"],
             "B_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/B5LUT"],
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/B5LUT"],
             "C_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/C5LUT"],
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/C5LUT"],
             "D_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/D5LUT"]
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/D5LUT"]
         },
         "DPRAM32_O5": {
             "A_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/A5LUT"],
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/A5LUT"],
             "B_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/B5LUT"],
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/B5LUT"],
             "C_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/C5LUT"],
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/C5LUT"],
             "D_DRAM":
-                ["LUT_OR_MEM5LRAM.SLICEM/D5LUT"]
+                ["LUT_OR_MEM5LRAM.SLICEM", "LUT_OR_MEM5LRAM.SLICEM/D5LUT"]
         },
         "DPRAM64": {
             "A_DRAM":
-                ["LUT_OR_MEM6LRAM.SLICEM/A6LUT"],
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/A6LUT"],
             "B_DRAM":
-                ["LUT_OR_MEM6LRAM.SLICEM/B6LUT"],
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/B6LUT"],
             "C_DRAM":
-                ["LUT_OR_MEM6LRAM.SLICEM/C6LUT"],
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/C6LUT"],
             "D_DRAM":
-                ["LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
         },
         "DPRAM64_for_RAM128X1D": {
             "A_DRAM128":
-                ["LUT_OR_MEM6LRAM.SLICEM/A6LUT"],
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/A6LUT"],
             "B_DRAM128":
-                ["LUT_OR_MEM6LRAM.SLICEM/B6LUT"],
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/B6LUT"],
             "C_DRAM128":
-                ["LUT_OR_MEM6LRAM.SLICEM/C6LUT"],
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/C6LUT"],
             "D_DRAM128":
-                ["LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
+                ["LUT_OR_MEM6LRAM.SLICEM", "LUT_OR_MEM6LRAM.SLICEM/D6LUT"]
         },
         "SRLC32E_VPR":{
             "ASRL":

--- a/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram32.pb_type.xml
@@ -18,17 +18,26 @@
   <input  name="DI" num_pins="1" />
   <input  name="WE" num_pins="1" />
 
-  <T_setup      value="10e-12" port="WA"    clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="WA"    clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WA" out_port="O" />
+  <T_setup      value="{setup_CLK_WA1}" port="WA[0]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA2}" port="WA[1]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA3}" port="WA[2]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA4}" port="WA[3]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA5}" port="WA[4]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA1}" port="WA[0]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA2}" port="WA[1]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA3}" port="WA[2]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA4}" port="WA[3]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA5}" port="WA[4]"     clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O5}" port="WA"       clock="CLK"  />
 
-  <T_setup      value="10e-12" port="WE"    clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="WE"    clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WE" out_port="O" />
+  <T_setup      value="{setup_CLK_WE}" port="WE"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WE}" port="WE"      clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O5}" port="WE"    clock="CLK"  />
 
-  <T_setup      value="10e-12" port="DI"    clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="DI"    clock="CLK"  />
-  <delay_constant max="10e-12" in_port="DI" out_port="O" />
+  <T_setup      value="{setup_CLK_DI1}" port="DI"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_DI1}" port="DI"     clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O5}" port="DI"    clock="CLK"  />
+
   <metadata>
     <meta name="fasm_features">
       RAM

--- a/xc7/primitives/slicem/Ndram/dpram64.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram64.pb_type.xml
@@ -22,25 +22,34 @@
   <input  name="DI"  num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <T_setup      value="10e-12" port="WA"     clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="WA"     clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WA"  out_port="O" />
+  <T_setup      value="{setup_CLK_WA1}" port="WA[0]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA2}" port="WA[1]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA3}" port="WA[2]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA4}" port="WA[3]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA5}" port="WA[4]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA6}" port="WA[5]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA7}" port="WA7"      clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA8}" port="WA8"      clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA1}" port="WA[0]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA2}" port="WA[1]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA3}" port="WA[2]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA4}" port="WA[3]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA5}" port="WA[4]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA6}" port="WA[5]"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA7}" port="WA7"       clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA8}" port="WA8"       clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WA"       clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WA7"      clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WA8"      clock="CLK"  />
 
-  <T_setup      value="10e-12" port="WA7"    clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="WA7"    clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WA7" out_port="O" />
+  <T_setup      value="{setup_CLK_WE}" port="WE"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WE}" port="WE"      clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WE"    clock="CLK"  />
 
-  <T_setup      value="10e-12" port="WA8"    clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="WA8"    clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WA8" out_port="O" />
+  <T_setup      value="{setup_CLK_DI1}" port="DI"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_DI1}" port="DI"     clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="DI"    clock="CLK"  />
 
-  <T_setup      value="10e-12" port="WE"     clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="WE"     clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WE"  out_port="O" />
-
-  <T_setup      value="10e-12" port="DI"     clock="CLK"  />
-  <T_clock_to_Q   max="10e-12" port="DI"     clock="CLK"  />
-  <delay_constant max="10e-12" in_port="DI"  out_port="O" />
   <metadata>
     <meta name="fasm_params">
       INIT[63:0] = INIT

--- a/xc7/primitives/slicem/Ndram/dpram64_for_ram128x1d.pb_type.xml
+++ b/xc7/primitives/slicem/Ndram/dpram64_for_ram128x1d.pb_type.xml
@@ -27,21 +27,30 @@
   <input  name="DI"  num_pins="1" />
   <input  name="WE"  num_pins="1" />
 
-  <T_setup      value="10e-12"    port="WA"  clock="CLK"  />
-  <T_clock_to_Q   max="10e-12"    port="WA"  clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WA"  out_port="O" />
+  <T_setup      value="{setup_CLK_WA1}" port="WA[0]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA2}" port="WA[1]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA3}" port="WA[2]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA4}" port="WA[3]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA5}" port="WA[4]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA6}" port="WA[5]"    clock="CLK"  />
+  <T_setup      value="{setup_CLK_WA7}" port="WA7"      clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA1}"  port="WA[0]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA2}"  port="WA[1]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA3}"  port="WA[2]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA4}"  port="WA[3]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA5}"  port="WA[4]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA6}"  port="WA[5]"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_WA6}"  port="WA7"      clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WA"       clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WA7"      clock="CLK"  />
 
-  <T_setup      value="10e-12"    port="WA7" clock="CLK"  />
-  <T_clock_to_Q   max="10e-12"    port="WA7" clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WA7" out_port="O" />
+  <T_setup      value="{setup_CLK_WE}" port="WE"     clock="CLK"  />
+  <T_hold       value="{hold_CLK_WE}" port="WE"      clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="WE"    clock="CLK"  />
 
-  <T_setup      value="10e-12"    port="WE"  clock="CLK"  />
-  <T_clock_to_Q   max="10e-12"    port="WE"  clock="CLK"  />
-  <delay_constant max="10e-12" in_port="WE"  out_port="O" />
-
-  <T_setup      value="10e-12"    port="DI"  clock="CLK"  />
-  <T_clock_to_Q   max="10e-12"    port="DI"  clock="CLK"  />
-  <delay_constant max="10e-12" in_port="DI"  out_port="O" />
+  <T_setup      value="{setup_CLK_DI1}" port="DI"    clock="CLK"  />
+  <T_hold       value="{hold_CLK_DI1}" port="DI"     clock="CLK"  />
+  <T_clock_to_Q   max="{iopath_CLK_O6}" port="DI"    clock="CLK"  />
 
   <metadata>
     <meta name="fasm_params">

--- a/xc7/primitives/slicem/Ndram/ntemplate.N_dram.model.xml
+++ b/xc7/primitives/slicem/Ndram/ntemplate.N_dram.model.xml
@@ -9,11 +9,11 @@
  </model>
  <model name="DPRAM64_for_RAM128X1D">
   <input_ports>
-   <port is_clock="1"   name="CLK"  />
-   <port clock="CLK"    name="WE"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="DI"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="WA"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="WA7" combinational_sink_ports="O" />
+   <port is_clock="1"   name="CLK" />
+   <port clock="CLK"    name="WE"  />
+   <port clock="CLK"    name="DI"  />
+   <port clock="CLK"    name="WA"  />
+   <port clock="CLK"    name="WA7" />
 
    <port                name="A"   combinational_sink_ports="O" />
   </input_ports>
@@ -23,12 +23,12 @@
  </model>
  <model name="DPRAM64">
   <input_ports>
-   <port is_clock="1"   name="CLK"  />
-   <port clock="CLK"    name="WE"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="DI"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="WA"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="WA7" combinational_sink_ports="O" />
-   <port clock="CLK"    name="WA8" combinational_sink_ports="O" />
+   <port is_clock="1"   name="CLK" />
+   <port clock="CLK"    name="WE"  />
+   <port clock="CLK"    name="DI"  />
+   <port clock="CLK"    name="WA"  />
+   <port clock="CLK"    name="WA7" />
+   <port clock="CLK"    name="WA8" />
 
    <port                name="A"   combinational_sink_ports="O" />
   </input_ports>
@@ -38,10 +38,10 @@
  </model>
  <model name="DPRAM32">
   <input_ports>
-   <port is_clock="1"   name="CLK"  />
-   <port clock="CLK"    name="WE"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="DI"  combinational_sink_ports="O" />
-   <port clock="CLK"    name="WA"  combinational_sink_ports="O" />
+   <port is_clock="1"   name="CLK" />
+   <port clock="CLK"    name="WE"  />
+   <port clock="CLK"    name="DI"  />
+   <port clock="CLK"    name="WA"  />
 
    <port                name="A"   combinational_sink_ports="O" />
   </input_ports>


### PR DESCRIPTION
This PR adds timings injection to DRAM pb_types. Also, it modifies the DRAM models removing combinational connection of write port signals to output (the docs says all writes are sequential/reads are combinational)