### PR TITLE
Add xc7 two router diagnostic tooling

### DIFF
--- a/xc7/utils/animate_router_pop.py
+++ b/xc7/utils/animate_router_pop.py
@@ -1,0 +1,53 @@
+import re
+import sys
+
+
+def main():
+    # Popping node CLBLM_R_X27Y37/CLBLM_M_AMUX (1923686) (cost: 0)
+    POP_RE = re.compile(
+        r'Popping node ([A-Za-z0-9_/]+) \([0-9]+\) \(cost: ([0-9+\-.e]+)\)'
+    )
+
+    # rt_node: CLBLM_R_X27Y37/CLBLM_M_AMUX (1923687) (OPIN)
+    # rt_node: CLBLL_L_X38Y24/CLBLL_LL_C1 (3202101) (IPIN)
+    PIN_RE = re.compile(r'rt_node: ([A-Za-z0-9_/]+) \([0-9]+\) \(([IO])PIN\)')
+
+    print(
+        """
+proc animate {idx node_length} {
+    select_objects [get_nodes -of [get_wires [lindex $nodes $idx]]]
+    set idx [expr $idx+1]
+    if { $idx < $node_length } {
+        after 100 [animate $idx $node_length]
+    }
+}"""
+    )
+    print('set nodes {}')
+
+    wires = []
+
+    for l in sys.stdin:
+        m = POP_RE.search(l)
+
+        if m:
+            wires.append(m.group(1))
+
+        m = PIN_RE.search(l)
+        if m:
+            if m.group(2) == 'I':
+                ipin = m.group(1)
+            elif m.group(2) == 'O':
+                opin = m.group(1)
+            else:
+                assert False, l
+
+    print('unhighlight_objects')
+    print('highlight_objects [get_nodes -of [get_wires {}]]'.format(ipin))
+    print('highlight_objects [get_nodes -of [get_wires {}]]'.format(opin))
+
+    for wire in wires:
+        print('select_objects [get_nodes -of [get_wires {}]]'.format(wire))
+
+
+if __name__ == "__main__":
+    main()

--- a/xc7/utils/annotate_vpr_log.py
+++ b/xc7/utils/annotate_vpr_log.py
@@ -1,0 +1,67 @@
+"""
+
+"""
+import argparse
+import functools
+import pickle
+import re
+import sqlite3
+import sys
+
+
+def create_lookup_inode(conn, inode_to_graph_map):
+    cur = conn.cursor()
+
+    @functools.lru_cache(maxsize=1024 * 1024)
+    def lookup_inode(inode):
+        if inode not in inode_to_graph_map:
+            return '{}'.format(inode)
+        else:
+            cur.execute(
+                """
+SELECT phy_tile.name, wire_in_tile.name
+FROM graph_node
+INNER JOIN wire ON graph_node.node_pkey = wire.node_pkey
+INNER JOIN wire_in_tile ON wire.wire_in_tile_pkey = wire_in_tile.pkey
+INNER JOIN phy_tile ON wire.phy_tile_pkey = phy_tile.pkey
+WHERE graph_node.pkey = ?
+LIMIT 1;""", (inode_to_graph_map[inode], )
+            )
+            tile, wire = cur.fetchone()
+
+            return '{}/{} ({})'.format(tile, wire, inode)
+
+    return lookup_inode
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--rrgraph_node_map', required=True)
+    parser.add_argument('--connection_database', required=True)
+
+    args = parser.parse_args()
+
+    with open(args.rrgraph_node_map, 'rb') as f:
+        node_map = pickle.load(f)
+
+    inode_to_graph_map = {}
+    for graph_node_pkey, rr_inode in node_map.items():
+        assert rr_inode not in inode_to_graph_map
+        inode_to_graph_map[rr_inode] = graph_node_pkey
+
+    conn = sqlite3.connect(
+        'file:{}?mode=ro'.format(args.connection_database), uri=True
+    )
+
+    lookup_inode = create_lookup_inode(conn, inode_to_graph_map)
+
+    def replace_inode(match):
+        return match.group(1) + ' ' + lookup_inode(int(match.group(2)))
+
+    NODE_RE = re.compile('(node|rt_node:) ([1-9][0-9]*)')
+    for l in sys.stdin:
+        sys.stdout.write(NODE_RE.sub(replace_inode, l))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- annotate_vpr_log.py is designed to convert vpr logs (like the detailed
  routing diagnostic output) and change rr node ids to wire names.
- animate_router_pop.py is designed create a simple Vivado tcl script for
  animating the router search behavior for visualizing the VPR router behavior.