### PR TITLE
Use CMAKE_COMMAND for cmake executable if set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# Makefile
+
+ifeq ($(origin CMAKE_COMMAND),undefined)
+CMAKE_COMMAND := cmake
+else
+CMAKE_COMMAND := ${CMAKE_COMMAND}
+endif
+
 .PHONY: all env
 
 all: env
@@ -9,7 +17,7 @@ clean:
 env:
 	git submodule init
 	git submodule update --init --recursive
-	mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
+	mkdir -p build && cd build && $(CMAKE_COMMAND) ${CMAKE_FLAGS} ..
 
 build/Makefile:
 	make env


### PR DESCRIPTION
I'm not an expert by any stretch, but this is how I tweaked Makefile so that I could override the hard-coded "cmake" executable name with the path to /usr/bin/cmake3 available on the RedHat systems I have access to, using the CMAKE_COMMAND environment variable.

For reference, details about CMAKE_COMMAND can be found here: 

https://cmake.org/cmake/help/v3.4/variable/CMAKE_COMMAND.html

Enjoy!

Andrew.
