### PR TITLE
Add site pin delay to connection box annotation.

### DIFF
--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -154,7 +154,7 @@ class CanonicalLoc(namedtuple('CanonicalLoc', 'x y')):
     pass
 
 
-class ConnectionBox(namedtuple('ConnectionBox', 'x y id')):
+class ConnectionBox(namedtuple('ConnectionBox', 'x y id site_pin_delay')):
     """ Connection box location and definition.
 
     The connection box location is the place in the "canonical grid" where
@@ -167,6 +167,7 @@ class ConnectionBox(namedtuple('ConnectionBox', 'x y id')):
         Canonical location of connection box for IPIN.
     id : int
         0-based index into ConnectionBoxes.boxes vector of connection box names.
+    site_pin_delay : float
 
     """
     pass

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -436,6 +436,7 @@ class Graph(object):
                     "x": node.connection_box.x,
                     "y": node.connection_box.y,
                     "id": node.connection_box.id,
+                    "site_pin_delay": node.connection_box.site_pin_delay,
                 }
                 self._write_xml_tag("connection_box", attrib)
 


### PR DESCRIPTION
This is important because the generic delay matrix doesn't account for
per site pin delays.  By adding an annotation of the portion of the IPIN
that varies dramatically (and varies at the end of the route and is
unaviodable), it enables the connection box lookahead to properly
account for this delay.

See https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1027
for more details and examples.