### PR TITLE
Makefile tweaks to allow for alternate cmake paths.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
+# Makefile
+
+ifeq ($(origin CMAKE_COMMAND),undefined)
+CMAKE_COMMAND := cmake
+else
+CMAKE_COMMAND := ${CMAKE_COMMAND}
+endif
+
 .PHONY: all env
 
 all: env
@@ -9,7 +17,7 @@ clean:
 env:
 	git submodule init
 	git submodule update --init --recursive
-	mkdir -p build && cd build && cmake ${CMAKE_FLAGS} ..
+	mkdir -p build && cd build && $(CMAKE_COMMAND) ${CMAKE_FLAGS} ..
 
 build/Makefile:
 	make env


### PR DESCRIPTION
Signed-off-by: Andrew Plumb <andrew@plumb.org>

Tweaks to the Makefile to allow for alternate cmake paths, needed on the RedHat systems at work.

Signed-off-by: Andrew Plumb <andrew@plumb.org>
