### PR TITLE
[xc7] Enable all working FASM diff tests, disable failing tests

### DIFF
--- a/.github/kokoro/xc7-vendor.sh
+++ b/.github/kokoro/xc7-vendor.sh
@@ -5,7 +5,18 @@ SCRIPT_DIR="$(dirname "${SCRIPT_SRC}")"
 
 export CMAKE_FLAGS=-GNinja
 export BUILD_TOOL=ninja
+export XRAY_VIVADO_SETTINGS=/opt/Xilinx/Vivado/2017.2/settings64.sh
 source ${SCRIPT_DIR}/common.sh
+source third_party/prjxray/.github/kokoro/steps/xilinx.sh
+echo
+echo "========================================"
+echo "Vivado version"
+echo "----------------------------------------"
+(
+    source third_party/prjxray/utils/environment.sh
+    $XRAY_VIVADO -version
+)
+echo "----------------------------------------"
 
 echo
 echo "========================================"
@@ -14,8 +25,8 @@ echo "----------------------------------------"
 (
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
-	# Disabled until tested
-	#ninja -j${MAX_CORES} all_xc7_diff_fasm
+	# Running with -k0 to attempt all tests, and show which ones failed.
+	ninja -k0 -j${MAX_CORES} all_xc7_diff_fasm
 )
 echo "----------------------------------------"
 

--- a/xc7/tests/buttons/CMakeLists.txt
+++ b/xc7/tests/buttons/CMakeLists.txt
@@ -15,6 +15,8 @@ add_fpga_target(
 add_vivado_target(
   NAME buttons_basys3_vivado
   PARENT_NAME buttons_basys3
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1018
+  DISABLE_DIFF_TEST
   )
 
 add_fpga_target(

--- a/xc7/tests/counter/CMakeLists.txt
+++ b/xc7/tests/counter/CMakeLists.txt
@@ -20,6 +20,8 @@ add_vivado_target(
     PARENT_NAME counter_basys3
     CLOCK_PINS clk
     CLOCK_PERIODS 10.0
+    # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1018
+    DISABLE_DIFF_TEST
     )
 
 add_fpga_target(

--- a/xc7/tests/pll/CMakeLists.txt
+++ b/xc7/tests/pll/CMakeLists.txt
@@ -35,6 +35,8 @@ add_vivado_target(
   PARENT_NAME pll_int_basys3_x1y0
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1018
+  DISABLE_DIFF_TEST
   )
 
 add_vivado_target(
@@ -42,6 +44,8 @@ add_vivado_target(
   PARENT_NAME pll_buf_basys3_x1y0
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1018
+  DISABLE_DIFF_TEST
   )
 
 add_vivado_target(
@@ -49,6 +53,8 @@ add_vivado_target(
   PARENT_NAME pll_ext_basys3_x1y0
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1018
+  DISABLE_DIFF_TEST
   )
 
 

--- a/xc7/tests/simple_ff/CMakeLists.txt
+++ b/xc7/tests/simple_ff/CMakeLists.txt
@@ -8,6 +8,8 @@ add_fpga_target(
 add_vivado_target(
   NAME simple_ff_vivado
   PARENT_NAME simple_ff
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1018
+  DISABLE_DIFF_TEST
   )
 
 add_fpga_target(

--- a/xc7/tests/srl/srl16_chain/CMakeLists.txt
+++ b/xc7/tests/srl/srl16_chain/CMakeLists.txt
@@ -15,6 +15,8 @@ add_vivado_target(
   PARENT_NAME srl16_chain
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1019
+  DISABLE_DIFF_TEST
   )
 
 add_dependencies(all_xc7_tests

--- a/xc7/tests/srl/srl32_amc31/CMakeLists.txt
+++ b/xc7/tests/srl/srl32_amc31/CMakeLists.txt
@@ -33,6 +33,8 @@ add_vivado_target(
   PARENT_NAME srl32_doutmux_mc31
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1019
+  DISABLE_DIFF_TEST
   )
 
 #add_vivado_target(

--- a/xc7/tests/srl/srl32_chain/CMakeLists.txt
+++ b/xc7/tests/srl/srl32_chain/CMakeLists.txt
@@ -15,6 +15,8 @@ add_vivado_target(
   PARENT_NAME srl32_chain
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1019
+  DISABLE_DIFF_TEST
   )
 
 add_dependencies(all_xc7_tests

--- a/xc7/tests/srl/srl32_shift/CMakeLists.txt
+++ b/xc7/tests/srl/srl32_shift/CMakeLists.txt
@@ -15,6 +15,8 @@ add_vivado_target(
   PARENT_NAME srl32_shift
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
+  # TODO: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1019
+  DISABLE_DIFF_TEST
   )
 
 add_dependencies(all_xc7_tests


### PR DESCRIPTION
Disabled tests:

Because of https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1019:
- srl16_chain
- srl32_doutmux_mc31
- srl32_chain
- srl32_shift

Unknown failures:
- buttons_basys3
- counter_basys3
- simple_ff

Because of Vivado clock routing violations:
- pll_int_basys3_x1y0
- pll_buf_basys3_x1y0
- pll_ext_basys3_x1y0