### PR TITLE
xc7-arch: disable pin feasibility filter once again

### DIFF
--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -24,6 +24,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --router_lookahead connection_box_map \
       --disable_check_route on \
       --strict_checks off \
+      --clustering_pin_feasibility_filter off \
       --allow_dangling_combinational_nodes on \
       --disable_errors check_unbuffered_edges:check_route \
       --congested_routing_iteration_threshold 0.8 \


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is needed to have the packer not failing during the OSERDES clustering.
The problem should still be solved to be able to re-enable the filter, which will reduce the packer run-time