### PR TITLE
WIP: Use "buffer" switch type for non-configurable switches (e.g. ppips).

### DIFF
--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -307,9 +307,11 @@ CREATE TABLE graph_node(
   capacity INT,
   capacitance REAL,
   resistance REAL,
+  site_pin_graph_node_pkey INT,
   FOREIGN KEY(connection_box_wire_pkey) REFERENCES wire(pkey),
   FOREIGN KEY(track_pkey) REFERENCES track(pkey),
   FOREIGN KEY(node_pkey) REFERENCES node(pkey)
+  FOREIGN KEY(site_pin_graph_node_pkey) REFERENCES graph_node(pkey)
 );
 
 -- Table of wires.  This table is the complete list of all wires in the
@@ -343,7 +345,6 @@ CREATE TABLE wire(
   bottom_graph_node_pkey INT,
   left_graph_node_pkey INT,
   right_graph_node_pkey INT,
-  site_pin_graph_node_pkey INT,
   FOREIGN KEY(node_pkey) REFERENCES node(pkey),
   FOREIGN KEY(phy_tile_pkey) REFERENCES phy_tile(pkey),
   FOREIGN KEY(tile_pkey) REFERENCES tile(pkey),
@@ -352,8 +353,7 @@ CREATE TABLE wire(
   FOREIGN KEY(top_graph_node_pkey) REFERENCES graph_node(pkey),
   FOREIGN KEY(bottom_graph_node_pkey) REFERENCES graph_node(pkey),
   FOREIGN KEY(left_graph_node_pkey) REFERENCES graph_node(pkey),
-  FOREIGN KEY(right_graph_node_pkey) REFERENCES graph_node(pkey),
-  FOREIGN KEY(site_pin_graph_node_pkey) REFERENCES graph_node(pkey)
+  FOREIGN KEY(right_graph_node_pkey) REFERENCES graph_node(pkey)
 );
 
 -- Table of graph edges.

--- a/xc7/utils/prjxray_edge_library.py
+++ b/xc7/utils/prjxray_edge_library.py
@@ -458,14 +458,20 @@ SELECT
     top_graph_node_pkey,
     bottom_graph_node_pkey,
     right_graph_node_pkey,
-    left_graph_node_pkey,
-    site_pin_graph_node_pkey
+    left_graph_node_pkey
 FROM wire WHERE pkey = ?""", (site_wire_pkey, )
         )
         values = cur.fetchone()
         node_pkey = values[0]
         edge_nodes = values[1:5]
-        site_pin_graph_node_pkey = values[5]
+
+        cur.execute(
+            """
+SELECT
+    site_pin_graph_node_pkey
+FROM graph_node WHERE pkey = ?""", (graph_node_pkey, )
+        )
+        site_pin_graph_node_pkey = cur.fetchone()[0]
 
         cur.execute(
             """
@@ -548,10 +554,10 @@ FROM graph_node WHERE pkey = ?""", (
 
             write_cur.execute(
                 """
-UPDATE wire SET site_pin_graph_node_pkey = ?
+UPDATE graph_node SET site_pin_graph_node_pkey = ?
 WHERE pkey = ?""", (
                     site_pin_graph_node_pkey,
-                    wire_pkey,
+                    graph_node_pkey,
                 )
             )
 

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -41,6 +41,7 @@ from lib.rr_graph import points
 from lib.rr_graph import tracks
 from lib.rr_graph import graph2
 from prjxray.grid import BlockType
+from prjxray.tile_segbits import PsuedoPipType
 import datetime
 import os
 import os.path
@@ -2093,8 +2094,15 @@ def main():
 
             feature = '{}.{}.{}'.format(tile, pip.net_to, pip.net_from)
 
-            is_ppip = feature in segbits.ppips
+            is_ppip = feature in segbits.ppips and segbits.ppips[
+                feature] == PsuedoPipType.ALWAYS
             if BlockType.CLB_IO_CLK not in segbits.segbits:
+                return False
+
+            # These wires are pretty weird, just leave as switches.
+            if 'CLK_FREQ_BB' in pip.name:
+                return False
+            if 'SYNC_BB' in pip.name:
                 return False
 
             is_configurable = feature in segbits.segbits[BlockType.CLB_IO_CLK]


### PR DESCRIPTION
This is part 1 of #1019 