### PR TITLE
arch: remove priority from physical tiles

### DIFF
--- a/xc7/make/project_xray.cmake
+++ b/xc7/make/project_xray.cmake
@@ -57,7 +57,6 @@ function(PROJECT_XRAY_TILE)
   # SITE_AS_TILE option to state if the tile physically is a site, but it needs to be treated as a site
   # USE_DATABASE option enables usage of connection database for tile
   #     definition, instead of using the project X-Ray database.
-  # PRIORITY option that enables the priority assignments to the equivalent sites
   # BOTH_SIDE_COORD option that enables the assignment of both coordinates to the fasm prefixes
   # FILTER_X can be supplied to filter to sites that have the given X
   #     coordinate.
@@ -69,7 +68,6 @@ function(PROJECT_XRAY_TILE)
   #   TILE <tile_name>
   #   SITE_TYPES <site_name_1> <site_name_2> ...
   #   EQUIVALENT_SITES <equivalent_site_name_1> <equivalent_site_name_2> ...
-  #   PRIORITY (option)
   #   SITE_AS_TILE (option)
   #   FUSED_SITES (option)
   #   USE_DATABASE (option)
@@ -79,7 +77,7 @@ function(PROJECT_XRAY_TILE)
   #   )
   # ~~~
 
-  set(options PRIORITY FUSED_SITES SITE_AS_TILE USE_DATABASE BOTH_SITE_COORDS NO_FASM_PREFIX)
+  set(options FUSED_SITES SITE_AS_TILE USE_DATABASE BOTH_SITE_COORDS NO_FASM_PREFIX)
   set(oneValueArgs PART TILE FILTER_X)
   set(multiValueArgs SITE_TYPES EQUIVALENT_SITES)
   cmake_parse_arguments(
@@ -126,11 +124,6 @@ function(PROJECT_XRAY_TILE)
       get_file_location(GENERIC_CHANNELS_LOCATION ${GENERIC_CHANNELS})
       append_file_dependency(DEPS ${GENERIC_CHANNELS})
       set(FUSED_SITES_ARGS --connection_database ${GENERIC_CHANNELS_LOCATION})
-  endif()
-
-  set(PHYSICAL_TILE_ARGS "")
-  if(PROJECT_XRAY_TILE_PRIORITY)
-    set(PHYSICAL_TILE_ARGS "--priority")
   endif()
 
   set(BOTH_SITE_COORDS_ARGS "")
@@ -207,7 +200,6 @@ function(PROJECT_XRAY_TILE)
     --pin-prefix=${PIN_PREFIX_COMMA}
     --output-tile ${CMAKE_CURRENT_BINARY_DIR}/${TILE}.tile.xml
     --pin_assignments ${PIN_ASSIGNMENTS}
-    ${PHYSICAL_TILE_ARGS}
     DEPENDS
     ${PHYSICAL_TILE_IMPORT}
       ${TILES_DEPS}

--- a/xc7/utils/prjxray_create_equiv_tiles.py
+++ b/xc7/utils/prjxray_create_equiv_tiles.py
@@ -1033,10 +1033,7 @@ AND
 
     for pb_type in pb_types:
         site_xml = ET.Element(
-            'site', {
-                'pb_type': add_vpr_tile_prefix(pb_type),
-                'priority': '0',
-            }
+            'site', {'pb_type': add_vpr_tile_prefix(pb_type)}
         )
         equivalent_sites_xml.append(site_xml)
 

--- a/xc7/utils/prjxray_physical_tile_import.py
+++ b/xc7/utils/prjxray_physical_tile_import.py
@@ -79,14 +79,12 @@ def import_physical_tile(args):
                         }
                     )
 
-    def add_equivalent_sites(tile_xml, equivalent_sites, inc_priority=False):
+    def add_equivalent_sites(tile_xml, equivalent_sites):
         """ Used to add to the <tile> tag the equivalent tiles associated with it."""
 
         pb_types = equivalent_sites.split(',')
 
         equivalent_sites_xml = ET.SubElement(tile_xml, 'equivalent_sites')
-
-        priority = 0
 
         for eq_site in pb_types:
             eq_pb_type_xml = ET.parse(
@@ -97,14 +95,9 @@ def import_physical_tile(args):
             pb_type_root = eq_pb_type_xml.getroot()
 
             site_xml = ET.SubElement(
-                equivalent_sites_xml, 'site', {
-                    'pb_type': tile_import.add_vpr_tile_prefix(eq_site),
-                    'priority': str(priority)
-                }
+                equivalent_sites_xml, 'site',
+                {'pb_type': tile_import.add_vpr_tile_prefix(eq_site)}
             )
-
-            if inc_priority:
-                priority += 1
 
             add_direct_mappings(tile_xml, site_xml, pb_type_root)
 
@@ -134,7 +127,7 @@ def import_physical_tile(args):
     add_ports(tile_xml, pb_type_root)
 
     equivalent_sites = args.equivalent_sites
-    add_equivalent_sites(tile_xml, equivalent_sites, args.priority)
+    add_equivalent_sites(tile_xml, equivalent_sites)
 
     fc_xml = tile_import.add_fc(tile_xml)
 
@@ -197,8 +190,6 @@ def main():
     parser.add_argument(
         '--pin_assignments', required=True, type=argparse.FileType('r')
     )
-
-    parser.add_argument('--priority', action='store_true')
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to remove the "priority" from the tiles in the architecture XML as it is not needed.