### PR TITLE
Update VtR with new-equivalent-tiles integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr v8.0.0_rc1_1403_g87b652827_0000_g87b652827 20191122_040942"
+  PACKAGE_SPEC "vtr v8.0.0_rc1_1532_g92e57c2d0_0000_g92e57c2d0 20191126_100023"
   )
 add_conda_package(
   NAME libxslt

--- a/xc7/utils/prjxray_create_equiv_tiles.py
+++ b/xc7/utils/prjxray_create_equiv_tiles.py
@@ -1040,7 +1040,10 @@ AND
 
     for pb_type in pb_types:
         site_xml = ET.Element(
-            'site', {'pb_type': add_vpr_tile_prefix(pb_type)}
+            'site', {
+                'pb_type': add_vpr_tile_prefix(pb_type),
+                'pin_mapping': 'custom'
+            }
         )
         equivalent_sites_xml.append(site_xml)
 

--- a/xc7/utils/prjxray_physical_tile_import.py
+++ b/xc7/utils/prjxray_physical_tile_import.py
@@ -95,8 +95,10 @@ def import_physical_tile(args):
             pb_type_root = eq_pb_type_xml.getroot()
 
             site_xml = ET.SubElement(
-                equivalent_sites_xml, 'site',
-                {'pb_type': tile_import.add_vpr_tile_prefix(eq_site)}
+                equivalent_sites_xml, 'site', {
+                    'pb_type': tile_import.add_vpr_tile_prefix(eq_site),
+                    'pin_mapping': 'custom'
+                }
             )
 
             add_direct_mappings(tile_xml, site_xml, pb_type_root)


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to add the `pin_mapping` attribute to the `site` tag in the `equivalent_sites` list of each tile.

CI fail due to the fact that `master+wip` VtR does not yet include the latest equivalent sites changes. Once the conda-environment will be updated with the new revision of VtR, CI will turn green.