### PR TITLE
Increase initial pres

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr v8.0.0_rc1_1194_gf91ea1cc3_0000_gf91ea1cc3 20191107_000440"
+  PACKAGE_SPEC "vtr v8.0.0_rc1_1403_g87b652827_0000_g87b652827 20191122_040942"
   )
 add_conda_package(
   NAME libxslt

--- a/tests/9-soc/murax/CMakeLists.txt
+++ b/tests/9-soc/murax/CMakeLists.txt
@@ -52,6 +52,13 @@ add_vivado_target(
     CLOCK_PERIODS 10.0
     )
 
+add_vivado_target(
+    NAME murax_basys_full_vivado
+    PARENT_NAME murax_basys_full
+    CLOCK_PINS io_mainClk
+    CLOCK_PERIODS 10.0
+    )
+
 add_vivado_pnr_target(
     NAME murax_basys_vivado_pnr
     PARENT_NAME murax_basys

--- a/tests/9-soc/picosoc/CMakeLists.txt
+++ b/tests/9-soc/picosoc/CMakeLists.txt
@@ -81,6 +81,13 @@ add_vivado_target(
     CLOCK_PERIODS 20.0
     )
 
+add_vivado_target(
+    NAME picosoc_basys3_full_vivado
+    PARENT_NAME picosoc_basys3_full
+    CLOCK_PINS clk
+    CLOCK_PERIODS 20.0
+    )
+
 add_vivado_pnr_target(
     NAME picosoc_basys3_vivado_pnr
     PARENT_NAME picosoc_basys3

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -30,6 +30,8 @@ function(ADD_XC7_ARCH_DEFINE)
       --allow_dangling_combinational_nodes on \
       --disable_errors check_unbuffered_edges:check_route \
       --congested_routing_iteration_threshold 0.8 \
+      --incremental_reroute_delay_ripup off \
+      --base_cost_type delay_normalized_length_bounded \
       --astar_fac 1.2 \
       --bb_factor 10 \
       --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R"

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -34,6 +34,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --base_cost_type delay_normalized_length_bounded \
       --astar_fac 1.2 \
       --bb_factor 10 \
+      --initial_pres_fac 4.0 \
       --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R"
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py

--- a/xc7/utils/prjxray_edge_library.py
+++ b/xc7/utils/prjxray_edge_library.py
@@ -13,6 +13,7 @@ from prjxray_constant_site_pins import yield_ties_to_wire
 from lib.connection_database import get_track_model, get_wire_in_tile_from_pin_name
 from lib.rr_graph.graph2 import NodeType
 import math
+import numpy
 
 from prjxray_db_cache import DatabaseCache
 
@@ -1859,11 +1860,9 @@ def get_segment_length(segment_lengths):
     if len(segment_lengths) == 0:
         return 1
 
-    mean_length = int(
-        math.ceil(float(sum(segment_lengths)) / len(segment_lengths))
-    )
+    median_length = int(math.ceil(numpy.median(segment_lengths)))
 
-    return max(1, mean_length)
+    return max(1, median_length)
 
 
 def compute_segment_lengths(conn):


### PR DESCRIPTION
- Use bounded base costs for routing (but not for the lookahead)
- Increase the initial present congestion factor from 0.5 to 4
- Disable incremental ripup
- Use median segment lengths for computing segments lengths, instead of mean