### PR TITLE
iserdes: add missing features

### DIFF
--- a/xc7/fasm2bels/ioi_models.py
+++ b/xc7/fasm2bels/ioi_models.py
@@ -175,6 +175,14 @@ def process_ilogic_idelay(top, features):
 
         bel.parameters['NUM_CE'] = num_ce
 
+        if site.has_feature('IDELMUXE3.P0') and site.has_feature(
+                'IFFDELMUXE3.P0'):
+            bel.parameters['IOBDELAY'] = '"BOTH"'
+        elif site.has_feature('IFFDELMUXE3.P0'):
+            bel.parameters['IOBDELAY'] = '"IFD"'
+        elif site.has_feature('IDELMUXE3.P0'):
+            bel.parameters['IOBDELAY'] = '"IBUF"'
+
         site.add_sink(bel, 'CE1', 'CE1')
         site.add_sink(bel, 'CE2', 'CE2')
 

--- a/xc7/primitives/ilogice3/ilogice3.pb_type.xml
+++ b/xc7/primitives/ilogice3/ilogice3.pb_type.xml
@@ -72,6 +72,7 @@
       <output name="SHIFTOUT1" num_pins="1"/>
       <output name="SHIFTOUT2" num_pins="1"/>
       <metadata>
+        <!-- TODO: Some features are named after the IFF site, but do enable functionalities for the ISERDES -->
         <meta name="fasm_features">
           ISERDES.IN_USE
           IDDR_OR_ISERDES.IN_USE
@@ -92,6 +93,9 @@
           ISERDES.INTERFACE_TYPE.Z_MEMORY = INTERFACE_TYPE_Z_MEMORY
 
           ISERDES.NUM_CE.N2 = NUM_CE_N2
+
+          IFFDELMUXE3.P0 = IOBDELAY_IFD
+          IDELMUXE3.P0 = IOBDELAY_IBUF
 
           IFF.ZINIT_Q1 = ZINIT_Q1
           IFF.ZINIT_Q2 = ZINIT_Q2

--- a/xc7/techmap/cells_map.v
+++ b/xc7/techmap/cells_map.v
@@ -2258,6 +2258,9 @@ module ISERDESE2 (
 
   parameter INTERFACE_TYPE = "MEMORY";
 
+  parameter IOBDELAY = "NONE";
+  parameter SERDES_MODE = "MASTER";
+
   parameter [0:0] INIT_Q1 = 1'b0;
   parameter [0:0] INIT_Q2 = 1'b0;
   parameter [0:0] INIT_Q3 = 1'b0;
@@ -2321,6 +2324,8 @@ module ISERDESE2 (
           .DATA_WIDTH_W5_7              (DATA_WIDTH == 5 || DATA_WIDTH == 7),
           .DATA_WIDTH_W8                (DATA_WIDTH == 8),
           .NUM_CE_N2                    (NUM_CE == 2),
+          .IOBDELAY_IFD                 (IOBDELAY == "IFD" || IOBDELAY == "BOTH"),
+          .IOBDELAY_IBUF                (IOBDELAY == "IBUF" || IOBDELAY == "BOTH"),
 
           // Inverters
           .ZINIT_Q1                     (!INIT_Q1),
@@ -2365,6 +2370,8 @@ module ISERDESE2 (
           .DATA_WIDTH_W5_7              (DATA_WIDTH == 5 || DATA_WIDTH == 7),
           .DATA_WIDTH_W8                (DATA_WIDTH == 8),
           .NUM_CE_N2                    (NUM_CE == 2),
+          .IOBDELAY_IFD                 (IOBDELAY == "IFD" || IOBDELAY == "BOTH"),
+          .IOBDELAY_IBUF                (IOBDELAY == "IBUF" || IOBDELAY == "BOTH"),
 
           // Inverters
           .ZINIT_Q1                     (!INIT_Q1),
@@ -2433,6 +2440,9 @@ module IDELAYE2 (
   parameter HIGH_PERFORMANCE_MODE = "FALSE";
   parameter IDELAY_TYPE = "FIXED";
   parameter PIPE_SEL = "FALSE";
+
+  parameter REFCLK_FREQUENCY = 200.0;
+  parameter SIGNAL_PATTERN = "DATA";
 
   parameter [4:0] IDELAY_VALUE = 5'b00000;
 

--- a/xc7/techmap/cells_sim.v
+++ b/xc7/techmap/cells_sim.v
@@ -767,6 +767,9 @@ module ISERDESE2_IDELAY_VPR (
   parameter [0:0] INTERFACE_TYPE_Z_MEMORY    = 1'b0;
   parameter [0:0] NUM_CE_N2 = 1'b0;
 
+  parameter [0:0] IOBDELAY_IFD = 1'b0;
+  parameter [0:0] IOBDELAY_IBUF = 1'b0;
+
   parameter [0:0] ZINIT_Q1 = 1'b0;
   parameter [0:0] ZINIT_Q2 = 1'b0;
   parameter [0:0] ZINIT_Q3 = 1'b0;
@@ -811,6 +814,9 @@ module ISERDESE2_NO_IDELAY_VPR (
   parameter [0:0] INTERFACE_TYPE_OVERSAMPLE  = 1'b0;
   parameter [0:0] INTERFACE_TYPE_Z_MEMORY    = 1'b0;
   parameter [0:0] NUM_CE_N2 = 1'b0;
+
+  parameter [0:0] IOBDELAY_IFD = 1'b0;
+  parameter [0:0] IOBDELAY_IBUF = 1'b0;
 
   parameter [0:0] ZINIT_Q1 = 1'b0;
   parameter [0:0] ZINIT_Q2 = 1'b0;


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR adds additional features for the ISERDES that were missing.

It also adds some parameters in the techmap which are left as default ones for IDELAY and ISERDES:
- SERDES_MODE
- REFCLK_FREQUENCY
- SIGNAL_PATTERN