### PR TITLE
Fix site pin switch when connecting pip is in another tile.

### DIFF
--- a/xc7/utils/prjxray_find_inode.py
+++ b/xc7/utils/prjxray_find_inode.py
@@ -45,8 +45,9 @@ AND
 SELECT pkey, graph_node_type FROM graph_node WHERE node_pkey = ?
         """, (node_pkey, )):
         print(
-            '  Node {} {}'.format(
-                node_map.get(graph_node_pkey), NodeType(graph_node_type)
+            '  Node inode={} pkey={} {}'.format(
+                node_map.get(graph_node_pkey), graph_node_pkey,
+                NodeType(graph_node_type)
             )
         )
 


### PR DESCRIPTION
This fixes the `IDELAYCTRL.RDY` and `IDELAYCTRL.RST`graph connections.