### PR TITLE
Implement pb_array element to allow moving num_pb out of pb_type

### DIFF
--- a/common/xml/convert-pb_type-attributes.xsl
+++ b/common/xml/convert-pb_type-attributes.xsl
@@ -14,6 +14,10 @@
       <xsl:if test="blif_model">
         <xsl:attribute name="blif_model"><xsl:value-of select="blif_model/text()"/></xsl:attribute>
       </xsl:if>
+      <!-- Inherit 'num_pb' attribute from pb_array elements -->
+      <xsl:if test="parent::pb_array/@num_pb">
+        <xsl:attribute name="num_pb"><xsl:value-of select="parent::pb_array/@num_pb"/></xsl:attribute>
+      </xsl:if>
       <!--
         Convert
           <pb_type><pb_class>XXX</pb_class></pb_type>
@@ -30,5 +34,10 @@
 
   <xsl:template match="pb_type/blif_model"/>
   <xsl:template match="pb_type/pb_class"/>
+
+  <!-- Copy pb_type elements out of pb_array elements -->
+  <xsl:template match="pb_array">
+    <xsl:apply-templates/>
+  </xsl:template>
 
 </xsl:stylesheet>

--- a/common/xml/convert_and_merge_composable_tests/composable-pb_type-middle.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-pb_type-middle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <pb_type name="MIDDLE" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <pb_type name="middle_inner" num_pb="1">
+  <pb_type name="middle_inner">
     <xi:include href="composable-pb_type-inner.xml" xpointer="xpointer(pb_type/child::node())"/>
   </pb_type>
 </pb_type>

--- a/common/xml/convert_and_merge_composable_tests/composable-pb_type.xml
+++ b/common/xml/convert_and_merge_composable_tests/composable-pb_type.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" ?>
 <pb_type name="top" num_pb="1" xmlns:xi="http://www.w3.org/2001/XInclude">
-  <pb_type name="top_inner" num_pb="1" >
-    <xi:include href="composable-pb_type-inner.xml" xpointer="xpointer(pb_type/child::node())"/>
-  </pb_type>
-  <pb_type name="middle" num_pb="1">
-    <xi:include href="composable-pb_type-middle.xml" xpointer="xpointer(pb_type/child::node())"/>
-  </pb_type>
+  <pb_array num_pb="1">
+    <pb_type name="top_inner">
+      <xi:include href="composable-pb_type-inner.xml" xpointer="xpointer(pb_type/child::node())"/>
+    </pb_type>
+    <pb_type name="middle">
+      <pb_array num_pb="1">
+        <xi:include href="composable-pb_type-middle.xml" xpointer="xpointer(pb_type/child::node())"/>
+      </pb_array>
+    </pb_type>
+  </pb_array>
 </pb_type>

--- a/common/xml/fpga_architecture.xsd
+++ b/common/xml/fpga_architecture.xsd
@@ -604,6 +604,7 @@
   <xs:complexType name="mode">
     <xs:choice maxOccurs="unbounded" minOccurs="0">
       <xs:element name="pb_type" type="pb_type"/>
+      <xs:element name="pb_array" type="pb_array"/>
       <xs:element name="interconnect" type="interconnect"/>
       <xs:element name="pinlocations" type="pinlocations"/>
       <xs:element name="switchblock_locations" type="switchblock_locations"/>
@@ -657,6 +658,7 @@
   <xs:complexType name="pb_type">
     <xs:choice maxOccurs="unbounded" minOccurs="0">
       <xs:element name="pb_type" type="pb_type"/>
+      <xs:element name="pb_array" type="pb_array"/>
       <xs:element name="input" type="input_port"/>
       <xs:element name="output" type="output_port"/>
       <xs:element name="clock" type="clock_port"/>
@@ -670,6 +672,12 @@
     <xs:attribute name="num_pb" type="xs:int"/>
     <xs:attribute name="blif_model" type="xs:string"/>
     <xs:attribute name="class" type="pb_type_class"/>
+  </xs:complexType>
+
+  <xs:complexType name="pb_array">
+    <xs:sequence>
+      <xs:element name="pb_type" type="pb_type" maxOccurs="unbounded"/>
+    </xs:sequence>
   </xs:complexType>
 
   <xs:simpleType name="segment_type">


### PR DESCRIPTION
Uses XSLT to transform
```xml
<pb_array num_pb="N">
   <pb_type ...>
```
to
```xml
<pb_type num_pb="N" ...>
```
to address https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/272
