### PR TITLE
soc tests: added sdc file to picosoc and murax on 50T

### DIFF
--- a/tests/9-soc/murax/CMakeLists.txt
+++ b/tests/9-soc/murax/CMakeLists.txt
@@ -42,6 +42,7 @@ add_fpga_target(
     basys3_toplevel_no_roi.v
     Murax.v
   INPUT_IO_FILE basys3.pcf
+  SDC_FILE basys3.sdc
   EXPLICIT_ADD_FILE_TARGET
 )
 

--- a/tests/9-soc/picosoc/CMakeLists.txt
+++ b/tests/9-soc/picosoc/CMakeLists.txt
@@ -70,6 +70,7 @@ add_fpga_target(
     picorv32.v
     simpleuart.v
     progmem.v
+  SDC_FILE ${symbiflow-arch-defs_SOURCE_DIR}/xc7/tests/common/basys3.sdc
   INPUT_IO_FILE ${symbiflow-arch-defs_SOURCE_DIR}/xc7/tests/common/basys3.pcf
   EXPLICIT_ADD_FILE_TARGET
 )


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This makes picosoc route in ~30 seconds and murax in ~18 seconds