### PR TITLE
Fixes for fasm2bels

### DIFF
--- a/xc7/fasm2bels/connection_db_utils.py
+++ b/xc7/fasm2bels/connection_db_utils.py
@@ -1,4 +1,24 @@
+import re
 import functools
+
+# A map of wires that require "SING" in their name for [LR]IOI3_SING tiles.
+IOI_SING_WIRES = {
+    "IOI_IOCLK0": "IOI_SING_IOCLK0",
+    "IOI_IOCLK1": "IOI_SING_IOCLK1",
+    "IOI_IOCLK2": "IOI_SING_IOCLK2",
+    "IOI_IOCLK3": "IOI_SING_IOCLK3",
+    "IOI_LEAF_GCLK0": "IOI_SING_LEAF_GCLK0",
+    "IOI_LEAF_GCLK1": "IOI_SING_LEAF_GCLK1",
+    "IOI_LEAF_GCLK2": "IOI_SING_LEAF_GCLK2",
+    "IOI_LEAF_GCLK3": "IOI_SING_LEAF_GCLK3",
+    "IOI_LEAF_GCLK4": "IOI_SING_LEAF_GCLK4",
+    "IOI_LEAF_GCLK5": "IOI_SING_LEAF_GCLK5",
+    "IOI_RCLK_FORIO0": "IOI_SING_RCLK_FORIO0",
+    "IOI_RCLK_FORIO1": "IOI_SING_RCLK_FORIO1",
+    "IOI_RCLK_FORIO2": "IOI_SING_RCLK_FORIO2",
+    "IOI_RCLK_FORIO3": "IOI_SING_RCLK_FORIO3",
+    "IOI_TBYTEIN": "IOI_SING_TBYTEIN",
+}
 
 
 def create_maybe_get_wire(conn):
@@ -14,6 +34,22 @@ def create_maybe_get_wire(conn):
 
     @functools.lru_cache(maxsize=None)
     def maybe_get_wire(tile, wire):
+
+        # Some wires in [LR]IOI3_SING tiles have different names than in regular
+        # IOI3 tiles. Rename them.
+        if "IOI3_SING" in tile:
+
+            # The connection database contains only wires with suffix "0" for
+            # SING tiles. Change the wire name accordingly.
+            wire = wire.replace("_1", "_0")
+            wire = wire.replace("ILOGIC1", "ILOGIC0")
+            wire = wire.replace("IDELAY1", "IDELAY0")
+            wire = wire.replace("OLOGIC1", "OLOGIC0")
+
+            # Add the "SING" part to wire name if applicable.
+            if wire in IOI_SING_WIRES:
+                wire = IOI_SING_WIRES[wire]
+
         phy_tile_pkey, tile_type_pkey = get_tile_type_pkey(tile)
 
         c.execute(

--- a/xc7/fasm2bels/connection_db_utils.py
+++ b/xc7/fasm2bels/connection_db_utils.py
@@ -1,24 +1,5 @@
 import functools
 
-# A map of wires that require "SING" in their name for [LR]IOI3_SING tiles.
-IOI_SING_WIRES = {
-    "IOI_IOCLK0": "IOI_SING_IOCLK0",
-    "IOI_IOCLK1": "IOI_SING_IOCLK1",
-    "IOI_IOCLK2": "IOI_SING_IOCLK2",
-    "IOI_IOCLK3": "IOI_SING_IOCLK3",
-    "IOI_LEAF_GCLK0": "IOI_SING_LEAF_GCLK0",
-    "IOI_LEAF_GCLK1": "IOI_SING_LEAF_GCLK1",
-    "IOI_LEAF_GCLK2": "IOI_SING_LEAF_GCLK2",
-    "IOI_LEAF_GCLK3": "IOI_SING_LEAF_GCLK3",
-    "IOI_LEAF_GCLK4": "IOI_SING_LEAF_GCLK4",
-    "IOI_LEAF_GCLK5": "IOI_SING_LEAF_GCLK5",
-    "IOI_RCLK_FORIO0": "IOI_SING_RCLK_FORIO0",
-    "IOI_RCLK_FORIO1": "IOI_SING_RCLK_FORIO1",
-    "IOI_RCLK_FORIO2": "IOI_SING_RCLK_FORIO2",
-    "IOI_RCLK_FORIO3": "IOI_SING_RCLK_FORIO3",
-    "IOI_TBYTEIN": "IOI_SING_TBYTEIN",
-}
-
 
 def create_maybe_get_wire(conn):
     c = conn.cursor()
@@ -33,22 +14,6 @@ def create_maybe_get_wire(conn):
 
     @functools.lru_cache(maxsize=None)
     def maybe_get_wire(tile, wire):
-
-        # Some wires in [LR]IOI3_SING tiles have different names than in regular
-        # IOI3 tiles. Rename them.
-        if "IOI3_SING" in tile:
-
-            # The connection database contains only wires with suffix "0" for
-            # SING tiles. Change the wire name accordingly.
-            wire = wire.replace("_1", "_0")
-            wire = wire.replace("ILOGIC1", "ILOGIC0")
-            wire = wire.replace("IDELAY1", "IDELAY0")
-            wire = wire.replace("OLOGIC1", "OLOGIC0")
-
-            # Add the "SING" part to wire name if applicable.
-            if wire in IOI_SING_WIRES:
-                wire = IOI_SING_WIRES[wire]
-
         phy_tile_pkey, tile_type_pkey = get_tile_type_pkey(tile)
 
         c.execute(

--- a/xc7/fasm2bels/connection_db_utils.py
+++ b/xc7/fasm2bels/connection_db_utils.py
@@ -1,4 +1,3 @@
-import re
 import functools
 
 # A map of wires that require "SING" in their name for [LR]IOI3_SING tiles.

--- a/xc7/fasm2bels/hclk_ioi3_models.py
+++ b/xc7/fasm2bels/hclk_ioi3_models.py
@@ -5,9 +5,12 @@ def process_hclk_ioi3(conn, top, tile, features):
     have_idelayctrl = False
 
     for f in features:
+        if f.value == 0:
+            continue
+
         if 'HCLK_IOI_IDELAYCTRL_REFCLK' in f.feature:
             have_idelayctrl = True
-            break
+            continue
 
         if 'VREF' in f.feature:
             # HCLK_IOI3_X113Y26.VREF.V_675_MV

--- a/xc7/fasm2bels/iob_models.py
+++ b/xc7/fasm2bels/iob_models.py
@@ -1,6 +1,33 @@
 from .utils import eprint
 from .verilog_modeling import Bel, Site
 
+# Mapping of IOB type to its IO ports
+IOB_PORTS = {
+    "IBUF": ("I", ),
+    "IBUF_INTERMDISABLE": ("I", ),
+    "IBUF_IBUFDISABLE": ("I", ),
+    "OBUF": ("O", ),
+    "OBUFT": ("O", ),
+    "IOBUF": ("IO", ),
+    "IOBUF_INTERMDISABLE": ("IO", ),
+    "IBUFDS": (
+        "I",
+        "IB",
+    ),
+    "OBUFDS": (
+        "O",
+        "OB",
+    ),
+    "OBUFTDS": (
+        "O",
+        "OB",
+    ),
+    "IOBUFDS": (
+        "IO",
+        "IOB",
+    ),
+}
+
 
 def get_iob_site(db, grid, tile, site):
     """ Return the prjxray.tile.Site objects and tiles for the given IOB site.
@@ -107,20 +134,22 @@ def append_obuf_iostandard_params(
 
             # Demote NSTD-1 to warning
             top.disable_drc("NSTD-1")
-            return
 
-        bel.parameters["IOSTANDARD"] = '"{}"'.format(iostandard)
+        # Valid
+        else:
+            bel.parameters["IOSTANDARD"] = '"{}"'.format(iostandard)
 
-        if drive is not None:
-            bel.parameters["DRIVE"] = '"{}"'.format(drive)
+            if drive is not None:
+                bel.parameters["DRIVE"] = '"{}"'.format(drive)
 
     # Input termination (here for inouts)
     if in_term is not None:
-        top.add_extra_tcl_line(
-            "set_property IN_TERM {} [get_ports {}]".format(
-                in_term, bel.connections["O"]
+        for port in IOB_PORTS[bel.module]:
+            top.add_extra_tcl_line(
+                "set_property IN_TERM {} [get_ports {}]".format(
+                    in_term, bel.connections[port]
+                )
             )
-        )
 
     # Slew rate
     bel.parameters["SLEW"] = '"{}"'.format(slew)
@@ -158,17 +187,19 @@ def append_ibuf_iostandard_params(
 
             # Demote NSTD-1 to warning
             top.disable_drc("NSTD-1")
-            return
 
-        bel.parameters["IOSTANDARD"] = '"{}"'.format(iostandard)
+        # Valid
+        else:
+            bel.parameters["IOSTANDARD"] = '"{}"'.format(iostandard)
 
     # Input termination
     if in_term is not None:
-        top.add_extra_tcl_line(
-            "set_property IN_TERM {} [get_ports {}]".format(
-                in_term, bel.connections["I"]
+        for port in IOB_PORTS[bel.module]:
+            top.add_extra_tcl_line(
+                "set_property IN_TERM {} [get_ports {}]".format(
+                    in_term, bel.connections[port]
+                )
             )
-        )
 
 
 def decode_iostandard_params(site, diff=False):

--- a/xc7/fasm2bels/iob_models.py
+++ b/xc7/fasm2bels/iob_models.py
@@ -118,7 +118,7 @@ def append_obuf_iostandard_params(
     if in_term is not None:
         top.add_extra_tcl_line(
             "set_property IN_TERM {} [get_ports {}]".format(
-                in_term, bel.connections["I"]
+                in_term, bel.connections["O"]
             )
         )
 


### PR DESCRIPTION
This PR fixes handling of some pips/wires that are named differently for `[LR]IOI3_SING` tiles. Basically undoes wire renaming in fasm2bels flow that was introduced by https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1242

Also fixes bugs with setting of the `IN_TERM` parameter on top-level ports.