### PR TITLE
xc7: re-added cluster feasibility pin

### DIFF
--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -26,7 +26,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --router_lookahead connection_box_map \
       --disable_check_route on \
       --strict_checks off \
-      --clustering_pin_feasibility_filter off \
+      --clustering_pin_feasibility_filter on \
       --allow_dangling_combinational_nodes on \
       --disable_errors check_unbuffered_edges:check_route \
       --congested_routing_iteration_threshold 0.8 \


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

The clsuter pin feasibility filter should be re-enabled to have faster packing.