### PR TITLE
idelay: fixed fasm2bels issue

### DIFF
--- a/xc7/fasm2bels/ioi_models.py
+++ b/xc7/fasm2bels/ioi_models.py
@@ -61,6 +61,13 @@ def process_idelay(top, features):
         if site.has_feature("IS_IDATAIN_INVERTED"):
             bel.parameters['IS_IDATAIN_INVERTED'] = 1
 
+        if site.has_feature("IDELAY_TYPE_VARIABLE"):
+            bel.parameters['IDELAY_TYPE'] = '"VARIABLE"'
+        elif site.has_feature("IDELAY_TYPE_VAR_LOAD"):
+            bel.parameters['IDELAY_TYPE'] = '"VAR_LOAD"'
+        else:
+            bel.parameters['IDELAY_TYPE'] = '"FIXED"'
+
         # Adding sinks
         site.add_sink(bel, 'C', 'C')
         site.add_sink(bel, 'CE', 'CE')

--- a/xc7/fasm2bels/ioi_models.py
+++ b/xc7/fasm2bels/ioi_models.py
@@ -31,8 +31,8 @@ def process_idelay(top, features):
 
     site = Site(features, ioi_site)
 
-    if site.has_feature("IN_USE") and site.has_feature(
-            "IDELAY_VALUE") and site.has_feature("ZIDELAY_VALUE"):
+    if site.has_feature("IN_USE") and (site.has_feature("IDELAY_VALUE")
+                                       or site.has_feature("ZIDELAY_VALUE")):
         bel = Bel('IDELAYE2')
 
         if site.has_feature("CINVCTRL_SEL"):
@@ -186,10 +186,9 @@ def process_ilogic_idelay(top, features):
         site.add_sink(bel, 'CE1', 'CE1')
         site.add_sink(bel, 'CE2', 'CE2')
 
-        if idelay_site and idelay_site.has_feature(
-                "IN_USE") and idelay_site.has_feature(
-                    "IDELAY_VALUE") and idelay_site.has_feature("ZIDELAY_VALUE"
-                                                                ):
+        if idelay_site and idelay_site.has_feature("IN_USE") and (
+                idelay_site.has_feature("IDELAY_VALUE")
+                or idelay_site.has_feature("ZIDELAY_VALUE")):
             site.add_sink(bel, 'DDLY', 'DDLY')
         else:
             site.add_sink(bel, 'D', 'D')

--- a/xc7/tests/serdes/serdes_test_idelay.v
+++ b/xc7/tests/serdes/serdes_test_idelay.v
@@ -81,7 +81,7 @@ IDELAYE2 #
 (
 .IDELAY_TYPE    ("FIXED"),
 .DELAY_SRC      ("IDATAIN"),
-.IDELAY_VALUE   (5'd16)
+.IDELAY_VALUE   (5'd32)
 )
 idelay
 (

--- a/xc7/tests/serdes/serdes_test_idelay.v
+++ b/xc7/tests/serdes/serdes_test_idelay.v
@@ -81,7 +81,7 @@ IDELAYE2 #
 (
 .IDELAY_TYPE    ("FIXED"),
 .DELAY_SRC      ("IDATAIN"),
-.IDELAY_VALUE   (5'd32)
+.IDELAY_VALUE   (5'd31)
 )
 idelay
 (


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes an issue in IDELAYs for which, in some cases, their instantiation was skipped in fasm2bels.