### PR TITLE
Add penalty cost switch to avoid wrong routes

### DIFF
--- a/common/xml/routing_resource.xsd
+++ b/common/xml/routing_resource.xsd
@@ -41,6 +41,7 @@
     <xs:attribute name="Cinternal" type="xs:float"/>
     <xs:attribute name="Cout" type="xs:float"/>
     <xs:attribute name="Tdel" type="xs:float"/>
+    <xs:attribute name="penalty_cost" type="xs:float"/>
   </xs:complexType>
 
   <xs:complexType name="sizing">

--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -25,11 +25,11 @@ def create_tables(conn):
     c.execute(
         """
 INSERT INTO
-    switch(name, internal_capacitance, drive_resistance, intrinsic_delay, switch_type)
+    switch(name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, switch_type)
 VALUES
-    ("__vpr_delayless_switch__", 0.0, 0.0, 0.0, "mux"),
-    ("__vpr_delayfull_switch__", 0.0, 0.0, 1.0e-9, "mux"),
-    ("short", 0.0, 0.0, 0.0, "short")
+    ("__vpr_delayless_switch__", 0.0, 0.0, 0.0, 0.0, "mux"),
+    ("__vpr_penalty_switch__", 0.0, 0.0, 0.0, 1.0, "mux"),
+    ("short", 0.0, 0.0, 0.0, 0.0, "short")
 """
     )
     conn.commit()

--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -28,6 +28,7 @@ INSERT INTO
     switch(name, internal_capacitance, drive_resistance, intrinsic_delay, switch_type)
 VALUES
     ("__vpr_delayless_switch__", 0.0, 0.0, 0.0, "mux"),
+    ("__vpr_delayfull_switch__", 0.0, 0.0, 1.0e-9, "mux"),
     ("short", 0.0, 0.0, 0.0, "short")
 """
     )

--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -28,7 +28,6 @@ INSERT INTO
     switch(name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, switch_type)
 VALUES
     ("__vpr_delayless_switch__", 0.0, 0.0, 0.0, 0.0, "mux"),
-    ("__vpr_penalty_switch__", 0.0, 0.0, 0.0, 1.0, "mux"),
     ("short", 0.0, 0.0, 0.0, 0.0, "short")
 """
     )

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -188,6 +188,7 @@ CREATE TABLE switch(
   internal_capacitance REAL,
   drive_resistance REAL,
   intrinsic_delay REAL,
+  penalty_cost REAL,
   switch_type TEXT
 );
 

--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -68,7 +68,7 @@ class Channels(namedtuple(
 
 
 class SwitchTiming(namedtuple('SwitchTiming',
-                              'r c_in c_out c_internal t_del')):
+                              'r c_in c_out c_internal t_del p_cost')):
     """Encapsulation for timing attributes of a VPR switch
     see: https://vtr-verilog-to-routing.readthedocs.io/en/latest/arch/reference.html#switches
     """

--- a/utils/lib/rr_graph/tests/test_graph2.py
+++ b/utils/lib/rr_graph/tests/test_graph2.py
@@ -12,7 +12,7 @@ from ..tracks import Track, Direction
 class Graph2Tests(unittest.TestCase):
     def setUp(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         delayless = Switch(
@@ -27,7 +27,7 @@ class Graph2Tests(unittest.TestCase):
 
     def test_init(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         self.switches = [
@@ -244,7 +244,7 @@ class Graph2Tests(unittest.TestCase):
 class Graph2MediumTests(unittest.TestCase):
     def setUp(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         self.switches = [

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -79,6 +79,7 @@ def graph_from_xml(input_file_name, progressbar=None, filter_nodes=True):
                 c_out=float(element.attrib.get('Cout', 0)),
                 c_internal=float(element.attrib.get('Cinternal', 0)),
                 t_del=float(element.attrib.get('Tdel', 0)),
+                p_cost=float(element.attrib.get('penalty_cost', 0)),
             )
 
         # Switch sizing
@@ -508,6 +509,7 @@ class Graph(object):
                     "Cin": switch.timing.c_in,
                     "Cout": switch.timing.c_out,
                     "Tdel": switch.timing.t_del,
+                    "penalty_cost": switch.timing.p_cost,
                 }
 
                 if VPR_HAS_C_INTERNAL_SUPPORT:

--- a/xc7/utils/prjxray_arch_import.py
+++ b/xc7/utils/prjxray_arch_import.py
@@ -783,13 +783,14 @@ def main():
 
         switchlist_xml = ET.SubElement(arch_xml, 'switchlist')
 
-        for name, internal_capacitance, drive_resistance, intrinsic_delay, \
+        for name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, \
                 switch_type in c.execute("""
 SELECT
     name,
     internal_capacitance,
     drive_resistance,
     intrinsic_delay,
+    penalty_cost,
     switch_type
 FROM
     switch;"""):
@@ -799,6 +800,7 @@ FROM
                 "R": str(drive_resistance),
                 "Cin": str(0),
                 "Cout": str(0),
+                "penalty_cost": str(penalty_cost),
                 "Tdel": str(intrinsic_delay),
             }
 

--- a/xc7/utils/prjxray_edge_library.py
+++ b/xc7/utils/prjxray_edge_library.py
@@ -2047,10 +2047,10 @@ def create_and_insert_edges(
 
     write_cur.execute(
         'SELECT pkey FROM switch WHERE name = ?;',
-        ('__vpr_delayfull_switch__', )
+        ('__vpr_penalty_switch__', )
     )
-    delayfull_switch_pkey = write_cur.fetchone()[0]
-    delayfull_switch = KnownSwitch(delayfull_switch_pkey)
+    penalty_switch_pkey = write_cur.fetchone()[0]
+    penalty_switch = KnownSwitch(penalty_switch_pkey)
 
     switch = delayless_switch
 
@@ -2107,7 +2107,7 @@ def create_and_insert_edges(
                     "BYP_ALT" in pip.net_from
                     and "BYP" in pip.net_to) or ("FAN_ALT" in pip.net_from
                                                  and "FAN" in pip.net_to):
-                switch = delayfull_switch
+                switch = penalty_switch
 
             connections = make_connection(
                 conn=conn,

--- a/xc7/utils/prjxray_edge_library.py
+++ b/xc7/utils/prjxray_edge_library.py
@@ -994,9 +994,8 @@ def create_get_tile_loc(conn):
 
 
 def yield_edges(
-        const_connectors, switch, phy_tile_pkey, src_connector,
-        sink_connector, pip, pip_obj, src_wire_pkey, sink_wire_pkey, loc,
-        forward
+        const_connectors, switch, phy_tile_pkey, src_connector, sink_connector,
+        pip, pip_obj, src_wire_pkey, sink_wire_pkey, loc, forward
 ):
     if forward:
         for (src_graph_node_pkey, switch_pkey, dest_graph_node_pkey,
@@ -1033,8 +1032,7 @@ def yield_edges(
         for constant_src in yield_ties_to_wire(pip.net_to):
             for (src_graph_node_pkey, switch_pkey, dest_graph_node_pkey
                  ) in const_connectors[constant_src].connect_at(
-                     pip=switch, loc=loc,
-                     other_connector=sink_connector):
+                     pip=switch, loc=loc, other_connector=sink_connector):
                 assert switch_pkey is not None, (
                     pip, src_graph_node_pkey, dest_graph_node_pkey,
                     phy_tile_pkey, pip_pkey
@@ -1047,8 +1045,8 @@ def yield_edges(
 
 def make_connection(
         conn, input_only_nodes, output_only_nodes, find_wire, find_pip,
-        find_connector, get_tile_loc, tile_name, tile_type, pip,
-        switch, const_connectors, forward
+        find_connector, get_tile_loc, tile_name, tile_type, pip, switch,
+        const_connectors, forward
 ):
     """ Attempt to connect graph nodes on either side of a pip.
 
@@ -1114,11 +1112,11 @@ def make_connection(
     loc = get_tile_loc(tile_pkey)
 
     for edge in yield_edges(
-            const_connectors=const_connectors,
-            switch=switch, phy_tile_pkey=phy_tile_pkey,
-            src_connector=src_connector, sink_connector=sink_connector,
-            pip=pip, pip_obj=pip_obj, src_wire_pkey=src_wire_pkey,
-            sink_wire_pkey=sink_wire_pkey, loc=loc, forward=forward):
+            const_connectors=const_connectors, switch=switch,
+            phy_tile_pkey=phy_tile_pkey, src_connector=src_connector,
+            sink_connector=sink_connector, pip=pip, pip_obj=pip_obj,
+            src_wire_pkey=src_wire_pkey, sink_wire_pkey=sink_wire_pkey,
+            loc=loc, forward=forward):
         yield edge
 
 

--- a/xc7/utils/prjxray_edge_library.py
+++ b/xc7/utils/prjxray_edge_library.py
@@ -2047,6 +2047,15 @@ def create_and_insert_edges(
     delayless_switch_pkey = write_cur.fetchone()[0]
     delayless_switch = KnownSwitch(delayless_switch_pkey)
 
+    write_cur.execute(
+        'SELECT pkey FROM switch WHERE name = ?;',
+        ('__vpr_delayfull_switch__', )
+    )
+    delayfull_switch_pkey = write_cur.fetchone()[0]
+    delayfull_switch = KnownSwitch(delayfull_switch_pkey)
+
+    switch = delayless_switch
+
     find_pip = create_find_pip(conn)
     find_wire = create_find_wire(conn)
     find_connector = create_find_connector(conn)
@@ -2096,6 +2105,12 @@ def create_and_insert_edges(
             if "PS72_" in pip.net_to or "PS72_" in pip.net_from:
                 continue
 
+            if ("GCLK" in pip.net_from and "GFAN" in pip.net_to) or (
+                    "BYP_ALT" in pip.net_from
+                    and "BYP" in pip.net_to) or ("FAN_ALT" in pip.net_from
+                                                 and "FAN" in pip.net_to):
+                switch = delayfull_switch
+
             connections = make_connection(
                 conn=conn,
                 input_only_nodes=input_only_nodes,
@@ -2107,7 +2122,7 @@ def create_and_insert_edges(
                 tile_name=tile_name,
                 tile_type=gridinfo.tile_type,
                 pip=pip,
-                delayless_switch=delayless_switch,
+                delayless_switch=switch,
                 const_connectors=const_connectors,
                 forward=forward,
             )

--- a/xc7/utils/prjxray_edge_library.py
+++ b/xc7/utils/prjxray_edge_library.py
@@ -994,7 +994,7 @@ def create_get_tile_loc(conn):
 
 
 def yield_edges(
-        const_connectors, delayless_switch, phy_tile_pkey, src_connector,
+        const_connectors, switch, phy_tile_pkey, src_connector,
         sink_connector, pip, pip_obj, src_wire_pkey, sink_wire_pkey, loc,
         forward
 ):
@@ -1033,7 +1033,7 @@ def yield_edges(
         for constant_src in yield_ties_to_wire(pip.net_to):
             for (src_graph_node_pkey, switch_pkey, dest_graph_node_pkey
                  ) in const_connectors[constant_src].connect_at(
-                     pip=delayless_switch, loc=loc,
+                     pip=switch, loc=loc,
                      other_connector=sink_connector):
                 assert switch_pkey is not None, (
                     pip, src_graph_node_pkey, dest_graph_node_pkey,
@@ -1048,7 +1048,7 @@ def yield_edges(
 def make_connection(
         conn, input_only_nodes, output_only_nodes, find_wire, find_pip,
         find_connector, get_tile_loc, tile_name, tile_type, pip,
-        delayless_switch, const_connectors, forward
+        switch, const_connectors, forward
 ):
     """ Attempt to connect graph nodes on either side of a pip.
 
@@ -1115,7 +1115,7 @@ def make_connection(
 
     for edge in yield_edges(
             const_connectors=const_connectors,
-            delayless_switch=delayless_switch, phy_tile_pkey=phy_tile_pkey,
+            switch=switch, phy_tile_pkey=phy_tile_pkey,
             src_connector=src_connector, sink_connector=sink_connector,
             pip=pip, pip_obj=pip_obj, src_wire_pkey=src_wire_pkey,
             sink_wire_pkey=sink_wire_pkey, loc=loc, forward=forward):
@@ -2122,7 +2122,7 @@ def create_and_insert_edges(
                 tile_name=tile_name,
                 tile_type=gridinfo.tile_type,
                 pip=pip,
-                delayless_switch=switch,
+                switch=switch,
                 const_connectors=const_connectors,
                 forward=forward,
             )

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -98,7 +98,7 @@ def create_get_switch(conn):
     pip_cache[(False, 0.0, 0.0, 0.0)] = write_cur.fetchone()[0]
 
     def get_switch_timing(
-            is_pass_transistor, delay, internal_capacitance, drive_resistance
+            is_pass_transistor, delay, internal_capacitance, drive_resistance, penalty_cost=0.0
     ):
         """ Return a switch that matches provided timing.
 
@@ -140,10 +140,10 @@ def create_get_switch(conn):
 
             write_cur.execute(
                 """
-INSERT INTO switch(name, internal_capacitance, drive_resistance, intrinsic_delay, switch_type)
+INSERT INTO switch(name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, switch_type)
 VALUES
-    (?, ?, ?, ?, ?)""", (
-                    name, internal_capacitance, drive_resistance, delay,
+    (?, ?, ?, ?, ?, ?)""", (
+                    name, internal_capacitance, drive_resistance, delay, penalty_cost,
                     switch_type
                 )
             )

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -198,9 +198,8 @@ VALUES
                 # milliOhms -> Ohms
                 drive_resistance = pip_timing.drive_resistance / 1e3
 
-        if ("GCLK" in pip.net_from and "GFAN" in pip.net_to
-            ) or "BYP_ALT" in pip.net_to or "FAN_ALT" in pip.net_to:
-            penalty_cost = 1 / 1e7
+        if "GCLK" in pip.net_from and "GFAN" in pip.net_to:
+            penalty_cost = 1e-7
 
         return get_switch_timing(
             pip.is_pass_transistor, delay, internal_capacitance,

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -98,7 +98,11 @@ def create_get_switch(conn):
     pip_cache[(False, 0.0, 0.0, 0.0)] = write_cur.fetchone()[0]
 
     def get_switch_timing(
-            is_pass_transistor, delay, internal_capacitance, drive_resistance, penalty_cost=0.0
+            is_pass_transistor,
+            delay,
+            internal_capacitance,
+            drive_resistance,
+            penalty_cost=0.0
     ):
         """ Return a switch that matches provided timing.
 
@@ -143,8 +147,8 @@ def create_get_switch(conn):
 INSERT INTO switch(name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, switch_type)
 VALUES
     (?, ?, ?, ?, ?, ?)""", (
-                    name, internal_capacitance, drive_resistance, delay, penalty_cost,
-                    switch_type
+                    name, internal_capacitance, drive_resistance, delay,
+                    penalty_cost, switch_type
                 )
             )
             pip_cache[key] = write_cur.lastrowid

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -120,6 +120,9 @@ def create_get_switch(conn):
         drive_resistance : float or convertable to float
             Drive resistance from switch (Ohms).
 
+        penalty_cost : float or convertable to float
+            Penalty Cost assigned through this switch
+
         Returns
         -------
         switch_pkey : int
@@ -128,7 +131,7 @@ def create_get_switch(conn):
         """
         key = (
             bool(is_pass_transistor), float(delay), float(drive_resistance),
-            float(internal_capacitance)
+            float(internal_capacitance), float(penalty_cost)
         )
 
         if key not in pip_cache:
@@ -138,8 +141,9 @@ def create_get_switch(conn):
                 name = 'pass_transistor'
                 switch_type = 'pass_gate'
 
-            name = '{}_R{}_C{}_Tdel{}'.format(
-                name, drive_resistance, internal_capacitance, delay
+            name = '{}_R{}_C{}_Tdel{}_Pcost{}'.format(
+                name, drive_resistance, internal_capacitance, delay,
+                penalty_cost
             )
 
             write_cur.execute(
@@ -176,6 +180,7 @@ VALUES
         delay = 0.0
         drive_resistance = 0.0
         internal_capacitance = 0.0
+        penalty_cost = 0.0
 
         if pip_timing is not None:
             if pip_timing.delays is not None:
@@ -193,9 +198,13 @@ VALUES
                 # milliOhms -> Ohms
                 drive_resistance = pip_timing.drive_resistance / 1e3
 
+        if ("GCLK" in pip.net_from and "GFAN" in pip.net_to
+            ) or "BYP_ALT" in pip.net_to or "FAN_ALT" in pip.net_to:
+            penalty_cost = 1.0
+
         return get_switch_timing(
             pip.is_pass_transistor, delay, internal_capacitance,
-            drive_resistance
+            drive_resistance, penalty_cost
         )
 
     return get_switch, get_switch_timing

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -200,7 +200,7 @@ VALUES
 
         if ("GCLK" in pip.net_from and "GFAN" in pip.net_to
             ) or "BYP_ALT" in pip.net_to or "FAN_ALT" in pip.net_to:
-            penalty_cost = 1.0
+            penalty_cost = 1 / 1e7
 
         return get_switch_timing(
             pip.is_pass_transistor, delay, internal_capacitance,

--- a/xc7/utils/prjxray_form_channels.py
+++ b/xc7/utils/prjxray_form_channels.py
@@ -199,7 +199,7 @@ VALUES
                 drive_resistance = pip_timing.drive_resistance / 1e3
 
         if "GCLK" in pip.net_from and "GFAN" in pip.net_to:
-            penalty_cost = 1e-7
+            penalty_cost = 1e-6
 
         return get_switch_timing(
             pip.is_pass_transistor, delay, internal_capacitance,

--- a/xc7/utils/prjxray_routing_import.py
+++ b/xc7/utils/prjxray_routing_import.py
@@ -1261,13 +1261,14 @@ def main():
         populate_bufg_rebuf_map(conn)
 
         cur = conn.cursor()
-        for name, internal_capacitance, drive_resistance, intrinsic_delay, \
+        for name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, \
                 switch_type in cur.execute("""
 SELECT
     name,
     internal_capacitance,
     drive_resistance,
     intrinsic_delay,
+    penalty_cost,
     switch_type
 FROM
     switch;"""):
@@ -1293,6 +1294,7 @@ FROM
                             c_out=0.0,
                             c_internal=internal_capacitance,
                             t_del=intrinsic_delay,
+                            p_cost=penalty_cost,
                         ),
                         sizing=graph2.SwitchSizing(
                             mux_trans_size=0,


### PR DESCRIPTION
This PR adds a `delayfull` switch that has an intrinsic `fake` delay that forces the router to take other paths.
This should solve https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1153 and https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1019