### PR TITLE
Convert from rrgraph XML to capnp during lookahead computation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr v8.0.0_rc1_1532_g92e57c2d0_127_g7b9b69d0e_428_g1c5263d74_290_g3b3182dd7_0125_g5c324d19b 20200123_213533"
+  PACKAGE_SPEC "vtr v8.0.0_rc1_1532_g92e57c2d0_127_g7b9b69d0e_428_g1c5263d74_290_g3b3182dd7_0380_gbb0ba83ea 20200130_041332"
   )
 add_conda_package(
   NAME libxslt

--- a/testarch/devices/CMakeLists.txt
+++ b/testarch/devices/CMakeLists.txt
@@ -8,6 +8,7 @@ define_device(
   DEVICE_TYPE clutff-unidir-s4
   PACKAGES dummy
   RR_PATCH_DEPS intervaltree progressbar2
+  CACHE_ARGS --route_chan_width 100
   )
 
 define_device(
@@ -16,4 +17,5 @@ define_device(
   DEVICE_TYPE clutff-unidir-s4
   PACKAGES dummy
   RR_PATCH_DEPS intervaltree progressbar2
+  CACHE_ARGS --route_chan_width 100
   )


### PR DESCRIPTION
The incremental XML writer we use during rr graph patching is actually
pretty memory efficent, so for now I don't see a reason to do anything
other than to write XML first, then convert to capnp using VPR.