### PR TITLE
add sdc file to iobuf_i2c test

### DIFF
--- a/xc7/tests/iobuf_i2c/CMakeLists.txt
+++ b/xc7/tests/iobuf_i2c/CMakeLists.txt
@@ -3,12 +3,14 @@ add_file_target(FILE i2c_probe.v SCANNER_TYPE verilog)
 add_file_target(FILE i2c_scan.v SCANNER_TYPE verilog)
 add_file_target(FILE simpleuart.v SCANNER_TYPE verilog)
 add_file_target(FILE iobuf_i2c_basys3.v SCANNER_TYPE verilog)
+add_file_target(FILE basys3.sdc)
 
 add_fpga_target(
   NAME iobuf_i2c_basys3
   BOARD basys3-full
   SOURCES iobuf_i2c_basys3.v
   INPUT_IO_FILE ${COMMON}/basys3_pmod.pcf
+  SDC_FILE basys3.sdc
   EXPLICIT_ADD_FILE_TARGET
   )
 

--- a/xc7/tests/iobuf_i2c/basys3.sdc
+++ b/xc7/tests/iobuf_i2c/basys3.sdc
@@ -1,2 +1,2 @@
-create_clock -period 10.0 clk_g -waveform {0.000 5.000}
+create_clock -period 10.0 i2c_scan.uart.clk__clk_g__i2c_scan.clk__i2c_scan.i2c_probe.clk__i2c_scan.i2c_probe.i2c_master.clk -waveform {0.000 5.000}
 create_clock -period 10.0 clk -waveform {0.000 5.000}

--- a/xc7/tests/iobuf_i2c/basys3.sdc
+++ b/xc7/tests/iobuf_i2c/basys3.sdc
@@ -1,0 +1,2 @@
+create_clock -period 10.0 clk_g -waveform {0.000 5.000}
+create_clock -period 10.0 clk -waveform {0.000 5.000}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to check whether the clock to general interconnect issue can be solved also by adding SDC files to constrain the clock.