### PR TITLE
Added optional loading rr graph edges to the graph library

### DIFF
--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -227,6 +227,7 @@ class Graph(object):
             block_types,
             grid,
             nodes,
+            edges=None,
             build_pin_edges=True
     ):
         self.switches = switches
@@ -259,7 +260,7 @@ class Graph(object):
         self.tracks = []
         self.nodes = nodes
         self.nodes.sort(key=lambda node: node.id)
-        self.edges = []
+        self.edges = edges if edges is not None else []
 
         self.connection_boxes = []
         self.connection_box_map = {}


### PR DESCRIPTION
This PR adds optional loading of VPR rr graph edges. By default they are not loaded. It also adds loading segment_id for rr graph nodes.