### PR TITLE
Fix iostandard fasm2bels

### DIFF
--- a/xc7/fasm2bels/iob_models.py
+++ b/xc7/fasm2bels/iob_models.py
@@ -108,6 +108,11 @@ def append_obuf_iostandard_params(
             "DRIVE": top.default_drive
         }
 
+    # SSTL135 must have no DRIVE setting. If present, the DRIVE setting gets removes,
+    # as it was set by DEFAULT in the EBLIF
+    if "SSTL135" in iosettings["IOSTANDARD"]:
+        iosettings["DRIVE"] = None
+
     iostandard = iosettings.get("IOSTANDARD", None)
     drive = iosettings.get("DRIVE", None)
 
@@ -175,6 +180,11 @@ def append_ibuf_iostandard_params(
             "IOSTANDARD": top.default_iostandard,
             "DRIVE": top.default_drive
         }
+
+    # SSTL135 must have no DRIVE setting. If present, the DRIVE setting gets removes,
+    # as it was set by DEFAULT in the EBLIF
+    if "SSTL135" in iosettings["IOSTANDARD"]:
+        iosettings["DRIVE"] = None
 
     iostandard = iosettings.get("IOSTANDARD", None)
 


### PR DESCRIPTION
This PR is to fix an issue in fasm2bels for which, if the IOSTANDARD is set to `SSTL135`, which should have no DRIVE setting, the correct settings would not end up in the resulting verilog file, causing an issue in Vivado.
With this PR, whenever the SSTL135 setting is active, the DRIVE setting is set to `None`.

There is also a simplification of the INOUT regexp when building the `iosettings_map`