### PR TITLE
Remove VPR flags set to default values, and set --quick_check_route

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -752,7 +752,6 @@ function(ADD_OUTPUT_TO_FPGA_TARGET name property file)
 endfunction()
 
 set(VPR_BASE_ARGS
-    --min_route_chan_width_hint 100
     --max_router_iterations 500
     --routing_failure_predictor off
     --router_high_fanout_threshold -1

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -30,15 +30,13 @@ function(ADD_XC7_ARCH_DEFINE)
       --clock_modeling route \
       --place_delay_model delta_override \
       --router_lookahead connection_box_map \
-      --disable_check_route on \
+      --quick_check_route on \
       --strict_checks off \
-      --clustering_pin_feasibility_filter on \
       --allow_dangling_combinational_nodes on \
       --disable_errors check_unbuffered_edges:check_route \
       --congested_routing_iteration_threshold 0.8 \
       --incremental_reroute_delay_ripup off \
       --base_cost_type delay_normalized_length_bounded \
-      --astar_fac 1.2 \
       --bb_factor 10 \
       --initial_pres_fac 4.0 \
       --disable_check_rr_graph on \


### PR DESCRIPTION
Clean up unnecessary flags, and enable `--quick_check_route`.