### PR TITLE
fasm2bels: fix LDCE is_c_inverted

### DIFF
--- a/xc7/fasm2bels/clb_models.py
+++ b/xc7/fasm2bels/clb_models.py
@@ -1073,7 +1073,11 @@ def process_slice(top, s):
 
             site.add_internal_source(ff5, 'Q', lut + '5Q')
             ff5.parameters['INIT'] = init
-            ff5.parameters['IS_C_INVERTED'] = IS_C_INVERTED
+
+            if name in ['LDCE', 'LDPE']:
+                ff5.parameters['IS_G_INVERTED'] = IS_C_INVERTED
+            else:
+                ff5.parameters['IS_C_INVERTED'] = IS_C_INVERTED
 
             site.add_bel(ff5)
 
@@ -1121,7 +1125,11 @@ def process_slice(top, s):
         connect_ce_sr(ff, ce, sr)
 
         ff.parameters['INIT'] = init
-        ff.parameters['IS_C_INVERTED'] = IS_C_INVERTED
+
+        if name in ['LDCE', 'LDPE']:
+            ff.parameters['IS_G_INVERTED'] = IS_C_INVERTED
+        else:
+            ff.parameters['IS_C_INVERTED'] = IS_C_INVERTED
 
         site.add_bel(ff)
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Apparently the `IS_C_INVERTED` parameter for the LDCE does not exist. In fact, I get the following when building a fasm2bels generated verilog file:

```
ERROR: [Synth 8-3438] module 'LDCE' declared at '/opt/Xilinx/Vivado/2017.2/scripts/rt/data/unisim_comp.v:20239' does not have any parameter 'IS_C_INVERTED' used as named parameter override [symbiflow/prjxray/minitests/f2b_vivado/build/top_bit.v:89128]
```
