### PR TITLE
oserdes: fix IS_T_INVERTED parameter

### DIFF
--- a/xc7/techmap/cells_map.v
+++ b/xc7/techmap/cells_map.v
@@ -2498,7 +2498,7 @@ module OSERDESE2 (
     localparam INV_T1 = ~IS_T1_INVERTED;
     wire t1 = 1'b1;
   end else begin
-    localparam INV_T1 = ~IS_T1_INVERTED;
+    localparam INV_T1 = IS_T1_INVERTED;
     wire t1 = T1;
   end endgenerate
 
@@ -2509,7 +2509,7 @@ module OSERDESE2 (
     localparam INV_T2 = ~IS_T2_INVERTED;
     wire t2 = 1'b1;
   end else begin
-    localparam INV_T2 = ~IS_T2_INVERTED;
+    localparam INV_T2 = IS_T2_INVERTED;
     wire t2 = T2;
   end endgenerate
 
@@ -2520,7 +2520,7 @@ module OSERDESE2 (
     localparam INV_T3 = ~IS_T3_INVERTED;
     wire t3 = 1'b1;
   end else begin
-    localparam INV_T3 = ~IS_T3_INVERTED;
+    localparam INV_T3 = IS_T3_INVERTED;
     wire t3 = T3;
   end endgenerate
 
@@ -2531,7 +2531,7 @@ module OSERDESE2 (
     localparam INV_T4 = ~IS_T4_INVERTED;
     wire t4 = 1'b1;
   end else begin
-    localparam INV_T4 = ~IS_T4_INVERTED;
+    localparam INV_T4 = IS_T4_INVERTED;
     wire t4 = T4;
   end endgenerate
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR fixes a bug related to the `IS_T{N}_INVERTED` parameter during techmap of OSERDESes.