### PR TITLE
Suppress useless warnings from check_route.

### DIFF
--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -45,7 +45,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --bb_factor 10 \
       --initial_pres_fac 4.0 \
       --disable_check_rr_graph on \
-      --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R"
+      --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R:check_route"
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py
     RR_PATCH_CMD "${CMAKE_COMMAND} -E env \


### PR DESCRIPTION
These warnings are now being generated since check route is running.

For context without this there are ~50k lines saying something to affect of:
```
Warning 17512: in check_route: found non-adjacent segments in traceback while checking net 6591:
  RR node: 863411 type: CHANY location: (96,14) track: 393 len: 0 longline: 0 seg_type: FAN_BOUNCE dir: BI_DIR capacity: 1
  RR node: 801604 type: CHANY location: (95,14) track: 61 len: 0 longline: 0 seg_type: INPINFEED dir: BI_DIR capacity: 1
```

Which is totally meaningless for our graph.