### PR TITLE
Use latest VtR from conda and update flags.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr v7.0.5_10791_g7351b7cfc 20200306_235616"
+  PACKAGE_SPEC "vtr 8.0.0.rc1_3433_g7351b7cfc 20200308_024213"
   )
 add_conda_package(
   NAME libxslt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr v0.0_12941_g4214c3776 20200304_002908"
+  PACKAGE_SPEC "vtr v7.0.5_10791_g7351b7cfc 20200306_235616"
   )
 add_conda_package(
   NAME libxslt

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -639,7 +639,7 @@ function(DEFINE_DEVICE)
           ${symbiflow-arch-defs_SOURCE_DIR}/common/wire.eblif
           --read_rr_graph ${OUT_RRXML_REAL}
           --write_rr_graph ${OUT_RRBIN_REAL}
-          --read_edge_metadata on
+          --read_rr_edge_metadata on
           --outfile_prefix ${DEVICE}_${PACKAGE}_cache
           --pack
           --place

--- a/xc7/make/arch_define.cmake
+++ b/xc7/make/arch_define.cmake
@@ -44,7 +44,7 @@ function(ADD_XC7_ARCH_DEFINE)
       --base_cost_type delay_normalized_length_bounded \
       --bb_factor 10 \
       --initial_pres_fac 4.0 \
-      --disable_check_rr_graph on \
+      --check_rr_graph off \
       --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R:check_route"
     RR_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc7/utils/prjxray_routing_import.py


### PR DESCRIPTION
As part of upstream PRs being accepted some flags were renamed for
clarity.