### PR TITLE
cmake: update minimum version to 3.14.0

### DIFF
--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -5,8 +5,6 @@ set -e
 
 $SPACER
 
-which cmake
-
 start_section "symbiflow.configure_cmake" "Configuring CMake (make env)"
 make env
 cd build

--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -5,6 +5,8 @@ set -e
 
 $SPACER
 
+which cmake
+
 start_section "symbiflow.configure_cmake" "Configuring CMake (make env)"
 make env
 cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ before_install:
 
 install:
  - stdbuf -i0 -o0 -e0 ./.github/travis/install.sh
-
+ - wget https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.tar.gz
+ - tar -xf cmake-3.14.0-Linux-x86_64.tar.gz
+ - export PATH=`realpath cmake-3.14.0-Linux-x86_64/bin`:$PATH
 script:
   # ping stdout every 9 minutes or Travis kills build
   # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
     packages:
      - g++-6
      - bash
@@ -14,15 +16,14 @@ addons:
      - graphviz
      - inkscape
      - make
+     - cmake
 
 before_install:
  - source ./.github/travis/common.sh
 
 install:
  - stdbuf -i0 -o0 -e0 ./.github/travis/install.sh
- - wget https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.tar.gz
- - tar -xf cmake-3.14.0-Linux-x86_64.tar.gz
- - export PATH=`realpath cmake-3.14.0-Linux-x86_64/bin`:$PATH
+ - export PATH=/usr/bin:$PATH
 script:
   # ping stdout every 9 minutes or Travis kills build
   # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.14.0)
 project(symbiflow-arch-defs)
 enable_testing()
 


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR updates the minimum CMake version required.  This should solve https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1370#issuecomment-602045210