### PR TITLE
Heterogeneous tiles implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 8.0.0.rc1_3433_g7351b7cfc 20200308_024213"
+  PACKAGE_SPEC "vtr 8.0.0.rc2_3575_g253f75b6d 20200401_084607"
   )
 add_conda_package(
   NAME libxslt

--- a/common/xml/fpga_architecture.xsd
+++ b/common/xml/fpga_architecture.xsd
@@ -291,6 +291,7 @@
     <xs:attribute name="Tdel" type="xs:float"/>
     <xs:attribute name="buf_size" type="buf_size" default="auto"/>
     <xs:attribute name="mux_trans_size" type="xs:float"/>
+    <xs:attribute name="penalty_cost" type="xs:float"/>
     <xs:attribute name="power_buf_size" type="xs:int"/>
   </xs:complexType>
 
@@ -631,7 +632,7 @@
     </xs:choice>
   </xs:complexType>
 
-  <xs:complexType name="tile">
+  <xs:complexType name="sub_tile">
     <xs:choice maxOccurs="unbounded" minOccurs="0">
       <xs:element name="input" type="input_port"/>
       <xs:element name="output" type="output_port"/>
@@ -639,10 +640,17 @@
       <xs:element name="equivalent_sites" type="equivalent_sites"/>
       <xs:element name="pinlocations" type="pinlocations"/>
       <xs:element name="fc" type="fc"/>
-      <xs:element name="switchblock_locations" type="switchblock_locations"/>
     </xs:choice>
     <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="capacity" type="xs:int"/>
+  </xs:complexType>
+
+  <xs:complexType name="tile">
+    <xs:choice maxOccurs="unbounded" minOccurs="0">
+      <xs:element name="sub_tile" type="sub_tile"/>
+      <xs:element name="switchblock_locations" type="switchblock_locations"/>
+    </xs:choice>
+    <xs:attribute name="name" type="xs:string" use="required"/>
     <xs:attribute name="width" type="xs:int"/>
     <xs:attribute name="height" type="xs:int"/>
     <xs:attribute name="area" type="xs:float"/>

--- a/utils/lib/pb_type_xml.py
+++ b/utils/lib/pb_type_xml.py
@@ -247,9 +247,7 @@ def start_tile(
 
                 tile_xml.append(sub_tile_xml)
     else:
-        sub_tile_xml = start_sub_tile(
-            tile_name, pin_assignments, input_wires, output_wires
-        )
+        sub_tile_xml = start_sub_tile(tile_name, input_wires, output_wires)
 
         fc_xml = add_fc(sub_tile_xml)
 

--- a/utils/update_arch_tiles.py
+++ b/utils/update_arch_tiles.py
@@ -180,7 +180,9 @@ def add_sub_tiles(arch):
 
     """
 
-    TAGS_TO_SWAP = ['fc', 'pinlocations', 'input', 'output', 'clock', 'equivalent_sites']
+    TAGS_TO_SWAP = [
+        'fc', 'pinlocations', 'input', 'output', 'clock', 'equivalent_sites'
+    ]
 
     def swap_tags(sub_tile, tile):
         # Moving tags from top level pb_type to tile

--- a/utils/update_arch_tiles.py
+++ b/utils/update_arch_tiles.py
@@ -7,41 +7,6 @@ parsing capabilities of Verilog-to-Routing.
 This script needs to be used only if the architecture import scripts do not
 take into account the physical tiles tags. In fact, it is used as last step
 of the architecture description generation.
-
-It moves the top level pb_types attributes and tags to the tiles high-level tag.
-
-BEFORE:
-<complexblocklist>
-    <pb_type name="BRAM" area="2" height="4" width="1" capacity="1">
-        <inputs ... />
-        <outputs ... />
-        <interconnect ... />
-        <fc ... />
-        <pinlocations ... />
-        <switchblock_locations ... />
-    </pb_type>
-</complexblocklist>
-
-AFTER:
-<tiles>
-    <tile name="BRAM" area="2" height="4" width="1" capacity="1">
-        <inputs ... />
-        <outputs ... />
-        <fc ... />
-        <pinlocations ... />
-        <switchblock_locations ... />
-        <equivalent_sites>
-            <site pb_type="BRAM"/>
-        </equivalent_sites>
-    </tile>
-</tiles>
-<complexblocklist
-    <pb_type name="BRAM">
-        <inputs ... />
-        <outputs ... />
-        <interconnect ... />
-    </pb_type>
-</complexblocklist>
 """
 
 import argparse
@@ -52,6 +17,44 @@ from lxml import etree as ET
 
 
 def add_tile_tags(arch):
+    """
+    This function moves the top level pb_types attributes
+    and tags to the tiles high-level tag.
+
+    BEFORE:
+    <complexblocklist>
+        <pb_type name="BRAM" area="2" height="4" width="1" capacity="1">
+            <inputs ... />
+            <outputs ... />
+            <interconnect ... />
+            <fc ... />
+            <pinlocations ... />
+            <switchblock_locations ... />
+        </pb_type>
+    </complexblocklist>
+
+    AFTER:
+    <tiles>
+        <tile name="BRAM" area="2" height="4" width="1" capacity="1">
+            <inputs ... />
+            <outputs ... />
+            <fc ... />
+            <pinlocations ... />
+            <switchblock_locations ... />
+            <equivalent_sites>
+                <site pb_type="BRAM"/>
+            </equivalent_sites>
+        </tile>
+    </tiles>
+    <complexblocklist
+        <pb_type name="BRAM">
+            <inputs ... />
+            <outputs ... />
+            <interconnect ... />
+        </pb_type>
+    </complexblocklist>
+    """
+
     TAGS_TO_SWAP = ['fc', 'pinlocations', 'switchblock_locations']
     TAGS_TO_COPY = ['input', 'output', 'clock']
     ATTR_TO_SWAP = ['area', 'height', 'width', 'capacity']
@@ -138,6 +141,78 @@ def add_site_directs(arch):
     return True
 
 
+def add_sub_tiles(arch):
+    """
+    This function adds the sub tiles tags to the input architecture.
+    Each physical tile must contain at least one sub tile.
+
+    Note: the example below is only for explanatory reasons, the port/tile names are invented.
+
+    BEFORE:
+    <tiles>
+        <tile name="BRAM_TILE" area="2" height="4" width="1" capacity="1">
+            <inputs ... />
+            <outputs ... />
+            <fc ... />
+            <pinlocations ... />
+            <switchblock_locations ... />
+            <equivalent_sites>
+                <site pb_type="BRAM" pin_mapping="direct">
+            </equivalent_sites>
+        </tile>
+    </tiles>
+
+    AFTER:
+    <tiles>
+        <tile name="BRAM_TILE" area="2" height="4" width="1">
+            <sub_tile name="BRAM_SUB_TILE_X" capacity="1">
+                <inputs ... />
+                <outputs ... />
+                <fc ... />
+                <pinlocations ... />
+                <equivalent_sites>
+                    <site pb_type="BRAM" pin_mapping="direct">
+                </equivalent_sites>
+            </sub_tile>
+            <switchblock_locations ... />
+        </tile>
+    </tiles>
+
+    """
+
+    TAGS_TO_SWAP = ['fc', 'pinlocations', 'input', 'output', 'clock', 'equivalent_sites']
+
+    def swap_tags(sub_tile, tile):
+        # Moving tags from top level pb_type to tile
+        for child in tile:
+            if child.tag in TAGS_TO_SWAP:
+                tile.remove(child)
+                sub_tile.append(child)
+
+    modified = False
+
+    for tile in arch.iter('tile'):
+        if tile.findall('./sub_tile'):
+            continue
+
+        sub_tile_name = tile.attrib['name']
+        sub_tile = ET.Element('sub_tile', name='{}'.format(sub_tile_name))
+
+        # Transfer capacity to sub tile
+        if 'capacity' in tile.attrib.keys():
+            sub_tile.attrib['capacity'] = tile.attrib['capacity']
+            del tile.attrib['capacity']
+
+        #Transfer tags to swap from tile to sub tile
+        swap_tags(sub_tile, tile)
+
+        tile.append(sub_tile)
+
+        modified = True
+
+    return modified
+
+
 def main():
     parser = argparse.ArgumentParser()
 
@@ -160,6 +235,7 @@ def main():
     modified = False
     result = add_tile_tags(arch)
     result = add_site_directs(arch)
+    result = add_sub_tiles(arch)
 
     if result:
         modified = True

--- a/utils/update_arch_tiles.py
+++ b/utils/update_arch_tiles.py
@@ -205,7 +205,7 @@ def add_sub_tiles(arch):
             sub_tile.attrib['capacity'] = tile.attrib['capacity']
             del tile.attrib['capacity']
 
-        #Transfer tags to swap from tile to sub tile
+        # Transfer tags to swap from tile to sub tile
         swap_tags(sub_tile, tile)
 
         tile.append(sub_tile)

--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -59,6 +59,7 @@ function(ADD_XC_ARCH_DEFINE)
   set(YOSYS_CONV_SCRIPT ${ADD_XC_ARCH_DEFINE_YOSYS_CONV_SCRIPT})
   set(YOSYS_TECHMAP ${symbiflow-arch-defs_SOURCE_DIR}/xc/${FAMILY}/techmap)
   set(VPR_ARCH_ARGS "\
+      --router_heap bucket \
       --clock_modeling route \
       --place_delay_model delta_override \
       --router_lookahead connection_box_map \

--- a/xc/common/cmake/project_ray.cmake
+++ b/xc/common/cmake/project_ray.cmake
@@ -610,9 +610,8 @@ function(PROJECT_RAY_TILE_CAPACITY)
   #   )
   # ~~~
   #
-  # SITE_TYPES: contains the comma separated list of sites that are going to be used
-  #             as sub tiles for the specified tile. The total number of instances
-  #             of a site type appears as the capacity of the sub tile
+  # SITE_TYPES: contains a list of sites that are used as sub tiles for the specified tile.
+  #             The total number of instances of a site type appears as the capacity of the sub tile
 
   set(options)
   set(oneValueArgs ARCH TILE)

--- a/xc/common/cmake/project_ray.cmake
+++ b/xc/common/cmake/project_ray.cmake
@@ -606,7 +606,7 @@ function(PROJECT_RAY_TILE_CAPACITY)
   # PROJECT_RAY_TILE_CAPACITY(
   #   ARCH <arch>
   #   TILE <tile>
-  #   SITE_TYPES <site type>
+  #   SITE_TYPES <site types>
   #   )
   # ~~~
   #
@@ -615,8 +615,8 @@ function(PROJECT_RAY_TILE_CAPACITY)
   #             of a site type appears as the capacity of the sub tile
 
   set(options)
-  set(oneValueArgs ARCH TILE SITE_TYPES)
-  set(multiValueArgs)
+  set(oneValueArgs ARCH TILE)
+  set(multiValueArgs SITE_TYPES)
   cmake_parse_arguments(
     PROJECT_RAY_TILE_CAPACITY
     "${options}"
@@ -645,6 +645,8 @@ function(PROJECT_RAY_TILE_CAPACITY)
 
   set(TILE_CAPACITY_IMPORT ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_import_tile_capacity.py)
 
+  string(REPLACE ";" "," SITE_TYPES_COMMA "${PROJECT_RAY_TILE_CAPACITY_SITE_TYPES}")
+
   string(TOLOWER ${TILE} TILE_LOWER)
 
   add_custom_command(
@@ -656,7 +658,7 @@ function(PROJECT_RAY_TILE_CAPACITY)
       --output_directory ${CMAKE_CURRENT_BINARY_DIR}
       --site_directory ${symbiflow-arch-defs_BINARY_DIR}/xc/common/primitives
       --tile_type ${TILE}
-      --pb_types ${PROJECT_RAY_TILE_CAPACITY_SITE_TYPES}
+      --pb_types ${SITE_TYPES_COMMA}
       --pin_assignments ${PIN_ASSIGNMENTS}
     DEPENDS
       ${TILE_CAPACITY_IMPORT}

--- a/xc/common/cmake/project_ray.cmake
+++ b/xc/common/cmake/project_ray.cmake
@@ -606,15 +606,14 @@ function(PROJECT_RAY_TILE_CAPACITY)
   # PROJECT_RAY_TILE_CAPACITY(
   #   ARCH <arch>
   #   TILE <tile>
-  #   SITE_TYPE <site type>
+  #   SITE_TYPES <site type>
   #   )
   # ~~~
   #
-  # Import a tile from project xray that contains exactly 1 site type, and emit
-  # a tile with capacity for each instance of that site type.
-  #
-  # Future support: Emit tiles with capacity that contain more than 1 site type
-  # once VPR supports it.
+  # SITE_TYPES: contains the comma separated list of sites that are going to be used
+  #             as sub tiles for the specified tile. The total number of instances
+  #             of a site type appears as the capacity of the sub tile
+
   set(options)
   set(oneValueArgs ARCH TILE SITE_TYPES)
   set(multiValueArgs)

--- a/xc/common/cmake/project_ray.cmake
+++ b/xc/common/cmake/project_ray.cmake
@@ -607,7 +607,6 @@ function(PROJECT_RAY_TILE_CAPACITY)
   #   ARCH <arch>
   #   TILE <tile>
   #   SITE_TYPE <site type>
-  #   SITE_COORDS [X|Y|XY]
   #   )
   # ~~~
   #
@@ -617,7 +616,7 @@ function(PROJECT_RAY_TILE_CAPACITY)
   # Future support: Emit tiles with capacity that contain more than 1 site type
   # once VPR supports it.
   set(options)
-  set(oneValueArgs ARCH TILE SITE_TYPE SITE_COORDS)
+  set(oneValueArgs ARCH TILE SITE_TYPES)
   set(multiValueArgs)
   cmake_parse_arguments(
     PROJECT_RAY_TILE_CAPACITY
@@ -658,9 +657,8 @@ function(PROJECT_RAY_TILE_CAPACITY)
       --output_directory ${CMAKE_CURRENT_BINARY_DIR}
       --site_directory ${symbiflow-arch-defs_BINARY_DIR}/xc/common/primitives
       --tile_type ${TILE}
-      --pb_type ${PROJECT_RAY_TILE_CAPACITY_SITE_TYPE}
+      --pb_types ${PROJECT_RAY_TILE_CAPACITY_SITE_TYPES}
       --pin_assignments ${PIN_ASSIGNMENTS}
-      --site_coords ${PROJECT_RAY_TILE_CAPACITY_SITE_COORDS}
     DEPENDS
       ${TILE_CAPACITY_IMPORT}
       ${DEPS}

--- a/xc/common/utils/prjxray_arch_import.py
+++ b/xc/common/utils/prjxray_arch_import.py
@@ -36,11 +36,13 @@ def create_synth_io_tiles(complexblocklist_xml, tiles_xml, pb_name, is_input):
         'name': pb_name,
     })
 
-    equivalent_sites = ET.SubElement(tile_xml, 'equivalent_sites')
+    sub_tile_xml = ET.SubElement(tile_xml, 'sub_tile', {'name': pb_name})
+
+    equivalent_sites = ET.SubElement(sub_tile_xml, 'equivalent_sites')
     site = ET.SubElement(equivalent_sites, 'site', {'pb_type': pb_name})
 
     ET.SubElement(
-        tile_xml, 'fc', {
+        sub_tile_xml, 'fc', {
             'in_type': 'abs',
             'in_val': '2',
             'out_type': 'abs',
@@ -64,10 +66,12 @@ def create_synth_io_tiles(complexblocklist_xml, tiles_xml, pb_name, is_input):
         'num_pins': '1',
     })
 
-    ET.SubElement(tile_xml, port_type, {
-        'name': pad_name,
-        'num_pins': '1',
-    })
+    ET.SubElement(
+        sub_tile_xml, port_type, {
+            'name': pad_name,
+            'num_pins': '1',
+        }
+    )
 
     port_pin = '{}.{}'.format(pb_name, pad_name)
     pad_pin = '{}.{}'.format(pad_name, pad_name)
@@ -130,11 +134,13 @@ def create_synth_constant_tiles(
         'name': pb_name,
     })
 
-    equivalent_sites = ET.SubElement(tile_xml, 'equivalent_sites')
+    sub_tile_xml = ET.SubElement(tile_xml, 'sub_tile', {'name': pb_name})
+
+    equivalent_sites = ET.SubElement(sub_tile_xml, 'equivalent_sites')
     site = ET.SubElement(equivalent_sites, 'site', {'pb_type': pb_name})
 
     ET.SubElement(
-        tile_xml, 'fc', {
+        sub_tile_xml, 'fc', {
             'in_type': 'abs',
             'in_val': '2',
             'out_type': 'abs',
@@ -153,10 +159,12 @@ def create_synth_constant_tiles(
         'num_pins': '1',
     })
 
-    ET.SubElement(tile_xml, port_type, {
-        'name': pin_name,
-        'num_pins': '1',
-    })
+    ET.SubElement(
+        sub_tile_xml, port_type, {
+            'name': pin_name,
+            'num_pins': '1',
+        }
+    )
 
     port_pin = '{}.{}'.format(pb_name, pin_name)
     pad_pin = '{}.{}'.format(pin_name, pin_name)
@@ -695,9 +703,16 @@ def main():
 
             tile_root = tile_xml.getroot()
             assert tile_root.tag == 'tile'
-            tile_capacity[tile_type] = 1
-            if 'capacity' in tile_root.attrib:
-                tile_capacity[tile_type] = int(tile_root.attrib['capacity'])
+            tile_capacity[tile_type] = 0
+
+            for sub_tile in tile_root.iter('sub_tile'):
+                print("ITERATION")
+                if 'capacity' in sub_tile.attrib:
+                    tile_capacity[tile_type] += int(
+                        sub_tile.attrib['capacity']
+                    )
+                else:
+                    tile_capacity[tile_type] += 1
 
     complexblocklist_xml = ET.SubElement(arch_xml, 'complexblocklist')
     for pb_type in pb_types:

--- a/xc/common/utils/prjxray_arch_import.py
+++ b/xc/common/utils/prjxray_arch_import.py
@@ -706,7 +706,6 @@ def main():
             tile_capacity[tile_type] = 0
 
             for sub_tile in tile_root.iter('sub_tile'):
-                print("ITERATION")
                 if 'capacity' in sub_tile.attrib:
                     tile_capacity[tile_type] += int(
                         sub_tile.attrib['capacity']

--- a/xc/common/utils/prjxray_create_equiv_tiles.py
+++ b/xc/common/utils/prjxray_create_equiv_tiles.py
@@ -23,9 +23,9 @@ import sqlite3
 
 import lxml.etree as ET
 from lib.pb_type_xml import (
-    start_pb_type, add_vpr_tile_prefix, add_tile_direct, object_ref,
-    add_switchblock_locations, write_xml, ModelXml, add_direct, XI_INCLUDE,
-    XI_URL
+    start_pb_type, start_tile, add_vpr_tile_prefix, add_tile_direct,
+    object_ref, add_switchblock_locations, write_xml, ModelXml, add_direct,
+    XI_INCLUDE, XI_URL
 )
 
 
@@ -618,7 +618,6 @@ GROUP BY site_pin.direction;
         pin_assignments,
         ['{}_{}'.format(site, pin) for site, pin in all_pb_type_output_pins],
         ['{}_{}'.format(site, pin) for site, pin in all_pb_type_input_pins],
-        root_pb_type=False
     )
 
     interconnect_xml = ET.Element('interconnect')
@@ -823,13 +822,11 @@ AND
                 else:
                     assert False, (wire_name, direction)
 
-    tile_xml = start_pb_type(
+    tile_xml = start_tile(
         tile_type,
         pin_assignments,
         input_wires,
         output_wires,
-        root_pb_type=True,
-        root_tag='tile',
     )
 
     equivalent_sites_xml = ET.Element('equivalent_sites')
@@ -859,7 +856,9 @@ AND
                     ),
                 )
 
-    tile_xml.append(equivalent_sites_xml)
+    sub_tile_xml = tile_xml.find('./sub_tile')
+
+    sub_tile_xml.append(equivalent_sites_xml)
 
     add_switchblock_locations(tile_xml)
 

--- a/xc/common/utils/prjxray_create_place_constraints.py
+++ b/xc/common/utils/prjxray_create_place_constraints.py
@@ -473,12 +473,16 @@ def get_tile_capacities(arch_xml_filename):
     tile_capacities = {}
     for el in root.iter('tile'):
         tile_name = el.attrib['name']
-        capacity = 1
 
-        if 'capacity' in el.attrib:
-            capacity = int(el.attrib['capacity'])
+        tile_capacities[tile_name] = 0
 
-        tile_capacities[tile_name] = capacity
+        for sub_tile in el.iter('sub_tile'):
+            capacity = 1
+
+            if 'capacity' in sub_tile.attrib:
+                capacity = int(sub_tile.attrib['capacity'])
+
+            tile_capacities[tile_name] += capacity
 
     grid = {}
     for el in root.iter('single'):

--- a/xc/common/utils/prjxray_import_tile_capacity.py
+++ b/xc/common/utils/prjxray_import_tile_capacity.py
@@ -3,10 +3,7 @@ import argparse
 import json
 import prjxray.db
 from prjxray.site_type import SitePinDirection
-from lib.pb_type_xml import (
-    start_pb_type, start_tile, add_vpr_tile_prefix, add_tile_direct,
-    object_ref, add_switchblock_locations
-)
+from lib.pb_type_xml import start_tile, add_switchblock_locations
 import lxml.etree as ET
 
 

--- a/xc/common/utils/prjxray_import_tile_capacity.py
+++ b/xc/common/utils/prjxray_import_tile_capacity.py
@@ -3,7 +3,7 @@ import argparse
 import json
 import prjxray.db
 from prjxray.site_type import SitePinDirection
-from lib.pb_type_xml import start_tile, add_switchblock_locations
+from lib.pb_type_xml import start_heterogeneous_tile, add_switchblock_locations
 import lxml.etree as ET
 
 
@@ -60,10 +60,10 @@ def main():
 
         sites[site.type].append((site, input_wires, output_wires))
 
-    tile_xml = start_tile(
+    tile_xml = start_heterogeneous_tile(
         args.tile_type,
         pin_assignments,
-        sites=sites,
+        sites,
     )
 
     add_switchblock_locations(tile_xml)

--- a/xc/common/utils/prjxray_import_tile_capacity.py
+++ b/xc/common/utils/prjxray_import_tile_capacity.py
@@ -4,10 +4,28 @@ import json
 import prjxray.db
 from prjxray.site_type import SitePinDirection
 from lib.pb_type_xml import (
-    start_pb_type, add_vpr_tile_prefix, add_tile_direct, object_ref,
-    add_switchblock_locations
+    start_pb_type, start_tile, add_vpr_tile_prefix, add_tile_direct,
+    object_ref, add_switchblock_locations
 )
 import lxml.etree as ET
+
+
+def get_wires(site, site_type):
+    """Get wires related to a site"""
+    input_wires = set()
+    output_wires = set()
+
+    for site_pin in site.site_pins:
+        if site_type.get_site_pin(
+                site_pin.name).direction == SitePinDirection.IN:
+            input_wires.add(site_pin.wire)
+        elif site_type.get_site_pin(
+                site_pin.name).direction == SitePinDirection.OUT:
+            output_wires.add(site_pin.wire)
+        else:
+            assert False, site_pin
+
+    return input_wires, output_wires
 
 
 def main():
@@ -18,9 +36,8 @@ def main():
     parser.add_argument('--output_directory', required=True)
     parser.add_argument('--site_directory', required=True)
     parser.add_argument('--tile_type', required=True)
-    parser.add_argument('--pb_type', required=True)
+    parser.add_argument('--pb_types', required=True)
     parser.add_argument('--pin_assignments', required=True)
-    parser.add_argument('--site_coords', required=True)
 
     args = parser.parse_args()
 
@@ -30,70 +47,28 @@ def main():
     db = prjxray.db.Database(args.db_root, args.part)
     tile_type = db.get_tile_type(args.tile_type)
 
-    input_wires = set()
-    output_wires = set()
+    sites = {}
 
-    sites = []
+    pb_types = args.pb_types.split(',')
+
+    for pb_type in pb_types:
+        sites[pb_type] = []
 
     for site in tile_type.get_sites():
-        if site.type != args.pb_type:
+        if site.type not in pb_types:
             continue
 
         site_type = db.get_site_type(site.type)
-        sites.append(site)
+        input_wires, output_wires = get_wires(site, site_type)
 
-        for site_pin in site.site_pins:
-            if site_type.get_site_pin(
-                    site_pin.name).direction == SitePinDirection.IN:
-                input_wires.add(site_pin.wire)
-            elif site_type.get_site_pin(
-                    site_pin.name).direction == SitePinDirection.OUT:
-                output_wires.add(site_pin.wire)
-            else:
-                assert False, site_pin
+        sites[site.type].append((site, input_wires, output_wires))
 
-    sites.sort(key=lambda site: (site.x, site.y))
-
-    tile_xml = start_pb_type(
+    tile_xml = start_tile(
         args.tile_type,
         pin_assignments,
-        input_wires,
-        output_wires,
-        root_pb_type=True,
-        root_tag='tile',
+        sites=sites,
     )
 
-    tile_xml.attrib['capacity'] = str(len(sites))
-    tile_xml.attrib['capacity_type'] = "explicit"
-
-    equivalent_sites_xml = ET.Element('equivalent_sites')
-
-    site_xml = ET.Element(
-        'site', {
-            'pb_type': add_vpr_tile_prefix(site.type),
-            'pin_mapping': 'custom'
-        }
-    )
-    for site_idx, site in enumerate(sites):
-        if site.type != args.pb_type:
-            continue
-
-        for site_pin in site.site_pins:
-            add_tile_direct(
-                site_xml,
-                tile=object_ref(
-                    add_vpr_tile_prefix(args.tile_type),
-                    site_pin.wire,
-                ),
-                pb_type=object_ref(
-                    pb_name=add_vpr_tile_prefix(site.type),
-                    pb_idx=site_idx,
-                    pin_name=site_pin.name,
-                ),
-            )
-
-    equivalent_sites_xml.append(site_xml)
-    tile_xml.append(equivalent_sites_xml)
     add_switchblock_locations(tile_xml)
 
     with open('{}/{}.tile.xml'.format(args.output_directory,

--- a/xc/common/utils/prjxray_physical_tile_import.py
+++ b/xc/common/utils/prjxray_physical_tile_import.py
@@ -123,18 +123,27 @@ def import_physical_tile(args):
         nsmap={'xi': XI_URL},
     )
 
-    add_ports(tile_xml, pb_type_root)
+    sub_tile_xml = ET.Element(
+        'sub_tile',
+        {
+            'name': tile_import.add_vpr_tile_prefix(tile_name),
+        },
+        nsmap={'xi': XI_URL},
+    )
+
+    add_ports(sub_tile_xml, pb_type_root)
 
     equivalent_sites = args.equivalent_sites
-    add_equivalent_sites(tile_xml, equivalent_sites)
+    add_equivalent_sites(sub_tile_xml, equivalent_sites)
 
-    fc_xml = tile_import.add_fc(tile_xml)
+    fc_xml = tile_import.add_fc(sub_tile_xml)
 
     pin_assignments = json.load(args.pin_assignments)
     tile_import.add_pinlocations(
-        tile_name, tile_xml, fc_xml, pin_assignments, ports
+        tile_name, sub_tile_xml, fc_xml, pin_assignments, ports
     )
 
+    tile_xml.append(sub_tile_xml)
     tile_import.add_switchblock_locations(tile_xml)
 
     tile_str = ET.tostring(tile_xml, pretty_print=True).decode('utf-8')

--- a/xc/common/utils/prjxray_physical_tile_import.py
+++ b/xc/common/utils/prjxray_physical_tile_import.py
@@ -18,7 +18,7 @@ import argparse
 import sys
 import copy
 import simplejson as json
-import prjxray_tile_import as tile_import
+from lib.pb_type_xml import add_fc, add_vpr_tile_prefix, add_pinlocations, add_switchblock_locations
 
 import lxml.etree as ET
 
@@ -93,7 +93,7 @@ def import_physical_tile(args):
 
             site_xml = ET.SubElement(
                 equivalent_sites_xml, 'site', {
-                    'pb_type': tile_import.add_vpr_tile_prefix(eq_site),
+                    'pb_type': add_vpr_tile_prefix(eq_site),
                     'pin_mapping': 'custom'
                 }
             )
@@ -118,7 +118,7 @@ def import_physical_tile(args):
     tile_xml = ET.Element(
         'tile',
         {
-            'name': tile_import.add_vpr_tile_prefix(tile_name),
+            'name': add_vpr_tile_prefix(tile_name),
         },
         nsmap={'xi': XI_URL},
     )
@@ -126,7 +126,7 @@ def import_physical_tile(args):
     sub_tile_xml = ET.Element(
         'sub_tile',
         {
-            'name': tile_import.add_vpr_tile_prefix(tile_name),
+            'name': add_vpr_tile_prefix(tile_name),
         },
         nsmap={'xi': XI_URL},
     )
@@ -136,15 +136,13 @@ def import_physical_tile(args):
     equivalent_sites = args.equivalent_sites
     add_equivalent_sites(sub_tile_xml, equivalent_sites)
 
-    fc_xml = tile_import.add_fc(sub_tile_xml)
+    fc_xml = add_fc(sub_tile_xml)
 
     pin_assignments = json.load(args.pin_assignments)
-    tile_import.add_pinlocations(
-        tile_name, sub_tile_xml, fc_xml, pin_assignments, ports
-    )
+    add_pinlocations(tile_name, sub_tile_xml, fc_xml, pin_assignments, ports)
 
     tile_xml.append(sub_tile_xml)
-    tile_import.add_switchblock_locations(tile_xml)
+    add_switchblock_locations(tile_xml)
 
     tile_str = ET.tostring(tile_xml, pretty_print=True).decode('utf-8')
     args.output_tile.write(tile_str)

--- a/xc/common/utils/prjxray_tile_import.py
+++ b/xc/common/utils/prjxray_tile_import.py
@@ -15,7 +15,6 @@ import argparse
 import sys
 import prjxray.db
 import prjxray.site_type
-import simplejson as json
 import re
 import sqlite3
 

--- a/xc/common/utils/prjxray_tile_import.py
+++ b/xc/common/utils/prjxray_tile_import.py
@@ -152,68 +152,6 @@ class ModelXml(object):
         write_xml(self.f, self.model_xml)
 
 
-def add_pinlocations(tile_name, xml, fc_xml, pin_assignments, wires):
-    """ Adds the pin locations.
-
-    It requires the ports of the physical tile which are retrieved
-    by the pb_type.xml definition.
-    """
-    pinlocations_xml = ET.SubElement(
-        xml, 'pinlocations', {
-            'pattern': 'custom',
-        }
-    )
-
-    sides = {}
-    for pin in wires:
-        for side in pin_assignments['pin_directions'][tile_name][pin]:
-            if side not in sides:
-                sides[side] = []
-
-            sides[side].append(object_ref(add_vpr_tile_prefix(tile_name), pin))
-
-    for side, pins in sides.items():
-        ET.SubElement(pinlocations_xml, 'loc', {
-            'side': side.lower(),
-        }).text = ' '.join(pins)
-
-    direct_pins = set()
-    for direct in pin_assignments['direct_connections']:
-        if direct['from_pin'].split('.')[0] == tile_name:
-            direct_pins.add(direct['from_pin'].split('.')[1])
-
-        if direct['to_pin'].split('.')[0] == tile_name:
-            direct_pins.add(direct['to_pin'].split('.')[1])
-
-    for fc_override in direct_pins:
-        ET.SubElement(
-            fc_xml, 'fc_override', {
-                'fc_type': 'frac',
-                'fc_val': '0.0',
-                'port_name': fc_override,
-            }
-        )
-
-
-def add_fc(xml):
-    fc_xml = ET.SubElement(
-        xml, 'fc', {
-            'in_type': 'abs',
-            'in_val': '2',
-            'out_type': 'abs',
-            'out_val': '2',
-        }
-    )
-
-    return fc_xml
-
-
-def add_switchblock_locations(xml):
-    ET.SubElement(xml, 'switchblock_locations', {
-        'pattern': 'all',
-    })
-
-
 def start_pb_type(tile_name, f_pin_assignments, input_wires, output_wires):
     """ Starts a pb_type by adding input, clock and output tags. """
     pb_type_xml = ET.Element(
@@ -253,14 +191,6 @@ def start_pb_type(tile_name, f_pin_assignments, input_wires, output_wires):
                 'num_pins': '1'
             },
         )
-
-    fc_xml = add_fc(pb_type_xml)
-
-    pin_assignments = json.load(f_pin_assignments)
-    add_pinlocations(
-        tile_name, pb_type_xml, fc_xml, pin_assignments,
-        input_wires | output_wires
-    )
 
     pb_type_xml.append(ET.Comment(" Internal Sites "))
 
@@ -642,8 +572,6 @@ def import_tile(db, args):
 
     pb_type_xml.append(interconnect_xml)
 
-    add_switchblock_locations(pb_type_xml)
-
     model.write_model()
     write_xml(args.output_pb_type, pb_type_xml)
 
@@ -734,8 +662,6 @@ def import_site_as_tile(db, args):
             assert False, site_type_pin.direction
 
     pb_type_xml.append(interconnect_xml)
-
-    add_switchblock_locations(pb_type_xml)
 
     write_xml(args.output_pb_type, pb_type_xml)
 
@@ -1402,8 +1328,6 @@ WHERE
         )
 
     pb_type_xml.append(interconnect_xml)
-
-    add_switchblock_locations(pb_type_xml)
 
     write_xml(args.output_pb_type, pb_type_xml)
 

--- a/xc/xc7/archs/artix7/tiles/clk_bufg_bot_r/CMakeLists.txt
+++ b/xc/xc7/archs/artix7/tiles/clk_bufg_bot_r/CMakeLists.txt
@@ -1,6 +1,6 @@
 project_ray_tile_capacity(
     ARCH artix7
     TILE CLK_BUFG_BOT_R
-    SITE_TYPE BUFGCTRL
+    SITE_TYPES BUFGCTRL
     SITE_COORDS XY
     )

--- a/xc/xc7/archs/artix7/tiles/clk_bufg_bot_r/CMakeLists.txt
+++ b/xc/xc7/archs/artix7/tiles/clk_bufg_bot_r/CMakeLists.txt
@@ -2,5 +2,4 @@ project_ray_tile_capacity(
     ARCH artix7
     TILE CLK_BUFG_BOT_R
     SITE_TYPES BUFGCTRL
-    SITE_COORDS XY
     )

--- a/xc/xc7/archs/artix7/tiles/clk_bufg_top_r/CMakeLists.txt
+++ b/xc/xc7/archs/artix7/tiles/clk_bufg_top_r/CMakeLists.txt
@@ -1,6 +1,5 @@
 project_ray_tile_capacity(
     ARCH artix7
     TILE CLK_BUFG_TOP_R
-    SITE_TYPE BUFGCTRL
-    SITE_COORDS XY
+    SITE_TYPES BUFGCTRL
     )

--- a/xc/xc7/archs/artix7_200t/tiles/clk_bufg_bot_r/CMakeLists.txt
+++ b/xc/xc7/archs/artix7_200t/tiles/clk_bufg_bot_r/CMakeLists.txt
@@ -1,6 +1,5 @@
 project_ray_tile_capacity(
     ARCH artix7_200t
     TILE CLK_BUFG_BOT_R
-    SITE_TYPE BUFGCTRL
-    SITE_COORDS XY
+    SITE_TYPES BUFGCTRL
     )

--- a/xc/xc7/archs/artix7_200t/tiles/clk_bufg_top_r/CMakeLists.txt
+++ b/xc/xc7/archs/artix7_200t/tiles/clk_bufg_top_r/CMakeLists.txt
@@ -1,6 +1,5 @@
 project_ray_tile_capacity(
     ARCH artix7_200t
     TILE CLK_BUFG_TOP_R
-    SITE_TYPE BUFGCTRL
-    SITE_COORDS XY
+    SITE_TYPES BUFGCTRL
     )

--- a/xc/xc7/archs/zynq7/tiles/clk_bufg_bot_r/CMakeLists.txt
+++ b/xc/xc7/archs/zynq7/tiles/clk_bufg_bot_r/CMakeLists.txt
@@ -1,6 +1,5 @@
 project_ray_tile_capacity(
     ARCH zynq7
     TILE CLK_BUFG_BOT_R
-    SITE_TYPE BUFGCTRL
-    SITE_COORDS XY
+    SITE_TYPES BUFGCTRL
     )

--- a/xc/xc7/archs/zynq7/tiles/clk_bufg_top_r/CMakeLists.txt
+++ b/xc/xc7/archs/zynq7/tiles/clk_bufg_top_r/CMakeLists.txt
@@ -1,6 +1,5 @@
 project_ray_tile_capacity(
     ARCH zynq7
     TILE CLK_BUFG_TOP_R
-    SITE_TYPE BUFGCTRL
-    SITE_COORDS XY
+    SITE_TYPES BUFGCTRL
     )

--- a/xc/xc7/tests/bram_test/CMakeLists.txt
+++ b/xc/xc7/tests/bram_test/CMakeLists.txt
@@ -31,5 +31,7 @@ foreach(type 18 36)
       PARENT_NAME bram_test_${type}
       CLOCK_PINS clk
       CLOCK_PERIODS 10.0
+      # FIXME: https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1400
+      DISABLE_DIFF_TEST
       )
 endforeach()


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is an initial implementation of the heterogeneous tiles introduced with https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1208.

TODO:
- [ ] find a better way to use the `start_tile` implementation so that it gets used more generally by the various tile import scripts.
- [x] produce a new VtR master+wip with the heterogeneous tiles implementation