### PR TITLE
Add .gitattributes so GitHub gets the language right.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Settings to improve linguist data reporting (used by GitHub)
+*.v                     linguist-language=Verilog
+*.vh                    linguist-language=Verilog
+*.sql                   linguist-language=SQL
+
+third_party/**          linguist-vendored
+
+# FIXME: All vendor files should be under third_party
+tests/9-soc/**          linguist-vendored
+xc/xc7/tests/ddr/**     linguist-vendored
+xc/xc7/tests/soc/**     linguist-vendored


### PR DESCRIPTION
GitHub uses https://github.com/github/linguist to do language stats. linguist however mis-detects a bunch of things in this repo. It also needs to be told about the "vendored" files in the repo.

This can be fixed by setting values via `.gitattributes` file which is done here.

#### Before
```
52.90%  Coq
24.67%  Python
15.74%  Verilog
5.54%   CMake
0.46%   Shell
0.25%   C
0.23%   PLSQL
0.12%   Tcl
0.05%   Makefile
0.04%   Assembly
```

#### After
```
57.04%  Python
28.79%  Verilog
12.71%  CMake
1.08%   Shell
0.29%   Tcl
0.10%   Makefile
```
