### PR TITLE
Update to latest VtR

### DIFF
--- a/.github/kokoro/continuous-xc7-vendor.cfg
+++ b/.github/kokoro/continuous-xc7-vendor.cfg
@@ -18,6 +18,7 @@ action {
     regex: "**/place.log"
     regex: "**/route.log"
     regex: "**/*_qor.csv"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-xc7-vendor/"
   }
 }

--- a/.github/kokoro/presubmit-xc7-vendor.cfg
+++ b/.github/kokoro/presubmit-xc7-vendor.cfg
@@ -18,6 +18,7 @@ action {
     regex: "**/place.log"
     regex: "**/route.log"
     regex: "**/*_qor.csv"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7-vendor/"
   }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 8.0.0.rc2_3575_g253f75b6d 20200401_084607"
+  PACKAGE_SPEC "vtr 8.0.0.rc2_3792_g82b720de7 20200415_151618"
   )
 add_conda_package(
   NAME libxslt

--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -61,6 +61,7 @@ function(ADD_XC_ARCH_DEFINE)
   set(VPR_ARCH_ARGS "\
       --router_heap bucket \
       --clock_modeling route \
+      --place_delta_delay_matrix_calculation_method dijkstra \
       --place_delay_model delta_override \
       --router_lookahead connection_box_map \
       --quick_check_route on \

--- a/xc/common/primitives/bufgctrl/bufgctrl.model.xml
+++ b/xc/common/primitives/bufgctrl/bufgctrl.model.xml
@@ -12,7 +12,7 @@
    <port name="S1" />
   </input_ports>
   <output_ports>
-   <port name="O" is_clock="1" />
+   <port name="O" />
   </output_ports>
  </model>
 </models>

--- a/xc/common/primitives/bufgctrl/bufgctrl.model.xml
+++ b/xc/common/primitives/bufgctrl/bufgctrl.model.xml
@@ -4,15 +4,15 @@
   <input_ports>
    <port name="CE0" />
    <port name="CE1" />
-   <port name="I0" is_clock="1" combinational_sink_ports="O"/>
-   <port name="I1" is_clock="1" combinational_sink_ports="O"/>
+   <port name="I0" is_clock="1"/>
+   <port name="I1" is_clock="1"/>
    <port name="IGNORE0" />
    <port name="IGNORE1" />
    <port name="S0" />
    <port name="S1" />
   </input_ports>
   <output_ports>
-   <port name="O" />
+   <port name="O" is_clock="1"/>
   </output_ports>
  </model>
 </models>

--- a/xc/common/primitives/bufgctrl/bufgctrl.pb_type.xml
+++ b/xc/common/primitives/bufgctrl/bufgctrl.pb_type.xml
@@ -24,8 +24,11 @@
       <input name="IGNORE1" num_pins="1"/>
       <input name="S0" num_pins="1"/>
       <input name="S1" num_pins="1"/>
+      <!-- FIXME: delay constants cannot be used as there is no
+           combinational sink from I0/I1 to the O pin
       <delay_constant max="{iopath_I_O}" in_port="I0" out_port="O"/>
       <delay_constant max="{iopath_I_O}" in_port="I1" out_port="O"/>
+      -->
       <metadata>
         <meta name="fasm_params">
           ZPRESELECT_I0 = ZPRESELECT_I0

--- a/xc/common/primitives/plle2_adv/plle2_adv.model.xml
+++ b/xc/common/primitives/plle2_adv/plle2_adv.model.xml
@@ -8,8 +8,8 @@
       <port clock="DCLK" name="DI"/>
 
       <port is_clock="1" name="CLKFBIN"/>
-      <port is_clock="1" name="CLKIN1" combinational_sink_ports="CLKFBOUT CLKOUT0 CLKOUT1 CLKOUT2 CLKOUT3 CLKOUT4 CLKOUT5"/>
-      <port is_clock="1" name="CLKIN2" combinational_sink_ports="CLKFBOUT CLKOUT0 CLKOUT1 CLKOUT2 CLKOUT3 CLKOUT4 CLKOUT5"/>
+      <port is_clock="1" name="CLKIN1"/>
+      <port is_clock="1" name="CLKIN2"/>
       <port name="CLKINSEL"/>
       <port name="PWRDWN"/>
       <port name="RST" combinational_sink_ports="LOCKED"/>

--- a/xc/common/primitives/plle2_adv/plle2_adv.pb_type.xml
+++ b/xc/common/primitives/plle2_adv/plle2_adv.pb_type.xml
@@ -42,6 +42,8 @@
   <!-- The following timings depend on the PLL COMPENSATION setting.
        For now the worst ones were chosen (for the "BUF_IN" mode). This may
        be changed in the bels.json file -->
+  <!-- FIXME: delay constants are not allowed for clock generators as the combinational sink
+       cannot be used in the model
   <delay_constant max="{iopath_CLKIN1_CLKFBOUT}" in_port="CLKIN1" out_port="CLKFBOUT"/>
   <delay_constant max="{iopath_CLKIN1_CLKOUT0}" in_port="CLKIN1" out_port="CLKOUT0"/>
   <delay_constant max="{iopath_CLKIN1_CLKOUT1}" in_port="CLKIN1" out_port="CLKOUT1"/>
@@ -56,7 +58,7 @@
   <delay_constant max="{iopath_CLKIN2_CLKOUT2}" in_port="CLKIN2" out_port="CLKOUT2"/>
   <delay_constant max="{iopath_CLKIN2_CLKOUT3}" in_port="CLKIN2" out_port="CLKOUT3"/>
   <delay_constant max="{iopath_CLKIN2_CLKOUT4}" in_port="CLKIN2" out_port="CLKOUT4"/>
-  <delay_constant max="{iopath_CLKIN2_CLKOUT5}" in_port="CLKIN2" out_port="CLKOUT5"/>
+  <delay_constant max="{iopath_CLKIN2_CLKOUT5}" in_port="CLKIN2" out_port="CLKOUT5"/> -->
 
   <!-- Metadata -->
   <metadata>


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR changes the way PLL and BUFGCTRL model is defined:

- PLL: remove the combinational sink from CLKIN to CLKOUTs. This allows not to use the VPR wip branch `revert_clock_propagation`. The downside though is that the delay constants in the pb_type cannot be used anymore, as there is no combinational sink in the model for the clock signals.

- BUFGCTRL: remove the `is_clock` attribute from the clock output, as the clock path should be detected by the timing graph build step.

This PR needs to have a new VtR master+wip with the `wip/revert_clock_propagation` branch removed from the octopus merge.