### PR TITLE
Add techmap for LDCE

### DIFF
--- a/xc/xc7/techmap/cells_map.v
+++ b/xc/xc7/techmap/cells_map.v
@@ -180,6 +180,21 @@ FDPE_ZINI #(.ZINI(!|INIT), .IS_C_INVERTED(|1))
 endmodule
 
 // ============================================================================
+// Latches
+
+module LDCE (
+   output reg Q,
+   input CLR, D, G, GE
+);
+
+parameter [0:0] INIT = 1'b0;
+
+LDCE_ZINI #(.ZINI(!INIT))
+  _TECHMAP_REPLACE_ (.Q(Q), .CLR(CLR), .D(D), .G(G), .GE(GE));
+
+endmodule
+
+// ============================================================================
 // LUTs
 
 module LUT1(output O, input I0);

--- a/xc/xc7/techmap/cells_sim.v
+++ b/xc/xc7/techmap/cells_sim.v
@@ -50,6 +50,24 @@ module FDPE_ZINI (output reg Q, input C, CE, D, PRE);
 endmodule
 
 // ============================================================================
+// Latches
+
+module LDCE_ZINI (
+  output reg Q,
+  input CLR,
+  input D,
+  input G,
+  input GE
+);
+  parameter [0:0] ZINI = 1'b0;
+
+  initial Q = !ZINI;
+  always @*
+    if (CLR) Q <= 1'b0;
+    else if (GE && g) Q <= D;
+endmodule
+
+// ============================================================================
 // LUT related muxes
 
 module MUXF6(output O, input I0, I1, S);


### PR DESCRIPTION
This commit adds missing LDCE latch techmap.
The Xilinx documentation of the primitive is available in  [[HERE]](https://www.xilinx.com/support/documentation/sw_manuals/xilinx13_2/7series_scm.pdf#page=285)