### PR TITLE
Allow import scripts to parse huge .net files

### DIFF
--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -56,9 +56,11 @@ class IoPlace(object):
         net_root = net_xml.getroot()
         self.net_to_block = {}
 
-        for block in net_root.xpath(
-                "//block[@instance='inpad[0]'] | //block[@instance='outpad[0]']"
-        ):
+        for block in net_root.xpath("//block"):
+            instance = block.attrib["instance"]
+            if instance != "inpad[0]" and instance != "outpad[0]":
+                continue
+
             top_block = block.getparent()
             assert top_block is not None
             while top_block.getparent() is not net_root:

--- a/utils/vpr_place_constraints.py
+++ b/utils/vpr_place_constraints.py
@@ -45,7 +45,11 @@ class PlaceConstraints(object):
                 self.block_to_root_block[el.attrib['name']
                                          ] = root_block.attrib['name']
 
-        for attr in net_root.xpath("//attribute[@name='LOC']"):
+        for attr in net_root.xpath("//attribute"):
+            name = attr.attrib["name"]
+            if name != 'LOC':
+                continue
+
             # Get block name
             top_block = attr.getparent()
             assert top_block is not None


### PR DESCRIPTION
This commit changes the architecture importing scripts and allows them to parse huge .net files. Without these changes, libxml fails on using XPath expressions due to the internal memory allocation limit. In that situation, the python wrapper on the libxml library throws misleading error message about incorrect XPath expression.

This changes are required for OpenTitan and are related to https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1442#issuecomment-619055675