### PR TITLE
Upgrades miniconda and pycapn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(all_xc7_tests)
 add_custom_target(all_ice40_tests)
 
 setup_env(
-    MINICONDA3_VERSION 4.7.10
+    MINICONDA3_VERSION py37_4.8.2
     )
 add_conda_package(
   NAME yosys
@@ -93,6 +93,7 @@ add_conda_pip(
 )
 add_conda_pip(
   NAME pycapnp
+  PACKAGE_SPEC "1.0.0b1"
   NO_EXE
 )
 add_conda_pip(

--- a/common/cmake/env.cmake
+++ b/common/cmake/env.cmake
@@ -251,6 +251,7 @@ function(ADD_CONDA_PIP)
   # ~~~
   # ADD_CONDA_PIP(
   #   NAME <name>
+  #   [PACKAGE_SPEC <package_spec>]
   #   [NO_EXE]
   #   )
   # ~~~
@@ -259,7 +260,7 @@ function(ADD_CONDA_PIP)
   # <name> is set to the path to the executable. <name>_TARGET is set to the
   # target that will invoke pip if not already installed.
   set(options NO_EXE)
-  set(oneValueArgs NAME)
+  set(oneValueArgs NAME PACKAGE_SPEC)
   set(multiValueArgs)
   cmake_parse_arguments(
     ADD_CONDA_PIP
@@ -270,6 +271,12 @@ function(ADD_CONDA_PIP)
   )
 
   set(NAME ${ADD_CONDA_PIP_NAME})
+  if(NOT ${ADD_CONDA_PIP_PACKAGE_SPEC} STREQUAL "")
+    set(PACKAGE_SPEC "${ADD_CONDA_PIP_NAME}==${ADD_CONDA_PIP_PACKAGE_SPEC}")
+  else()
+    set(PACKAGE_SPEC ${ADD_CONDA_PIP_NAME})
+  endif()
+
   get_target_property_required(USE_CONDA env USE_CONDA)
   string(TOUPPER ${NAME} binary_upper)
   if(${USE_CONDA})
@@ -282,7 +289,7 @@ function(ADD_CONDA_PIP)
       add_custom_command(
         OUTPUT ${NAME}.pip
         COMMAND ${CMAKE_COMMAND} -E echo "Taking ${PIP}.lock"
-        COMMAND flock ${PIP}.lock ${PYTHON3} -m pip install ${NAME}
+        COMMAND flock ${PIP}.lock ${PYTHON3} -m pip install ${PACKAGE_SPEC}
         COMMAND ${CMAKE_COMMAND} -E touch ${NAME}.pip
         DEPENDS ${PYTHON3} ${PIP} ${PIP_TARGET}
         )
@@ -297,7 +304,7 @@ function(ADD_CONDA_PIP)
       add_custom_command(
         OUTPUT ${BIN}
         COMMAND ${CMAKE_COMMAND} -E echo "Taking ${PIP}.lock"
-        COMMAND flock ${PIP}.lock ${PYTHON3} -m pip install ${NAME}
+        COMMAND flock ${PIP}.lock ${PYTHON3} -m pip install ${PACKAGE_SPEC}
         DEPENDS ${PYTHON3} ${PIP} ${PIP_TARGET}
         )
       add_custom_target(


### PR DESCRIPTION
Hello all!
We are seeing some build issues on OpenSuse and Arch. When running `make all_conda`, we encountered the following error:

```
    g++ -pthread -shared -B /scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/compiler_compat -L/scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/lib -Wl,-rpath=/scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/pyjson5.o -o build/lib.linux-x86_64-3.7/pyjson5.cpython-37m-x86_64-linux-gnu.so -std=c++11 -O2 -fPIC -ggdb1 -pipe -fomit-frame-pointer -fstack-protector-strong
    /scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: build/temp.linux-x86_64-3.7/pyjson5.o: unable to initialize decompress status for section .debug_info
    /scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: build/temp.linux-x86_64-3.7/pyjson5.o: unable to initialize decompress status for section .debug_info
    /scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: build/temp.linux-x86_64-3.7/pyjson5.o: unable to initialize decompress status for section .debug_info
    /scratch/safe/syed/dev/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: build/temp.linux-x86_64-3.7/pyjson5.o: unable to initialize decompress status for section .debug_info
    build/temp.linux-x86_64-3.7/pyjson5.o: file not recognized: file format not recognized
    collect2: error: ld returned 1 exit status
    error: command 'g++' failed with exit status 1
```
As mentioned here: https://github.com/ContinuumIO/anaconda-issues/issues/11152#issuecomment-567158290, apparently ld being pulled by conda is related to the python version conda pulls. Looks like it happens in conda’s python 3.7.4 version, which is what conda pulls for https://github.com/SymbiFlow/symbiflow-arch-defs/blob/master/CMakeLists.txt#L33. I updated miniconda version to `py37_4.8.2` (which pulls python 3.7.6) and that solved the pyjson5 problem but not captain proto. 

We got the following error for captain proto:
```
g++ -pthread -shared -B /scratch/safe/syed/symbiflow-arch-defs/build/env/conda/compiler_compat -L/scratch/safe/syed/symbiflow-arch-defs/build/env/conda/lib -Wl,-rpath=/scratch/safe/syed/symbiflow-arch-defs/build/env/conda/lib -Wl,--no-as-needed -Wl,--sysroot=/ build/temp.linux-x86_64-3.7/capnp/lib/capnp.o -L/tmp/pip-install-ml0mmc51/pycapnp/build/lib -lcapnpc -lcapnp-rpc -lcapnp -lkj-async -lkj -o build/lib.linux-x86_64-3.7/capnp/lib/capnp.cpython-37m-x86_64-linux-gnu.so
  /scratch/safe/syed/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: cannot find -lcapnpc
  /scratch/safe/syed/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: cannot find -lcapnp-rpc
  /scratch/safe/syed/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: cannot find -lcapnp
  /scratch/safe/syed/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: cannot find -lkj-async
  /scratch/safe/syed/symbiflow-arch-defs/build/env/conda/compiler_compat/ld: cannot find -lkj
  collect2: error: ld returned 1 exit status
  error: command 'g++' failed with exit status 1
```
It seems like a packaging problem in captain proto 0.6.4 version and being on opensuse/arch. I saw that captain proto was being installed with pip and pypi has a pre-release version of captain proto. So added some code in Cmake to download the specific "1.0.0b1" version of captain proto and that solved the linker issues.