### PR TITLE
Bump VPR + delayless switch fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ add_conda_package(
 add_conda_package(
   NAME vtr
   PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 8.0.0.rc2_3935_g7d6424bb0 20200514_163723"
+  PACKAGE_SPEC "vtr 8.0.0.rc2_4003_g8980e4621 20200527_075234"
   )
 add_conda_package(
   NAME libxslt

--- a/xc/common/utils/prjxray_arch_import.py
+++ b/xc/common/utils/prjxray_arch_import.py
@@ -835,7 +835,10 @@ SELECT
     penalty_cost,
     switch_type
 FROM
-    switch;"""):
+    switch
+WHERE
+    name != "__vpr_delayless_switch__";"""):
+
             attrib = {
                 'type': switch_type,
                 'name': name,


### PR DESCRIPTION
This PR bumps VPR to the recent master+wip with post synthesis netlist write fix (analysis targets work). Also suppresses emission of `__vpr_delayless_switch__` to the arch.xml. It is now implicitly defined.