### PR TITLE
Support for IO constraints read from XDC

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -1677,6 +1677,9 @@ function(ADD_FPGA_TARGET)
         set(OUT_BIT_VERILOG ${OUT_LOCAL}/${TOP}_bit.v)
         get_target_property_required(BIT_TO_V ${ARCH} BIT_TO_V)
         get_target_property_required(BIT_TO_V_CMD ${ARCH} BIT_TO_V_CMD)
+        if(NOT ${ADD_FPGA_TARGET_INPUT_IO_FILE} STREQUAL "")
+            set(PCF_INPUT_IO_FILE "--pcf ${INPUT_IO_FILE}")
+        endif()
         string(CONFIGURE ${BIT_TO_V_CMD} BIT_TO_V_CMD_FOR_TARGET)
         separate_arguments(
           BIT_TO_V_CMD_FOR_TARGET_LIST UNIX_COMMAND ${BIT_TO_V_CMD_FOR_TARGET}

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -26,6 +26,20 @@ class IoPlace(object):
         self.inout_nets = set()
         self.net_to_pad = set()
 
+    def read_io_loc_pairs(self, blif):
+        if 'subckt' not in blif:
+            return
+        for attr in blif['subckt']:
+            if 'param' not in attr:
+                continue
+            if 'IO_LOC_PAIRS' in attr['param']:
+                locs = attr['param']['IO_LOC_PAIRS'][1:-1].split(',')
+                if 'NONE' in locs:
+                    continue
+                for loc in locs:
+                    net, pad = loc.split(':')
+                    self.net_to_pad.add((net, pad))
+
     def read_io_list_from_eblif(self, eblif_file):
         blif = eblif.parse_blif(eblif_file)
 
@@ -47,18 +61,7 @@ class IoPlace(object):
                 self.net_map[net] = alias
             else:
                 self.net_map[net] = net
-        if 'subckt' not in blif:
-            return
-        for attr in blif['subckt']:
-            if 'param' not in attr:
-                continue
-            if 'IO_LOC_PAIRS' in attr['param']:
-                locs = attr['param']['IO_LOC_PAIRS'][1:-1].split(',')
-                if 'NONE' in locs:
-                    continue
-                for loc in locs:
-                    net, pad = loc.split(':')
-                    self.net_to_pad.add((net, pad))
+        self.read_io_loc_pairs(blif)
 
     def load_block_names_from_net_file(self, net_file):
         """

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -27,6 +27,12 @@ class IoPlace(object):
         self.net_to_pad = set()
 
     def read_io_loc_pairs(self, blif):
+        """
+         Read IO_LOC_PAIRS parameters from eblif carrying the information
+         which package pin a specified top port is constrained, e.g. O_LOC_PAIRS = "portA:D1"
+         In case of differential inputs/outputs there are two pairs of the parameter,
+         i.e. IO_LOC_PAIRS = "portA_p:D2,portA_n:D4"
+        """
         if 'subckt' not in blif:
             return
         for attr in blif['subckt']:

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -24,6 +24,7 @@ class IoPlace(object):
         self.net_to_block = None
         self.net_map = {}
         self.inout_nets = set()
+        self.net_to_pad = set()
 
     def read_io_list_from_eblif(self, eblif_file):
         blif = eblif.parse_blif(eblif_file)
@@ -46,6 +47,18 @@ class IoPlace(object):
                 self.net_map[net] = alias
             else:
                 self.net_map[net] = net
+        if 'subckt' not in blif:
+            return
+        for attr in blif['subckt']:
+            if 'param' not in attr:
+                continue
+            if 'IO_LOC_PAIRS' in attr['param']:
+                locs = attr['param']['IO_LOC_PAIRS'][1:-1].split(',')
+                if 'NONE' in locs:
+                    continue
+                for loc in locs:
+                    net, pad = loc.split(':')
+                    self.net_to_pad.add((net, pad))
 
     def load_block_names_from_net_file(self, net_file):
         """

--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -165,7 +165,7 @@ function(ADD_XC_ARCH_DEFINE)
         --fasm_file \${OUT_BIN}.fasm \
         --iostandard ${DEFAULT_IOSTANDARD} \
         --drive ${DEFAULT_DRIVE} \
-        --pcf \${INPUT_IO_FILE} \
+        \${PCF_INPUT_IO_FILE} \
         --eblif \${OUT_EBLIF} \
         --top \${TOP} \
         \${OUT_BIT_VERILOG} \${OUT_BIT_VERILOG}.tcl"

--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -122,7 +122,7 @@ function(ADD_XC_ARCH_DEFINE)
     \${PYTHON3} \${PLACE_TOOL} \
         --map \${PINMAP} \
         --blif \${OUT_EBLIF} \
-        --pcf \${INPUT_IO_FILE} \
+        \${PCF_INPUT_IO_FILE} \
         --net \${OUT_NET}"
     PLACE_CONSTR_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_create_place_constraints.py

--- a/xc/common/utils/prjxray_create_ioplace.py
+++ b/xc/common/utils/prjxray_create_ioplace.py
@@ -6,6 +6,7 @@ import json
 import sys
 import os
 import vpr_io_place
+from lib.parse_pcf import parse_simple_pcf
 
 
 def main():
@@ -100,13 +101,17 @@ def main():
         if os.path.isfile(fname):
             with open(fname, "r") as fp:
                 iostandard_constraints = json.load(fp)
+    if args.pcf:
+        pcf_constraints = parse_simple_pcf(args.pcf)
+        net_to_pad = [(constr.net, constr.pad) for constr in pcf_constraints]
+    else:
+        net_to_pad = io_place.net_to_pad
     # Constrain nets
-    for net, pad in io_place.net_to_pad:
+    for net, pad in net_to_pad:
         if not io_place.is_net(net):
             print(
                 """ERROR:
-XDC constraints net {} which is not in available netlist:\n{}"""
-                .format(
+Constrained net {} is not in available netlist:\n{}""".format(
                     net, '\n'.join(io_place.get_nets())
                 ),
                 file=sys.stderr
@@ -116,8 +121,7 @@ XDC constraints net {} which is not in available netlist:\n{}"""
         if pad not in pad_map:
             print(
                 """ERROR:
-XDC constraints pad {} which is not in available pad map:\n{}"""
-                .format(
+Constrained pad {} is not in available pad map:\n{}""".format(
                     pad, '\n'.join(sorted(pad_map.keys()))
                 ),
                 file=sys.stderr

--- a/xc/xc7/fasm2bels/fasm2bels.py
+++ b/xc/xc7/fasm2bels/fasm2bels.py
@@ -46,6 +46,7 @@ from .net_map import create_net_list
 import lib.rr_graph_capnp.graph2 as capnp_graph2
 from lib.parse_pcf import parse_simple_pcf
 import eblif
+import vpr_io_place
 
 
 def null_process(conn, top, tile, tiles):
@@ -204,23 +205,31 @@ def bit2fasm(db_root, db, grid, bit_file, fasm_file, bitread, part):
         )
 
 
-def load_io_sites(db_root, part, pcf):
-    """ Load map of sites to signal names from pcf and part pin definitions.
+def load_io_sites(db_root, part, pcf, eblif):
+    """ Load map of sites to signal names from pcf or eblif and part pin definitions.
 
     Args:
         db_root (str): Path to database root folder
         part (str): Part name being targeted.
         pcf (str): Full path to pcf file for this bitstream.
+        eblif (str): Parsed contents of EBLIF file.
 
     Returns:
         Dict from pad site name to net name.
 
     """
     pin_to_signal = {}
-    with open(pcf) as f:
-        for pcf_constraint in parse_simple_pcf(f):
-            assert pcf_constraint.pad not in pin_to_signal, pcf_constraint.pad
-            pin_to_signal[pcf_constraint.pad] = pcf_constraint.net
+    if pcf:
+        with open(pcf) as f:
+            for pcf_constraint in parse_simple_pcf(f):
+                assert pcf_constraint.pad not in pin_to_signal, pcf_constraint.pad
+                pin_to_signal[pcf_constraint.pad] = pcf_constraint.net
+    elif eblif:
+        io_place = vpr_io_place.IoPlace()
+        io_place.read_io_loc_pairs(eblif)
+        for net, pad in io_place.net_to_pad:
+            assert pad not in pin_to_signal, pad
+            pin_to_signal[pad] = net
 
     site_to_signal = {}
 
@@ -341,9 +350,13 @@ def main():
     maybe_get_wire = create_maybe_get_wire(conn)
 
     top = Module(db, grid, conn, name=args.top)
-    if args.pcf:
+    if args.eblif:
+        with open(args.eblif) as f:
+            parsed_eblif = eblif.parse_blif(f)
+
+    if args.eblif or args.pcf:
         top.set_site_to_signal(
-            load_io_sites(args.db_root, args.part, args.pcf)
+            load_io_sites(args.db_root, args.part, args.pcf, parsed_eblif)
         )
 
     if args.route_file:
@@ -360,9 +373,6 @@ def main():
             top.set_io_banks(part_data['iobanks'])
 
     if args.eblif:
-        with open(args.eblif) as f:
-            parsed_eblif = eblif.parse_blif(f)
-
         top.add_to_cname_map(parsed_eblif)
         top.make_iosettings_map(parsed_eblif)
 

--- a/xc/xc7/techmap/cells_map.v
+++ b/xc/xc7/techmap/cells_map.v
@@ -1912,6 +1912,7 @@ module IBUF (
   parameter IBUF_LOW_PWR = 0;   // TODO: Map this to fasm
   parameter IN_TERM = "NONE";   // Not supported by Vivado ?
   parameter PULLTYPE = "NONE";  // Not supported by Vivado ?
+  parameter IO_LOC_PAIRS = "NONE";
 
   IBUF_VPR # (
     .LVCMOS12_LVCMOS15_LVCMOS18_IN(
@@ -1968,7 +1969,8 @@ module IBUF (
     .PULLTYPE_KEEPER(PULLTYPE == "KEEPER"),
 
     .PULLTYPE(PULLTYPE),
-    .IOSTANDARD(IOSTANDARD)
+    .IOSTANDARD(IOSTANDARD),
+    .IO_LOC_PAIRS(IO_LOC_PAIRS)
   ) _TECHMAP_REPLACE_ (
     .I(I),
     .O(O)
@@ -1985,6 +1987,7 @@ module OBUF (
   parameter DRIVE = 12;
   parameter SLEW = "SLOW";
   parameter PULLTYPE = "NONE";  // Not supported by Vivado ?
+  parameter IO_LOC_PAIRS = "NONE";
 
   OBUF_VPR # (
     .LVCMOS12_DRIVE_I12(
@@ -2088,7 +2091,8 @@ module OBUF (
     .PULLTYPE(PULLTYPE),
     .IOSTANDARD(IOSTANDARD),
     .DRIVE(DRIVE),
-    .SLEW(SLEW)
+    .SLEW(SLEW),
+    .IO_LOC_PAIRS(IO_LOC_PAIRS)
   ) _TECHMAP_REPLACE_ (
     .I(I),
     .O(O)
@@ -2109,6 +2113,7 @@ module IOBUF (
   parameter IBUF_LOW_PWR = 0;  // TODO: Map this to fasm
   parameter IN_TERM = "NONE";  // Not supported by Vivado ?
   parameter PULLTYPE = "NONE"; // Not supported by Vivado ?
+  parameter IO_LOC_PAIRS = "NONE";
 
   IOBUF_VPR # (
     .LVCMOS12_DRIVE_I12(
@@ -2232,7 +2237,8 @@ module IOBUF (
     .PULLTYPE(PULLTYPE),
     .IOSTANDARD(IOSTANDARD),
     .DRIVE(DRIVE),
-    .SLEW(SLEW)
+    .SLEW(SLEW),
+    .IO_LOC_PAIRS(IO_LOC_PAIRS)
   ) _TECHMAP_REPLACE_ (
     .I(I),
     .T(T),
@@ -2255,6 +2261,7 @@ module OBUFTDS (
   parameter SLEW = "FAST";
   parameter IN_TERM = "NONE";  // Not supported by Vivado ?
   parameter PULLTYPE = "NONE"; // Not supported by Vivado ?
+  parameter IO_LOC_PAIRS = "NONE";
 
   wire complementary;
 
@@ -2289,7 +2296,8 @@ module OBUFTDS (
 
     .PULLTYPE(PULLTYPE),
     .IOSTANDARD(IOSTANDARD),
-    .SLEW(SLEW)
+    .SLEW(SLEW),
+    .IO_LOC_PAIRS(IO_LOC_PAIRS)
   ) obuftds_m (
   .I(I),
   .T(T),
@@ -2328,7 +2336,8 @@ module OBUFTDS (
 
     .PULLTYPE(PULLTYPE),
     .IOSTANDARD(IOSTANDARD),
-    .SLEW(SLEW)
+    .SLEW(SLEW),
+    .IO_LOC_PAIRS(IO_LOC_PAIRS)
   ) obuftds_s (
   .IB(complementary),
   .OB(OB)
@@ -2346,6 +2355,7 @@ module OBUFDS (
   parameter IOSTANDARD = "DIFF_SSTL135";  // TODO: Is this the default ?
   parameter SLEW = "FAST";
   parameter PULLTYPE = "NONE";  // Not supported by Vivado ?
+  parameter IO_LOC_PAIRS = "NONE";
 
   OBUFTDS # (
   .PULLTYPE(PULLTYPE),
@@ -2500,6 +2510,7 @@ module OSERDESE2 (
   parameter DATA_WIDTH = 4;
   parameter SERDES_MODE = "MASTER";
   parameter TRISTATE_WIDTH = 4;
+  parameter IO_LOC_PAIRS = "NONE";
 
   if (DATA_RATE_OQ == "DDR" &&
       !(DATA_WIDTH == 2 || DATA_WIDTH == 4 ||

--- a/xc/xc7/tests/soc/litex/mini_ddr/CMakeLists.txt
+++ b/xc/xc7/tests/soc/litex/mini_ddr/CMakeLists.txt
@@ -16,7 +16,6 @@ add_fpga_target(
   SOURCES
     minilitex_ddr_arty.v
     VexRiscv_Lite.v
-  INPUT_IO_FILE arty.pcf
   INPUT_XDC_FILE minilitex_ddr_arty.xdc
   SDC_FILE arty.sdc
   EXPLICIT_ADD_FILE_TARGET

--- a/xc/xc7/tests/soc/litex/mini_ddr/minilitex_ddr_arty.xdc
+++ b/xc/xc7/tests/soc/litex/mini_ddr/minilitex_ddr_arty.xdc
@@ -1,218 +1,225 @@
-# ## serial:0.tx
-#set_property LOC D10 [get_ports serial_tx]
+set_property LOC H5 [get_ports {led[0]}]
+set_property LOC J5 [get_ports {led[1]}]
+set_property LOC T9 [get_ports {led[2]}]
+set_property LOC T10 [get_ports {led[3]}]
+ ## serial:0.tx
+set_property LOC D10 [get_ports serial_tx]
 set_property IOSTANDARD LVCMOS33 [get_ports serial_tx]
 # ## serial:0.rx
-#set_property LOC A9 [get_ports serial_rx]
+set_property LOC A9 [get_ports serial_rx]
 set_property IOSTANDARD LVCMOS33 [get_ports serial_rx]
 # ## clk100:0
-#set_property LOC E3 [get_ports clk100]
+set_property LOC E3 [get_ports clk100]
 set_property IOSTANDARD LVCMOS33 [get_ports clk100]
 # ## cpu_reset:0
-#set_property LOC C2 [get_ports cpu_reset]
+set_property LOC C2 [get_ports cpu_reset]
 set_property IOSTANDARD LVCMOS33 [get_ports cpu_reset]
 # ## ddram:0.a
-#set_property LOC R2 [get_ports {ddram_a[0]} ]
+set_property LOC R2 [get_ports {ddram_a[0]} ]
 set_property SLEW FAST [get_ports {ddram_a[0]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[0]} ]
 # ## ddram:0.a
-#set_property LOC M6 [get_ports {ddram_a[1]} ]
+set_property LOC M6 [get_ports {ddram_a[1]} ]
 set_property SLEW FAST [get_ports {ddram_a[1]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[1]} ]
 # ## ddram:0.a
-#set_property LOC N4 [get_ports {ddram_a[2]} ]
+set_property LOC N4 [get_ports {ddram_a[2]} ]
 set_property SLEW FAST [get_ports {ddram_a[2]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[2]} ]
 # ## ddram:0.a
-#set_property LOC T1 [get_ports {ddram_a[3]} ]
+set_property LOC T1 [get_ports {ddram_a[3]} ]
 set_property SLEW FAST [get_ports {ddram_a[3]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[3]} ]
 # ## ddram:0.a
-#set_property LOC N6 [get_ports {ddram_a[4]} ]
+set_property LOC N6 [get_ports {ddram_a[4]} ]
 set_property SLEW FAST [get_ports {ddram_a[4]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[4]} ]
 # ## ddram:0.a
-#set_property LOC R7 [get_ports {ddram_a[5]} ]
+set_property LOC R7 [get_ports {ddram_a[5]} ]
 set_property SLEW FAST [get_ports {ddram_a[5]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[5]} ]
 # ## ddram:0.a
-#set_property LOC V6 [get_ports {ddram_a[6]} ]
+set_property LOC V6 [get_ports {ddram_a[6]} ]
 set_property SLEW FAST [get_ports {ddram_a[6]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[6]} ]
 # ## ddram:0.a
-#set_property LOC U7 [get_ports {ddram_a[7]} ]
+set_property LOC U7 [get_ports {ddram_a[7]} ]
 set_property SLEW FAST [get_ports {ddram_a[7]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[7]} ]
 # ## ddram:0.a
-#set_property LOC R8 [get_ports {ddram_a[8]} ]
+set_property LOC R8 [get_ports {ddram_a[8]} ]
 set_property SLEW FAST [get_ports {ddram_a[8]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[8]} ]
 # ## ddram:0.a
-#set_property LOC V7 [get_ports {ddram_a[9]} ]
+set_property LOC V7 [get_ports {ddram_a[9]} ]
 set_property SLEW FAST [get_ports {ddram_a[9]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[9]} ]
 # ## ddram:0.a
-#set_property LOC R6 [get_ports {ddram_a[10]} ]
+set_property LOC R6 [get_ports {ddram_a[10]} ]
 set_property SLEW FAST [get_ports {ddram_a[10]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[10]} ]
 # ## ddram:0.a
-#set_property LOC U6 [get_ports {ddram_a[11]} ]
+set_property LOC U6 [get_ports {ddram_a[11]} ]
 set_property SLEW FAST [get_ports {ddram_a[11]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[11]} ]
 # ## ddram:0.a
-#set_property LOC T6 [get_ports {ddram_a[12]} ]
+set_property LOC T6 [get_ports {ddram_a[12]} ]
 set_property SLEW FAST [get_ports {ddram_a[12]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[12]} ]
 # ## ddram:0.a
-#set_property LOC T8 [get_ports {ddram_a[13]} ]
+set_property LOC T8 [get_ports {ddram_a[13]} ]
 set_property SLEW FAST [get_ports {ddram_a[13]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_a[13]} ]
 # ## ddram:0.ba
-#set_property LOC R1 [get_ports {ddram_ba[0]} ]
+set_property LOC R1 [get_ports {ddram_ba[0]} ]
 set_property SLEW FAST [get_ports {ddram_ba[0]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[0]} ]
 # ## ddram:0.ba
+set_property LOC P4 [get_ports {ddram_ba[1]} ]
+set_property SLEW FAST [get_ports {ddram_ba[1]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[1]} ]
 # ## ddram:0.ba
-#set_property LOC P2 [get_ports {ddram_ba[2]} ]
+set_property LOC P2 [get_ports {ddram_ba[2]} ]
 set_property SLEW FAST [get_ports {ddram_ba[2]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[2]} ]
 # ## ddram:0.ras_n
-#set_property LOC P3 [get_ports {ddram_ras_n]
+set_property LOC P3 [get_ports ddram_ras_n]
 set_property SLEW FAST [get_ports ddram_ras_n]
 set_property IOSTANDARD SSTL135 [get_ports ddram_ras_n]
 # ## ddram:0.cas_n
-#set_property LOC M4 [get_ports {ddram_cas_n]
+set_property LOC M4 [get_ports ddram_cas_n]
 set_property SLEW FAST [get_ports ddram_cas_n]
 set_property IOSTANDARD SSTL135 [get_ports ddram_cas_n]
 # ## ddram:0.we_n
-#set_property LOC P5 [get_ports {ddram_we_n]
+set_property LOC P5 [get_ports ddram_we_n]
 set_property SLEW FAST [get_ports ddram_we_n]
 set_property IOSTANDARD SSTL135 [get_ports ddram_we_n]
 # ## ddram:0.cs_n
-#set_property LOC U8 [get_ports {ddram_cs_n]
+set_property LOC U8 [get_ports ddram_cs_n]
 set_property SLEW FAST [get_ports ddram_cs_n]
 set_property IOSTANDARD SSTL135 [get_ports ddram_cs_n]
 # ## ddram:0.dm
-#set_property LOC L1 [get_ports {ddram_dm[0]} ]
+set_property LOC L1 [get_ports {ddram_dm[0]} ]
 set_property SLEW FAST [get_ports {ddram_dm[0]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dm[0]} ]
 # ## ddram:0.dm
-#set_property LOC U1 [get_ports {ddram_dm[1]} ]
+set_property LOC U1 [get_ports {ddram_dm[1]} ]
 set_property SLEW FAST [get_ports {ddram_dm[1]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dm[1]} ]
 # ## ddram:0.dq
-#set_property LOC K5 [get_ports {ddram_dq[0]} ]
+set_property LOC K5 [get_ports {ddram_dq[0]} ]
 set_property SLEW FAST [get_ports {ddram_dq[0]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[0]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[0]} ]
 # ## ddram:0.dq
-#set_property LOC L3 [get_ports {ddram_dq[1]} ]
+set_property LOC L3 [get_ports {ddram_dq[1]} ]
 set_property SLEW FAST [get_ports {ddram_dq[1]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[1]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[1]} ]
 # ## ddram:0.dq
-#set_property LOC K3 [get_ports {ddram_dq[2]} ]
+set_property LOC K3 [get_ports {ddram_dq[2]} ]
 set_property SLEW FAST [get_ports {ddram_dq[2]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[2]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[2]} ]
 # ## ddram:0.dq
-#set_property LOC L6 [get_ports {ddram_dq[3]} ]
+set_property LOC L6 [get_ports {ddram_dq[3]} ]
 set_property SLEW FAST [get_ports {ddram_dq[3]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[3]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[3]} ]
 # ## ddram:0.dq
-#set_property LOC M3 [get_ports {ddram_dq[4]} ]
+set_property LOC M3 [get_ports {ddram_dq[4]} ]
 set_property SLEW FAST [get_ports {ddram_dq[4]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[4]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[4]} ]
 # ## ddram:0.dq
-#set_property LOC M1 [get_ports {ddram_dq[5]} ]
+set_property LOC M1 [get_ports {ddram_dq[5]} ]
 set_property SLEW FAST [get_ports {ddram_dq[5]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[5]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[5]} ]
 # ## ddram:0.dq
-#set_property LOC L4 [get_ports {ddram_dq[6]} ]
+set_property LOC L4 [get_ports {ddram_dq[6]} ]
 set_property SLEW FAST [get_ports {ddram_dq[6]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[6]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[6]} ]
 # ## ddram:0.dq
-#set_property LOC M2 [get_ports {ddram_dq[7]} ]
+set_property LOC M2 [get_ports {ddram_dq[7]} ]
 set_property SLEW FAST [get_ports {ddram_dq[7]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[7]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[7]} ]
 # ## ddram:0.dq
-#set_property LOC V4 [get_ports {ddram_dq[8]} ]
+set_property LOC V4 [get_ports {ddram_dq[8]} ]
 set_property SLEW FAST [get_ports {ddram_dq[8]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[8]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[8]} ]
 # ## ddram:0.dq
-#set_property LOC T5 [get_ports {ddram_dq[9]} ]
+set_property LOC T5 [get_ports {ddram_dq[9]} ]
 set_property SLEW FAST [get_ports {ddram_dq[9]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[9]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[9]} ]
 # ## ddram:0.dq
-#set_property LOC U4 [get_ports {ddram_dq[10]} ]
+set_property LOC U4 [get_ports {ddram_dq[10]} ]
 set_property SLEW FAST [get_ports {ddram_dq[10]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[10]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[10]} ]
 # ## ddram:0.dq
-#set_property LOC V5 [get_ports {ddram_dq[11]} ]
+set_property LOC V5 [get_ports {ddram_dq[11]} ]
 set_property SLEW FAST [get_ports {ddram_dq[11]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[11]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[11]} ]
 # ## ddram:0.dq
-#set_property LOC V1 [get_ports {ddram_dq[12]} ]
+set_property LOC V1 [get_ports {ddram_dq[12]} ]
 set_property SLEW FAST [get_ports {ddram_dq[12]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[12]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[12]} ]
 # ## ddram:0.dq
-#set_property LOC T3 [get_ports {ddram_dq[13]} ]
+set_property LOC T3 [get_ports {ddram_dq[13]} ]
 set_property SLEW FAST [get_ports {ddram_dq[13]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[13]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[13]} ]
 # ## ddram:0.dq
-#set_property LOC U3 [get_ports {ddram_dq[14]} ]
+set_property LOC U3 [get_ports {ddram_dq[14]} ]
 set_property SLEW FAST [get_ports {ddram_dq[14]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[14]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[14]} ]
 # ## ddram:0.dq
-#set_property LOC R3 [get_ports {ddram_dq[15]} ]
+set_property LOC R3 [get_ports {ddram_dq[15]} ]
 set_property SLEW FAST [get_ports {ddram_dq[15]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_dq[15]} ]
 set_property IN_TERM UNTUNED_SPLIT_40 [get_ports {ddram_dq[15]} ]
 # ## ddram:0.dqs_p
-#set_property LOC N2 [get_ports {ddram_dqs_p[0]} ]
+set_property LOC N2 [get_ports {ddram_dqs_p[0]} ]
 set_property SLEW FAST [get_ports {ddram_dqs_p[0]} ]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_p[0]} ]
 # ## ddram:0.dqs_p
-#set_property LOC U2 [get_ports {ddram_dqs_p[1]} ]
+set_property LOC U2 [get_ports {ddram_dqs_p[1]} ]
 set_property SLEW FAST [get_ports {ddram_dqs_p[1]} ]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_p[1]} ]
 # ## ddram:0.dqs_n
-#set_property LOC N1 [get_ports {ddram_dqs_n[0]} ]
+set_property LOC N1 [get_ports {ddram_dqs_n[0]} ]
 set_property SLEW FAST [get_ports {ddram_dqs_n[0]} ]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_n[0]} ]
 # ## ddram:0.dqs_n
-#set_property LOC V2 [get_ports {ddram_dqs_n[1]} ]
+set_property LOC V2 [get_ports {ddram_dqs_n[1]} ]
 set_property SLEW FAST [get_ports {ddram_dqs_n[1]} ]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports {ddram_dqs_n[1]} ]
 # ## ddram:0.clk_p
-#set_property LOC U9 [get_ports ddram_clk_p]
+set_property LOC U9 [get_ports ddram_clk_p]
 set_property SLEW FAST [get_ports ddram_clk_p]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports ddram_clk_p]
 # ## ddram:0.clk_n
-#set_property LOC V9 [get_ports ddram_clk_n]
+set_property LOC V9 [get_ports ddram_clk_n]
 set_property SLEW FAST [get_ports ddram_clk_n]
 set_property IOSTANDARD DIFF_SSTL135 [get_ports ddram_clk_n]
 # ## ddram:0.cke
-#set_property LOC N5 [get_ports ddram_cke]
+set_property LOC N5 [get_ports ddram_cke]
 set_property SLEW FAST [get_ports ddram_cke]
 set_property IOSTANDARD SSTL135 [get_ports ddram_cke]
 # ## ddram:0.odt
-#set_property LOC R5 [get_ports ddram_odt]
+set_property LOC R5 [get_ports ddram_odt]
 set_property SLEW FAST [get_ports ddram_odt]
 set_property IOSTANDARD SSTL135 [get_ports ddram_odt]
 # ## ddram:0.reset_n
-#set_property LOC K6 [get_ports ddram_reset_n]
+set_property LOC K6 [get_ports ddram_reset_n]
 set_property SLEW FAST [get_ports ddram_reset_n]
 set_property IOSTANDARD SSTL135 [get_ports ddram_reset_n]
 


### PR DESCRIPTION
This PR adds support for the LOC properties read from XDC (addresses issue #1471). 
The enhanced XDC Yosys plugin processes the LOC property settings from the XDC file (look [PR](https://github.com/SymbiFlow/yosys-symbiflow-plugins/pull/16)). 
The IO constraints land in the eblif in form of LOC parameters for each IOBUF subckt.
The IoPlace class got enhanced to parse the settings and populate a net_to_pads set which made the pcf parser redundant.
The CI will fail until the new XDC plugin is in place. 
 
minilitex_ddr_arty test has been modified to take the LOC settings from XDC instead of PCF.