### PR TITLE
Fix clock placement in devices with limited grid

### DIFF
--- a/xc/common/cmake/device_define.cmake
+++ b/xc/common/cmake/device_define.cmake
@@ -137,6 +137,14 @@ function(ADD_XC_BOARD)
       )
   endif()
 
+  get_target_property(GRAPH_LIMIT ${DEVICE_TYPE} GRAPH_LIMIT)
+  if(NOT "${GRAPH_LIMIT}" STREQUAL "GRAPH_LIMIT-NOTFOUND")
+    set_property(
+      TARGET ${BOARD}
+      APPEND_STRING PROPERTY PLACE_CONSTR_TOOL_EXTRA_ARGS "--graph_limit ${GRAPH_LIMIT}"
+    )
+  endif()
+
   add_file_target(FILE ${PINMAP_CSV} GENERATED)
 
   set_target_properties(

--- a/xc/xc7/archs/artix7/devices/xc7a50t-bottom-virt/CMakeLists.txt
+++ b/xc/xc7/archs/artix7/devices/xc7a50t-bottom-virt/CMakeLists.txt
@@ -28,5 +28,5 @@ add_xc_device_define_type(
     BUFGCTRL
     PLLE2_ADV
     HCLK_IOI3
-  GRAPH_LIMIT 0,103,114,155
+  GRAPH_LIMIT 0,105,114,155
 )


### PR DESCRIPTION
This commit adds the ability to verify if the clock location is available in the FPGA grid before placement. It uses architecture XML for the verification.

Resolves https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1517
