### PR TITLE
Filter NULL tiles in synth tile map to vpr coord

### DIFF
--- a/xc/common/utils/prjxray_create_synth_tiles.py
+++ b/xc/common/utils/prjxray_create_synth_tiles.py
@@ -16,11 +16,14 @@ def map_tile_to_vpr_coord(conn, tile):
     c.execute("SELECT pkey FROM phy_tile WHERE name = ?;", (tile, ))
     phy_tile_pkey = c.fetchone()[0]
 
+    c.execute("SELECT pkey FROM tile_type WHERE name = 'NULL'")
+    null_tile_type_pkey, = c.fetchone()
+
     # It is expected that this tile has only one logical location,
     # because why split a tile with no sites?
     c.execute(
-        "SELECT tile_pkey FROM tile_map WHERE phy_tile_pkey = ?",
-        (phy_tile_pkey, )
+        "SELECT tile_pkey FROM tile_map WHERE phy_tile_pkey = ? AND tile_type_pkey != ?",
+        (phy_tile_pkey, null_tile_type_pkey)
     )
     mapped_tiles = c.fetchall()
     assert len(mapped_tiles) == 1, tile

--- a/xc/common/utils/prjxray_create_synth_tiles.py
+++ b/xc/common/utils/prjxray_create_synth_tiles.py
@@ -23,8 +23,9 @@ def map_tile_to_vpr_coord(conn, tile):
     # because why split a tile with no sites?
     c.execute(
         """
-SELECT tile_pkey FROM tile_map INNER JOIN phy_tile ON tile_map.phy_tile_pkey = phy_tile.pkey
-WHERE phy_tile_pkey = ? AND tile_type_pkey != ?
+SELECT tile_map.tile_pkey FROM tile_map INNER JOIN phy_tile
+ON tile_map.phy_tile_pkey = phy_tile.pkey
+WHERE tile_map.phy_tile_pkey = ? AND phy_tile.tile_type_pkey != ?
         """, (phy_tile_pkey, null_tile_type_pkey)
     )
     mapped_tiles = c.fetchall()

--- a/xc/common/utils/prjxray_create_synth_tiles.py
+++ b/xc/common/utils/prjxray_create_synth_tiles.py
@@ -22,8 +22,10 @@ def map_tile_to_vpr_coord(conn, tile):
     # It is expected that this tile has only one logical location,
     # because why split a tile with no sites?
     c.execute(
-        "SELECT tile_pkey FROM tile_map WHERE phy_tile_pkey = ? AND tile_type_pkey != ?",
-        (phy_tile_pkey, null_tile_type_pkey)
+        """
+SELECT tile_pkey FROM tile_map INNER JOIN phy_tile ON tile_map.phy_tile_pkey = phy_tile.pkey
+WHERE phy_tile_pkey = ? AND tile_type_pkey != ?
+        """, (phy_tile_pkey, null_tile_type_pkey)
     )
     mapped_tiles = c.fetchall()
     assert len(mapped_tiles) == 1, tile

--- a/xc/common/utils/prjxray_create_synth_tiles.py
+++ b/xc/common/utils/prjxray_create_synth_tiles.py
@@ -23,10 +23,11 @@ def map_tile_to_vpr_coord(conn, tile):
     # because why split a tile with no sites?
     c.execute(
         """
-SELECT tile_map.tile_pkey FROM tile_map INNER JOIN phy_tile
-ON tile_map.phy_tile_pkey = phy_tile.pkey
-WHERE tile_map.phy_tile_pkey = ? AND phy_tile.tile_type_pkey != ?
-        """, (phy_tile_pkey, null_tile_type_pkey)
+SELECT tile_map.tile_pkey FROM tile_map INNER JOIN tile
+ON tile_map.tile_pkey = tile.pkey INNER JOIN tile_type
+ON tile.tile_type_pkey = tile_type.pkey
+WHERE tile_map.phy_tile_pkey = ? AND tile_type.name != 'NULL'
+    """, (phy_tile_pkey, )
     )
     mapped_tiles = c.fetchall()
     assert len(mapped_tiles) == 1, tile


### PR DESCRIPTION
Signed-off-by: Andrew Butt <andrewb1999@gmail.com>

Filters NULL tile types when mapping synth tiles to vpr coordinates.  Fixes #1538 