### PR TITLE
README.md: Update reference to xc7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repo contains documentation of various FPGA architectures, it is currently
 concentrating on;
 
  * [Lattice iCE40](ice40)
- * [Xilinx Series 7 (Artix 7 and Zynq 7)](xc7)
+ * [Xilinx Series 7 (Artix 7 and Zynq 7)](xc/xc7)
 
 The aim is to include useful documentation (both human and machine readable) on
 the primitives and routing infrastructure for these architectures. We hope this


### PR DESCRIPTION
The documentation of the "Xilinx Series 7" was relocated in commit:
a1ab7beb03c8f7ef6756b94fddc4e0d947832a67

Adjust the reference accordingly.

Signed-off-by: Marcello Sylvester Bauer <sylv@sylv.io>