### PR TITLE
Use make-env to setup conda instead of CMake invoking conda

### DIFF
--- a/.github/kokoro/docs.sh
+++ b/.github/kokoro/docs.sh
@@ -13,6 +13,7 @@ echo "========================================"
 echo "Doing document generation"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	cd build
 	make -j ${CORES} --output-sync=target \
 		docs

--- a/.github/kokoro/ice40.sh
+++ b/.github/kokoro/ice40.sh
@@ -10,6 +10,7 @@ echo "========================================"
 echo "Running ice40 tests (make all_ice40)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
 	export MAKE_ARGS="-j${MAX_CORES} --output-sync=target"

--- a/.github/kokoro/install.sh
+++ b/.github/kokoro/install.sh
@@ -13,6 +13,7 @@ echo "========================================"
 echo "Running install tests (make install)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	pushd build
 	export VPR_NUM_WORKERS=${CORES}
 	ninja -j${MAX_CORES} install
@@ -36,7 +37,7 @@ echo "========================================"
 echo "Running installed toolchain tests"
 echo "----------------------------------------"
 (
-
+	source env/conda/bin/activate symbiflow_arch_def_base
 	pushd build
 	export VPR_NUM_WORKERS=${CORES}
 	export CTEST_OUTPUT_ON_FAILURE=1

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -79,6 +79,8 @@ echo "----------------------------------------"
 	echo
 	echo " Configuring CMake"
 	echo "----------------------------------------"
+	git submodule init
+	git submodule update --init --recursive
 	make env
 	source env/conda/bin/activate symbiflow_arch_def_base
 	echo "----------------------------------------"

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -80,17 +80,12 @@ echo "----------------------------------------"
 	echo " Configuring CMake"
 	echo "----------------------------------------"
 	make env
-	cd build
+	source env/conda/bin/activate symbiflow_arch_def_base
 	echo "----------------------------------------"
-
-	echo
-	echo " Setting up basic conda environment"
-	echo "----------------------------------------"
-	${BUILD_TOOL} all_conda
 
 	echo
 	echo " Output information about conda environment"
 	echo "----------------------------------------"
-	env/conda/bin/conda info
-	env/conda/bin/conda config --show
+	conda info
+	conda config --show
 )

--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -79,8 +79,6 @@ echo "----------------------------------------"
 	echo
 	echo " Configuring CMake"
 	echo "----------------------------------------"
-	git submodule init
-	git submodule update --init --recursive
 	make env
 	source env/conda/bin/activate symbiflow_arch_def_base
 	echo "----------------------------------------"

--- a/.github/kokoro/testarch.sh
+++ b/.github/kokoro/testarch.sh
@@ -10,6 +10,7 @@ echo "========================================"
 echo "Running testarch tests (make all_testarch)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
 	export MAKE_ARGS="-j${MAX_CORES} --output-sync=target"

--- a/.github/kokoro/xc7-vendor.sh
+++ b/.github/kokoro/xc7-vendor.sh
@@ -23,6 +23,7 @@ echo "========================================"
 echo "Running xc7 vendor tests (make all_xc7_diff_fasm)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
 	# Running with -k0 to attempt all tests, and show which ones failed.

--- a/.github/kokoro/xc7.sh
+++ b/.github/kokoro/xc7.sh
@@ -12,6 +12,7 @@ echo "========================================"
 echo "Running xc7 tests (make all_xc7)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	pushd build
 	export VPR_NUM_WORKERS=${CORES}
 	ninja -j${MAX_CORES} all_xc7

--- a/.github/kokoro/xc7a200t-vendor.sh
+++ b/.github/kokoro/xc7a200t-vendor.sh
@@ -23,6 +23,7 @@ echo "========================================"
 echo "Running artix7_200t_vendor tests (make all_artix7_200t_diff_fasm)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
 	# Running with -k0 to attempt all tests, and show which ones failed.

--- a/.github/kokoro/xc7a200t.sh
+++ b/.github/kokoro/xc7a200t.sh
@@ -12,6 +12,7 @@ echo "========================================"
 echo "Running xc7 tests (make all_xc7_200t)"
 echo "----------------------------------------"
 (
+	source env/conda/bin/activate symbiflow_arch_def_base
 	cd build
 	export VPR_NUM_WORKERS=${CORES}
 	ninja -j${MAX_CORES} all_xc7_200t

--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -6,6 +6,8 @@ set -e
 $SPACER
 
 start_section "symbiflow.configure_cmake" "Configuring CMake (make env)"
+git submodule init
+git submodule update --init --recursive
 make env
 source env/conda/bin/activate symbiflow_arch_def_base
 cd build

--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -6,8 +6,6 @@ set -e
 $SPACER
 
 start_section "symbiflow.configure_cmake" "Configuring CMake (make env)"
-git submodule init
-git submodule update --init --recursive
 make env
 source env/conda/bin/activate symbiflow_arch_def_base
 cd build

--- a/.github/travis/script.sh
+++ b/.github/travis/script.sh
@@ -7,22 +7,19 @@ $SPACER
 
 start_section "symbiflow.configure_cmake" "Configuring CMake (make env)"
 make env
+source env/conda/bin/activate symbiflow_arch_def_base
 cd build
 end_section "symbiflow.configure_cmake"
 
 $SPACER
 
-make_target all_conda "Setting up basic ${YELLOW}conda environment${NC}"
-
-$SPACER
-
 # Output some useful info
 start_section "info.conda.env" "Info on ${YELLOW}conda environment${NC}"
-env/conda/bin/conda info
+conda info
 end_section "info.conda.env"
 
 start_section "info.conda.config" "Info on ${YELLOW}conda config${NC}"
-env/conda/bin/conda config --show
+conda config --show
 end_section "info.conda.config"
 
 $SPACER

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+env/
+
 # Python files
 __pycache__/
 *.py[cod]

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "python-symbiflow-v2x"]
 	path = third_party/python-symbiflow-v2x
 	url = https://github.com/SymbiFlow/python-symbiflow-v2x.git
+[submodule "third_party/make-env"]
+	path = third_party/make-env
+	url = https://github.com/SymbiFlow/make-env.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,9 @@ add_custom_target(clean_locks)
 add_custom_target(all_xc7_tests)
 add_custom_target(all_ice40_tests)
 
-set(ENV_DIR ${symbiflow-arch-defs_SOURCE_DIR}/env/conda/envs/symbiflow_arch_def_base CACHE PATH "Path to environment")
-set(YOSYS_DATADIR ${ENV_DIR}share/yosys CACHE PATH "Path to yosys data directory")
-set(VPR_CAPNP_SCHEMA_DIR ${ENV_DIR}capnp CACHE PATH "Path to VPR schema directory")
+set(ENV_DIR ${symbiflow-arch-defs_SOURCE_DIR}/env/conda/envs/symbiflow_arch_def_base/ CACHE PATH "Path to environment")
+set(YOSYS_DATADIR ${ENV_DIR}/share/yosys CACHE PATH "Path to yosys data directory")
+set(VPR_CAPNP_SCHEMA_DIR ${ENV_DIR}/capnp CACHE PATH "Path to VPR schema directory")
 
 setup_env()
 add_env_executable(EXE yosys REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,7 @@ include(common/cmake/tools.cmake)
 
 find_package(PythonInterp 3 REQUIRED)
 
-add_custom_target(
-   test_python
-   DEPENDS
-      conda_pytest all_pip
-   )
+add_custom_target(test_python)
 
 # Some commands use file locks to prevent incorrect parallel access.
 # All file locks are required to register a clean command with the clean_locks
@@ -29,158 +25,26 @@ add_custom_target(clean_locks)
 add_custom_target(all_xc7_tests)
 add_custom_target(all_ice40_tests)
 
-setup_env(
-    MINICONDA3_VERSION py37_4.8.2
-    )
-add_conda_package(
-  NAME yosys
-  PROVIDES yosys
-  PACKAGE_SPEC "yosys 0.8_3923_g8fe9c84e 20191206_160120"
-  )
-add_conda_package(
-  NAME openocd
-  PROVIDES openocd
-  )
-
-add_conda_package(
-  NAME vtr
-  PROVIDES vpr genfasm
-  PACKAGE_SPEC "vtr 8.0.0.rc2_4003_g8980e4621 20200527_075234"
-  )
-add_conda_package(
-  NAME libxslt
-  PROVIDES xsltproc
-  )
-add_conda_package(
-  NAME libxml2
-  PROVIDES xmllint
-  PACKAGE_SPEC "libxml2 2.9.9 h14c3975_5"
-  )
-add_conda_package(
-  NAME pytest
-  PROVIDES pytest
-  )
-add_conda_package(
-  NAME flake8
-  PROVIDES flake8
-  )
-add_conda_package(
-  NAME yapf
-  PROVIDES yapf
-  PACKAGE_SPEC "yapf 0.26.0 py_0"
-  )
-add_conda_package(
-  NAME nodejs
-  PROVIDES node npm
-  )
-add_conda_package(
-  NAME iverilog
-  PROVIDES iverilog vvp
-  )
-add_conda_package(
-  NAME yosys-plugins
-  PACKAGE_SPEC "yosys-plugins 1.0.0.7_0025_ge04ea5b 20200308_024213"
-  NO_EXE
-  )
-
-add_conda_package(
-  NAME libiconv
-  NO_EXE
-)
-add_conda_pip(
-  NAME progressbar2
-  NO_EXE
-)
-add_conda_pip(
-  NAME pycapnp
-  PACKAGE_SPEC "1.0.0b1"
-  NO_EXE
-)
-add_conda_pip(
-  NAME simplejson
-  NO_EXE
-)
-add_conda_pip(
-  NAME intervaltree
-  NO_EXE
-)
-add_conda_pip(
-  NAME pdfminer.six
-  NO_EXE
-)
-add_conda_pip(
-  NAME pyjson5
-  NO_EXE
-)
-add_conda_pip(
-  NAME ply
-  NO_EXE
-)
-add_conda_pip(
-  NAME svgwrite
-  NO_EXE
-)
-add_conda_pip(
-  NAME cairosvg
-  NO_EXE
-)
-add_conda_pip(
-  NAME gitpython
-  NO_EXE
-)
-add_conda_pip(
-  NAME hilbertcurve
-  NO_EXE
-)
-add_conda_pip(
-  NAME scipy
-  NO_EXE
-)
-add_conda_pip(
-  NAME matplotlib
-  NO_EXE
-)
-add_conda_pip(
-  NAME python-constraint
-  NO_EXE
-)
-
-add_conda_pip(
-  NAME numpy
-  NO_EXE
-)
+setup_env()
+add_env_executable(EXE yosys REQUIRED)
+add_env_executable(EXE vpr REQUIRED)
+add_env_executable(EXE genfasm REQUIRED)
+add_env_executable(EXE node REQUIRED)
+add_env_executable(EXE npm REQUIRED)
+add_env_executable(EXE pytest REQUIRED)
+add_env_executable(EXE xmllint REQUIRED)
+add_env_executable(EXE openocd REQUIRED)
+add_env_executable(EXE yapf REQUIRED)
+add_env_executable(EXE icebox.py REQUIRED)
+add_env_executable(EXE icebox_hlc2asc REQUIRED)
+add_env_executable(EXE icebox_vlog REQUIRED)
+add_env_executable(EXE icepack REQUIRED)
+add_env_executable(EXE icetime REQUIRED)
+add_env_executable(EXE tinyfpgab REQUIRED)
+add_env_executable(EXE tinyprog REQUIRED)
+add_env_executable(EXE flake8 REQUIRED)
 
 get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-get_target_property(LIBICONV_TARGET env LIBICONV_TARGET)
-
-add_thirdparty_package(
-  NAME sdf_timing
-  BUILD_INSTALL_COMMAND "cd ${symbiflow-arch-defs_SOURCE_DIR}/third_party/python-sdf-timing && ${PYTHON3} setup.py develop"
-  NO_EXE
-  DEPENDS ${PYTHON3_TARGET}
-)
-
-# FIXME: This is a workaround until fix for dependencies of arch.xml patching script(s) is in place
-if(${USE_CONDA})
-  get_target_property(SDF_TIMING_TARGET env SDF_TIMING_TARGET)
-  add_dependencies(all_conda ${SDF_TIMING_TARGET})
-endif()
-
-add_thirdparty_package(
-  NAME vtr_xml_utils
-  BUILD_INSTALL_COMMAND "cd ${symbiflow-arch-defs_SOURCE_DIR}/third_party/vtr-xml-utils && ${PYTHON3} setup.py develop"
-  PROVIDES vtr_xml_utils
-  DEPENDS ${PYTHON3} ${PYTHON3_TARGET}
-  NO_EXE
-)
-
-add_thirdparty_package(
-  NAME v2x
-  BUILD_INSTALL_COMMAND "cd ${symbiflow-arch-defs_SOURCE_DIR}/third_party/python-symbiflow-v2x && ${PYTHON3} setup.py develop"
-  NO_EXE
-  DEPENDS ${PYTHON3_TARGET} ${LIBICONV_TARGET}
-)
 
 include(common/cmake/image_gen.cmake)
 include(common/cmake/gen.cmake)
@@ -218,23 +82,18 @@ add_subdirectory(testarch)
 add_subdirectory(tests)
 
 get_target_property_required(YAPF env YAPF)
-get_target_property_required(YAPF_TARGET env YAPF_TARGET)
 add_custom_target(
   check_python
-  DEPENDS ${YAPF_TARGET}
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -c -y ${YAPF}
   )
 add_custom_target(
   format_python
-  DEPENDS ${YAPF_TARGET}
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -f -y ${YAPF}
   )
 
 get_target_property_required(FLAKE8 env FLAKE8)
-get_target_property_required(FLAKE8_TARGET env FLAKE8_TARGET)
 add_custom_target(
   lint_python
-  DEPENDS ${FLAKE8_TARGET}
   COMMAND ${symbiflow-arch-defs_SOURCE_DIR}/common/python_health_helper.sh -l -p "${FLAKE8}"
   )
 
@@ -353,5 +212,4 @@ add_custom_target(docs)
 
 add_custom_target(print_qor
     COMMAND ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/print_qor.py ${symbiflow-arch-defs_BINARY_DIR}
-    DEPENDS ${PYTHON3_TARGET}
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ add_custom_target(clean_locks)
 add_custom_target(all_xc7_tests)
 add_custom_target(all_ice40_tests)
 
+set(ENV_DIR ${symbiflow-arch-defs_SOURCE_DIR}/env/conda/envs/symbiflow_arch_def_base CACHE PATH "Path to environment")
+set(YOSYS_DATADIR ${ENV_DIR}share/yosys CACHE PATH "Path to yosys data directory")
+set(VPR_CAPNP_SCHEMA_DIR ${ENV_DIR}capnp CACHE PATH "Path to VPR schema directory")
+
 setup_env()
 add_env_executable(EXE yosys REQUIRED)
 add_env_executable(EXE vpr REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,8 @@ find_package(PythonInterp 3 REQUIRED)
 
 add_custom_target(test_python)
 
-# Some commands use file locks to prevent incorrect parallel access.
-# All file locks are required to register a clean command with the clean_locks
-# targets to prevent stale locks.
+# Dummy old targets, left in for backwards compability.
+add_custom_target(all_conda)
 add_custom_target(clean_locks)
 
 # Add dummy targets for attaching test targets too.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ add_env_executable(EXE icetime REQUIRED)
 add_env_executable(EXE tinyfpgab REQUIRED)
 add_env_executable(EXE tinyprog REQUIRED)
 add_env_executable(EXE flake8 REQUIRED)
+add_env_executable(EXE vvp REQUIRED)
+add_env_executable(EXE iverilog REQUIRED)
 
 get_target_property_required(PYTHON3 env PYTHON3)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
 # Makefile
+TOP_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+REQUIREMENTS_FILE := requirements.txt
+ENVIRONMENT_FILE := environment.yml
+
+include third_party/make-env/conda.mk
 
 ifeq ($(origin CMAKE_COMMAND),undefined)
 CMAKE_COMMAND := cmake
@@ -11,18 +16,18 @@ endif
 all: env
 	cd build && $(MAKE)
 
-clean:
+clean::
 	rm -rf build
 
-env:
+env:: | $(CONDA_ENV_PYTHON)
 	git submodule init
 	git submodule update --init --recursive
-	mkdir -p build && cd build && $(CMAKE_COMMAND) ${CMAKE_FLAGS} ..
+	@$(IN_CONDA_ENV) mkdir -p build && cd build && $(CMAKE_COMMAND) ${CMAKE_FLAGS} ..
 
 build/Makefile:
 	make env
 
 .PHONY: Makefile
 
-%: build/Makefile
-	cd build && $(MAKE) $@
+#%: build/Makefile
+#	@$(IN_CONDA_ENV) cd build && $(MAKE) $@

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ TOP_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 REQUIREMENTS_FILE := requirements.txt
 ENVIRONMENT_FILE := environment.yml
 
+third_party/make-env/conda.mk:
+	git submodule init
+	git submodule update --init --recursive
+
 include third_party/make-env/conda.mk
 
 ifeq ($(origin CMAKE_COMMAND),undefined)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ To initialize submodule and setup the CMake build system, from the root of the
 `symbiflow-arch-defs` directory run:
 
 ```
-git submodule init
-git submodule update --init --recursive
 make env
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,17 +27,9 @@ To initialize submodule and setup the CMake build system, from the root of the
 `symbiflow-arch-defs` directory run:
 
 ```
+git submodule init
+git submodule update --init --recursive
 make env
-```
-
-At this point a new directory `build` will have been created, which is where
-you can invoke make to build various targets.
-
-To initialize the conda environment that contains all the tools and libraries,
-from the root of the `symbiflow-arch-defs` directory run:
-
-```
-make all_conda
 ```
 
 To build all demo bitstreams there are 3 useful targets

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -386,7 +386,6 @@ function(DEFINE_DEVICE_TYPE)
     OUTPUT ${DEVICE_MERGED_FILE}
   )
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   append_file_dependency(SPECIALIZE_CARRYCHAINS_DEPS ${DEVICE_MERGED_FILE})
 
@@ -396,7 +395,7 @@ function(DEFINE_DEVICE_TYPE)
       COMMAND ${PYTHON3} ${SPECIALIZE_CARRYCHAINS}
       --input_arch_xml ${MERGE_XML_OUTPUT} > ${DEVICE_UNIQUE_PACK_FILE}
       DEPENDS
-        ${PYTHON3} ${PYTHON3_TARGET}
+        ${PYTHON3}
         ${SPECIALIZE_CARRYCHAINS}
         ${SPECIALIZE_CARRYCHAINS_DEPS}
   )
@@ -421,7 +420,7 @@ function(DEFINE_DEVICE_TYPE)
       separate_arguments(CMD_W_ARGS UNIX_COMMAND ${SCRIPT})
       list(GET CMD_W_ARGS 0 CMD)
       set(TEMP_TARGET arch.${OUTPUT_NAME}.xml)
-      set(DEFINE_DEVICE_DEPS ${PYTHON3} ${PYTHON3_TARGET} ${CMD} ${DEFINE_DEVICE_TYPE_SCRIPT_DEP_VAR})
+      set(DEFINE_DEVICE_DEPS ${PYTHON3} ${CMD} ${DEFINE_DEVICE_TYPE_SCRIPT_DEP_VAR})
       append_file_dependency(DEFINE_DEVICE_DEPS ${FINAL_OUTPUT})
 
       add_custom_command(
@@ -557,10 +556,8 @@ function(DEFINE_DEVICE)
   get_file_target(DEVICE_MERGED_FILE_TARGET ${VIRT_DEVICE_MERGED_FILE})
   get_file_location(DEVICE_MERGED_FILE ${VIRT_DEVICE_MERGED_FILE})
   get_target_property_required(VPR env VPR)
-  get_target_property(VPR_TARGET env VPR_TARGET)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
   get_target_property_required(RR_GRAPH_EXT ${DEFINE_DEVICE_ARCH} RR_GRAPH_EXT)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
 
   set(ROUTING_SCHEMA ${symbiflow-arch-defs_SOURCE_DIR}/common/xml/routing_resource.xsd)
 
@@ -595,8 +592,8 @@ function(DEFINE_DEVICE)
       DEPENDS
         ${WIRE_EBLIF}
         ${DEVICE_MERGED_FILE} ${DEVICE_MERGED_FILE_TARGET}
-        ${QUIET_CMD} ${QUIET_CMD_TARGET}
-        ${VPR} ${VPR_TARGET} ${DEFINE_DEVICE_DEVICE_TYPE}
+        ${QUIET_CMD}
+        ${VPR} ${DEFINE_DEVICE_DEVICE_TYPE}
       COMMAND
         ${QUIET_CMD} ${VPR} ${DEVICE_MERGED_FILE}
         --device ${DEVICE_FULL}
@@ -693,10 +690,10 @@ function(DEFINE_DEVICE)
       OUTPUT ${OUT_RRXML_REAL}.cache ${OUTPUTS}
       DEPENDS
           ${WIRE_EBLIF}
-          ${VPR} ${VPR_TARGET}
-          ${QUIET_CMD} ${QUIET_CMD_TARGET}
+          ${VPR}
+          ${QUIET_CMD}
           ${DEFINE_DEVICE_DEVICE_TYPE}
-          ${DEPS} ${PYTHON3} ${PYTHON3_TARGET}
+          ${DEPS} ${PYTHON3}
       COMMAND
           ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/check_cache.py ${OUT_RRXML_REAL} ${OUT_RRXML_REAL}.cache ${OUTPUTS} || (
           ${QUIET_CMD} ${VPR} ${DEVICE_MERGED_FILE}
@@ -1018,9 +1015,7 @@ function(ADD_FPGA_TARGET)
   get_target_property_required(DEVICE_TYPE ${DEVICE} DEVICE_TYPE)
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
   get_target_property_required(YOSYS_SYNTH_SCRIPT ${ARCH} YOSYS_SYNTH_SCRIPT)
   get_target_property_required(YOSYS_CONV_SCRIPT ${ARCH} YOSYS_CONV_SCRIPT)
 
@@ -1148,7 +1143,7 @@ function(ADD_FPGA_TARGET)
     add_custom_command(
       OUTPUT ${OUT_JSON_SYNTH} ${OUT_SYNTH_V} ${OUT_FASM_EXTRA}
       DEPENDS ${SOURCE_FILES} ${SOURCE_FILES_DEPS} ${INPUT_XDC_FILE} ${CELLS_SIM_DEPS}
-              ${YOSYS} ${YOSYS_TARGET} ${QUIET_CMD} ${QUIET_CMD_TARGET} ${YOSYS_IO_DEPS}
+              ${YOSYS} ${QUIET_CMD} ${YOSYS_IO_DEPS}
               ${YOSYS_SYNTH_SCRIPT}
       COMMAND
         ${CMAKE_COMMAND} -E make_directory ${OUT_LOCAL}
@@ -1177,7 +1172,7 @@ function(ADD_FPGA_TARGET)
 
     add_custom_command(
       OUTPUT ${OUT_JSON}
-      DEPENDS ${OUT_JSON_SYNTH} ${QUIET_CMD} ${QUIET_CMD_TARGET} ${SPLIT_INOUTS} ${PYTHON3} ${PYTHON3_TARGET} simplejson
+      DEPENDS ${OUT_JSON_SYNTH} ${QUIET_CMD} ${SPLIT_INOUTS} ${PYTHON3}
       COMMAND
         ${PYTHON3} ${SPLIT_INOUTS} -i ${OUT_JSON_SYNTH} -o ${OUT_JSON}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -1187,7 +1182,7 @@ function(ADD_FPGA_TARGET)
     add_custom_command(
       OUTPUT ${OUT_EBLIF}
       DEPENDS ${OUT_JSON}
-              ${YOSYS} ${YOSYS_TARGET} ${QUIET_CMD} ${QUIET_CMD_TARGET}
+              ${YOSYS} ${QUIET_CMD}
               ${YOSYS_CONV_SCRIPT}
       COMMAND
         ${CMAKE_COMMAND} -E env
@@ -1234,7 +1229,6 @@ function(ADD_FPGA_TARGET)
   endforeach()
 
   get_target_property_required(VPR env VPR)
-  get_target_property(VPR_TARGET env VPR_TARGET)
 
   get_target_property_required(ROUTE_CHAN_WIDTH ${ARCH} ROUTE_CHAN_WIDTH)
 
@@ -1304,7 +1298,7 @@ function(ADD_FPGA_TARGET)
     list(APPEND VPR_CMD --read_placement_delay_lookup ${PLACE_DELAY_LOCATION})
   endif()
 
-  list(APPEND VPR_DEPS ${VPR} ${VPR_TARGET} ${QUIET_CMD} ${QUIET_CMD_TARGET})
+  list(APPEND VPR_DEPS ${VPR} ${QUIET_CMD})
   append_file_dependency(VPR_DEPS ${OUT_EBLIF_REL})
 
   # Generate packing.
@@ -1330,7 +1324,7 @@ function(ADD_FPGA_TARGET)
           COMMAND ${PYTHON3} ${USAGE_UTIL}
             --assert_usage ${ADD_FPGA_TARGET_ASSERT_USAGE}
             ${OUT_LOCAL}/pack.log
-          DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ${USAGE_UTIL} ${OUT_LOCAL}/pack.log
+          DEPENDS ${PYTHON3} ${USAGE_UTIL} ${OUT_LOCAL}/pack.log
           )
   endif()
 
@@ -1489,7 +1483,6 @@ function(ADD_FPGA_TARGET)
 
   if(${USE_FASM})
     get_target_property_required(GENFASM env GENFASM)
-    get_target_property(GENFASM_TARGET env GENFASM_TARGET)
     set(
       GENFASM_CMD
       ${QUIET_CMD} ${GENFASM}
@@ -1503,7 +1496,6 @@ function(ADD_FPGA_TARGET)
     )
   else()
     get_target_property_required(GENHLC env GENHLC)
-    get_target_property(GENHLC_TARGET env GENHLC_TARGET)
     set(
       GENHLC_CMD
       ${QUIET_CMD} ${GENHLC}
@@ -1525,7 +1517,7 @@ function(ADD_FPGA_TARGET)
     set(OUT_FASM_GENFASM ${OUT_LOCAL}/${TOP}.genfasm.fasm)
     add_custom_command(
       OUTPUT ${OUT_FASM}
-      DEPENDS ${OUT_ROUTE} ${OUT_PLACE} ${VPR_DEPS} ${GENFASM_TARGET}
+      DEPENDS ${OUT_ROUTE} ${OUT_PLACE} ${VPR_DEPS}
       COMMAND ${GENFASM_CMD}
       COMMAND
         ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
@@ -1546,7 +1538,7 @@ function(ADD_FPGA_TARGET)
     set(OUT_HLC ${OUT_LOCAL}/${TOP}.hlc)
     add_custom_command(
       OUTPUT ${OUT_HLC}
-      DEPENDS ${OUT_ROUTE} ${OUT_PLACE} ${VPR_DEPS} ${GENHLC_TARGET}
+      DEPENDS ${OUT_ROUTE} ${OUT_PLACE} ${VPR_DEPS}
       COMMAND ${GENHLC_CMD}
       COMMAND
         ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
@@ -1885,9 +1877,7 @@ function(add_check_test)
   )
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
   set(EQUIV_CHECK_SCRIPT ${ADD_CHECK_TEST_EQUIV_CHECK_SCRIPT})
   if("${EQUIV_CHECK_SCRIPT}" STREQUAL "")
     message(FATAL_ERROR "EQUIV_CHECK_SCRIPT is not optional to add_check_test.")
@@ -1908,7 +1898,6 @@ function(add_check_test)
       ${EQUIV_CHECK_SCRIPT_TARGET}
       ${EQUIV_CHECK_SCRIPT_LOCATION}
       ${YOSYS}
-      ${YOSYS_TARGET}
     )
   add_test(
     NAME _test_${ADD_CHECK_TEST_NAME}_build
@@ -1932,11 +1921,10 @@ function(add_check_test)
     ${ADD_CHECK_TEST_NAME}
     COMMAND ${QUIET_CMD} ${YOSYS} -p "${ADD_CHECK_TEST_READ_GOLD} $<SEMICOLON> ${ADD_CHECK_TEST_READ_GATE} $<SEMICOLON> script ${EQUIV_CHECK_SCRIPT_LOCATION}" ${PATH_TO_CELLS_SIM}
     DEPENDS
-      ${QUIET_CMD} ${QUIET_CMD_TARGET}
+      ${QUIET_CMD}
       ${ADD_CHECK_TEST_DEPENDS} ${PATH_TO_CELLS_SIM}
       ${EQUIV_CHECK_SCRIPT_TARGET} ${EQUIV_CHECK_SCRIPT_LOCATION}
       ${YOSYS}
-      ${YOSYS_TARGET}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     VERBATIM
     )
@@ -1973,9 +1961,7 @@ function(add_testbench)
   )
 
   get_target_property(IVERILOG env IVERILOG)
-  get_target_property(IVERILOG_TARGET env IVERILOG_TARGET)
   get_target_property(VVP env VVP)
-  get_target_property(VVP_TARGET env VVP_TARGET)
   set(SOURCE_LOCATIONS "")
   set(FILE_DEPENDS "")
   foreach(SRC ${ADD_TESTBENCH_SOURCES})
@@ -1994,7 +1980,7 @@ function(add_testbench)
       -DCLK_MHZ=0.001 -o ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.vpp
       ${PATH_TO_CELLS_SIM}
       ${SOURCE_LOCATIONS}
-      DEPENDS ${IVERILOG} ${IVERILOG_TARGET} ${FILE_DEPENDS}
+      DEPENDS ${IVERILOG} ${FILE_DEPENDS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     VERBATIM
     )
@@ -2005,13 +1991,13 @@ function(add_testbench)
   add_custom_target(
     ${NAME}
     COMMAND ${VVP} -v -N ${NAME}.vpp
-    DEPENDS ${VVP} ${VVP_TARGET} ${NAME}.vpp
+    DEPENDS ${VVP} ${NAME}.vpp
     )
 
   add_custom_command(
     OUTPUT ${NAME}.vcd
     COMMAND ${VVP} -v -N ${NAME}.vpp
-    DEPENDS ${VVP} ${VVP_TARGET} ${NAME}.vpp
+    DEPENDS ${VVP} ${NAME}.vpp
     )
   add_custom_target(
     ${NAME}_view
@@ -2051,11 +2037,8 @@ function(generate_pinmap)
   )
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
 
   set(BOARD ${GENERATE_PINMAP_BOARD})
   get_target_property_required(DEVICE ${BOARD} DEVICE)
@@ -2077,8 +2060,8 @@ function(generate_pinmap)
     OUTPUT ${GENERATE_PINMAP_NAME}.json
     COMMAND ${QUIET_CMD} ${YOSYS} -p "write_json ${CMAKE_CURRENT_BINARY_DIR}/${GENERATE_PINMAP_NAME}.json" ${SOURCE_FILES}
     DEPENDS
-      ${QUIET_CMD} ${QUIET_CMD_TARGET}
-      ${YOSYS} ${YOSYS_TARGET}
+      ${QUIET_CMD}
+      ${YOSYS}
       ${SOURCE_FILES} ${SOURCE_FILES_DEPS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     )
@@ -2090,7 +2073,7 @@ function(generate_pinmap)
       --pinmap_csv ${PINMAP}
       --module ${GENERATE_PINMAP_TOP} > ${CMAKE_CURRENT_BINARY_DIR}/${GENERATE_PINMAP_NAME}
     DEPENDS
-      ${PYTHON3_TARGET} ${PYTHON3}
+      ${PYTHON3}
       ${CREATE_PINMAP}
       ${PINMAP} ${PINMAP_TARGET}
       ${GENERATE_PINMAP_NAME}.json
@@ -2129,14 +2112,13 @@ function(add_autosim)
   endforeach()
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
 
   set(AUTOSIM_VCD ${ADD_AUTOSIM_NAME}.vcd)
   get_cells_sim_path(CELLS_SIM_LOCATION ${ADD_AUTOSIM_ARCH})
   add_custom_command(
     OUTPUT ${AUTOSIM_VCD}
     COMMAND ${YOSYS} -p "prep -top ${ADD_AUTOSIM_TOP}; $<SEMICOLON> sim -clock clk -n ${ADD_AUTOSIM_CYCLES} -vcd ${AUTOSIM_VCD} -zinit ${ADD_AUTOSIM_TOP}" ${SOURCE_FILES} ${CELLS_SIM_LOCATION}
-    DEPENDS ${YOSYS} ${YOSYS_TARGET} ${SOURCE_FILES_DEPS} ${CELLS_SIM_LOCATION}
+    DEPENDS ${YOSYS} ${SOURCE_FILES_DEPS} ${CELLS_SIM_LOCATION}
     VERBATIM
     )
 

--- a/common/cmake/env.cmake
+++ b/common/cmake/env.cmake
@@ -5,9 +5,6 @@ function(REPLACE_WITH_ENV_IF_SET var)
   endif()
 endfunction()
 
-set(USE_CONDA TRUE
-  CACHE BOOL "Whether to create a conda enviroment for tools.")
-
 function(SETUP_ENV)
   # Creates a target "env" that has the properties that are all paths to
   # executables.  See OTHER_BINARIES and MAYBE_CONDA_BINARIES for list of
@@ -28,7 +25,7 @@ function(SETUP_ENV)
   # FIXME: Consider using CMake CACHE variables instead of target properties.
 
   set(options)
-  set(oneValueArgs MINICONDA3_VERSION)
+  set(oneValueArgs)
   set(multiValueArgs)
   cmake_parse_arguments(
       SETUP_ENV
@@ -39,107 +36,25 @@ function(SETUP_ENV)
   )
 
   add_custom_target(env)
-  set(ENV_DIR ${symbiflow-arch-defs_BINARY_DIR}/env)
-  set(REL_ENV_DIR env)
-  add_custom_target(clean_env
-    COMMAND ${CMAKE_COMMAND} -E remove_directory ${ENV_DIR}
-    )
-  add_custom_target(clean_pip)
-  add_custom_target(all_conda)
-  add_custom_target(all_pip)
-
   set(
     MAYBE_CONDA_BINARIES
     python3
-    pip
   )
 
-  if(${USE_CONDA})
-    set_target_properties(env PROPERTIES USE_CONDA TRUE)
+  set_target_properties(env PROPERTIES USE_CONDA FALSE)
+  foreach(binary ${MAYBE_CONDA_BINARIES})
+    string(TOUPPER ${binary} binary_upper)
+    if(DEFINED ENV{${binary_upper}})
+      set(${binary_upper} $ENV{${binary_upper}})
+    else()
+      find_program(${binary_upper} ${binary})
+    endif()
 
-    set(MINICONDA_FILE Miniconda3-${SETUP_ENV_MINICONDA3_VERSION}-Linux-x86_64.sh)
-    set(MINICONDA_URL https://repo.continuum.io/miniconda/${MINICONDA_FILE})
-    find_program(WGET wget)
-    add_custom_command(
-      OUTPUT ${ENV_DIR}/${MINICONDA_FILE}
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${ENV_DIR}
-      COMMAND ${WGET} ${MINICONDA_URL} -O ${ENV_DIR}/${MINICONDA_FILE}
-      COMMAND ${CMAKE_COMMAND} -E touch ${ENV_DIR}/${MINICONDA_FILE}
-      DEPENDS ${WGET})
-    set(CONDA_DIR ${ENV_DIR}/conda)
-    set_target_properties(env PROPERTIES CONDA_DIR ${CONDA_DIR})
-
-    set(CONDA_BIN ${CONDA_DIR}/bin/conda)
-    set_target_properties(env PROPERTIES CONDA_BIN ${CONDA_BIN})
-    set(OUTPUTS ${CONDA_BIN})
-    foreach(BINARY ${MAYBE_CONDA_BINARIES})
-      list(APPEND OUTPUTS ${CONDA_DIR}/bin/${BINARY})
-    endforeach()
-
-    add_file_target(FILE ${REL_ENV_DIR}/${MINICONDA_FILE} GENERATED)
-    set(DEPS "")
-    append_file_dependency(DEPS ${REL_ENV_DIR}/${MINICONDA_FILE})
-
-    add_custom_command(
-      OUTPUT ${OUTPUTS}
-      COMMAND sh ${ENV_DIR}/${MINICONDA_FILE} -p ${CONDA_DIR} -b -f
-      COMMAND ${CONDA_BIN} config --system --set always_yes yes
-      COMMAND ${CONDA_BIN} config --system --add envs_dirs ${CONDA_DIR}/envs
-      COMMAND ${CONDA_BIN} config --system --add pkgs_dirs ${CONDA_DIR}/pkgs
-      COMMAND ${CONDA_BIN} config --add channels m-labs
-      COMMAND ${CONDA_BIN} config --add channels conda-forge
-      COMMAND ${CONDA_BIN} config --add channels pkgw-forge
-      # Make sure symbiflow is highest priority channel
-      COMMAND ${CONDA_BIN} config --add channels symbiflow
-      COMMAND ${CONDA_BIN} install lxml
-      COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${CONDA_BIN}
-      DEPENDS ${DEPS}
-      )
-
-    add_file_target(FILE ${REL_ENV_DIR}/conda/bin/conda GENERATED)
-    append_file_dependency(DEPS ${REL_ENV_DIR}/conda/bin/conda)
-
-    add_custom_target(
-      conda DEPENDS ${DEPS}
-     )
-
-    foreach(binary ${MAYBE_CONDA_BINARIES})
-      string(TOUPPER ${binary} binary_upper)
-      set(${binary_upper} ${CONDA_DIR}/bin/${binary})
-      replace_with_env_if_set(${binary_upper})
-      set_target_properties(env PROPERTIES
-        ${binary_upper} ${${binary_upper}}
-        ${binary_upper}_TARGET conda
+    set_target_properties(env PROPERTIES
+      ${binary_upper} ${${binary_upper}}
+      ${binary_upper}_TARGET ${binary}
         )
-    endforeach()
-
-    get_target_property_required(PIP env PIP)
-    add_custom_target(clean_conda_locks
-        COMMAND ${CMAKE_COMMAND} -E remove -f ${CONDA_BIN}.lock
-        COMMAND ${CMAKE_COMMAND} -E remove -f ${PIP}.lock
-        )
-
-    add_dependencies(clean_locks clean_conda_locks)
-  else()
-    set_target_properties(env PROPERTIES USE_CONDA FALSE)
-    foreach(binary ${MAYBE_CONDA_BINARIES})
-      string(TOUPPER ${binary} binary_upper)
-      if(DEFINED ENV{${binary_upper}})
-        set(${binary_upper} $ENV{${binary_upper}})
-      else()
-        find_program(${binary_upper} ${binary})
-      endif()
-      # pip is not required for USE_CONDA=false
-      if(NOT ${binary_upper} AND (NOT ${binary} STREQUAL "pip"))
-        message(FATAL_ERROR "Could not find program ${binary}.")
-      endif()
-      add_custom_target(${binary})
-      set_target_properties(env PROPERTIES
-        ${binary_upper} ${${binary_upper}}
-        ${binary_upper}_TARGET ${binary}
-        )
-    endforeach()
-  endif()
+  endforeach()
 
   set(YOSYS_DATADIR ${ENV_DIR}/conda/share/yosys CACHE PATH "Path to yosys data directory")
   set(VPR_CAPNP_SCHEMA_DIR ${ENV_DIR}/conda/capnp CACHE PATH "Path to VPR schema directory")
@@ -150,313 +65,33 @@ function(SETUP_ENV)
     )
 endfunction()
 
-function(ADD_CONDA_PACKAGE)
-  # ~~~
-  # ADD_CONDA_PACKAGE(
-  #   NAME <name>
-  #   PROVIDES <exe list>
-  #   [PACKAGE_SPEC <package_spec>]
-  #   [NO_EXE]
-  #   )
-  # ~~~
-  #
-  # Installs a package via conda.  This generates two env properties per name
-  # in PROVIDES list. <name> is set to the path the executable.  <name>_TARGET
-  # is set to the target that will invoke conda.
-  #
-  # PACKAGE_SPEC can optionally be provided. This is useful to specify
-  # version and build for debugging. See conda documention for details:
-  # https://docs.conda.io/projects/conda-build/en/latest/source/package-spec.html#package-match-specifications
-  # Find specific versions and builds: conda search <package>
-  #
-  set(options NO_EXE)
-  set(oneValueArgs NAME PACKAGE_SPEC)
-  set(multiValueArgs PROVIDES)
-  cmake_parse_arguments(
-    ADD_CONDA_PACKAGE
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN}
-  )
-
-  get_target_property_required(USE_CONDA env USE_CONDA)
-
-  if(${USE_CONDA})
-    set(OUTPUTS "")
-    set(TOUCH_COMMANDS "")
-    get_target_property_required(CONDA_DIR env CONDA_DIR)
-    get_target_property_required(CONDA_BIN env CONDA_BIN)
-
-    if(${ADD_CONDA_PACKAGE_NO_EXE})
-      list(LENGTH "${ADD_CONDA_PACKAGE_PROVIDES}" PROVIDES_LENGTH)
-      if (NOT ${PROVIDES_LENGTH} EQUAL "0")
-        message(FATAL_ERROR "for NO_EXE ${ADD_CONDA_PACKAGE_NAME} do not set PROVIDE")
-      endif()
-      set(ADD_CONDA_PACKAGE_PROVIDES ${ADD_CONDA_PACKAGE_NAME})
-
-      list(APPEND OUTPUTS ${ADD_CONDA_PACKAGE_NAME}.conda)
-      list(APPEND TOUCH_COMMANDS COMMAND ${CMAKE_COMMAND} -E touch ${ADD_CONDA_PACKAGE_NAME}.conda)
-    else()
-      foreach(OUTPUT ${ADD_CONDA_PACKAGE_PROVIDES})
-        list(APPEND OUTPUTS ${CONDA_DIR}/bin/${OUTPUT})
-        list(APPEND TOUCH_COMMANDS COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${CONDA_DIR}/bin/${OUTPUT})
-      endforeach()
-    endif()
-
-    if(NOT ${ADD_CONDA_PACKAGE_PACKAGE_SPEC} STREQUAL "")
-      set(PACKAGE_SPEC ${ADD_CONDA_PACKAGE_PACKAGE_SPEC})
-    else()
-      set(PACKAGE_SPEC ${ADD_CONDA_PACKAGE_NAME})
-    endif()
-
-    add_custom_command(
-      OUTPUT ${OUTPUTS}
-      COMMAND ${CMAKE_COMMAND} -E echo "Taking ${CONDA_BIN}.lock"
-      COMMAND flock ${CONDA_BIN}.lock ${CONDA_BIN} install --force ${PACKAGE_SPEC}
-      ${TOUCH_COMMANDS}
-      DEPENDS conda ${CONDA_BIN}
-      )
-
-    set(TARGET conda_${ADD_CONDA_PACKAGE_NAME})
-    add_custom_target(${TARGET} DEPENDS ${OUTPUTS})
-    add_dependencies(all_conda ${TARGET})
-
-    foreach(OUTPUT ${ADD_CONDA_PACKAGE_PROVIDES})
-      string(TOUPPER ${OUTPUT} binary_upper)
-      set(${binary_upper} ${CONDA_DIR}/bin/${OUTPUT})
-      replace_with_env_if_set(${binary_upper})
-      set_target_properties(env PROPERTIES
-        ${binary_upper} ${${binary_upper}}
-        ${binary_upper}_TARGET ${TARGET})
-    endforeach()
-  else()
-    foreach(OUTPUT ${ADD_CONDA_PACKAGE_PROVIDES})
-      string(TOUPPER ${OUTPUT} binary_upper)
-      if(DEFINED ENV{${binary_upper}})
-        set(${binary_upper} $ENV{${binary_upper}})
-      else()
-        find_program(${binary_upper} ${OUTPUT})
-      endif()
-      if(NOT ${binary_upper})
-        message(FATAL_ERROR "Could not find program ${OUTPUT}.")
-      endif()
-      add_custom_target(${OUTPUT})
-      set_target_properties(env PROPERTIES
-        ${binary_upper} ${${binary_upper}}
-        ${binary_upper}_TARGET ${OUTPUT})
-    endforeach()
-  endif()
-endfunction()
-
-function(ADD_CONDA_PIP)
-  # ~~~
-  # ADD_CONDA_PIP(
-  #   NAME <name>
-  #   [PACKAGE_SPEC <package_spec>]
-  #   [NO_EXE]
-  #   )
-  # ~~~
-  #
-  # Installs an executable via conda PIP.  This generates two env properties.
-  # <name> is set to the path to the executable. <name>_TARGET is set to the
-  # target that will invoke pip if not already installed.
-  set(options NO_EXE)
-  set(oneValueArgs NAME PACKAGE_SPEC)
+function(ADD_ENV_EXECUTABLE)
+    set(options REQUIRED)
+  set(oneValueArgs EXE)
   set(multiValueArgs)
   cmake_parse_arguments(
-    ADD_CONDA_PIP
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN}
+      ADD_ENV_EXECUTABLE
+      "${options}"
+      "${oneValueArgs}"
+      "${multiValueArgs}"
+       ${ARGN}
   )
 
-  set(NAME ${ADD_CONDA_PIP_NAME})
-  if(NOT ${ADD_CONDA_PIP_PACKAGE_SPEC} STREQUAL "")
-    set(PACKAGE_SPEC "${ADD_CONDA_PIP_NAME}==${ADD_CONDA_PIP_PACKAGE_SPEC}")
+  set(binary ${ADD_ENV_EXECUTABLE_EXE})
+  string(TOUPPER ${binary} binary_upper)
+  if(DEFINED ENV{${binary_upper}})
+    set(${binary_upper} $ENV{${binary_upper}})
   else()
-    set(PACKAGE_SPEC ${ADD_CONDA_PIP_NAME})
+    find_program(${binary_upper} ${binary})
   endif()
 
-  get_target_property_required(USE_CONDA env USE_CONDA)
-  string(TOUPPER ${NAME} binary_upper)
-  if(${USE_CONDA})
-    get_target_property_required(CONDA_DIR env CONDA_DIR)
-    get_target_property_required(PIP env PIP)
-    get_target_property_required(PYTHON3 env PYTHON3)
-    get_target_property(PIP_TARGET env PIP_TARGET)
+  set_target_properties(env PROPERTIES
+    ${binary_upper} ${${binary_upper}}
+    )
 
-    if(ADD_CONDA_PIP_NO_EXE)
-      add_custom_command(
-        OUTPUT ${NAME}.pip
-        COMMAND ${CMAKE_COMMAND} -E echo "Taking ${PIP}.lock"
-        COMMAND flock ${PIP}.lock ${PYTHON3} -m pip install ${PACKAGE_SPEC}
-        COMMAND ${CMAKE_COMMAND} -E touch ${NAME}.pip
-        DEPENDS ${PYTHON3} ${PIP} ${PIP_TARGET}
-        )
-
-      add_custom_target(
-        ${NAME}
-        DEPENDS ${NAME}.pip
-        )
-      set_target_properties(env PROPERTIES ${binary_upper}_TARGET ${NAME})
-    else()
-      set(BIN ${CONDA_DIR}/bin/${NAME})
-      add_custom_command(
-        OUTPUT ${BIN}
-        COMMAND ${CMAKE_COMMAND} -E echo "Taking ${PIP}.lock"
-        COMMAND flock ${PIP}.lock ${PYTHON3} -m pip install ${PACKAGE_SPEC}
-        DEPENDS ${PYTHON3} ${PIP} ${PIP_TARGET}
-        )
-      add_custom_target(
-        ${NAME}
-        DEPENDS ${BIN}
-        )
-
-      set(${binary_upper} ${BIN})
-      replace_with_env_if_set(${binary_upper})
-      set_target_properties(env PROPERTIES ${binary_upper} ${BIN})
-      set_target_properties(env PROPERTIES ${binary_upper}_TARGET ${NAME})
-    endif()
-
-    add_dependencies(all_pip ${NAME})
-    add_dependencies(all_conda ${NAME})
-
-    add_custom_target(
-      _clean_pip_${NAME}
-      COMMAND ${PIP} uninstall -y ${NAME}
-      )
-    add_dependencies(clean_pip _clean_pip_${NAME})
-  else()
-    if(ADD_CONDA_PIP_NO_EXE)
-      add_custom_target(${NAME})
-      string(TOUPPER ${NAME} name_upper)
-      set_target_properties(env PROPERTIES ${name_upper}_TARGET ${NAME})
-    else()
-      if(DEFINED ENV{${binary_upper}})
-        set(${binary_upper} $ENV{${binary_upper}})
-      else()
-        find_program(${binary_upper} ${NAME})
-      endif()
-      if(NOT ${binary_upper})
-        message(FATAL_ERROR "Could not find program ${NAME}.")
-      endif()
-      set_target_properties(env PROPERTIES ${binary_upper} ${${binary_upper}})
-      set_target_properties(env PROPERTIES ${binary_upper}_TARGET "")
+  if(${ADD_ENV_EXECUTABLE_REQUIRED})
+    if(NOT EXISTS ${${binary_upper}})
+      message(FATAL_ERROR "Executable ${binary} not found and is marked required.  Either set env var ${binary_upper} or ensure ${binary} is on the path.")
     endif()
   endif()
 endfunction()
-
-
-
-function(ADD_THIRDPARTY_PACKAGE)
-  # ~~~
-  # ADD_THIRDPARTY_PACKAGE(
-  #   NAME <name>
-  #   [NO_EXE]
-  #   [PROVIDES <exe list>]
-  #   [FILES <file list>]
-  #   [BUILD_INSTALL_COMMAND <build_install command>]
-  #   [DEPENDS <dependencies>]
-  #   )
-  # ~~~
-  #
-  # Provide target and dependency for thirdparty software
-  # Package should be install in env directory.
-  # This generates two env properties per name
-  # in PROVIDES list. <name> is set to the path the executable.  <name>_TARGET
-  # is set to the target that will invoke conda.
-  #
-  # The FILES argument is for non-binary outputs of the add_thirdparty_package.
-  #
-  set(options NO_EXE)
-  set(oneValueArgs NAME BUILD_INSTALL_COMMAND)
-  set(multiValueArgs PROVIDES FILES DEPENDS)
-  cmake_parse_arguments(
-    ADD_THIRDPARTY_PACKAGE
-    "${options}"
-    "${oneValueArgs}"
-    "${multiValueArgs}"
-    ${ARGN}
-  )
-
-  set(NAME ${ADD_THIRDPARTY_PACKAGE_NAME})
-  get_target_property_required(USE_CONDA env USE_CONDA)
-
-  #if using conda and a command given, run it then look in conda
-  # otherwise just look for it. This is so python packages show up in site-packages
-  if( ${USE_CONDA})
-    if (NOT ADD_THIRDPARTY_PACKAGE_BUILD_INSTALL_COMMAND)
-      message(FATAL_ERROR "BUILD_INSTALL_COMMAND not supplied for thirdparty package ${NAME}")
-    endif()
-
-    set(INSTALL_COMMAND ${ADD_THIRDPARTY_PACKAGE_BUILD_INSTALL_COMMAND})
-
-    set(OUTPUTS "")
-    set(TOUCH_COMMANDS "")
-    get_target_property_required(PREFIX env CONDA_DIR)
-
-    if(${ADD_THIRDPARTY_PACKAGE_NO_EXE})
-      list(APPEND OUTPUTS ${PREFIX}/bin/${ADD_THIRDPARTY_PACKAGE_NAME}.install)
-      list(APPEND TOUCH_COMMANDS COMMAND ${CMAKE_COMMAND} -E touch ${PREFIX}/bin/${ADD_THIRDPARTY_PACKAGE_NAME}.install)
-    else()
-      foreach(OUTPUT ${ADD_THIRDPARTY_PACKAGE_PROVIDES})
-        list(APPEND OUTPUTS ${PREFIX}/bin/${OUTPUT})
-        list(APPEND TOUCH_COMMANDS COMMAND ${CMAKE_COMMAND} -E touch_nocreate ${PREFIX}/bin/${OUTPUT})
-      endforeach()
-      foreach(OUTPUT ${ADD_THIRDPARTY_PACKAGE_FILES})
-        list(APPEND OUTPUTS ${PREFIX}/${OUTPUT})
-      endforeach()
-    endif()
-
-    get_target_property_required(PIP env PIP)
-
-    add_custom_command(
-      OUTPUT ${OUTPUTS}
-      COMMAND ${CMAKE_COMMAND} -E echo "Taking ${PIP}.lock"
-      COMMAND flock ${PIP}.lock -c "${INSTALL_COMMAND}"
-      ${TOUCH_COMMANDS}
-      DEPENDS ${ADD_THIRDPARTY_PACKAGE_DEPENDS}
-      VERBATIM
-      )
-
-    add_custom_target(${NAME} DEPENDS ${OUTPUTS})
-    string(TOUPPER ${NAME} name_upper)
-    set_target_properties(env PROPERTIES ${name_upper}_TARGET ${NAME})
-
-    foreach(OUTPUT ${ADD_THIRDPARTY_PACKAGE_PROVIDES})
-      string(TOUPPER ${OUTPUT} binary_upper)
-      set(${binary_upper} ${PREFIX}/bin/${OUTPUT})
-      replace_with_env_if_set(${binary_upper})
-      set_target_properties(env PROPERTIES
-        ${binary_upper} ${${binary_upper}}
-        ${binary_upper}_TARGET ${NAME})
-    endforeach()
-  else()
-    add_custom_target(${NAME})
-    string(TOUPPER ${NAME} name_upper)
-    set_target_properties(env PROPERTIES ${name_upper}_TARGET ${NAME})
-    if(NOT ${ADD_THIRDPARTY_PACKAGE_NO_EXE})
-      # if command not provide, just look the provides
-      foreach(OUTPUT ${ADD_THIRDPARTY_PACKAGE_PROVIDES})
-        string(TOUPPER ${OUTPUT} binary_upper)
-        if(DEFINED ENV{${binary_upper}})
-          set(${binary_upper} $ENV{${binary_upper}})
-        else()
-          find_program(${binary_upper} ${OUTPUT})
-        endif()
-        if(NOT ${binary_upper})
-          message(FATAL_ERROR "Could not find program ${OUTPUT}.")
-        endif()
-        if(NOT TARGET ${OUTPUT})
-          add_custom_target(${OUTPUT})
-        endif()
-        set_target_properties(env PROPERTIES
-          ${binary_upper} ${${binary_upper}}
-          ${binary_upper}_TARGET ${OUTPUT})
-      endforeach()
-    endif()
-  endif()
-
-endfunction(ADD_THIRDPARTY_PACKAGE)

--- a/common/cmake/env.cmake
+++ b/common/cmake/env.cmake
@@ -56,9 +56,6 @@ function(SETUP_ENV)
         )
   endforeach()
 
-  set(YOSYS_DATADIR ${ENV_DIR}/conda/share/yosys CACHE PATH "Path to yosys data directory")
-  set(VPR_CAPNP_SCHEMA_DIR ${ENV_DIR}/conda/capnp CACHE PATH "Path to VPR schema directory")
-
   set_target_properties(env PROPERTIES
     QUIET_CMD ${symbiflow-arch-defs_SOURCE_DIR}/utils/quiet_cmd.sh
     QUIET_CMD_TARGET ""

--- a/common/cmake/gen.cmake
+++ b/common/cmake/gen.cmake
@@ -140,12 +140,11 @@ function(MUX_GEN)
   endif()
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   add_custom_command(
     OUTPUT ${OUTPUTS}
     DEPENDS
-      ${PYTHON3} ${PYTHON3_TARGET}
+      ${PYTHON3}
       ${symbiflow-arch-defs_SOURCE_DIR}/utils/mux_gen.py
       #${symbiflow-arch-defs_SOURCE_DIR}/vpr/muxes/logic/mux${MUX_GEN_WIDTH}/mux${MUX_GEN_WIDTH}.sim.v
     COMMAND ${PYTHON3} ${symbiflow-arch-defs_SOURCE_DIR}/utils/mux_gen.py ${MUX_GEN_ARGS}
@@ -243,7 +242,6 @@ function(N_TEMPLATE)
 
   set(OUTPUTS "")
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   foreach(PREFIX ${N_TEMPLATE_PREFIXES})
     foreach(SRC ${N_TEMPLATE_SRCS})
@@ -269,7 +267,7 @@ function(N_TEMPLATE)
       add_custom_command(
         OUTPUT ${SRC_WITH_PREFIX}
         DEPENDS
-          ${PYTHON3} ${PYTHON3_TARGET}
+          ${PYTHON3}
           ${symbiflow-arch-defs_SOURCE_DIR}/utils/n.py ${SRC_LOCATION}
           ${DEPS}
         COMMAND

--- a/common/cmake/image_gen.cmake
+++ b/common/cmake/image_gen.cmake
@@ -12,16 +12,14 @@ function(setup_netlistsvg)
   # Creates target netlistsvg that installs netlistsvg to the local node
   # environment.
   get_target_property_required(NODE env NODE)
-  get_target_property(NODE_TARGET env NODE_TARGET)
   get_target_property_required(NPM env NPM)
-  get_target_property(NPM_TARGET env NPM_TARGET)
   add_custom_command(
     OUTPUT ${NETLISTSVG_LOCK}
     COMMAND ${NODE} ${NPM} install
     WORKING_DIRECTORY ${NETLISTSVG}
     DEPENDS
-      ${NODE} ${NODE_TARGET}
-      ${NPM} ${NPM_TARGET}
+      ${NODE}
+      ${NPM}
       ${NETLISTSVG}/package.json
     )
 
@@ -145,13 +143,11 @@ function(add_verilog_image_gen)
   set(SVGS ${SRC_BB_YOSYS_SVG} ${SRC_FLAT_YOSYS_SVG})
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
   get_target_property_required(NODE env NODE)
-  get_target_property(NODE_TARGET env NODE_TARGET)
   add_custom_command(
     OUTPUT ${SRC_BB_JSON}
     COMMAND ${YOSYS} -p "prep -top ${SIM_TOP} $<SEMICOLON> write_json ${SRC_BB_JSON}" ${SRC_LOCATION}
-    DEPENDS ${DEPS} ${YOSYS} ${YOSYS_TARGET}
+    DEPENDS ${DEPS} ${YOSYS}
     WORKING_DIRECTORY ${SRC_DIR}
     VERBATIM
     )
@@ -159,7 +155,7 @@ function(add_verilog_image_gen)
   add_custom_command(
     OUTPUT ${SRC_BB_YOSYS_SVG}
     COMMAND ${YOSYS} -p "prep -top ${SIM_TOP} $<SEMICOLON> show -format svg -prefix ${SRC_BASE}.bb.yosys ${SIM_TOP}" ${SRC}
-    DEPENDS ${DEPS} ${YOSYS} ${YOSYS_TARGET}
+    DEPENDS ${DEPS} ${YOSYS}
     WORKING_DIRECTORY ${SRC_DIR}
     VERBATIM
     )
@@ -167,7 +163,7 @@ function(add_verilog_image_gen)
   add_custom_command(
     OUTPUT ${SRC_AIG_JSON}
     COMMAND ${YOSYS} -p "prep -top ${SIM_TOP} -flatten $<SEMICOLON> aigmap $<SEMICOLON> write_json ${SRC_AIG_JSON}" ${SRC}
-    DEPENDS ${DEPS} ${YOSYS} ${YOSYS_TARGET}
+    DEPENDS ${DEPS} ${YOSYS}
     WORKING_DIRECTORY ${SRC_DIR}
     VERBATIM
     )
@@ -175,7 +171,7 @@ function(add_verilog_image_gen)
   add_custom_command(
     OUTPUT ${SRC_FLAT_JSON}
     COMMAND ${YOSYS} -p "prep -top ${SIM_TOP} -flatten $<SEMICOLON> write_json ${SRC_FLAT_JSON}" ${SRC}
-    DEPENDS ${DEPS} ${YOSYS} ${YOSYS_TARGET}
+    DEPENDS ${DEPS} ${YOSYS}
     WORKING_DIRECTORY ${SRC_DIR}
     VERBATIM
     )
@@ -183,7 +179,7 @@ function(add_verilog_image_gen)
   add_custom_command(
     OUTPUT ${SRC_FLAT_YOSYS_SVG}
     COMMAND ${YOSYS} -p "prep -top ${SIM_TOP} -flatten $<SEMICOLON> show -format svg -prefix ${SRC_BASE}.flat.yosys ${SIM_TOP}" ${SRC}
-    DEPENDS ${DEPS} ${YOSYS} ${YOSYS_TARGET}
+    DEPENDS ${DEPS} ${YOSYS}
     WORKING_DIRECTORY ${SRC_DIR}
     VERBATIM
     )
@@ -196,7 +192,7 @@ function(add_verilog_image_gen)
     add_custom_command(
       OUTPUT ${SRC_SVG}
       COMMAND ${NODE} ${NETLISTSVG_BIN} ${SRC_JSON} -o ${SRC_SVG} --skin ${NETLISTSVG_SKIN}
-      DEPENDS ${NODE} ${NODE_TARGET} ${NETLISTSVG_BIN} ${NETLISTSVG_SKIN} netlistsvg ${SRC_JSON}
+      DEPENDS ${NODE} ${NETLISTSVG_BIN} ${NETLISTSVG_SKIN} netlistsvg ${SRC_JSON}
       )
   endforeach()
 

--- a/common/cmake/timings.cmake
+++ b/common/cmake/timings.cmake
@@ -17,14 +17,13 @@ function(UPDATE_ARCH_TIMINGS)
 
   if(IS_DIRECTORY ${SDF_TIMING_DIRECTORY} AND EXISTS ${BELS_MAP})
     get_target_property_required(PYTHON3 env PYTHON3)
-    get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
     set(update_arch_timings ${symbiflow-arch-defs_SOURCE_DIR}/utils/update_arch_timings.py)
 
     add_custom_command(
       OUTPUT ${output}
       DEPENDS
-        ${PYTHON3} ${PYTHON3_TARGET}
+        ${PYTHON3}
         ${update_arch_timings}
         ${input}
       COMMAND

--- a/common/cmake/v2x.cmake
+++ b/common/cmake/v2x.cmake
@@ -34,15 +34,10 @@ function(V2X)
   set(MODEL_INCLUDE_FILES "")
   set(PB_TYPE_INCLUDE_FILES "")
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-  list(APPEND DEPENDS_LIST ${PYTHON3} ${PYTHON3_TARGET})
+  list(APPEND DEPENDS_LIST ${PYTHON3})
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
-  list(APPEND DEPENDS_LIST ${YOSYS} ${YOSYS_TARGET})
-
-  get_target_property(V2X_TARGET env V2X_TARGET)
-  list(APPEND DEPENDS_LIST ${V2X_TARGET})
+  list(APPEND DEPENDS_LIST ${YOSYS})
 
   set(V2X_DIR ${symbiflow-arch-defs_SOURCE_DIR}/third_party/python-symbiflow-v2x)
 
@@ -156,10 +151,7 @@ function(VPR_TEST_PB_TYPE)
   )
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-
   get_target_property_required(XMLLINT env XMLLINT)
-  get_target_property(XMLLINT_TARGET env XMLLINT_TARGET)
 
   set(DEPENDS_ARCH "")
   append_file_dependency(DEPENDS_ARCH "${symbiflow-arch-defs_SOURCE_DIR}/utils/template.arch.xml")
@@ -168,8 +160,8 @@ function(VPR_TEST_PB_TYPE)
   add_custom_command(
     OUTPUT "${VPR_TEST_PB_TYPE_NAME}.arch.xml"
     DEPENDS
-      ${PYTHON3} ${PYTHON3_TARGET}
-      ${XMLLINT} ${XMLLINT_TARGET}
+      ${PYTHON3}
+      ${XMLLINT}
       ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_pbtype_arch_wrapper.py
       ${DEPENDS_ARCH}
     COMMAND
@@ -191,11 +183,10 @@ function(VPR_TEST_PB_TYPE)
   set(YOSYS_OUTPUT_BLIF "${VPR_TEST_PB_TYPE_NAME}.test.eblif")
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
   add_custom_command(
     OUTPUT "${YOSYS_OUTPUT_BLIF}"
     DEPENDS
-      ${YOSYS} ${YOSYS_TARGET}
+      ${YOSYS}
       ${DEPENDS_EBLIF} ${TECHMAP_DEP}
     COMMAND
     ${YOSYS} -p "read_verilog ${PB_TYPE_VERILOG}\; hierarchy -top ${VPR_TEST_PB_TYPE_TOP_MODULE}\; techmap -map ${PB_TYPE_TECHMAP}\; flatten\; proc\; opt\; write_blif ${YOSYS_OUTPUT_BLIF}"
@@ -220,7 +211,7 @@ function(VPR_TEST_PB_TYPE)
   add_custom_command(
     OUTPUT "${ARCH_TILES_XML}"
     DEPENDS
-      ${PYTHON3} ${PYTHON3_TARGET}
+      ${PYTHON3}
       ${ARCH_MERGED_XML}
       ${update_arch_tiles_py}
     COMMAND
@@ -232,9 +223,7 @@ function(VPR_TEST_PB_TYPE)
   update_arch_timings(INPUT ${ARCH_TILES_XML} OUTPUT ${ARCH_TIMINGS_XML})
 
   get_target_property_required(VPR env VPR)
-  get_target_property(VPR_TARGET env VPR_TARGET)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
   set(OUT_LOCAL_REL test_${VPR_TEST_PB_TYPE_NAME})
   set(OUT_LOCAL ${CMAKE_CURRENT_BINARY_DIR}/${OUT_LOCAL_REL})
 
@@ -245,8 +234,8 @@ function(VPR_TEST_PB_TYPE)
     OUTPUT
       ${OUT_LOCAL_REL}/vpr.stdout
     DEPENDS
-      ${QUIET_CMD} ${QUIET_CMD_TARGET}
-      ${VPR} ${VPR_TARGET}
+      ${QUIET_CMD}
+      ${VPR}
       ${DEPENDS_TEST}
     COMMAND
       ${CMAKE_COMMAND} -E make_directory ${OUT_LOCAL}

--- a/common/cmake/xml.cmake
+++ b/common/cmake/xml.cmake
@@ -75,7 +75,7 @@ function(XML_CANONICALIZE_MERGE)
     OUTPUT ${XML_CANONICALIZE_MERGE_OUTPUT}
     DEPENDS
       ${DEPS}
-      ${PYTHON3} ${PYTHON3_TARGET}
+      ${PYTHON3}
     COMMAND
       PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/third_party/vtr-xml-utils/:${PYTHONPATH}
       ${PYTHON3} -m vtr_xml_utils

--- a/common/cmake/xml.cmake
+++ b/common/cmake/xml.cmake
@@ -18,13 +18,12 @@ function(XML_LINT)
     )
 
   get_target_property_required(XMLLINT env XMLLINT)
-  get_target_property(XMLLINT_TARGET env XMLLINT_TARGET)
 
   # For xmllint we use head to shortcircuit failure as it can take a
   # very long time to output all of the errors
   add_custom_command(
     OUTPUT ${XML_LINT_LINT_OUTPUT}
-    DEPENDS ${XML_LINT_FILE} ${XML_LINT_SCHEMA} ${XMLLINT} ${XMLLINT_TARGET}
+    DEPENDS ${XML_LINT_FILE} ${XML_LINT_SCHEMA} ${XMLLINT}
     COMMAND bash -c
     '${XMLLINT}
     --output ${XML_LINT_LINT_OUTPUT}

--- a/common/cmake/xml.cmake
+++ b/common/cmake/xml.cmake
@@ -69,8 +69,6 @@ function(XML_CANONICALIZE_MERGE)
     ${ARGN}
     )
 
-  get_target_property_required(VTR_XML_UTILS_TARGET env VTR_XML_UTILS_TARGET)
-
   set(DEPS "")
   append_file_dependency(DEPS ${XML_CANONICALIZE_MERGE_FILE})
 
@@ -78,7 +76,7 @@ function(XML_CANONICALIZE_MERGE)
     OUTPUT ${XML_CANONICALIZE_MERGE_OUTPUT}
     DEPENDS
       ${DEPS}
-      ${PYTHON3} ${VTR_XML_UTILS_TARGET} ${PYTHON3_TARGET}
+      ${PYTHON3} ${PYTHON3_TARGET}
     COMMAND
       PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/third_party/vtr-xml-utils/:${PYTHONPATH}
       ${PYTHON3} -m vtr_xml_utils

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,6 @@ dependencies:
   - symbiflow-yosys-plugins=1.0.0.7_0041_g1c495fd=20200627_023447
   - symbiflow-vtr=8.0.0.rc2_4003_g8980e4621=20200627_023447
   - cmake
-  - ninja
   - make
   - openocd
   - yapf=0.26.0=py37_0

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,6 @@ dependencies:
   - cmake
   - make
   - openocd
-  - yapf=0.26.0=py37_0
-  - pytest
   - flake8
   - nodejs
   - libiconv

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,20 @@
+name: symbiflow_arch_def_base
+channels:
+  - defaults
+  - symbiflow
+dependencies:
+  - symbiflow-yosys=0.8_3925_g6bccd35a=20200627_023447
+  - symbiflow-yosys-plugins=1.0.0.7_0041_g1c495fd=20200627_023447
+  - symbiflow-vtr=8.0.0.rc2_4003_g8980e4621=20200627_023447
+  - openocd
+  - yapf=0.26.0=py37_0
+  - pytest
+  - flake8
+  - nodejs
+  - libiconv
+  - iverilog
+  - libxml2=2.9.10=20200629_180127
+  - icestorm
+  - pip
+  - pip:
+    - -r file:requirements.txt

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,9 @@ dependencies:
   - symbiflow-yosys=0.8_3925_g6bccd35a=20200627_023447
   - symbiflow-yosys-plugins=1.0.0.7_0041_g1c495fd=20200627_023447
   - symbiflow-vtr=8.0.0.rc2_4003_g8980e4621=20200627_023447
+  - cmake
+  - ninja
+  - make
   - openocd
   - yapf=0.26.0=py37_0
   - pytest

--- a/ice40/boards.cmake
+++ b/ice40/boards.cmake
@@ -66,6 +66,8 @@ define_ice40_board(
   PACKAGE sg48
 )
 
+get_target_property_required(TINYFPGAB env TINYFPGAB)
+
 # TinyFPGA B2
 # iCE40-LP8K-CM81
 # ---------------------------------------------
@@ -73,7 +75,6 @@ define_ice40_board(
   BOARD tinyfpga-b2
   DEVICE lp8k
   PACKAGE cm81
-  PROG_TOOL ${TINYFPGAB_TARGET}
   PROG_CMD "${TINYFPGAB} --program \${OUT_BIN}"
 )
 
@@ -86,7 +87,6 @@ define_ice40_board(
   BOARD tinyfpga-bx
   DEVICE lp8k
   PACKAGE cm81
-  PROG_TOOL ${TINYPROG_TARGET}
   PROG_CMD "${TINYPROG} -p \${OUT_BIN}"
 )
 

--- a/ice40/boards.cmake
+++ b/ice40/boards.cmake
@@ -1,6 +1,3 @@
-get_target_property_required(ICEPROG env ICEPROG)
-get_target_property(ICEPROG_TARGET env ICEPROG_TARGET)
-
 function(define_ice40_board)
   set(options)
   set(oneValueArgs BOARD DEVICE PACKAGE PROG_TOOL PROG_CMD)
@@ -38,8 +35,6 @@ define_ice40_board(
   BOARD icestick
   DEVICE hx1k
   PACKAGE tq144
-  PROG_TOOL ${ICEPROG_TARGET}
-  PROG_CMD "${ICEPROG} \${OUT_BIN}"
   )
 
 # Lattice iCEblink40-LP1K Evaluation Kit
@@ -49,8 +44,6 @@ define_ice40_board(
   BOARD iceblink40-lp1k
   DEVICE lp1k
   PACKAGE qn84
-  PROG_TOOL ${ICEPROG_TARGET}
-  PROG_CMD "${ICEPROG} -ew \${OUT_BIN}"
 )
 
 if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
@@ -62,8 +55,6 @@ define_ice40_board(
   BOARD hx8k-b-evn
   DEVICE hx8k
   PACKAGE ct256
-  PROG_TOOL ${ICEPROG_TARGET}
-  PROG_CMD "${ICEPROG} \${OUT_BIN}"
 )
 
 # DPControl icevision board
@@ -73,15 +64,7 @@ define_ice40_board(
   BOARD icevision
   DEVICE up5k
   PACKAGE sg48
-  PROG_TOOL ${ICEPROG_TARGET}
-  PROG_CMD "${ICEPROG} \${OUT_BIN}"
 )
-add_conda_pip(
-  NAME tinyfpgab
-  )
-
-get_target_property_required(TINYFPGAB env TINYFPGAB)
-get_target_property(TINYFPGAB_TARGET env TINYFPGAB_TARGET)
 
 # TinyFPGA B2
 # iCE40-LP8K-CM81
@@ -94,12 +77,7 @@ define_ice40_board(
   PROG_CMD "${TINYFPGAB} --program \${OUT_BIN}"
 )
 
-add_conda_pip(
-  NAME tinyprog
-  )
-
 get_target_property_required(TINYPROG env TINYPROG)
-get_target_property(TINYPROG_TARGET env TINYPROG_TARGET)
 
 # TinyFPGA BX
 # iCE40-LP8K-CM81

--- a/ice40/devices/layouts/icebox/CMakeLists.txt
+++ b/ice40/devices/layouts/icebox/CMakeLists.txt
@@ -43,16 +43,14 @@ function(generate_all_icebox_layouts)
   endforeach()
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
   add_custom_command(
     OUTPUT ${OUTPUTS}
     COMMAND ${QUIET_CMD} ${CMAKE_COMMAND} -E env PYTHONPATH=${ICEBOX_PATH}:${PYUTILS_PATH}
     ${PYTHON3} ${ICESTORM_LAYOUT_IMPORT}
     DEPENDS
-      ${QUIET_CMD} ${QUIET_CMD_TARGET}
-      ${PYTHON3} ${PYTHON3_TARGET}
+      ${QUIET_CMD}
+      ${PYTHON3}
       ${ICESTORM_LAYOUT_IMPORT} ${ICESTORM_LAYOUT_LIST} ${ICESTORM_DB}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )

--- a/ice40/devices/top-routing-virt/CMakeLists.txt
+++ b/ice40/devices/top-routing-virt/CMakeLists.txt
@@ -3,8 +3,6 @@ add_subdirectory(tiles)
 add_file_target(FILE arch.xml SCANNER_TYPE xml)
 
 get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property_required(PYTHON3_TARGET env PYTHON3_TARGET)
-get_target_property_required(ICESTORM_TARGET env ICESTORM_TARGET)
 
 set(ICEBOX_TIMING ${symbiflow-arch-defs_SOURCE_DIR}/third_party/icestorm/icefuzz/timings.py)
 set(CLEAN_ICEBOX_TIMING cleaned_timing.txt)
@@ -18,7 +16,7 @@ add_custom_command(
   COMMAND grep -v \\* ${TIMING_TXT_FILE} > ${CLEAN_ICEBOX_TIMING}
   COMMAND ${PYTHON3} ${ICEBOX_TIMING} -t ${CLEAN_ICEBOX_TIMING} -s > ${SDF_FILE}
   BYPRODUCTS ${CLEAN_ICEBOX_TIMING}
-  DEPENDS ${TIMING_TXT_FILE} ${ICESTORM_TARGET} ${ICEBOX_TIMING} ${PYTHON3} ${PYTHON3_TARGET}
+  DEPENDS ${TIMING_TXT_FILE} ${ICEBOX_TIMING} ${PYTHON3}
   )
 
 add_custom_target(

--- a/ice40/icestorm.cmake
+++ b/ice40/icestorm.cmake
@@ -7,7 +7,7 @@ function(icestorm_setup)
   set(FASM2ASC ${symbiflow-arch-defs_SOURCE_DIR}/ice40/utils/fasm_icebox/fasm2asc.py)
   add_custom_target(
     fasm2asc_deps
-    DEPENDS ${FASM2ASC_DEPS} ${FASM_TARGET} ${FASM2ASC} ${PYTHON3}
+    DEPENDS ${FASM2ASC_DEPS} ${FASM2ASC} ${PYTHON3}
     )
 
   add_custom_target(
@@ -24,11 +24,6 @@ function(icestorm_setup)
   get_target_property_required(ICEPACK env ICEPACK)
   get_target_property_required(ICETIME env ICETIME)
   get_target_property_required(ICEBOX_HLC2ASC env ICEBOX_HLC2ASC)
-
-  get_target_property(ICEBOX_VLOG_TARGET env ICEBOX_VLOG_TARGET)
-  get_target_property(ICEPACK_TARGET env ICEPACK_TARGET)
-  get_target_property(ICETIME_TARGET env ICETIME_TARGET)
-  get_target_property(ICEBOX_HLC2ASC_TARGET env ICEBOX_HLC2ASC_TARGET)
 
   get_filename_component(ICEBOX_PATH ${ICEBOX_VLOG} DIRECTORY)
   set(ICEBOX_SHARE ${ICEBOX_PATH}/../share/icebox CACHE PATH "")
@@ -64,12 +59,12 @@ function(icestorm_setup)
     --blif \${OUT_EBLIF} \
     --pcf \${INPUT_IO_FILE}"
     CELLS_SIM ${CELLS_SIM}
-    BIT_TO_V ${ICEBOX_VLOG_TARGET}
+    BIT_TO_V ${ICEBOX_VLOG}
     BIT_TO_V_CMD "${ICEBOX_VLOG} -D -c -n \${TOP} -p \${INPUT_IO_FILE} -d \${PACKAGE} \${OUT_BITSTREAM} > \${OUT_BIT_VERILOG}"
     BITSTREAM_EXTENSION asc
-    BIT_TO_BIN ${ICEPACK_TARGET}
+    BIT_TO_BIN ${ICEPACK}
     BIT_TO_BIN_CMD "${ICEPACK} \${OUT_BITSTREAM} > \${OUT_BIN}"
-    BIT_TIME ${ICETIME_TARGET}
+    BIT_TIME ${ICETIME}
     BIN_EXTENSION bin
     BIT_TIME_CMD "${ICETIME} -v -t -p \${INPUT_IO_FILE} -d \${DEVICE} \${OUT_BITSTREAM} -o \${OUT_TIME_VERILOG}"
     FASM_TO_BIT fasm2asc_deps

--- a/ice40/icestorm.cmake
+++ b/ice40/icestorm.cmake
@@ -1,65 +1,23 @@
 function(icestorm_setup)
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property_required(PYTHON3_TARGET env PYTHON3_TARGET)
 
   set(ICESTORM_SRC ${symbiflow-arch-defs_SOURCE_DIR}/third_party/icestorm CACHE PATH "Path to icestorm repository")
   set(PYUTILS_PATH ${symbiflow-arch-defs_SOURCE_DIR}/utils:${symbiflow-arch-defs_SOURCE_DIR}/ice40/utils/fasm_icebox)
 
-  if(${USE_CONDA})
-    get_target_property_required(PYTHON_PREFIX env CONDA_DIR)
-    set(ICESTORM_PREFIX "PREFIX=${PYTHON_PREFIX}")
-  else()
-    set(ICESTORM_PREFIX "" CACHE PATH "PYTHON_PREFIX for icestorm tools")
-  endif()
-
-  add_conda_package(
-    NAME pkg-config
-    PROVIDES pkg-config
-    )
-  add_conda_package(
-    NAME libftdi
-    NO_EXE
-    )
-  get_target_property(LIBFTDI_TARGET env LIBFTDI_TARGET)
-
-  add_thirdparty_package(
-    NAME fasm
-    BUILD_INSTALL_COMMAND "cd ${symbiflow-arch-defs_SOURCE_DIR}/third_party/fasm && ${PYTHON3} setup.py develop"
-    PROVIDES fasm
-    DEPENDS ${PYTHON3} ${PYTHON3_TARGET}
-    )
-
-  get_target_property_required(FASM_TARGET env FASM_TARGET)
-
-  get_target_property(NUMPY_TARGET env NUMPY_TARGET)
-  set(FASM2ASC_DEPS ${NUMPY_TARGET})
-
   set(FASM2ASC ${symbiflow-arch-defs_SOURCE_DIR}/ice40/utils/fasm_icebox/fasm2asc.py)
   add_custom_target(
     fasm2asc_deps
-    DEPENDS ${FASM2ASC_DEPS} ${FASM_TARGET} ${FASM2ASC} ${PYTHON3} ${PYTHON3_TARGET}
+    DEPENDS ${FASM2ASC_DEPS} ${FASM_TARGET} ${FASM2ASC} ${PYTHON3}
     )
 
-  get_target_property_required(SDF_TIMING_TARGET env SDF_TIMING_TARGET)
   add_custom_target(
     ice40_import_timing_deps
-    DEPENDS ${ICE40_IMPORT_TIMING} ${SDF_TIMING_TARGET} ${PYTHON3} ${PYTHON3_TARGET}
+    DEPENDS ${ICE40_IMPORT_TIMING} ${PYTHON3}
     )
 
   set_target_properties(
     ice40_import_timing_deps
     PROPERTIES ICE40_IMPORT_TIMING ${symbiflow-arch-defs_SOURCE_DIR}/ice40/utils/ice40_import_bel_timing.py
-    )
-
-  get_target_property_required(PKG-CONFIG env PKG-CONFIG)
-  get_target_property(PKG-CONFIG_TARGET env PKG-CONFIG_TARGET)
-
-  add_thirdparty_package(
-    NAME icestorm
-    PROVIDES iceprog icebox_hlc2asc icebox_vlog icepack icetime
-    FILES share/icebox/timings_hx1k.txt
-    BUILD_INSTALL_COMMAND "make -j1 -C ${ICESTORM_SRC} clean && make -j1 -C ${ICESTORM_SRC} ${ICESTORM_PREFIX} PKG_CONFIG=${PKG-CONFIG} install"
-    DEPENDS ${LIBFTDI_TARGET} ${PKG-CONFIG} ${PKG-CONFIG_TARGET}
     )
 
   get_target_property_required(ICEBOX_VLOG env ICEBOX_VLOG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,22 @@
-pip
-virtualenv
-lxml
-hdlparse
 progressbar2
+pycapnp==1.0.0b1
 simplejson
+intervaltree
+pdfminer.six
 pyjson5
+ply
 svgwrite
 cairosvg
 gitpython
-matplotlib
+hilbertcurve
 scipy
+matplotlib
+python-constraint
+numpy
+textx
+tinyfpgab
+tinyprog
+-e third_party/python-sdf-timing
+-e third_party/fasm
+-e third_party/vtr-xml-utils
+-e third_party/python-symbiflow-v2x

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,24 @@
-progressbar2
-pycapnp==1.0.0b1
-simplejson
-intervaltree
-pdfminer.six
-pyjson5
-ply
-svgwrite
 cairosvg
 gitpython
 hilbertcurve
-scipy
+intervaltree
 matplotlib
-python-constraint
 numpy
+pdfminer.six
+ply
+progressbar2
+pycapnp==1.0.0b1
+pyjson5
+pytest
+python-constraint
+scipy
+simplejson
+svgwrite
 textx
 tinyfpgab
 tinyprog
--e third_party/python-sdf-timing
+yapf==0.26.0
 -e third_party/fasm
--e third_party/vtr-xml-utils
+-e third_party/python-sdf-timing
 -e third_party/python-symbiflow-v2x
+-e third_party/vtr-xml-utils

--- a/testarch/devices/CMakeLists.txt
+++ b/testarch/devices/CMakeLists.txt
@@ -7,7 +7,6 @@ define_device(
   ARCH testarch
   DEVICE_TYPE clutff-unidir-s4
   PACKAGES dummy
-  RR_PATCH_DEPS intervaltree progressbar2
   CACHE_ARGS --route_chan_width 100
   )
 
@@ -16,6 +15,5 @@ define_device(
   ARCH testarch
   DEVICE_TYPE clutff-unidir-s4
   PACKAGES dummy
-  RR_PATCH_DEPS intervaltree progressbar2
   CACHE_ARGS --route_chan_width 100
   )

--- a/testarch/devices/clutff-unidir-s4/CMakeLists.txt
+++ b/testarch/devices/clutff-unidir-s4/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_file_target(FILE arch.xml SCANNER_TYPE xml)
 
 get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
 set(UPDATE_TILES "${symbiflow-arch-defs_SOURCE_DIR}/utils/update_arch_tiles.py")
 set(UPDATE_TILES_CMD "${PYTHON3} ${UPDATE_TILES} --in_xml /dev/stdin --out_xml /dev/stdout")

--- a/tests/7-carry_stress/CMakeLists.txt
+++ b/tests/7-carry_stress/CMakeLists.txt
@@ -1,13 +1,12 @@
 
 get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 foreach(CARRY_DEPTH 1 2 3 4 7 8 9 15 16 17 31 32)
     set(CARRY_TEST carry_test_${CARRY_DEPTH}_init0.v)
     add_custom_command(
         OUTPUT ${CARRY_TEST}
         COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate_carry_test.py --init 0 --carry_depth
             ${CARRY_DEPTH} > ${CARRY_TEST}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_carry_test.py ${PYTHON3} ${PYTHON3_TARGET}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/generate_carry_test.py ${PYTHON3}
         )
     add_file_target(
         FILE ${CARRY_TEST}
@@ -27,7 +26,7 @@ foreach(CARRY_DEPTH 1 2 3 4 7 8 9 15 16 17 31 32)
         OUTPUT ${CARRY_TEST}
         COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate_carry_test.py --init 1 --carry_depth
             ${CARRY_DEPTH} > ${CARRY_TEST}
-        DEPENDS generate_carry_test.py ${PYTHON3} ${PYTHON3_TARGET}
+        DEPENDS generate_carry_test.py ${PYTHON3}
         )
     add_file_target(
         FILE ${CARRY_TEST}
@@ -47,7 +46,7 @@ foreach(CARRY_DEPTH 1 2 3 4 7 8 9 15 16 17 31 32)
         OUTPUT ${CARRY_TEST}
         COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/generate_carry_test.py --init fabric --carry_depth
             ${CARRY_DEPTH} > ${CARRY_TEST}
-        DEPENDS generate_carry_test.py ${PYTHON3} ${PYTHON3_TARGET}
+        DEPENDS generate_carry_test.py ${PYTHON3}
         )
     add_file_target(
         FILE ${CARRY_TEST}

--- a/tests/9-scalable_proc/CMakeLists.txt
+++ b/tests/9-scalable_proc/CMakeLists.txt
@@ -5,7 +5,6 @@ add_file_target(FILE basys3.pcf)
 add_file_target(FILE basys3.sdc)
 
 get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
 # Generate ROM veilog modules with different styles of implementation
 set(ROM_FILE_BRAM rom_bram.v)
@@ -19,19 +18,19 @@ add_file_target(FILE ${ROM_FILE_DRAM} GENERATED)
 add_custom_command(
     OUTPUT ${ROM_FILE_BRAM}
     COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py --rom-style bram >${ROM_FILE_BRAM}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py ${PYTHON3} ${PYTHON3_TARGET}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py ${PYTHON3}
 )
 
 add_custom_command(
     OUTPUT ${ROM_FILE_BRAM36}
     COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py --rom-style bram36 >${ROM_FILE_BRAM36}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py ${PYTHON3} ${PYTHON3_TARGET}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py ${PYTHON3}
 )
 
 add_custom_command(
     OUTPUT ${ROM_FILE_DRAM}
     COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py --rom-style dram64 >${ROM_FILE_DRAM}
-    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py ${PYTHON3} ${PYTHON3_TARGET}
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/utils/rom_generator.py ${PYTHON3}
 )
 
 if (NOT DEFINED ENV{CI} OR NOT $ENV{CI})
@@ -73,7 +72,7 @@ function(SCALABLE_PROC)
       DEPENDS
         ${CMAKE_CURRENT_SOURCE_DIR}/parametrize.py
         ${CMAKE_CURRENT_SOURCE_DIR}/${SCALABLE_PROC_TOP_FILE}
-        ${PYTHON3} ${PYTHON3_TARGET}
+        ${PYTHON3}
       )
 
    add_file_target(

--- a/tests/9-soc/picosoc/CMakeLists.txt
+++ b/tests/9-soc/picosoc/CMakeLists.txt
@@ -25,7 +25,7 @@ foreach(HEX_FILE ${HEX_FILES})
     add_custom_command(
         OUTPUT ${HEX_TITLE}.v
         COMMAND ${PYTHON3} ${CMAKE_CURRENT_SOURCE_DIR}/hex2progmem.py ${CMAKE_CURRENT_SOURCE_DIR}/${HEX_FILE} --rom-style initial >${HEX_TITLE}.v
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hex2progmem.py ${PYTHON3} ${PYTHON3_TARGET}
+        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/hex2progmem.py ${PYTHON3}
     )
     add_file_target(FILE ${HEX_TITLE}.v GENERATED)
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,10 +1,7 @@
 get_target_property_required(PYTEST env PYTEST)
-get_target_property(SDF_TIMING_TARGET env SDF_TIMING_TARGET)
 
 add_custom_target(
   test_python_utils
-  DEPENDS
-    conda_pytest all_pip ${SDF_TIMING_TARGET}
   COMMAND ${PYTEST} --doctest-modules -vv
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/utils/lib/rr_graph/tracks.py
+++ b/utils/lib/rr_graph/tracks.py
@@ -46,8 +46,8 @@ def make_tracks(xs, ys, points, grid_width=None, grid_height=None):
      Track(direction='Y', x_low=3, x_high=3, y_low=1, y_high=5),
      Track(direction='X', x_low=1, x_high=3, y_low=2, y_high=2),
      Track(direction='X', x_low=1, x_high=3, y_low=4, y_high=4)]
-    >>> print(connections)
-    [(3, 0), (2, 0), (2, 1)]
+    >>> print(sorted(connections))
+    [(2, 0), (2, 1), (3, 0)]
 
     >>> pos = [
     ... (68,48), (69,48),

--- a/xc/common/cmake/device_define.cmake
+++ b/xc/common/cmake/device_define.cmake
@@ -79,7 +79,6 @@ function(ADD_XC_BOARD)
   ")
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property_required(PYTHON3_TARGET env PYTHON3_TARGET)
 
   if(${USE_ROI})
     get_target_property_required(ROI_DIR ${DEVICE_TYPE} ROI_DIR)
@@ -101,7 +100,7 @@ function(ADD_XC_BOARD)
     set(SYNTH_TILES_TO_PINMAP_CSV ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_synth_tiles_to_pinmap_csv.py)
     set(PINMAP_CSV ${BOARD}_synth_tiles_pinmap.csv)
 
-    set(PINMAP_CSV_DEPS ${PYTHON3} ${PYTHON3_TARGET} ${SYNTH_TILES_TO_PINMAP_CSV})
+    set(PINMAP_CSV_DEPS ${PYTHON3} ${SYNTH_TILES_TO_PINMAP_CSV})
     append_file_dependency(PINMAP_CSV_DEPS ${SYNTH_TILES})
     add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PINMAP_CSV}
@@ -125,7 +124,7 @@ function(ADD_XC_BOARD)
 
     set(CREATE_PINMAP_CSV ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_create_pinmap_csv.py)
     set(PINMAP_CSV ${BOARD}_pinmap.csv)
-    set(PINMAP_CSV_DEPS ${PYTHON3} ${PYTHON3_TARGET} ${CREATE_PINMAP_CSV})
+    set(PINMAP_CSV_DEPS ${PYTHON3} ${CREATE_PINMAP_CSV})
     append_file_dependency(PINMAP_CSV_DEPS ${CHANNELS_DB})
 
     add_custom_command(

--- a/xc/common/cmake/device_define.cmake
+++ b/xc/common/cmake/device_define.cmake
@@ -317,7 +317,6 @@ function(ADD_XC_DEVICE_DEFINE)
 
     # Clear variable before adding deps for next device
     set(DEVICE_RR_PATCH_DEPS "")
-    list(APPEND DEVICE_RR_PATCH_DEPS intervaltree textx)
     append_file_dependency(DEVICE_RR_PATCH_DEPS ${CHANNELS_DB})
 
     if(${USE_ROI})

--- a/xc/common/cmake/device_define.cmake
+++ b/xc/common/cmake/device_define.cmake
@@ -1,8 +1,3 @@
-add_conda_pip(
-  NAME textx
-  NO_EXE
-)
-
 function(ADD_XC_BOARD)
   # ~~~
   # ADD_XC_BOARD(

--- a/xc/common/cmake/install.cmake
+++ b/xc/common/cmake/install.cmake
@@ -12,9 +12,7 @@ function(DEFINE_XC_TOOLCHAIN_TARGET)
   )
 
   get_target_property_required(VPR env VPR)
-  get_target_property(VPR_TARGET env VPR_TARGET)
   get_target_property_required(GENFASM env GENFASM)
-  get_target_property(GENFASM_TARGET env GENFASM_TARGET)
 
   set(ARCH ${DEFINE_XC_TOOLCHAIN_TARGET_ARCH})
   set(VPR_ARCH_ARGS ${DEFINE_XC_TOOLCHAIN_TARGET_VPR_ARCH_ARGS})

--- a/xc/common/cmake/project_ray.cmake
+++ b/xc/common/cmake/project_ray.cmake
@@ -96,7 +96,7 @@ function(PROJECT_RAY_ARCH)
       DEPENDS
         ${CREATE_SYNTH_TILES}
         ${PROJECT_RAY_ARCH_USE_ROI} ${SYNTH_DEPS}
-        ${PYTHON3} simplejson intervaltree
+        ${PYTHON3}
         )
 
     add_file_target(FILE synth_tiles.json GENERATED)

--- a/xc/common/cmake/project_ray.cmake
+++ b/xc/common/cmake/project_ray.cmake
@@ -21,7 +21,6 @@ function(PROJECT_RAY_ARCH)
   )
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   set(ARCH ${PROJECT_RAY_ARCH_ARCH})
   get_target_property_required(PRJRAY_ARCH ${ARCH} PRJRAY_ARCH)
@@ -97,7 +96,7 @@ function(PROJECT_RAY_ARCH)
       DEPENDS
         ${CREATE_SYNTH_TILES}
         ${PROJECT_RAY_ARCH_USE_ROI} ${SYNTH_DEPS}
-        ${PYTHON3} ${PYTHON3_TARGET} simplejson intervaltree
+        ${PYTHON3} simplejson intervaltree
         )
 
     add_file_target(FILE synth_tiles.json GENERATED)
@@ -124,9 +123,6 @@ function(PROJECT_RAY_ARCH)
   list(APPEND CHANNELS_DEPS ${PRJRAY_DB_DIR}/${PRJRAY_ARCH}/${PART}/tilegrid.json)
   list(APPEND CHANNELS_DEPS ${PRJRAY_DB_DIR}/${PRJRAY_ARCH}/${PART}/tileconn.json)
 
-  get_target_property(NUMPY_TARGET env NUMPY_TARGET)
-  set(CREATE_EDGES_DEPS ${NUMPY_TARGET})
-
   add_custom_command(
     OUTPUT channels.db vpr_grid_map.csv
     COMMAND ${CMAKE_COMMAND} -E copy ${GENERIC_CHANNELS_LOCATION} ${CMAKE_CURRENT_BINARY_DIR}/channels.db
@@ -139,7 +135,7 @@ function(PROJECT_RAY_ARCH)
       --connection_database ${CMAKE_CURRENT_BINARY_DIR}/channels.db
       ${ROI_ARG_FOR_CREATE_EDGES}
     DEPENDS
-    ${PYTHON3} ${PYTHON3_TARGET} ${CREATE_EDGES} ${CREATE_EDGES_DEPS} ${CHANNELS_DEPS}
+    ${PYTHON3} ${CREATE_EDGES} ${CREATE_EDGES_DEPS} ${CHANNELS_DEPS}
     )
 
   add_file_target(FILE channels.db GENERATED)
@@ -173,7 +169,7 @@ function(PROJECT_RAY_ARCH)
     DEPENDS
     ${ARCH_IMPORT}
     ${DEPS}
-    ${PYTHON3} ${PYTHON3_TARGET} simplejson
+    ${PYTHON3}
     )
 
   add_file_target(FILE arch.xml GENERATED)
@@ -194,7 +190,6 @@ function(PROJECT_RAY_PREPARE_DATABASE)
   )
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   set(FAMILY ${PROJECT_RAY_PREPARE_DATABASE_PRJRAY_FAMILY})
   set(PRJRAY_ARCH ${PROJECT_RAY_PREPARE_DATABASE_PRJRAY_ARCH})
@@ -223,8 +218,8 @@ function(PROJECT_RAY_PREPARE_DATABASE)
       --grid_map_output ${CMAKE_CURRENT_BINARY_DIR}/${VPR_GRID_MAP}
       DEPENDS
       ${FORM_CHANNELS}
-      ${DEPS} ${DEPS2} ${DEPS3} simplejson progressbar2 intervaltree hilbertcurve
-      ${PYTHON3} ${PYTHON3_TARGET}
+      ${DEPS} ${DEPS2} ${DEPS3}
+      ${PYTHON3}
       )
 
     add_file_target(FILE ${CHANNELS} GENERATED)
@@ -252,7 +247,7 @@ function(PROJECT_RAY_PREPARE_DATABASE)
     DEPENDS
     ${ASSIGN_PINS}
     ${DEPS} ${DEPS2} ${DEPS3}
-    ${PYTHON3} ${PYTHON3_TARGET} simplejson progressbar2
+    ${PYTHON3}
     )
 
   add_file_target(FILE ${PIN_ASSIGNMENTS} GENERATED)
@@ -302,7 +297,6 @@ function(PROJECT_RAY_TILE)
   string(TOLOWER ${PROJECT_RAY_TILE_TILE} TILE)
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   set(ARCH ${PROJECT_RAY_TILE_ARCH})
   get_target_property_required(PRJRAY_ARCH ${ARCH} PRJRAY_ARCH)
@@ -382,7 +376,7 @@ function(PROJECT_RAY_TILE)
     DEPENDS
     ${TILE_IMPORT}
       ${DEPS}
-      ${PYTHON3} ${PYTHON3_TARGET} simplejson
+      ${PYTHON3}
     )
 
   add_file_target(FILE ${TILE}.pb_type.xml GENERATED)
@@ -426,7 +420,7 @@ function(PROJECT_RAY_TILE)
     DEPENDS
     ${PHYSICAL_TILE_IMPORT}
       ${TILES_DEPS}
-      ${PYTHON3} ${PYTHON3_TARGET} simplejson
+      ${PYTHON3}
     )
 
   add_file_target(FILE ${TILE}.tile.xml GENERATED)
@@ -524,7 +518,6 @@ function(PROJECT_RAY_EQUIV_TILE)
 
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   get_target_property(PROTOTYPE_PART ${ARCH} PROTOTYPE_PART)
   set(PB_TYPE_INCLUDE_FILES "")
@@ -583,7 +576,7 @@ function(PROJECT_RAY_EQUIV_TILE)
     DEPENDS
       ${TILE_IMPORT}
       ${DEPS}
-      ${PYTHON3} ${PYTHON3_TARGET} simplejson
+      ${PYTHON3}
     )
 
   set(TARGETS "")
@@ -651,7 +644,6 @@ function(PROJECT_RAY_TILE_CAPACITY)
   set(ARCH ${PROJECT_RAY_TILE_CAPACITY_ARCH})
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
   get_target_property_required(PRJRAY_ARCH ${ARCH} PRJRAY_ARCH)
   get_target_property_required(FAMILY ${ARCH} FAMILY)
   get_target_property_required(PROTOTYPE_PART ${ARCH} PROTOTYPE_PART)
@@ -684,7 +676,7 @@ function(PROJECT_RAY_TILE_CAPACITY)
     DEPENDS
       ${TILE_CAPACITY_IMPORT}
       ${DEPS}
-      ${PYTHON3} ${PYTHON3_TARGET} simplejson
+      ${PYTHON3}
     )
   add_file_target(FILE ${TILE_LOWER}.tile.xml GENERATED)
 endfunction()

--- a/xc/common/cmake/vivado.cmake
+++ b/xc/common/cmake/vivado.cmake
@@ -34,7 +34,6 @@ function(COMMON_VIVADO_TARGETS)
   )
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   set(NAME ${COMMON_VIVADO_TARGETS_NAME})
   set(WORK_DIR ${COMMON_VIVADO_TARGETS_WORK_DIR})
@@ -85,7 +84,6 @@ function(COMMON_VIVADO_TARGETS)
       )
 
   set(CLEAN_JSON5 ${symbiflow-arch-defs_SOURCE_DIR}/utils/clean_json5.py)
-  get_target_property(PYJSON5_TARGET env PYJSON5_TARGET)
   add_custom_command(
       OUTPUT ${WORK_DIR}/timing_${NAME}.json
       COMMAND ${PRJRAY_DIR}/utils/vivado.sh
@@ -103,7 +101,7 @@ function(COMMON_VIVADO_TARGETS)
       WORKING_DIRECTORY ${WORK_DIR}
       DEPENDS
         ${WORK_DIR}/design_${NAME}.dcp
-        ${PYTHON3} ${PYTHON3_TARGET} ${PYJSON5_TARGET}
+        ${PYTHON3}
       )
 
   add_custom_command(
@@ -118,7 +116,7 @@ function(COMMON_VIVADO_TARGETS)
           > ${CMAKE_CURRENT_BINARY_DIR}/${WORK_DIR}/design_${NAME}.bit.fasm
       WORKING_DIRECTORY ${WORK_DIR}
       DEPENDS
-        ${PYTHON3} ${PYTHON3_TARGET}
+        ${PYTHON3}
         ${WORK_DIR}/design_${NAME}.bit
       )
 
@@ -233,7 +231,6 @@ function(ADD_VIVADO_TARGET)
   endif()
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   set(CREATE_RUNME ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/vivado_create_runme.py)
   add_custom_command(
@@ -248,7 +245,7 @@ function(ADD_VIVADO_TARGET)
         ${CLOCK_ARGS}
         ${XDC_ARGS}
       DEPENDS
-        ${PYTHON3_TARGET} ${PYTHON3}
+        ${PYTHON3}
         ${CREATE_RUNME}
         )
 
@@ -260,7 +257,7 @@ function(ADD_VIVADO_TARGET)
         --output_tcl ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_sim.tcl
         ${CLOCK_ARGS}
       DEPENDS
-        ${PYTHON3_TARGET} ${PYTHON3}
+        ${PYTHON3}
         ${CREATE_SIM}
         )
 
@@ -340,13 +337,10 @@ function(ADD_VIVADO_PNR_TARGET)
   get_target_property_required(PART ${BOARD} PART)
 
   get_target_property_required(YOSYS env YOSYS)
-  get_target_property(YOSYS_TARGET env YOSYS_TARGET)
 
   get_target_property_required(QUIET_CMD env QUIET_CMD)
-  get_target_property(QUIET_CMD_TARGET env QUIET_CMD_TARGET)
 
   get_target_property_required(PYTHON3 env PYTHON3)
-  get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
   get_target_property_required(FAMILY ${ARCH} FAMILY)
   get_target_property_required(DOC_PRJ ${ARCH} DOC_PRJ)
@@ -372,8 +366,8 @@ function(ADD_VIVADO_PNR_TARGET)
         -b verilog -o ${SYNTH_OUT}
         -p "techmap -map ${UNMAP_V}"
         ${SYNTH_V_LOC}.premap.v
-      DEPENDS ${YOSYS_TARGET} ${YOSYS}
-        ${QUIET_CMD} ${QUIET_CMD_TARGET}
+      DEPENDS ${YOSYS}
+        ${QUIET_CMD}
         ${SYNTH_DEPS} ${SYNTH_V_LOC}.premap.v ${UNMAP_V}
         )
 
@@ -410,7 +404,7 @@ function(ADD_VIVADO_PNR_TARGET)
             --pcf ${PCF_FILE}
             --xdc ${XDC_FILE}
             --iostandard ${ADD_VIVADO_PNR_TARGET_IOSTANDARD}
-          DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ${PCF_TO_XDC_TOOL} ${XDC_DEPS}
+          DEPENDS ${PYTHON3} ${PCF_TO_XDC_TOOL} ${XDC_DEPS}
           )
 
       add_file_target(FILE ${NAME}.xdc GENERATED)
@@ -435,7 +429,7 @@ function(ADD_VIVADO_PNR_TARGET)
         --clock_periods "${ADD_VIVADO_PNR_TARGET_CLOCK_PERIODS}"
         --output_tcl ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_runme.tcl
       DEPENDS
-        ${PYTHON3_TARGET} ${PYTHON3}
+        ${PYTHON3}
         ${CREATE_RUNME}
         )
 
@@ -448,7 +442,7 @@ function(ADD_VIVADO_PNR_TARGET)
         --clock_periods "${ADD_VIVADO_PNR_TARGET_CLOCK_PERIODS}"
         --output_tcl ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_sim.tcl
       DEPENDS
-        ${PYTHON3_TARGET} ${PYTHON3}
+        ${PYTHON3}
         ${CREATE_SIM}
         )
 

--- a/xc/xc7/CMakeLists.txt
+++ b/xc/xc7/CMakeLists.txt
@@ -5,11 +5,10 @@ set(PRJXRAY_DB_DIR
   ${symbiflow-arch-defs_SOURCE_DIR}/third_party/prjxray-db
   CACHE PATH "Path to prjxray database files")
 
-get_target_property_required(SDF_TIMING_TARGET env SDF_TIMING_TARGET)
 set(ARCH_IMPORT_TIMING ${symbiflow-arch-defs_SOURCE_DIR}/utils/update_arch_timings.py)
 add_custom_target(
 	arch_import_timing_deps
-  DEPENDS ${ARCH_IMPORT_TIMING} ${SDF_TIMING_TARGET}
+  DEPENDS ${ARCH_IMPORT_TIMING}
 )
 
 add_file_target(FILE "bels.json")

--- a/xc/xc7/boards.cmake
+++ b/xc/xc7/boards.cmake
@@ -1,11 +1,9 @@
 get_target_property_required(OPENOCD env OPENOCD)
-get_target_property_required(OPENOCD_TARGET env OPENOCD_TARGET)
 
 add_xc_board(
   BOARD basys3
   DEVICE xc7a50t-basys3
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a35tcpg236-1
 )
@@ -14,7 +12,6 @@ add_xc_board(
   BOARD basys3-full
   DEVICE xc7a50t
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a35tcpg236-1
 )
@@ -23,7 +20,6 @@ add_xc_board(
   BOARD basys3-bottom
   DEVICE xc7a50t-bottom
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a35tcpg236-1
 )
@@ -32,7 +28,6 @@ add_xc_board(
   BOARD arty-swbut
   DEVICE xc7a50t-arty-swbut
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a35tcsg324-1
 )
@@ -41,7 +36,6 @@ add_xc_board(
   BOARD arty-uart
   DEVICE xc7a50t-arty-uart
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a35tcsg324-1
 )
@@ -50,7 +44,6 @@ add_xc_board(
   BOARD arty-full
   DEVICE xc7a50t
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a35tcsg324-1
 )
@@ -59,7 +52,6 @@ add_xc_board(
   BOARD arty100t-full
   DEVICE xc7a100t
   PACKAGE test
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-basys3.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
   PART xc7a100tcsg324-1
 )
@@ -84,7 +76,6 @@ add_xc_board(
   DEVICE xc7a200t
   PACKAGE test
   PART xc7a200tsbg484-1
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f board/digilent_nexys_video.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
 )
 
@@ -107,7 +98,6 @@ add_xc_board(
   DEVICE xc7z020
   PACKAGE test
   PART xc7z020clg400-1
-  PROG_TOOL ${OPENOCD_TARGET}
   PROG_CMD "${OPENOCD} -f ${PRJXRAY_DIR}/utils/openocd/board-digilent-pynqz1.cfg -c \\\"init $<SEMICOLON> pld load 0 \${OUT_BIN} $<SEMICOLON> exit\\\""
 )
 

--- a/xc/xc7/tests/ddr/CMakeLists.txt
+++ b/xc/xc7/tests/ddr/CMakeLists.txt
@@ -7,9 +7,6 @@ add_file_target(FILE arty.xdc)
 add_file_target(FILE arty_clocks.xdc)
 add_file_target(FILE arty.sdc)
 
-get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-
 add_fpga_target(
   NAME ddr_uart_arty
   BOARD arty-full

--- a/xc/xc7/tests/ff_sr_ce/CMakeLists.txt
+++ b/xc/xc7/tests/ff_sr_ce/CMakeLists.txt
@@ -7,10 +7,7 @@ add_dependencies(all_xc7_tests all_ff_ce_sr_test)
 
 function(ff_ce_sr_test num_ff)
     get_target_property_required(PYTHON3 env PYTHON3)
-    get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-
     get_target_property_required(YOSYS env YOSYS)
-    get_target_property(YOSYS_TARGET env YOSYS_TARGET)
 
     set(SBY
         ${symbiflow-arch-defs_SOURCE_DIR}/third_party/symbiyosys/sbysrc/sby.py)
@@ -25,7 +22,7 @@ function(ff_ce_sr_test num_ff)
                 --params "'NUM_FF=${num_ff},FF_TYPE=\"${ff_type}\"'"
                 --output
                   ${CMAKE_CURRENT_BINARY_DIR}/ff_ce_sr_${num_ff}_${ff_type_lower}.v
-            DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ff_ce_sr.v generate.py
+            DEPENDS ${PYTHON3} ff_ce_sr.v generate.py
             )
         add_file_target(FILE ff_ce_sr_${num_ff}_${ff_type_lower}.v GENERATED)
 
@@ -38,7 +35,7 @@ function(ff_ce_sr_test num_ff)
                     --template ${CMAKE_CURRENT_SOURCE_DIR}/ff_ce_sr_testbench.v
                     --params "NUM_FF=${num_ff}"
                     --output ${CMAKE_CURRENT_BINARY_DIR}/ff_ce_sr_${num_ff}_tb.v
-                DEPENDS ${PYTHON3} ${PYTHON3_TARGET} ff_ce_sr_testbench.v generate.py
+                DEPENDS ${PYTHON3} ff_ce_sr_testbench.v generate.py
                 )
             add_file_target(FILE ff_ce_sr_${num_ff}_tb.v GENERATED)
             get_file_target(TB_SOURCE_TARGET ff_ce_sr_testbench.v)
@@ -81,7 +78,7 @@ function(ff_ce_sr_test num_ff)
                     ff_ce_sr_${num_ff}_${ff_type_lower}_proof.sby
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS
-                ${PYTHON3} ${PYTHON3_TARGET}
+                ${PYTHON3}
                 ${CMAKE_CURRENT_SOURCE_DIR}/create_sby.py
             )
 
@@ -95,8 +92,8 @@ function(ff_ce_sr_test num_ff)
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS
                 ff_ce_sr_${num_ff}_${ff_type_lower}_proof.sby
-                ${PYTHON3} ${PYTHON3_TARGET}
-                ${YOSYS} ${YOSYS_TARGET}
+                ${PYTHON3}
+                ${YOSYS}
                 ff_ce_sr_${num_ff}_${ff_type_lower}_bit_v
             )
 

--- a/xc/xc7/tests/install_test/CMakeLists.txt
+++ b/xc/xc7/tests/install_test/CMakeLists.txt
@@ -1,3 +1,12 @@
+set(INSTALLATION_DIR_BIN "${CMAKE_INSTALL_PREFIX}/bin")
+
 add_test(NAME binary_toolchain_test
-	COMMAND make
+	COMMAND ${CMAKE_COMMAND} -E env
+	PATH=${INSTALLATION_DIR_BIN}:$ENV{PATH}
+	${CMAKE_COMMAND} -E env
+	PYTHONPATH=${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm
+	XRAY_FASM2FRAMES=${PRJXRAY_DIR}/utils/fasm2frames.py
+	XRAY_TOOLS_DIR=${symbiflow-arch-defs_SOURCE_DIR}/build/third_party/prjxray/tools
+	XRAY_DATABASE_DIR=${PRJXRAY_DB_DIR}
+	make
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/xc/xc7/tests/install_test/CMakeLists.txt
+++ b/xc/xc7/tests/install_test/CMakeLists.txt
@@ -1,30 +1,3 @@
-if(${USE_CONDA})
-set(INSTALLATION_DIR_BIN "${CMAKE_INSTALL_PREFIX}/bin")
-get_target_property_required(CONDA_DIR env CONDA_DIR)
-
 add_test(NAME binary_toolchain_test
-	COMMAND ${CMAKE_COMMAND} -E env
-	PATH=${INSTALLATION_DIR_BIN}:${CONDA_DIR}/bin:$ENV{PATH}
-	${CMAKE_COMMAND} -E env
-	LD_LIBRARY_PATH=${CONDA_DIR}/lib:$ENV{LD_LIBRARY_PATH}
-	${CMAKE_COMMAND} -E env
-	PYTHONPATH=${CONDA_DIR}/lib/python3.7/site-packages:${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm
-	XRAY_FASM2FRAMES=${PRJXRAY_DIR}/utils/fasm2frames.py
-	XRAY_TOOLS_DIR=${symbiflow-arch-defs_SOURCE_DIR}/build/third_party/prjxray/tools
-	XRAY_DATABASE_DIR=${PRJXRAY_DB_DIR}
-	make
+	COMMAND make
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-else()
-add_test(NAME binary_toolchain_test
-	COMMAND ${CMAKE_COMMAND} -E env
-	PATH=${INSTALLATION_DIR_BIN}:$ENV{PATH}
-	${CMAKE_COMMAND} -E env
-	LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}
-	${CMAKE_COMMAND} -E env
-	PYTHONPATH=${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm
-	XRAY_FASM2FRAMES=${PRJXRAY_DIR}/utils/fasm2frames.py
-	XRAY_TOOLS_DIR=${symbiflow-arch-defs_SOURCE_DIR}/build/third_party/prjxray/tools
-	XRAY_DATABASE_DIR=${PRJXRAY_DB_DIR}
-	make
-	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()

--- a/xc/xc7/tests/soc/ibex/CMakeLists.txt
+++ b/xc/xc7/tests/soc/ibex/CMakeLists.txt
@@ -2,7 +2,6 @@ add_file_target(FILE led.vmem)
 add_file_target(FILE pins_artya7.sdc)
 
 get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
 
 add_fpga_target(
   NAME ibex_arty

--- a/xc/xc7/tests/soc/litex/base/CMakeLists.txt
+++ b/xc/xc7/tests/soc/litex/base/CMakeLists.txt
@@ -4,9 +4,6 @@ add_file_target(FILE mem_2.init)
 add_file_target(FILE arty.sdc)
 add_file_target(FILE arty_clocks.xdc)
 
-get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-
 add_fpga_target(
   NAME baselitex_arty
   BOARD arty-full

--- a/xc/xc7/tests/soc/litex/mini/CMakeLists.txt
+++ b/xc/xc7/tests/soc/litex/mini/CMakeLists.txt
@@ -2,9 +2,6 @@ add_file_target(FILE mem.init)
 add_file_target(FILE mem_1.init)
 add_file_target(FILE mem_2.init)
 
-get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-
 add_fpga_target(
   NAME minilitex_arty
   BOARD arty-full

--- a/xc/xc7/tests/soc/litex/mini_ddr/CMakeLists.txt
+++ b/xc/xc7/tests/soc/litex/mini_ddr/CMakeLists.txt
@@ -10,10 +10,6 @@ add_file_target(FILE VexRiscv_Lite.v SCANNER_TYPE verilog)
 add_file_target(FILE minilitex_ddr_arty.v SCANNER_TYPE verilog)
 add_file_target(FILE minilitex_ddr_arty100t.v SCANNER_TYPE verilog)
 
-
-get_target_property_required(PYTHON3 env PYTHON3)
-get_target_property(PYTHON3_TARGET env PYTHON3_TARGET)
-
 add_fpga_target(
   NAME minilitex_ddr_arty
   BOARD arty-full


### PR DESCRIPTION
This PR is going to red for a while as a find all the right grep strings.  However some of it can be reviewed now, specifically around how bootstrap is done in CI and specifying of share paths via the ENV_DIR cache variable.