### PR TITLE
Transition to use XDC constraints instead of TCL in fasm2bels

### DIFF
--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -168,7 +168,7 @@ function(ADD_XC_ARCH_DEFINE)
         --pcf \${INPUT_IO_FILE} \
         --eblif \${OUT_EBLIF} \
         --top \${TOP} \
-        \${OUT_BIT_VERILOG} \${OUT_BIT_VERILOG}.tcl"
+        \${OUT_BIT_VERILOG} \${OUT_BIT_VERILOG}.xdc"
 
     NO_BIT_TIME
     USE_FASM

--- a/xc/common/cmake/vivado.cmake
+++ b/xc/common/cmake/vivado.cmake
@@ -208,7 +208,7 @@ function(ADD_VIVADO_TARGET)
   append_file_dependency(DEPS ${BIT_VERILOG})
 
   get_file_location(BIT_VERILOG_LOCATION ${BIT_VERILOG})
-  set(BIT_TCL_LOCATION ${BIT_VERILOG_LOCATION}.tcl)
+  set(BIT_XDC_LOCATION ${BIT_VERILOG_LOCATION}.xdc)
 
   if(NOT "${ADD_VIVADO_TARGET_CLOCK_PINS}" STREQUAL "")
     list(LENGTH ${ADD_VIVADO_TARGET_CLOCK_PINS} NUM_CLOCKS)
@@ -238,7 +238,7 @@ function(ADD_VIVADO_TARGET)
       COMMAND ${PYTHON3} ${CREATE_RUNME}
         --name ${NAME}
         --verilog ${BIT_VERILOG_LOCATION}
-        --routing_tcl ${BIT_TCL_LOCATION}
+        --routing_xdc ${BIT_XDC_LOCATION}
         --top ${TOP}
         --part ${PART}
         --output_tcl ${CMAKE_CURRENT_BINARY_DIR}/${NAME}_runme.tcl
@@ -422,7 +422,7 @@ function(ADD_VIVADO_PNR_TARGET)
       COMMAND ${PYTHON3} ${CREATE_RUNME}
         --name ${NAME}
         --verilog ${SYNTH_OUT}
-        --routing_tcl ${XDC_FILE}
+        --routing_xdc ${XDC_FILE}
         --top ${TOP}
         --part ${PART}
         --clock_pins "${ADD_VIVADO_PNR_TARGET_CLOCK_PINS}"

--- a/xc/common/utils/vivado_create_runme.py
+++ b/xc/common/utils/vivado_create_runme.py
@@ -14,12 +14,12 @@ synth_design -top {top}
 
 write_checkpoint -force design_{name}_pre_source.dcp
 
-source {bit_tcl}
+read_xdc {bit_xdc}
 """.format(
             name=args.name,
             bit_v=args.verilog,
             top=args.top,
-            bit_tcl=args.routing_tcl,
+            bit_xdc=args.routing_xdc,
             part=args.part
         ),
         file=f_out
@@ -111,7 +111,7 @@ def main():
         '--verilog', help="Input verilog file to build.", required=True
     )
     parser.add_argument(
-        '--routing_tcl',
+        '--routing_xdc',
         help="TCL script to run after synthesis to add static routing.",
         required=True
     )

--- a/xc/xc7/fasm2bels/fasm2bels.py
+++ b/xc/xc7/fasm2bels/fasm2bels.py
@@ -319,7 +319,7 @@ def main():
     )
     parser.add_argument('--eblif', help="EBLIF file used to generate design")
     parser.add_argument('verilog_file', help="Filename of output verilog file")
-    parser.add_argument('tcl_file', help="Filename of output tcl script.")
+    parser.add_argument('xdc_file', help="Filename of output xdc constraints file.")
 
     args = parser.parse_args()
 
@@ -414,7 +414,7 @@ def main():
         for line in top.output_verilog():
             print(line, file=f)
 
-    with open(args.tcl_file, 'w') as f:
+    with open(args.xdc_file, 'w') as f:
         for line in top.output_bel_locations():
             print(line, file=f)
 

--- a/xc/xc7/fasm2bels/fasm2bels.py
+++ b/xc/xc7/fasm2bels/fasm2bels.py
@@ -319,7 +319,9 @@ def main():
     )
     parser.add_argument('--eblif', help="EBLIF file used to generate design")
     parser.add_argument('verilog_file', help="Filename of output verilog file")
-    parser.add_argument('xdc_file', help="Filename of output xdc constraints file.")
+    parser.add_argument(
+        'xdc_file', help="Filename of output xdc constraints file."
+    )
 
     args = parser.parse_args()
 

--- a/xc/xc7/fasm2bels/make_routes.py
+++ b/xc/xc7/fasm2bels/make_routes.py
@@ -9,6 +9,25 @@ ONE_NET = -2
 
 DEBUG = False
 
+# The following constants are used to wrap lists so that 1-length
+# lists do not get trimmed away producing errors during parsing
+#
+# Error example:
+#   - Input: [list a b c [list d e] [list f] [list g h]]
+#   - Output: a b c {d e} f {g h}
+#
+#   In this example, the `f` list gets evaluated into a string, which is not
+#   the expected result
+#
+# Correct example:
+#   - Input: [list a b c " [list d e] " " [list f] " " [list g h] " ]]
+#   - Output: a b c {d e} {f} {g h}
+#
+#   The correct example has the `f` list correctly evaluated into an
+#   actual list
+TCL_LIST_OPEN = '"[list '
+TCL_LIST_CLOSE = '] "'
+
 
 def create_check_downstream_default(conn, db):
     """ Returns check_for_default function. """
@@ -90,13 +109,8 @@ def find_downstream_node(conn, check_downstream_default, source_node_pkey):
     return None
 
 
-def output_builder(fixed_route):
-    # TCL cannot express 1-length list, so the curly brackets are
-    # used to prevent TCL from collapsing the 1-length list.
-    if len(fixed_route) == 1:
-        yield '{ '
-    else:
-        yield '[list '
+def output_builder(fixed_route, first_run=False):
+    yield TCL_LIST_OPEN
 
     for i in fixed_route:
         if type(i) is list:
@@ -105,10 +119,7 @@ def output_builder(fixed_route):
         else:
             yield i
 
-    if len(fixed_route) == 1:
-        yield ' }'
-    else:
-        yield ' ]'
+    yield TCL_LIST_CLOSE
 
 
 class Net(object):
@@ -309,12 +320,7 @@ class Net(object):
                 if parent_node == self.source_wire_pkey:
                     source_nodes.append(node)
 
-            # TCL cannot express 1-length list, so the curly brackets are
-            # used to prevent TCL from collapsing the 1-length list.
-            if len(source_nodes) == 1:
-                yield '{ '
-            else:
-                yield '[list '
+            yield TCL_LIST_OPEN
 
             for source_node in source_nodes:
                 yield '('
@@ -325,10 +331,7 @@ class Net(object):
 
                 yield ')'
 
-            if len(source_nodes) == 1:
-                yield ' }'
-            else:
-                yield ' ]'
+            yield TCL_LIST_CLOSE
 
 
 def create_check_for_default(db, conn):

--- a/xc/xc7/fasm2bels/make_routes.py
+++ b/xc/xc7/fasm2bels/make_routes.py
@@ -100,9 +100,7 @@ def output_builder(fixed_route):
         else:
             yield i
 
-    # TCL cannot express 1-length list, so add an additional element to
-    # prevent TCL from collapsing the 1-length list.
-    yield ' {} ]'
+    yield ']'
 
 
 class Net(object):

--- a/xc/xc7/fasm2bels/make_routes.py
+++ b/xc/xc7/fasm2bels/make_routes.py
@@ -91,7 +91,12 @@ def find_downstream_node(conn, check_downstream_default, source_node_pkey):
 
 
 def output_builder(fixed_route):
-    yield '[list'
+    # TCL cannot express 1-length list, so the curly brackets are
+    # used to prevent TCL from collapsing the 1-length list.
+    if len(fixed_route) == 1:
+        yield '{ '
+    else:
+        yield '[list '
 
     for i in fixed_route:
         if type(i) is list:
@@ -100,7 +105,10 @@ def output_builder(fixed_route):
         else:
             yield i
 
-    yield ']'
+    if len(fixed_route) == 1:
+        yield ' }'
+    else:
+        yield ' ]'
 
 
 class Net(object):
@@ -301,7 +309,12 @@ class Net(object):
                 if parent_node == self.source_wire_pkey:
                     source_nodes.append(node)
 
-            yield '[list '
+            # TCL cannot express 1-length list, so the curly brackets are
+            # used to prevent TCL from collapsing the 1-length list.
+            if len(source_nodes) == 1:
+                yield '{ '
+            else:
+                yield '[list '
 
             for source_node in source_nodes:
                 yield '('
@@ -312,9 +325,10 @@ class Net(object):
 
                 yield ')'
 
-            # TCL cannot express 1-length list, so add an additional element
-            # to prevent TCL from collapsing the 1-length list.
-            yield '{} ]'
+            if len(source_nodes) == 1:
+                yield ' }'
+            else:
+                yield ' ]'
 
 
 def create_check_for_default(db, conn):

--- a/xc/xc7/fasm2bels/verilog_modeling.py
+++ b/xc/xc7/fasm2bels/verilog_modeling.py
@@ -1578,18 +1578,21 @@ class Module(object):
     def output_bel_locations(self):
         """ Yields lines of tcl that will assign set the location of BELs. """
         for bel in sorted(self.get_bels(), key=lambda bel: bel.priority):
-            yield """\
-set cell [get_cells *{cell}]""".format(cell=bel.get_prefixed_name())
+            get_cell = "[get_cells *{cell}]".format(
+                cell=bel.get_prefixed_name()
+            )
 
             if bel.bel is not None:
                 yield """\
-set_property BEL "[get_property SITE_TYPE [get_sites {site}]].{bel}" $cell""".format(
-                    site=bel.site,
+set_property BEL {bel} {get_cell}""".format(
                     bel=bel.bel,
+                    get_cell=get_cell,
                 )
 
             yield """\
-set_property LOC [get_sites {site}] $cell""".format(site=bel.site)
+set_property LOC {site} {get_cell}""".format(
+                site=bel.site, get_cell=get_cell
+            )
 
     def output_nets(self):
         """ Yields lines of tcl that will assign the exact routing path for nets.
@@ -1629,7 +1632,9 @@ set net [get_nets -of_object $pin]""".format(
                 assert net_wire_pkey in [ZERO_NET, ONE_NET]
                 continue
 
-            yield """set route {fixed_route}""".format(fixed_route=' '.join(fixed_route))
+            yield """set route {fixed_route}""".format(
+                fixed_route=' '.join(fixed_route)
+            )
 
             # Remove extra {} elements required to construct 1-length lists.
             yield """set_property FIXED_ROUTE $route $net"""

--- a/xc/xc7/fasm2bels/verilog_modeling.py
+++ b/xc/xc7/fasm2bels/verilog_modeling.py
@@ -1579,10 +1579,7 @@ class Module(object):
         """ Yields lines of tcl that will assign set the location of BELs. """
         for bel in sorted(self.get_bels(), key=lambda bel: bel.priority):
             yield """\
-set cell [get_cells *{cell}]
-if {{ $cell == {{}} }} {{
-    error "Failed to find cell!"
-}}""".format(cell=bel.get_prefixed_name())
+set cell [get_cells *{cell}]""".format(cell=bel.get_prefixed_name())
 
             if bel.bel is not None:
                 yield """\
@@ -1618,14 +1615,7 @@ set_property LOC [get_sites {site}] $cell""".format(site=bel.site)
 
                 yield """
 set pin [get_pins *{cell}/{pin}]
-if {{ $pin == {{}} }} {{
-    error "Failed to find pin!"
-}}
-set net [get_nets -of_object $pin]
-if {{ $net == {{}} }} {{
-    error "Failed to find net!"
-}}
-""".format(
+set net [get_nets -of_object $pin]""".format(
                     cell=bel.get_prefixed_name(),
                     pin=pin,
                 )
@@ -1639,14 +1629,10 @@ if {{ $net == {{}} }} {{
                 assert net_wire_pkey in [ZERO_NET, ONE_NET]
                 continue
 
-            yield """
-set route_with_dummy {fixed_route}
-""".format(fixed_route=' '.join(fixed_route))
+            yield """set route {fixed_route}""".format(fixed_route=' '.join(fixed_route))
 
             # Remove extra {} elements required to construct 1-length lists.
-            yield """\
-regsub -all {{}} $route_with_dummy "" route
-set_property FIXED_ROUTE $route $net"""
+            yield """set_property FIXED_ROUTE $route $net"""
 
     def output_disabled_drcs(self):
         for drc in self.disabled_drcs:


### PR DESCRIPTION
This PR is an initial work to have the XDC constraints, which will allow for faster fasm2bels step.

On an initial test (counter) everything seems to be working all right except for the CLK net constraints.

In fact, the XDC clock for a net constraints look like the following (this is generated by doing `write_xdc` on an implemented design from the old fasm2bels:

```
set_property FIXED_ROUTE { { CLK_HROW_CK_HCLK_OUT_L9 CLK_HROW_CK_BUFHCLK_L9 <8>HCLK_LEAF_CLK_B_TOPL3  { <7>GCLK_L_B9_WEST CLK_L1 CLBLL_LL_CLK }   { <4>GCLK_L_B9_WEST CLK_L1 CLBLL_LL_CLK }   { <8>GCLK_L_B9_WEST  CLK_L1 CLBLL_LL_CLK }   { <5>GCLK_L_B9_WEST CLK_L1 CLBLL_LL_CLK }   { <9>GCLK_L_B9_WEST CLK_L1 CLBLL_LL_CLK }   { <6>GCLK_L_B9_WEST CLK_L1 CLBLL_LL_CLK }  <3>GCLK_L_B9_WEST  { CLK_L1 CLBLL_LL_CLK }  CLK_L0      CLBLL_L_CLK }  } [get_nets CLK_HROW_BOT_R_X60Y26_BUFHCE_X0Y9_O]
```

The following node is the source of the issue: `<8>HCLK_LEAF_CLK_B_TOPL3` (as well as others nodes with the `<N>` prefix).
By inspecting the device view in Vivado, I came to the conclusion that the number reported in the prefix is related to the number of the HCLK tile from which the CLK net gets into the vertical clock lines.
