### PR TITLE
xc7: cmake: add calculate_average_switch func to warning ignore list

### DIFF
--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -74,7 +74,7 @@ function(ADD_XC_ARCH_DEFINE)
       --bb_factor 10 \
       --initial_pres_fac 4.0 \
       --check_rr_graph off \
-      --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R:check_route:set_rr_graph_tool_comment"
+      --suppress_warnings \${OUT_NOISY_WARNINGS},sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R:check_route:set_rr_graph_tool_comment:calculate_average_switch"
       )
 
   set(YOSYS_CELLS_SIM ${YOSYS_DATADIR}/xilinx/cells_sim.v)


### PR DESCRIPTION
This is to avoid VPR printing out tons of warnings related to "Inconsistent buffering of rr nodes .."

Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Output example:
```
Warning 65: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1316 type: CHANX location: (7,2) <-> (9,2) track: 165 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 66: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1317 type: CHANX location: (7,2) <-> (9,2) track: 164 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 67: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1318 type: CHANX location: (7,2) <-> (9,2) track: 163 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 68: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1319 type: CHANX location: (7,2) <-> (9,2) track: 162 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 69: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1320 type: CHANX location: (7,2) <-> (9,2) track: 161 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 70: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1321 type: CHANX location: (7,2) <-> (9,2) track: 160 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 71: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1322 type: CHANX location: (7,2) <-> (9,2) track: 159 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 72: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1323 type: CHANX location: (7,2) <-> (9,2) track: 158 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 73: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1324 type: CHANX location: (7,2) <-> (9,2) track: 157 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 74: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1325 type: CHANX location: (7,2) <-> (9,2) track: 156 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)
Warning 75: Inconsitent buffering of children of rr node OUTPINFEED (RR node: 1326 type: CHANX location: (7,2) <-> (9,2) track: 155 len: 2 longline: 0 seg_type: OUTPINFEED dir: BI_DIR capacity: 1)

```

This goes for ~1000 lines more