### PR TITLE
Do full P&R flow when requested.

### DIFF
--- a/xc/common/cmake/vivado.cmake
+++ b/xc/common/cmake/vivado.cmake
@@ -423,6 +423,7 @@ function(ADD_VIVADO_PNR_TARGET)
         --name ${NAME}
         --verilog ${SYNTH_OUT}
         --routing_xdc ${XDC_FILE}
+        --place_and_route
         --top ${TOP}
         --part ${PART}
         --clock_pins "${ADD_VIVADO_PNR_TARGET_CLOCK_PINS}"


### PR DESCRIPTION
The add_vivado_pnr targets are intended to run a full Vivado based P&R flow, rather than just the fasm2bels into DCP flow.