### PR TITLE
Add bitstreams to artifacts in kokoro presubmit tests

### DIFF
--- a/.github/kokoro/presubmit-ice40.cfg
+++ b/.github/kokoro/presubmit-ice40.cfg
@@ -17,6 +17,7 @@ action {
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"
+    regex: "**/*.bit"
     regex: "**/*_qor.csv"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-ice40/"
   }

--- a/.github/kokoro/presubmit-xc7.cfg
+++ b/.github/kokoro/presubmit-xc7.cfg
@@ -17,6 +17,7 @@ action {
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"
+    regex: "**/*.bit"
     regex: "**/*_qor.csv"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7/"
   }

--- a/.github/kokoro/presubmit-xc7a200t.cfg
+++ b/.github/kokoro/presubmit-xc7a200t.cfg
@@ -17,6 +17,7 @@ action {
     regex: "**/pack.log"
     regex: "**/place.log"
     regex: "**/route.log"
+    regex: "**/*.bit"
     regex: "**/*_qor.csv"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7a200t/"
   }


### PR DESCRIPTION
Having bitstreams in CI artifacts gives an opportunity to download and test them on hardware.