### PR TITLE
ice40: io constr: do not emit constraint that is not in packed netlist

### DIFF
--- a/ice40/icestorm.cmake
+++ b/ice40/icestorm.cmake
@@ -57,7 +57,8 @@ function(icestorm_setup)
     \${PYTHON3} \${PLACE_TOOL} \
     --map \${PINMAP} \
     --blif \${OUT_EBLIF} \
-    --pcf \${INPUT_IO_FILE}"
+    --pcf \${INPUT_IO_FILE} \
+    --net \${OUT_NET}"
     CELLS_SIM ${CELLS_SIM}
     BIT_TO_V ${ICEBOX_VLOG}
     BIT_TO_V_CMD "${ICEBOX_VLOG} -D -c -n \${TOP} -p \${INPUT_IO_FILE} -d \${PACKAGE} \${OUT_BITSTREAM} > \${OUT_BIT_VERILOG}"

--- a/ice40/utils/ice40_create_ioplace.py
+++ b/ice40/utils/ice40_create_ioplace.py
@@ -37,6 +37,13 @@ parser.add_argument(
     help='Pin map CSV file'
 )
 parser.add_argument(
+    "--net",
+    '-n',
+    type=argparse.FileType('r'),
+    required=True,
+    help='VPR Packed netlist file'
+)
+parser.add_argument(
     "--output",
     '-o',
     "-O",
@@ -59,9 +66,11 @@ def main(argv):
     io_place = vpr_io_place.IoPlace()
 
     io_place.read_io_list_from_eblif(args.blif)
+    io_place.load_net_file_ios(args.net)
 
     for name, (loc, pcf_line) in locs.items():
-        io_place.constrain_net(net_name=name, loc=loc, comment=pcf_line)
+        if io_place.is_net_packed(name):
+            io_place.constrain_net(net_name=name, loc=loc, comment=pcf_line)
 
     io_place.output_io_place(args.output)
 

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -110,7 +110,7 @@ class IoPlace(object):
         for io_line in get_ios(net_root, ["inputs", "outputs"]):
             io_list = io_line.split(" ")
             for io in io_list:
-                self.net_file_io.add(io.lstrip("out:"))
+                self.net_file_io.add(io.replace("out:", ""))
 
     def constrain_net(self, net_name, loc, comment=""):
         assert len(loc) == 3

--- a/utils/vpr_io_place.py
+++ b/utils/vpr_io_place.py
@@ -25,6 +25,7 @@ class IoPlace(object):
         self.net_map = {}
         self.inout_nets = set()
         self.net_to_pad = set()
+        self.net_file_io = set()
 
     def read_io_loc_pairs(self, blif):
         """
@@ -89,6 +90,27 @@ class IoPlace(object):
                 assert top_block is not None
                 top_block = top_block.getparent()
             self.net_to_block[block.get("name")] = top_block.get("name")
+
+    def load_net_file_ios(self, net_file):
+        """
+        Loads input and outputs net names from the netlist file.
+        """
+
+        def get_ios(net_root, io_types):
+            "Get the top level io signals from the netlist XML root."
+            for io_type in io_types:
+                io = net_root.xpath("/block/{}/text ()".format(io_type))
+
+                if len(io) == 1:
+                    yield io[0]
+
+        net_xml = ET.parse(net_file)
+        net_root = net_xml.getroot()
+
+        for io_line in get_ios(net_root, ["inputs", "outputs"]):
+            io_list = io_line.split(" ")
+            for io in io_list:
+                self.net_file_io.add(io.lstrip("out:"))
 
     def constrain_net(self, net_name, loc, comment=""):
         assert len(loc) == 3
@@ -179,6 +201,9 @@ class IoPlace(object):
 
     def is_net(self, net):
         return net in self.net_map.values()
+
+    def is_net_packed(self, net):
+        return net in self.net_file_io
 
     def get_nets(self):
         for net in self.inputs:


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to fix the IO constraints that are incorrectly emitted when the packed netlist (top.net) does not contain the requested IOs.

This fixes the issue found when running all_ice40 tests after the [new master+wip VTR upgrade](https://github.com/SymbiFlow/vtr-verilog-to-routing/pull/545) and described in https://github.com/verilog-to-routing/vtr-verilog-to-routing/pull/1541