### PR TITLE
Remove stragler PLL LOC constraint for 100T -- no longer necessary.

### DIFF
--- a/xc/xc7/tests/ddr/ddr_uart_100t.v
+++ b/xc/xc7/tests/ddr/ddr_uart_100t.v
@@ -11748,7 +11748,6 @@ end
 
 assign main_tag_port_dat_r = tag_mem[memadr_2];
 
-(* LOC="PLLE2_ADV_X1Y1" *)
 PLLE2_ADV #(
 	.CLKFBOUT_MULT(5'd16),
 	.CLKIN1_PERIOD(10.0),


### PR DESCRIPTION
Signed-off-by: Tim Callahan <tcal@google.com>