### PR TITLE
Transition to use extended map lookahead

### DIFF
--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -66,7 +66,7 @@ function(ADD_XC_ARCH_DEFINE)
       --clock_modeling route \
       --place_delta_delay_matrix_calculation_method dijkstra \
       --place_delay_model delta_override \
-      --router_lookahead connection_box_map \
+      --router_lookahead extended_map \
       --check_route quick \
       --strict_checks off \
       --allow_dangling_combinational_nodes on \

--- a/xc/common/cmake/device_define.cmake
+++ b/xc/common/cmake/device_define.cmake
@@ -416,7 +416,7 @@ function(ADD_XC_DEVICE_DEFINE)
         --clock_modeling route
         --place_delay_model delta_override
         --place_delta_delay_matrix_calculation_method dijkstra
-        --router_lookahead connection_box_map
+        --router_lookahead extended_map
         --disable_errors check_unbuffered_edges:check_route:check_place
         --suppress_warnings sum_pin_class:check_unbuffered_edges:load_rr_indexed_data_T_values:check_rr_node:trans_per_R
         --route_chan_width 500

--- a/xc/common/utils/prjxray_create_synth_tiles.py
+++ b/xc/common/utils/prjxray_create_synth_tiles.py
@@ -214,6 +214,7 @@ def main():
     with DatabaseCache(args.connection_database, read_only=True) as conn:
         tile_in_use = set()
         num_synth_tiles = 0
+
         for roi, j in rois.items():
             if args.overlay:
                 synth_tiles['info'].append(j['info'])
@@ -261,6 +262,7 @@ def main():
                         'pins': [],
                         'loc': vpr_loc,
                         'tile_name': tile_name,
+                        'wires_outside_roi': {},
                     }
                     num_synth_tiles += 1
                     tile_pin_count[tile] = 0
@@ -281,6 +283,18 @@ def main():
                             tile_pin_count[tile],
                     }
                 )
+
+                if 'wires_outside_roi' in port:
+                    outside_roi = synth_tiles['tiles'][tile
+                                                       ]['wires_outside_roi']
+
+                    for tile_wire in port['wires_outside_roi']:
+
+                        tile_name, wire_name = tile_wire.split('/')
+                        if tile_name in outside_roi.keys():
+                            outside_roi[tile_name].append(wire_name)
+                        else:
+                            outside_roi[tile_name] = [wire_name]
 
                 tile_pin_count[tile] += 1
 

--- a/xc/common/utils/prjxray_edge_library.py
+++ b/xc/common/utils/prjxray_edge_library.py
@@ -2255,7 +2255,8 @@ def create_edges(args):
                 tile_name = grid.tilename_at_loc(loc)
 
                 if tile_name in synth_tiles['tiles']:
-                    for pin in synth_tiles['tiles'][tile_name]['pins']:
+                    synth_tile = synth_tiles['tiles'][tile_name]
+                    for pin in synth_tile['pins']:
                         if pin['port_type'] not in ['input', 'output']:
                             continue
 
@@ -2263,14 +2264,38 @@ def create_edges(args):
                             tile_name, gridinfo.tile_type, pin['wire']
                         )
 
-                        if pin['port_type'] == 'input':
-                            # This track can output be used as a sink.
+                        is_input = pin['port_type'] == 'input'
+                        is_output = pin['port_type'] == 'output'
+
+                        assert is_input or is_output, pin
+
+                        if is_input:
+                            # This track can be used as a sink.
                             input_only_nodes |= set((node_pkey, ))
-                        elif pin['port_type'] == 'output':
-                            # This track can output be used as a src.
+                        elif is_output:
+                            # This track can be used as a src.
                             output_only_nodes |= set((node_pkey, ))
-                        else:
-                            assert False, pin
+
+                        # Adding all wires outside of the ROI relative to this synth tile
+                        # to the input/output only nodes, so that the corresponding nodes
+                        # have only outgoing or incoming edges
+                        for tile, wires in synth_tile['wires_outside_roi'
+                                                      ].items():
+                            tile_type = grid.gridinfo_at_tilename(
+                                tile
+                            ).tile_type
+
+                            for wire in wires:
+                                _, _, _, node_pkey = find_wire(
+                                    tile, tile_type, wire
+                                )
+
+                                if is_input:
+                                    # This track can be used as a sink.
+                                    input_only_nodes |= set((node_pkey, ))
+                                elif is_output:
+                                    # This track can be used as a src.
+                                    output_only_nodes |= set((node_pkey, ))
 
         create_and_insert_edges(
             db=db,

--- a/xc/common/utils/prjxray_edge_library.py
+++ b/xc/common/utils/prjxray_edge_library.py
@@ -2271,10 +2271,10 @@ def create_edges(args):
 
                         if is_input:
                             # This track can be used as a sink.
-                            input_only_nodes |= set((node_pkey, ))
+                            input_only_nodes.add(node_pkey)
                         elif is_output:
                             # This track can be used as a src.
-                            output_only_nodes |= set((node_pkey, ))
+                            output_only_nodes.add(node_pkey)
 
                         # Adding all wires outside of the ROI relative to this synth tile
                         # to the input/output only nodes, so that the corresponding nodes
@@ -2292,10 +2292,10 @@ def create_edges(args):
 
                                 if is_input:
                                     # This track can be used as a sink.
-                                    input_only_nodes |= set((node_pkey, ))
+                                    input_only_nodes.add(node_pkey)
                                 elif is_output:
                                     # This track can be used as a src.
-                                    output_only_nodes |= set((node_pkey, ))
+                                    output_only_nodes.add(node_pkey)
 
         create_and_insert_edges(
             db=db,


### PR DESCRIPTION
This PR builds on top of https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1666 and is intended to test the extended lookahead map.