### PR TITLE
Change how CARRY4 modelling is handled

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -1386,6 +1386,7 @@ function(ADD_FPGA_TARGET)
           USE_ROI=${USE_ROI}
           PCF_FILE=${INPUT_IO_FILE}
           PINMAP_FILE=${PINMAP}
+          PYTHON3=${PYTHON3}
           ${ADD_FPGA_TARGET_DEFINES}
           ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SYNTH_SCRIPT}" -l ${OUT_JSON_SYNTH}.log ${SOURCE_FILES}
       COMMAND

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -1375,8 +1375,7 @@ function(ADD_FPGA_TARGET)
       COMMAND
         ${CMAKE_COMMAND} -E env
           TECHMAP_PATH=${YOSYS_TECHMAP}
-          symbiflow-arch-defs_SOURCE_DIR=${symbiflow-arch-defs_SOURCE_DIR}
-          symbiflow-arch-defs_BINARY_DIR=${symbiflow-arch-defs_BINARY_DIR}
+          UTILS_PATH=${symbiflow-arch-defs_SOURCE_DIR}/utils
           OUT_JSON=${OUT_JSON_SYNTH}
           OUT_SYNTH_V=${OUT_SYNTH_V}
           OUT_FASM_EXTRA=${OUT_FASM_EXTRA}

--- a/utils/fix_xc7_carry.py
+++ b/utils/fix_xc7_carry.py
@@ -7,14 +7,19 @@ Usage:
 Description:
 
     In the 7-series SLICEL (and SLICEM) sites, there can be output congestion
-    if both the CO and O of the CARRY4 are used.  This congestion can be
-    avoided if transparent/open latches or registers on the output of the
+    if both the CO and O of the CARRY4 are used. This congestion can be
+    avoided by using a transparent/open latch or register on the output of the
     CARRY4.
 
     VPR does not currently support either of those options, so for now, if
     both CO and O are used, the CO output is converted into a LUT equation to
     recompute the CO output from O, DI and S.  See carry_map.v and
     clean_carry_map.v for details.
+
+    If VPR could emit the transparent/open latch on output congestion, this
+    would no longer be required.  The major problem with transparent latch
+    support is that it requires constants to be routed to the G/GE/CLR/PRE
+    ports, which VPR cannot express as a result of packing.
 
     This script identifies CARRY4 chains in the netlist, identifies if there
     is output congestion on the O and CO ports, and marks the congestion by
@@ -23,6 +28,8 @@ Description:
 
 
 Diagram showing one row of the 7-series CLE, focusing on O/CO congestion.
+This diagram shows that if both the O and CO outputs are needed, once must
+pass through the flip flop (xFF in the diagram).
 
                                       CLE Row
 
@@ -133,6 +140,8 @@ carry_map.v converts the CARRY4 into:
 |                  |
 +------------------+
 
+Each CARRY4 spans the 4 rows of the SLICEL/SLICEM.
+Row 0 is the S0/DI0/O0/CO0 ports, row 1 is S1/DI1/O1/CO1 ports, etc.
 
 So there are five cases the script has to handle:
 

--- a/xc/common/cmake/install.cmake
+++ b/xc/common/cmake/install.cmake
@@ -48,27 +48,14 @@ function(DEFINE_XC_TOOLCHAIN_TARGET)
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
 
   # install python scripts
-  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/split_inouts.py
-          DESTINATION bin/python
-          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
-
-        install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_create_ioplace.py
-          DESTINATION bin/python
-          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
-
-        install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_create_place_constraints.py
-          DESTINATION bin/python
-          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
-
-  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_io_place.py
-          DESTINATION bin/python
-          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
-
-  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_place_constraints.py
-          DESTINATION bin/python
-          PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
-
-  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/eblif.py
+  install(FILES
+            ${symbiflow-arch-defs_SOURCE_DIR}/utils/split_inouts.py
+            ${symbiflow-arch-defs_SOURCE_DIR}/utils/fix_xc7_carry.py
+            ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_create_ioplace.py
+            ${symbiflow-arch-defs_SOURCE_DIR}/xc/common/utils/prjxray_create_place_constraints.py
+            ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_io_place.py
+            ${symbiflow-arch-defs_SOURCE_DIR}/utils/vpr_place_constraints.py
+            ${symbiflow-arch-defs_SOURCE_DIR}/utils/eblif.py
           DESTINATION bin/python
           PERMISSIONS WORLD_EXECUTE WORLD_READ OWNER_WRITE OWNER_READ OWNER_EXECUTE GROUP_READ GROUP_EXECUTE)
 

--- a/xc/common/primitives/common_slice/carry/CMakeLists.txt
+++ b/xc/common/primitives/common_slice/carry/CMakeLists.txt
@@ -3,6 +3,16 @@ add_file_target(
   SCANNER_TYPE verilog
   )
 
+add_file_target(
+  FILE carry_cout_plug.sim.v
+  SCANNER_TYPE verilog
+  )
+
+v2x(
+    NAME carry_cout_plug
+    SRCS carry_cout_plug.sim.v
+    )
+
 # TODO - Switch to use V2X once FASM parameter support exists.
 #v2x(
 #  NAME carry4_vpr

--- a/xc/common/primitives/common_slice/carry/carry4_vpr.model.xml
+++ b/xc/common/primitives/common_slice/carry/carry4_vpr.model.xml
@@ -1,23 +1,22 @@
 <models xmlns:xi="http://www.w3.org/2001/XInclude">
   <model name="CARRY4_VPR">
     <input_ports>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 CO_FABRIC1 CO_FABRIC0 O3 O2 O1 O0" name="CIN"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 CO_FABRIC1 CO_FABRIC0 O3 O2 O1 O0" name="CYINIT"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 CO_FABRIC1 CO_FABRIC0 O3 O2 O1" name="DI0"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 CO_FABRIC1 O3 O2" name="DI1"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 O3" name="DI2"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3" name="DI3"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 CO_FABRIC1 CO_FABRIC0 O3 O2 O1 O0" name="S0"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 CO_FABRIC1 O3 O2 O1" name="S1"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 CO_FABRIC2 O3 O2" name="S2"/>
-      <port combinational_sink_ports="CO_CHAIN CO_FABRIC3 O3" name="S3"/>
+      <port combinational_sink_ports="CO3 CO2 CO1 CO0 O3 O2 O1 O0" name="CIN"/>
+      <port combinational_sink_ports="CO3 CO2 CO1 CO0 O3 O2 O1 O0" name="CYINIT"/>
+      <port combinational_sink_ports="CO3 CO2 CO1 CO0 O3 O2 O1" name="DI0"/>
+      <port combinational_sink_ports="CO3 CO2 CO1 O3 O2" name="DI1"/>
+      <port combinational_sink_ports="CO3 CO2 O3" name="DI2"/>
+      <port combinational_sink_ports="CO3" name="DI3"/>
+      <port combinational_sink_ports="CO3 CO2 CO1 CO0 O3 O2 O1 O0" name="S0"/>
+      <port combinational_sink_ports="CO3 CO2 CO1 O3 O2 O1" name="S1"/>
+      <port combinational_sink_ports="CO3 CO2 O3 O2" name="S2"/>
+      <port combinational_sink_ports="CO3 O3" name="S3"/>
     </input_ports>
     <output_ports>
-      <port name="CO_CHAIN"/>
-      <port name="CO_FABRIC0"/>
-      <port name="CO_FABRIC1"/>
-      <port name="CO_FABRIC2"/>
-      <port name="CO_FABRIC3"/>
+      <port name="CO0"/>
+      <port name="CO1"/>
+      <port name="CO2"/>
+      <port name="CO3"/>
       <port name="O0"/>
       <port name="O1"/>
       <port name="O2"/>

--- a/xc/common/primitives/common_slice/carry/carry4_vpr.pb_type.xml
+++ b/xc/common/primitives/common_slice/carry/carry4_vpr.pb_type.xml
@@ -1,11 +1,10 @@
 <?xml version='1.0' encoding='utf-8'?>
 <pb_type xmlns:xi="http://www.w3.org/2001/XInclude" blif_model=".subckt CARRY4_VPR" name="CARRY4_VPR" num_pb="1">
   <input  name="CIN"        num_pins="1"/>
-  <output name="CO_CHAIN"   num_pins="1"/>
-  <output name="CO_FABRIC0" num_pins="1"/>
-  <output name="CO_FABRIC1" num_pins="1"/>
-  <output name="CO_FABRIC2" num_pins="1"/>
-  <output name="CO_FABRIC3" num_pins="1"/>
+  <output name="CO0" num_pins="1"/>
+  <output name="CO1" num_pins="1"/>
+  <output name="CO2" num_pins="1"/>
+  <output name="CO3" num_pins="1"/>
   <input  name="CYINIT"     num_pins="1"/>
   <input  name="DI0"        num_pins="1"/>
   <input  name="DI1"        num_pins="1"/>
@@ -19,44 +18,34 @@
   <input  name="S1"         num_pins="1"/>
   <input  name="S2"         num_pins="1"/>
   <input  name="S3"         num_pins="1"/>
-  <delay_constant in_port="CIN"    max="{iopath_CIN_CO3}"    out_port="CO_CHAIN"/>
-  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO3}" out_port="CO_CHAIN"/>
-  <delay_constant in_port="DI0"    max="{iopath_DI0_CO3}"    out_port="CO_CHAIN"/>
-  <delay_constant in_port="DI1"    max="{iopath_DI1_CO3}"    out_port="CO_CHAIN"/>
-  <delay_constant in_port="DI2"    max="{iopath_DI2_CO3}"    out_port="CO_CHAIN"/>
-  <delay_constant in_port="DI3"    max="{iopath_DI3_CO3}"    out_port="CO_CHAIN"/>
-  <delay_constant in_port="S0"     max="{iopath_S0_CO3}"     out_port="CO_CHAIN"/>
-  <delay_constant in_port="S1"     max="{iopath_S1_CO3}"     out_port="CO_CHAIN"/>
-  <delay_constant in_port="S2"     max="{iopath_S2_CO3}"     out_port="CO_CHAIN"/>
-  <delay_constant in_port="S3"     max="{iopath_S3_CO3}"     out_port="CO_CHAIN"/>
-  <delay_constant in_port="CIN"    max="{iopath_CIN_CO0}"    out_port="CO_FABRIC0"/>
-  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO0}" out_port="CO_FABRIC0"/>
-  <delay_constant in_port="DI0"    max="{iopath_DI0_CO0}"    out_port="CO_FABRIC0"/>
-  <delay_constant in_port="S0"     max="{iopath_S0_CO0}"     out_port="CO_FABRIC0"/>
-  <delay_constant in_port="CIN"    max="{iopath_CIN_CO1}"    out_port="CO_FABRIC1"/>
-  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO1}" out_port="CO_FABRIC1"/>
-  <delay_constant in_port="DI0"    max="{iopath_DI0_CO1}"    out_port="CO_FABRIC1"/>
-  <delay_constant in_port="DI1"    max="{iopath_DI1_CO1}"    out_port="CO_FABRIC1"/>
-  <delay_constant in_port="S0"     max="{iopath_S0_CO1}"     out_port="CO_FABRIC1"/>
-  <delay_constant in_port="S1"     max="{iopath_S1_CO1}"     out_port="CO_FABRIC1"/>
-  <delay_constant in_port="CIN"    max="{iopath_CIN_CO2}"    out_port="CO_FABRIC2"/>
-  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO2}" out_port="CO_FABRIC2"/>
-  <delay_constant in_port="DI0"    max="{iopath_DI0_CO2}"    out_port="CO_FABRIC2"/>
-  <delay_constant in_port="DI1"    max="{iopath_DI1_CO2}"    out_port="CO_FABRIC2"/>
-  <delay_constant in_port="DI2"    max="{iopath_DI2_CO2}"    out_port="CO_FABRIC2"/>
-  <delay_constant in_port="S0"     max="{iopath_S0_CO2}"     out_port="CO_FABRIC2"/>
-  <delay_constant in_port="S1"     max="{iopath_S1_CO2}"     out_port="CO_FABRIC2"/>
-  <delay_constant in_port="S2"     max="{iopath_S2_CO2}"     out_port="CO_FABRIC2"/>
-  <delay_constant in_port="CIN"    max="{iopath_CIN_CO3}"    out_port="CO_FABRIC3"/>
-  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO3}" out_port="CO_FABRIC3"/>
-  <delay_constant in_port="DI0"    max="{iopath_DI0_CO3}"    out_port="CO_FABRIC3"/>
-  <delay_constant in_port="DI1"    max="{iopath_DI0_CO3}"    out_port="CO_FABRIC3"/>
-  <delay_constant in_port="DI2"    max="{iopath_DI0_CO3}"    out_port="CO_FABRIC3"/>
-  <delay_constant in_port="DI3"    max="{iopath_DI0_CO3}"    out_port="CO_FABRIC3"/>
-  <delay_constant in_port="S0"     max="{iopath_S0_CO3}"     out_port="CO_FABRIC3"/>
-  <delay_constant in_port="S1"     max="{iopath_S1_CO3}"     out_port="CO_FABRIC3"/>
-  <delay_constant in_port="S2"     max="{iopath_S2_CO3}"     out_port="CO_FABRIC3"/>
-  <delay_constant in_port="S3"     max="{iopath_S3_CO3}"     out_port="CO_FABRIC3"/>
+  <delay_constant in_port="CIN"    max="{iopath_CIN_CO0}"    out_port="CO0"/>
+  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO0}" out_port="CO0"/>
+  <delay_constant in_port="DI0"    max="{iopath_DI0_CO0}"    out_port="CO0"/>
+  <delay_constant in_port="S0"     max="{iopath_S0_CO0}"     out_port="CO0"/>
+  <delay_constant in_port="CIN"    max="{iopath_CIN_CO1}"    out_port="CO1"/>
+  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO1}" out_port="CO1"/>
+  <delay_constant in_port="DI0"    max="{iopath_DI0_CO1}"    out_port="CO1"/>
+  <delay_constant in_port="DI1"    max="{iopath_DI1_CO1}"    out_port="CO1"/>
+  <delay_constant in_port="S0"     max="{iopath_S0_CO1}"     out_port="CO1"/>
+  <delay_constant in_port="S1"     max="{iopath_S1_CO1}"     out_port="CO1"/>
+  <delay_constant in_port="CIN"    max="{iopath_CIN_CO2}"    out_port="CO2"/>
+  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO2}" out_port="CO2"/>
+  <delay_constant in_port="DI0"    max="{iopath_DI0_CO2}"    out_port="CO2"/>
+  <delay_constant in_port="DI1"    max="{iopath_DI1_CO2}"    out_port="CO2"/>
+  <delay_constant in_port="DI2"    max="{iopath_DI2_CO2}"    out_port="CO2"/>
+  <delay_constant in_port="S0"     max="{iopath_S0_CO2}"     out_port="CO2"/>
+  <delay_constant in_port="S1"     max="{iopath_S1_CO2}"     out_port="CO2"/>
+  <delay_constant in_port="S2"     max="{iopath_S2_CO2}"     out_port="CO2"/>
+  <delay_constant in_port="CIN"    max="{iopath_CIN_CO3}"    out_port="CO3"/>
+  <delay_constant in_port="CYINIT" max="{iopath_CYINIT_CO3}" out_port="CO3"/>
+  <delay_constant in_port="DI0"    max="{iopath_DI0_CO3}"    out_port="CO3"/>
+  <delay_constant in_port="DI1"    max="{iopath_DI0_CO3}"    out_port="CO3"/>
+  <delay_constant in_port="DI2"    max="{iopath_DI0_CO3}"    out_port="CO3"/>
+  <delay_constant in_port="DI3"    max="{iopath_DI0_CO3}"    out_port="CO3"/>
+  <delay_constant in_port="S0"     max="{iopath_S0_CO3}"     out_port="CO3"/>
+  <delay_constant in_port="S1"     max="{iopath_S1_CO3}"     out_port="CO3"/>
+  <delay_constant in_port="S2"     max="{iopath_S2_CO3}"     out_port="CO3"/>
+  <delay_constant in_port="S3"     max="{iopath_S3_CO3}"     out_port="CO3"/>
   <delay_constant in_port="CIN"    max="{iopath_CIN_O0}"     out_port="O0"/>
   <delay_constant in_port="CYINIT" max="{iopath_CYINIT_O0}"  out_port="O0"/>
   <delay_constant in_port="S0"     max="{iopath_S0_O0}"      out_port="O0"/>

--- a/xc/common/primitives/common_slice/carry/carry_cout_plug.sim.v
+++ b/xc/common/primitives/common_slice/carry/carry_cout_plug.sim.v
@@ -1,0 +1,14 @@
+// This CARRY_COUT_PLUG actually will form a molecule with the previous
+// CARRY4 primative, and allow VPR to distiguish between the net
+// connecting to the next CARRY4 and the general fabric.
+(* lib_whitebox *)
+module CARRY_COUT_PLUG(
+    input CIN,
+    output COUT
+);
+  (* DELAY_CONST_CIN="0" *)
+  wire COUT;
+
+  assign COUT = CIN;
+endmodule
+

--- a/xc/common/primitives/common_slice/common_slice.model.xml
+++ b/xc/common/primitives/common_slice/common_slice.model.xml
@@ -10,5 +10,6 @@
     </output_ports>
   </model>
   <xi:include href="carry/carry4_vpr.model.xml"    xpointer="xpointer(models/child::node())" />
+  <xi:include href="carry/carry_cout_plug.model.xml"    xpointer="xpointer(models/child::node())" />
   <xi:include href="../ff/ff.model.xml"            xpointer="xpointer(models/child::node())" />
 </models>

--- a/xc/common/primitives/common_slice/common_slice.pb_type.xml
+++ b/xc/common/primitives/common_slice/common_slice.pb_type.xml
@@ -59,6 +59,7 @@
 
   <!-- CARRY4 logic -->
   <xi:include href="carry/carry4_vpr.pb_type.xml" />
+  <xi:include href="carry/carry_cout_plug.pb_type.xml" />
 
   <pb_type name="CEUSEDMUX" num_pb="1" >
     <input name="CE" num_pins="1" />
@@ -322,11 +323,11 @@
 
     <!-- [A-D]MUX -->
     <mux name="DOUTMUX"
-      input="COMMON_SLICE.AMC31 SLICE_FF.Q5[3] CARRY4_VPR.O3 CARRY4_VPR.CO_FABRIC3 COMMON_SLICE.DO6 COMMON_SLICE.DO5"
+      input="COMMON_SLICE.AMC31 SLICE_FF.Q5[3] CARRY4_VPR.O3 CARRY4_VPR.CO3 COMMON_SLICE.DO6 COMMON_SLICE.DO5"
       output="COMMON_SLICE.DMUX">
       <delay_constant in_port="SLICE_FF.Q5[3]" max="{interconnect_d5ff_dmux}" out_port="COMMON_SLICE.DMUX" />
       <delay_constant in_port="CARRY4_VPR.O3" max="{interconnect_carry4_co3_dmux}" out_port="COMMON_SLICE.DMUX" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC3" max="{interconnect_carry4_o3_dmux}" out_port="COMMON_SLICE.DMUX" />
+      <delay_constant in_port="CARRY4_VPR.CO3" max="{interconnect_carry4_o3_dmux}" out_port="COMMON_SLICE.DMUX" />
       <delay_constant in_port="COMMON_SLICE.DO6" max="{interconnect_d6lut_dmux}" out_port="COMMON_SLICE.DMUX" />
       <delay_constant in_port="COMMON_SLICE.DO5" max="{interconnect_d5lut_dmux}" out_port="COMMON_SLICE.DMUX" />
       <metadata>
@@ -335,17 +336,17 @@
           SLICE_FF.Q5[3] = DOUTMUX.D5Q
           COMMON_SLICE.DO5 = DOUTMUX.O5
           COMMON_SLICE.DO6 = DOUTMUX.O6
-          CARRY4_VPR.CO_FABRIC3 = DOUTMUX.CY
+          CARRY4_VPR.CO3 = DOUTMUX.CY
           CARRY4_VPR.O3 = DOUTMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="COUTMUX"
-      input="SLICE_FF.Q5[2] CARRY4_VPR.O2 CARRY4_VPR.CO_FABRIC2 COMMON_SLICE.CO6 COMMON_SLICE.CO5 COMMON_SLICE.F7BMUX_O"
+      input="SLICE_FF.Q5[2] CARRY4_VPR.O2 CARRY4_VPR.CO2 COMMON_SLICE.CO6 COMMON_SLICE.CO5 COMMON_SLICE.F7BMUX_O"
       output="COMMON_SLICE.CMUX" >
       <delay_constant in_port="SLICE_FF.Q5[2]" max="{interconnect_c5ff_cmux}" out_port="COMMON_SLICE.CMUX" />
       <delay_constant in_port="CARRY4_VPR.O2" max="{interconnect_carry4_co2_cmux}" out_port="COMMON_SLICE.CMUX" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC2" max="{interconnect_carry4_o2_cmux}" out_port="COMMON_SLICE.CMUX" />
+      <delay_constant in_port="CARRY4_VPR.CO2" max="{interconnect_carry4_o2_cmux}" out_port="COMMON_SLICE.CMUX" />
       <delay_constant in_port="COMMON_SLICE.CO6" max="{interconnect_c6lut_cmux}" out_port="COMMON_SLICE.CMUX" />
       <delay_constant in_port="COMMON_SLICE.CO5" max="{interconnect_c5lut_cmux}" out_port="COMMON_SLICE.CMUX" />
       <metadata>
@@ -354,17 +355,17 @@
           COMMON_SLICE.F7BMUX_O = COUTMUX.F7
           COMMON_SLICE.CO5 = COUTMUX.O5
           COMMON_SLICE.CO6 = COUTMUX.O6
-          CARRY4_VPR.CO_FABRIC2 = COUTMUX.CY
+          CARRY4_VPR.CO2 = COUTMUX.CY
           CARRY4_VPR.O2 = COUTMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="BOUTMUX"
-      input="SLICE_FF.Q5[1] CARRY4_VPR.O1 CARRY4_VPR.CO_FABRIC1 COMMON_SLICE.BO6 COMMON_SLICE.BO5 COMMON_SLICE.F8MUX_O"
+      input="SLICE_FF.Q5[1] CARRY4_VPR.O1 CARRY4_VPR.CO1 COMMON_SLICE.BO6 COMMON_SLICE.BO5 COMMON_SLICE.F8MUX_O"
       output="COMMON_SLICE.BMUX" >
       <delay_constant in_port="SLICE_FF.Q5[1]" max="{interconnect_b5ff_bmux}" out_port="COMMON_SLICE.BMUX" />
       <delay_constant in_port="CARRY4_VPR.O1" max="{interconnect_carry4_co1_bmux}" out_port="COMMON_SLICE.BMUX" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC1" max="{interconnect_carry4_o1_bmux}" out_port="COMMON_SLICE.BMUX" />
+      <delay_constant in_port="CARRY4_VPR.CO1" max="{interconnect_carry4_o1_bmux}" out_port="COMMON_SLICE.BMUX" />
       <delay_constant in_port="COMMON_SLICE.BO6" max="{interconnect_b6lut_bmux}" out_port="COMMON_SLICE.BMUX" />
       <delay_constant in_port="COMMON_SLICE.BO5" max="{interconnect_b5lut_bmux}" out_port="COMMON_SLICE.BMUX" />
       <metadata>
@@ -373,17 +374,17 @@
           COMMON_SLICE.F8MUX_O = BOUTMUX.F8
           COMMON_SLICE.BO5 = BOUTMUX.O5
           COMMON_SLICE.BO6 = BOUTMUX.O6
-          CARRY4_VPR.CO_FABRIC1 = BOUTMUX.CY
+          CARRY4_VPR.CO1 = BOUTMUX.CY
           CARRY4_VPR.O1 = BOUTMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="AOUTMUX"
-      input="SLICE_FF.Q5[0] CARRY4_VPR.O0 CARRY4_VPR.CO_FABRIC0 COMMON_SLICE.AO6 COMMON_SLICE.AO5 COMMON_SLICE.F7AMUX_O"
+      input="SLICE_FF.Q5[0] CARRY4_VPR.O0 CARRY4_VPR.CO0 COMMON_SLICE.AO6 COMMON_SLICE.AO5 COMMON_SLICE.F7AMUX_O"
       output="COMMON_SLICE.AMUX" >
       <delay_constant in_port="SLICE_FF.Q5[0]" max="{interconnect_a5ff_amux}" out_port="COMMON_SLICE.AMUX" />
       <delay_constant in_port="CARRY4_VPR.O0" max="{interconnect_carry4_co0_amux}" out_port="COMMON_SLICE.AMUX" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC0" max="{interconnect_carry4_o0_amux}" out_port="COMMON_SLICE.AMUX" />
+      <delay_constant in_port="CARRY4_VPR.CO0" max="{interconnect_carry4_o0_amux}" out_port="COMMON_SLICE.AMUX" />
       <delay_constant in_port="COMMON_SLICE.AO6" max="{interconnect_a6lut_amux}" out_port="COMMON_SLICE.AMUX" />
       <delay_constant in_port="COMMON_SLICE.AO5" max="{interconnect_a5lut_amux}" out_port="COMMON_SLICE.AMUX" />
       <metadata>
@@ -392,7 +393,7 @@
           COMMON_SLICE.F7AMUX_O = AOUTMUX.F7
           COMMON_SLICE.AO5 = AOUTMUX.O5
           COMMON_SLICE.AO6 = AOUTMUX.O6
-          CARRY4_VPR.CO_FABRIC0 = AOUTMUX.CY
+          CARRY4_VPR.CO0 = AOUTMUX.CY
           CARRY4_VPR.O0 = AOUTMUX.XOR
         </meta>
       </metadata>
@@ -400,7 +401,7 @@
 
     <!-- [A-D]FFMUX -->
     <mux name="DFFMUX"
-      input="COMMON_SLICE.AMC31 CARRY4_VPR.O3 CARRY4_VPR.CO_FABRIC3 COMMON_SLICE.DO6 COMMON_SLICE.DO5 COMMON_SLICE.DX"
+      input="COMMON_SLICE.AMC31 CARRY4_VPR.O3 CARRY4_VPR.CO3 COMMON_SLICE.DO6 COMMON_SLICE.DO5 COMMON_SLICE.DX"
       output="SLICE_FF.D[3]" >
       <pack_pattern in_port="COMMON_SLICE.DO6" name="LUT_to_FF_FDSE" out_port="SLICE_FF.D[3]" />
       <pack_pattern in_port="COMMON_SLICE.DO6" name="LUT_to_FF_FDRE" out_port="SLICE_FF.D[3]" />
@@ -415,7 +416,7 @@
       <delay_constant in_port="COMMON_SLICE.DX" max="{interconnect_dx_dff}" out_port="SLICE_FF.D[3]" />
       <delay_constant in_port="COMMON_SLICE.DO5" max="{interconnect_d5lut_dff}" out_port="SLICE_FF.D[3]" />
       <delay_constant in_port="COMMON_SLICE.DO6" max="{interconnect_d6lut_dff}" out_port="SLICE_FF.D[3]" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC3" max="{interconnect_carry4_co3_dff}" out_port="SLICE_FF.D[3]" />
+      <delay_constant in_port="CARRY4_VPR.CO3" max="{interconnect_carry4_co3_dff}" out_port="SLICE_FF.D[3]" />
       <delay_constant in_port="CARRY4_VPR.O3" max="{interconnect_carry4_o3_dff}" out_port="SLICE_FF.D[3]" />
       <metadata>
         <meta name="fasm_mux">
@@ -423,13 +424,13 @@
           COMMON_SLICE.DX = DFFMUX.DX
           COMMON_SLICE.DO5 = DFFMUX.O5
           COMMON_SLICE.DO6 = DFFMUX.O6
-          CARRY4_VPR.CO_FABRIC3 = DFFMUX.CY
+          CARRY4_VPR.CO3 = DFFMUX.CY
           CARRY4_VPR.O3 = DFFMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="CFFMUX"
-      input="CARRY4_VPR.O2 CARRY4_VPR.CO_FABRIC2 COMMON_SLICE.CO6 COMMON_SLICE.CO5 COMMON_SLICE.CX COMMON_SLICE.F7BMUX_O"
+      input="CARRY4_VPR.O2 CARRY4_VPR.CO2 COMMON_SLICE.CO6 COMMON_SLICE.CO5 COMMON_SLICE.CX COMMON_SLICE.F7BMUX_O"
       output="SLICE_FF.D[2]" >
       <pack_pattern in_port="COMMON_SLICE.CO6" name="LUT_to_FF_FDSE" out_port="SLICE_FF.D[2]" />
       <pack_pattern in_port="COMMON_SLICE.CO6" name="LUT_to_FF_FDRE" out_port="SLICE_FF.D[2]" />
@@ -445,7 +446,7 @@
       <delay_constant in_port="COMMON_SLICE.F7BMUX_O" max="{interconnect_f7bmux_cff}" out_port="SLICE_FF.D[2]" />
       <delay_constant in_port="COMMON_SLICE.CO5" max="{interconnect_c5lut_cff}" out_port="SLICE_FF.D[2]" />
       <delay_constant in_port="COMMON_SLICE.CO6" max="{interconnect_c6lut_cff}" out_port="SLICE_FF.D[2]" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC2" max="{interconnect_carry4_co2_cff}" out_port="SLICE_FF.D[2]" />
+      <delay_constant in_port="CARRY4_VPR.CO2" max="{interconnect_carry4_co2_cff}" out_port="SLICE_FF.D[2]" />
       <delay_constant in_port="CARRY4_VPR.O2" max="{interconnect_carry4_o2_cff}" out_port="SLICE_FF.D[2]" />
       <metadata>
         <meta name="fasm_mux">
@@ -453,13 +454,13 @@
           COMMON_SLICE.F7BMUX_O = CFFMUX.F7
           COMMON_SLICE.CO5 = CFFMUX.O5
           COMMON_SLICE.CO6 = CFFMUX.O6
-          CARRY4_VPR.CO_FABRIC2 = CFFMUX.CY
+          CARRY4_VPR.CO2 = CFFMUX.CY
           CARRY4_VPR.O2 = CFFMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="BFFMUX"
-      input="CARRY4_VPR.O1 CARRY4_VPR.CO_FABRIC1 COMMON_SLICE.BO6 COMMON_SLICE.BO5 COMMON_SLICE.BX COMMON_SLICE.F8MUX_O"
+      input="CARRY4_VPR.O1 CARRY4_VPR.CO1 COMMON_SLICE.BO6 COMMON_SLICE.BO5 COMMON_SLICE.BX COMMON_SLICE.F8MUX_O"
       output="SLICE_FF.D[1]" >
       <pack_pattern in_port="COMMON_SLICE.BO6" name="LUT_to_FF_FDSE" out_port="SLICE_FF.D[1]" />
       <pack_pattern in_port="COMMON_SLICE.BO6" name="LUT_to_FF_FDRE" out_port="SLICE_FF.D[1]" />
@@ -475,7 +476,7 @@
       <delay_constant in_port="COMMON_SLICE.F8MUX_O" max="{interconnect_f8mux_bff}" out_port="SLICE_FF.D[1]" />
       <delay_constant in_port="COMMON_SLICE.BO5" max="{interconnect_b5lut_bff}" out_port="SLICE_FF.D[1]" />
       <delay_constant in_port="COMMON_SLICE.BO6" max="{interconnect_b6lut_bff}" out_port="SLICE_FF.D[1]" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC1" max="{interconnect_carry4_co1_bff}" out_port="SLICE_FF.D[1]" />
+      <delay_constant in_port="CARRY4_VPR.CO1" max="{interconnect_carry4_co1_bff}" out_port="SLICE_FF.D[1]" />
       <delay_constant in_port="CARRY4_VPR.O1" max="{interconnect_carry4_o1_bff}" out_port="SLICE_FF.D[1]" />
       <metadata>
         <meta name="fasm_mux">
@@ -483,13 +484,13 @@
           COMMON_SLICE.F8MUX_O = BFFMUX.F8
           COMMON_SLICE.BO5 = BFFMUX.O5
           COMMON_SLICE.BO6 = BFFMUX.O6
-          CARRY4_VPR.CO_FABRIC1 = BFFMUX.CY
+          CARRY4_VPR.CO1 = BFFMUX.CY
           CARRY4_VPR.O1 = BFFMUX.XOR
         </meta>
       </metadata>
     </mux>
     <mux name="AFFMUX"
-      input="CARRY4_VPR.O0 CARRY4_VPR.CO_FABRIC0 COMMON_SLICE.AO6 COMMON_SLICE.AO5 COMMON_SLICE.AX COMMON_SLICE.F7AMUX_O"
+      input="CARRY4_VPR.O0 CARRY4_VPR.CO0 COMMON_SLICE.AO6 COMMON_SLICE.AO5 COMMON_SLICE.AX COMMON_SLICE.F7AMUX_O"
       output="SLICE_FF.D[0]" >
       <pack_pattern in_port="COMMON_SLICE.AO6" name="LUT_to_FF_FDSE" out_port="SLICE_FF.D[0]" />
       <pack_pattern in_port="COMMON_SLICE.AO6" name="LUT_to_FF_FDRE" out_port="SLICE_FF.D[0]" />
@@ -505,7 +506,7 @@
       <delay_constant in_port="COMMON_SLICE.F7AMUX_O" max="{interconnect_f7amux_aff}" out_port="SLICE_FF.D[0]" />
       <delay_constant in_port="COMMON_SLICE.AO5" max="{interconnect_a5lut_aff}" out_port="SLICE_FF.D[0]" />
       <delay_constant in_port="COMMON_SLICE.AO6" max="{interconnect_a6lut_aff}" out_port="SLICE_FF.D[0]" />
-      <delay_constant in_port="CARRY4_VPR.CO_FABRIC0" max="{interconnect_carry4_co0_aff}" out_port="SLICE_FF.D[0]" />
+      <delay_constant in_port="CARRY4_VPR.CO0" max="{interconnect_carry4_co0_aff}" out_port="SLICE_FF.D[0]" />
       <delay_constant in_port="CARRY4_VPR.O0" max="{interconnect_carry4_o0_aff}" out_port="SLICE_FF.D[0]" />
       <metadata>
         <meta name="fasm_mux">
@@ -513,7 +514,7 @@
           COMMON_SLICE.F7AMUX_O = AFFMUX.F7
           COMMON_SLICE.AO5 = AFFMUX.O5
           COMMON_SLICE.AO6 = AFFMUX.O6
-          CARRY4_VPR.CO_FABRIC0 = AFFMUX.CY
+          CARRY4_VPR.CO0 = AFFMUX.CY
           CARRY4_VPR.O0 = AFFMUX.XOR
         </meta>
       </metadata>
@@ -562,10 +563,14 @@
     </direct>
 
     <!-- Carry selects -->
-    <direct name="CARRY_S3" input="COMMON_SLICE.DO6" output="CARRY4_VPR.S3" />
-    <direct name="CARRY_S2" input="COMMON_SLICE.CO6" output="CARRY4_VPR.S2" />
-    <direct name="CARRY_S1" input="COMMON_SLICE.BO6" output="CARRY4_VPR.S1" />
-    <direct name="CARRY_S0" input="COMMON_SLICE.AO6" output="CARRY4_VPR.S0" />
+    <direct name="CARRY_S3" input="COMMON_SLICE.DO6" output="CARRY4_VPR.S3" >
+    </direct>
+    <direct name="CARRY_S2" input="COMMON_SLICE.CO6" output="CARRY4_VPR.S2" >
+    </direct>
+    <direct name="CARRY_S1" input="COMMON_SLICE.BO6" output="CARRY4_VPR.S1" >
+    </direct>
+    <direct name="CARRY_S0" input="COMMON_SLICE.AO6" output="CARRY4_VPR.S0" >
+    </direct>
 
     <!-- Carry MUXCY.DI -->
     <mux name="CARRY_DI3" input="COMMON_SLICE.DO5 COMMON_SLICE.DX" output="CARRY4_VPR.DI3" >
@@ -605,9 +610,13 @@
       </metadata>
     </mux>
 
-    <direct name="COUT" input="CARRY4_VPR.CO_CHAIN" output="COMMON_SLICE.COUT" >
+    <direct name="COUT_TO_PLUG" input="CARRY4_VPR.CO3" output="CARRY_COUT_PLUG.CIN" >
       <pack_pattern name="CARRYCHAIN"/>
-      <delay_constant in_port="CARRY4_VPR.CO_CHAIN" max="{interconnect_carry4_co3_cout}" out_port="COMMON_SLICE.COUT" />
+      <delay_constant in_port="CARRY4_VPR.CO3" max="{interconnect_carry4_co3_cout}" out_port="CARRY_COUT_PLUG.CIN" />
+    </direct>
+
+    <direct name="COUT" input="CARRY_COUT_PLUG.COUT" output="COMMON_SLICE.COUT" >
+      <pack_pattern name="CARRYCHAIN"/>
     </direct>
 
     <!-- Clock, Clock Enable and Reset -->

--- a/xc/xc7/techmap/carry_map.v
+++ b/xc/xc7/techmap/carry_map.v
@@ -1,0 +1,133 @@
+module CARRY4(
+  output [3:0] CO,
+  output [3:0] O,
+  input        CI,
+  input        CYINIT,
+  input  [3:0] DI, S
+);
+  parameter _TECHMAP_CONSTMSK_CI_ = 1;
+  parameter _TECHMAP_CONSTVAL_CI_ = 1'b0;
+  parameter _TECHMAP_CONSTMSK_CYINIT_ = 1;
+  parameter _TECHMAP_CONSTVAL_CYINIT_ = 1'b0;
+
+  localparam [0:0] IS_CI_ZERO = (
+      _TECHMAP_CONSTMSK_CI_ == 1 && _TECHMAP_CONSTVAL_CI_ == 0 &&
+      _TECHMAP_CONSTMSK_CYINIT_ == 1 && _TECHMAP_CONSTVAL_CYINIT_ == 0);
+  localparam [0:0] IS_CI_ONE = (
+      _TECHMAP_CONSTMSK_CI_ == 1 && _TECHMAP_CONSTVAL_CI_ == 0 &&
+      _TECHMAP_CONSTMSK_CYINIT_ == 1 && _TECHMAP_CONSTVAL_CYINIT_ == 1);
+  localparam [0:0] IS_CYINIT_FABRIC = _TECHMAP_CONSTMSK_CYINIT_ == 0;
+  localparam [0:0] IS_CI_DISCONNECTED = _TECHMAP_CONSTMSK_CI_ == 1 &&
+    _TECHMAP_CONSTVAL_CI_ != 1;
+  localparam [0:0] IS_CYINIT_DISCONNECTED = _TECHMAP_CONSTMSK_CYINIT_ == 1 &&
+    _TECHMAP_CONSTVAL_CYINIT_ != 1;
+
+  wire [1023:0] _TECHMAP_DO_ = "proc; clean";
+  wire [3:0] O;
+  wire [3:0] CO;
+  wire [3:0] CO_output;
+
+  // Put in a placeholder object CARRY_CO_DIRECT.
+  //
+  // It will be used for 3 purposes:
+  //  - Remain as CARRY_CO_DIRECT when OUT only connects to CARRY_COUT_PLUG
+  //  - Remain as CARRY_CO_DIRECT when CO is used, but O is not used.
+  //  - Change into CARRY_CO_LUT when O and CO are required (e.g. compute CO
+  //    from O ^ S).
+  genvar i;
+  generate for (i = 0; i < 3; i = i + 1) begin:co_outputs
+      CARRY_CO_DIRECT #(.TOP_OF_CHAIN(0)) co_output(
+          .CO(CO_output[i]),
+          .O(O[i+1]),
+          .S(S[i+1]),
+          .OUT(CO[i])
+      );
+  end endgenerate
+
+  CARRY_CO_DIRECT #(.TOP_OF_CHAIN(1)) co_output(
+      .CO(CO_output[3]),
+      .O(O[3]),
+      .S(S[3]),
+      .DI(DI[3]),
+      .OUT(CO[3])
+  );
+
+  if(IS_CYINIT_FABRIC) begin
+    CARRY4_VPR #(
+        .CYINIT_AX(1'b1),
+        .CYINIT_C0(1'b0),
+        .CYINIT_C1(1'b0)
+    ) _TECHMAP_REPLACE_ (
+        .CO0(CO_output[0]),
+        .CO1(CO_output[1]),
+        .CO2(CO_output[2]),
+        .CO3(CO_output[3]),
+        .CYINIT(CYINIT),
+        .O0(O[0]),
+        .O1(O[1]),
+        .O2(O[2]),
+        .O3(O[3]),
+        .DI0(DI[0]),
+        .DI1(DI[1]),
+        .DI2(DI[2]),
+        .DI3(DI[3]),
+        .S0(S[0]),
+        .S1(S[1]),
+        .S2(S[2]),
+        .S3(S[3])
+    );
+  end else if(IS_CI_ZERO || IS_CI_ONE) begin
+    CARRY4_VPR #(
+        .CYINIT_AX(1'b0),
+        .CYINIT_C0(IS_CI_ZERO),
+        .CYINIT_C1(IS_CI_ONE)
+    ) _TECHMAP_REPLACE_ (
+        .CO0(CO_output[0]),
+        .CO1(CO_output[1]),
+        .CO2(CO_output[2]),
+        .CO3(CO_output[3]),
+        .O0(O[0]),
+        .O1(O[1]),
+        .O2(O[2]),
+        .O3(O[3]),
+        .DI0(DI[0]),
+        .DI1(DI[1]),
+        .DI2(DI[2]),
+        .DI3(DI[3]),
+        .S0(S[0]),
+        .S1(S[1]),
+        .S2(S[2]),
+        .S3(S[3])
+    );
+  end else begin
+    wire cin_from_below;
+    CARRY_COUT_PLUG cin_plug(
+        .CIN(CI),
+        .COUT(cin_from_below)
+    );
+
+    CARRY4_VPR #(
+        .CYINIT_AX(1'b0),
+        .CYINIT_C0(1'b0),
+        .CYINIT_C1(1'b0)
+    ) _TECHMAP_REPLACE_ (
+        .CO0(CO_output[0]),
+        .CO1(CO_output[1]),
+        .CO2(CO_output[2]),
+        .CO3(CO_output[3]),
+        .O0(O[0]),
+        .O1(O[1]),
+        .O2(O[2]),
+        .O3(O[3]),
+        .DI0(DI[0]),
+        .DI1(DI[1]),
+        .DI2(DI[2]),
+        .DI3(DI[3]),
+        .S0(S[0]),
+        .S1(S[1]),
+        .S2(S[2]),
+        .S3(S[3]),
+        .CIN(cin_from_below)
+    );
+  end
+endmodule

--- a/xc/xc7/techmap/cells_map.v
+++ b/xc/xc7/techmap/cells_map.v
@@ -1679,207 +1679,6 @@ end
   );
 endmodule // RAMB36E1
 
-module CARRY_COUT_PLUG(input CIN, output COUT);
-
-assign COUT = CIN;
-
-endmodule
-
-module CARRY4_CO_COUT(output [3:0] CO, output COUT, input CI, CYINIT, input [3:0] DI, S);
-  parameter _TECHMAP_CONSTMSK_CI_ = 1;
-  parameter _TECHMAP_CONSTVAL_CI_ = 1'b0;
-  parameter _TECHMAP_CONSTMSK_CYINIT_ = 1;
-  parameter _TECHMAP_CONSTVAL_CYINIT_ = 1'b0;
-
-  localparam [0:0] IS_CI_ZERO = (
-      _TECHMAP_CONSTMSK_CI_ == 1 && _TECHMAP_CONSTVAL_CI_ == 0 &&
-      _TECHMAP_CONSTMSK_CYINIT_ == 1 && _TECHMAP_CONSTVAL_CYINIT_ == 0);
-  localparam [0:0] IS_CI_ONE = (
-      _TECHMAP_CONSTMSK_CI_ == 1 && _TECHMAP_CONSTVAL_CI_ == 0 &&
-      _TECHMAP_CONSTMSK_CYINIT_ == 1 && _TECHMAP_CONSTVAL_CYINIT_ == 1);
-  localparam [0:0] IS_CYINIT_FABRIC = _TECHMAP_CONSTMSK_CYINIT_ == 0;
-  localparam [0:0] IS_CI_DISCONNECTED = _TECHMAP_CONSTMSK_CI_ == 1 &&
-    _TECHMAP_CONSTVAL_CI_ != 1;
-  localparam [0:0] IS_CYINIT_DISCONNECTED = _TECHMAP_CONSTMSK_CYINIT_ == 1 &&
-    _TECHMAP_CONSTVAL_CYINIT_ != 1;
-
-  wire [1023:0] _TECHMAP_DO_ = "proc; clean";
-  wire [3:0] O;
-
-  if(IS_CYINIT_FABRIC) begin
-    CARRY4_VPR #(
-        .CYINIT_AX(1'b1),
-        .CYINIT_C0(1'b0),
-        .CYINIT_C1(1'b0)
-    ) _TECHMAP_REPLACE_ (
-        .CO_CHAIN(COUT),
-        .CO_FABRIC0(CO[0]),
-        .CO_FABRIC1(CO[1]),
-        .CO_FABRIC2(CO[2]),
-        .CO_FABRIC3(CO[3]),
-        .CYINIT(CYINIT),
-        .O0(O[0]),
-        .O1(O[1]),
-        .O2(O[2]),
-        .O3(O[3]),
-        .DI0(DI[0]),
-        .DI1(DI[1]),
-        .DI2(DI[2]),
-        .DI3(DI[3]),
-        .S0(S[0]),
-        .S1(S[1]),
-        .S2(S[2]),
-        .S3(S[3])
-    );
-  end else if(IS_CI_ZERO || IS_CI_ONE) begin
-    CARRY4_VPR #(
-        .CYINIT_AX(1'b0),
-        .CYINIT_C0(IS_CI_ZERO),
-        .CYINIT_C1(IS_CI_ONE)
-    ) _TECHMAP_REPLACE_ (
-        .CO_CHAIN(COUT),
-        .CO_FABRIC0(CO[0]),
-        .CO_FABRIC1(CO[1]),
-        .CO_FABRIC2(CO[2]),
-        .CO_FABRIC3(CO[3]),
-        .O0(O[0]),
-        .O1(O[1]),
-        .O2(O[2]),
-        .O3(O[3]),
-        .DI0(DI[0]),
-        .DI1(DI[1]),
-        .DI2(DI[2]),
-        .DI3(DI[3]),
-        .S0(S[0]),
-        .S1(S[1]),
-        .S2(S[2]),
-        .S3(S[3])
-    );
-  end else begin
-    CARRY4_VPR #(
-        .CYINIT_AX(1'b0),
-        .CYINIT_C0(1'b0),
-        .CYINIT_C1(1'b0)
-    ) _TECHMAP_REPLACE_ (
-        .CO_CHAIN(COUT),
-        .CO_FABRIC0(CO[0]),
-        .CO_FABRIC1(CO[1]),
-        .CO_FABRIC2(CO[2]),
-        .CO_FABRIC3(CO[3]),
-        .O0(O[0]),
-        .O1(O[1]),
-        .O2(O[2]),
-        .O3(O[3]),
-        .DI0(DI[0]),
-        .DI1(DI[1]),
-        .DI2(DI[2]),
-        .DI3(DI[3]),
-        .S0(S[0]),
-        .S1(S[1]),
-        .S2(S[2]),
-        .S3(S[3]),
-        .CIN(CI)
-    );
-  end
-endmodule
-
-module CARRY4_COUT(output [3:0] CO, O, output COUT, input CI, CYINIT, input [3:0] DI, S);
-  parameter _TECHMAP_CONSTMSK_CI_ = 1;
-  parameter _TECHMAP_CONSTVAL_CI_ = 1'b0;
-  parameter _TECHMAP_CONSTMSK_CYINIT_ = 1;
-  parameter _TECHMAP_CONSTVAL_CYINIT_ = 1'b0;
-
-  localparam [0:0] IS_CI_ZERO = (
-      _TECHMAP_CONSTMSK_CI_ == 1 && _TECHMAP_CONSTVAL_CI_ == 0 &&
-      _TECHMAP_CONSTMSK_CYINIT_ == 1 && _TECHMAP_CONSTVAL_CYINIT_ == 0);
-  localparam [0:0] IS_CI_ONE = (
-      _TECHMAP_CONSTMSK_CI_ == 1 && _TECHMAP_CONSTVAL_CI_ == 0 &&
-      _TECHMAP_CONSTMSK_CYINIT_ == 1 && _TECHMAP_CONSTVAL_CYINIT_ == 1);
-  localparam [0:0] IS_CYINIT_FABRIC = _TECHMAP_CONSTMSK_CYINIT_ == 0;
-  localparam [0:0] IS_CI_DISCONNECTED = _TECHMAP_CONSTMSK_CI_ == 1 &&
-    _TECHMAP_CONSTVAL_CI_ != 1;
-  localparam [0:0] IS_CYINIT_DISCONNECTED = _TECHMAP_CONSTMSK_CYINIT_ == 1 &&
-    _TECHMAP_CONSTVAL_CYINIT_ != 1;
-
-  wire [1023:0] _TECHMAP_DO_ = "proc; clean";
-
-  if(IS_CYINIT_FABRIC) begin
-    CARRY4_VPR #(
-        .CYINIT_AX(1'b1),
-        .CYINIT_C0(1'b0),
-        .CYINIT_C1(1'b0)
-    ) _TECHMAP_REPLACE_ (
-        .CO_CHAIN(COUT),
-        .CO_FABRIC0(CO[0]),
-        .CO_FABRIC1(CO[1]),
-        .CO_FABRIC2(CO[2]),
-        .CO_FABRIC3(CO[3]),
-        .O0(O[0]),
-        .O1(O[1]),
-        .O2(O[2]),
-        .O3(O[3]),
-        .CYINIT(CYINIT),
-        .DI0(DI[0]),
-        .DI1(DI[1]),
-        .DI2(DI[2]),
-        .DI3(DI[3]),
-        .S0(S[0]),
-        .S1(S[1]),
-        .S2(S[2]),
-        .S3(S[3])
-    );
-  end else if(IS_CI_ZERO || IS_CI_ONE) begin
-    CARRY4_VPR #(
-        .CYINIT_AX(1'b0),
-        .CYINIT_C0(IS_CI_ZERO),
-        .CYINIT_C1(IS_CI_ONE)
-    ) _TECHMAP_REPLACE_ (
-        .CO_CHAIN(COUT),
-        .CO_FABRIC0(CO[0]),
-        .CO_FABRIC1(CO[1]),
-        .CO_FABRIC2(CO[2]),
-        .CO_FABRIC3(CO[3]),
-        .O0(O[0]),
-        .O1(O[1]),
-        .O2(O[2]),
-        .O3(O[3]),
-        .DI0(DI[0]),
-        .DI1(DI[1]),
-        .DI2(DI[2]),
-        .DI3(DI[3]),
-        .S0(S[0]),
-        .S1(S[1]),
-        .S2(S[2]),
-        .S3(S[3])
-    );
-  end else begin
-    CARRY4_VPR #(
-        .CYINIT_AX(1'b0),
-        .CYINIT_C0(1'b0),
-        .CYINIT_C1(1'b0)
-    ) _TECHMAP_REPLACE_ (
-        .CO_CHAIN(COUT),
-        .CO_FABRIC0(CO[0]),
-        .CO_FABRIC1(CO[1]),
-        .CO_FABRIC2(CO[2]),
-        .CO_FABRIC3(CO[3]),
-        .O0(O[0]),
-        .O1(O[1]),
-        .O2(O[2]),
-        .O3(O[3]),
-        .DI0(DI[0]),
-        .DI1(DI[1]),
-        .DI2(DI[2]),
-        .DI3(DI[3]),
-        .S0(S[0]),
-        .S1(S[1]),
-        .S2(S[2]),
-        .S3(S[3]),
-        .CIN(CI)
-    );
-  end
-endmodule
-
 // ============================================================================
 // SRLs
 
@@ -8368,3 +8167,81 @@ module PS7 (
 
 endmodule
 
+module CARRY4_FIX(output O0, O1, O2, O3, CO0, CO1, CO2, CO3, input CYINIT, CIN, DI0, DI1, DI2, DI3, S0, S1, S2, S3);
+  parameter CYINIT_AX = 1'b0;
+  parameter CYINIT_C0 = 1'b0;
+  parameter CYINIT_C1 = 1'b0;
+
+  if(CYINIT_AX) begin
+    CARRY4_VPR #(
+        .CYINIT_AX(1'b1),
+        .CYINIT_C0(1'b0),
+        .CYINIT_C1(1'b0)
+    ) _TECHMAP_REPLACE_ (
+        .CO0(CO0),
+        .CO1(CO1),
+        .CO2(CO2),
+        .CO3(CO3),
+        .CYINIT(CYINIT),
+        .O0(O0),
+        .O1(O1),
+        .O2(O2),
+        .O3(O3),
+        .DI0(DI0),
+        .DI1(DI1),
+        .DI2(DI2),
+        .DI3(DI3),
+        .S0(S0),
+        .S1(S1),
+        .S2(S2),
+        .S3(S3)
+    );
+  end else if(CYINIT_C0 || CYINIT_C1) begin
+    CARRY4_VPR #(
+        .CYINIT_AX(1'b0),
+        .CYINIT_C0(CYINIT_C0),
+        .CYINIT_C1(CYINIT_C1)
+    ) _TECHMAP_REPLACE_ (
+        .CO0(CO0),
+        .CO1(CO1),
+        .CO2(CO2),
+        .CO3(CO3),
+        .O0(O0),
+        .O1(O1),
+        .O2(O2),
+        .O3(O3),
+        .DI0(DI0),
+        .DI1(DI1),
+        .DI2(DI2),
+        .DI3(DI3),
+        .S0(S0),
+        .S1(S1),
+        .S2(S2),
+        .S3(S3)
+    );
+  end else begin
+    CARRY4_VPR #(
+        .CYINIT_AX(1'b0),
+        .CYINIT_C0(1'b0),
+        .CYINIT_C1(1'b0)
+    ) _TECHMAP_REPLACE_ (
+        .CO0(CO0),
+        .CO1(CO1),
+        .CO2(CO2),
+        .CO3(CO3),
+        .O0(O0),
+        .O1(O1),
+        .O2(O2),
+        .O3(O3),
+        .DI0(DI0),
+        .DI1(DI1),
+        .DI2(DI2),
+        .DI3(DI3),
+        .S0(S0),
+        .S1(S1),
+        .S2(S2),
+        .S3(S3),
+        .CIN(CIN)
+    );
+  end
+endmodule

--- a/xc/xc7/techmap/cells_sim.v
+++ b/xc/xc7/techmap/cells_sim.v
@@ -60,7 +60,33 @@ endmodule
 // ============================================================================
 // Carry chain primitives
 
-module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, CO_FABRIC3, CYINIT, CIN, DI0, DI1, DI2, DI3, S0, S1, S2, S3);
+// Output CO directly
+module CARRY_CO_DIRECT(input CO, input O, input S, input DI, output OUT);
+
+assign OUT = CO;
+
+endmodule
+
+// Compute CO from O and S
+module CARRY_CO_LUT(input CO, input O, input S, input DI, output OUT);
+
+assign OUT = O ^ S;
+
+endmodule
+
+(* abc9_box, blackbox *)
+module CARRY_COUT_PLUG(input CIN, output COUT);
+
+assign COUT = CIN;
+
+  specify
+    (CIN => COUT) = 0;
+  endspecify
+
+endmodule
+
+(* abc9_box, blackbox *)
+module CARRY4_VPR(O0, O1, O2, O3, CO0, CO1, CO2, CO3, CYINIT, CIN, DI0, DI1, DI2, DI3, S0, S1, S2, S3);
   parameter CYINIT_AX = 1'b0;
   parameter CYINIT_C0 = 1'b0;
   parameter CYINIT_C1 = 1'b0;
@@ -101,7 +127,7 @@ module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, 
   (* DELAY_CONST_CIN="0.293e-9" *)
   (* DELAY_CONST_S0="0.340e-9" *)
   (* DELAY_CONST_DI0="0.329e-9" *)
-  output wire CO_FABRIC0;
+  output wire CO0;
 
   (* DELAY_CONST_CYINIT="0.529e-9" *)
   (* DELAY_CONST_CIN="0.178e-9" *)
@@ -109,7 +135,7 @@ module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, 
   (* DELAY_CONST_S1="0.469e-9" *)
   (* DELAY_CONST_DI0="0.396e-9" *)
   (* DELAY_CONST_DI1="0.376e-9" *)
-  output wire CO_FABRIC1;
+  output wire CO1;
 
   (* DELAY_CONST_CYINIT="0.617e-9" *)
   (* DELAY_CONST_CIN="0.250e-9" *)
@@ -119,7 +145,7 @@ module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, 
   (* DELAY_CONST_DI0="0.474e-9" *)
   (* DELAY_CONST_DI1="0.459e-9" *)
   (* DELAY_CONST_DI2="0.289e-9" *)
-  output wire CO_FABRIC2;
+  output wire CO2;
 
   (* DELAY_CONST_CYINIT="0.580e-9" *)
   (* DELAY_CONST_CIN="0.114e-9" *)
@@ -131,19 +157,7 @@ module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, 
   (* DELAY_CONST_DI1="0.443e-9" *)
   (* DELAY_CONST_DI2="0.324e-9" *)
   (* DELAY_CONST_DI3="0.327e-9" *)
-  output wire CO_FABRIC3;
-
-  (* DELAY_CONST_CYINIT="0.580e-9" *)
-  (* DELAY_CONST_CIN="0.114e-9" *)
-  (* DELAY_CONST_S0="0.508e-9" *)
-  (* DELAY_CONST_S1="0.528e-9" *)
-  (* DELAY_CONST_S2="0.376e-9" *)
-  (* DELAY_CONST_S3="0.380e-9" *)
-  (* DELAY_CONST_DI0="0.456e-9" *)
-  (* DELAY_CONST_DI1="0.443e-9" *)
-  (* DELAY_CONST_DI2="0.324e-9" *)
-  (* DELAY_CONST_DI3="0.327e-9" *)
-  output wire CO_CHAIN;
+  output wire CO3;
 
   input wire DI0, DI1, DI2, DI3;
   input wire S0, S1, S2, S3;
@@ -166,17 +180,71 @@ module CARRY4_VPR(O0, O1, O2, O3, CO_CHAIN, CO_FABRIC0, CO_FABRIC1, CO_FABRIC2, 
   assign CI3 = S2 ? CI2 : DI2;
   assign CI4 = S3 ? CI3 : DI3;
 
-  assign CO_FABRIC0 = CI1;
-  assign CO_FABRIC1 = CI2;
-  assign CO_FABRIC2 = CI3;
-  assign CO_FABRIC3 = CI4;
+  assign CO0 = CI1;
+  assign CO1 = CI2;
+  assign CO2 = CI3;
+  assign CO3 = CI4;
 
   assign O0 = CI0 ^ S0;
   assign O1 = CI1 ^ S1;
   assign O2 = CI2 ^ S2;
   assign O3 = CI3 ^ S3;
 
-  assign CO_CHAIN = CO_FABRIC3;
+  specify
+    // https://github.com/SymbiFlow/prjxray-db/blob/34ea6eb08a63d21ec16264ad37a0a7b142ff6031/artix7/timings/CLBLL_L.sdf#L11-L46
+    (CYINIT => O0) = 482;
+    (S0     => O0) = 223;
+    (CIN    => O0) = 222;
+    (CYINIT => O1) = 598;
+    (DI0    => O1) = 407;
+    (S0     => O1) = 400;
+    (S1     => O1) = 205;
+    (CIN    => O1) = 334;
+    (CYINIT => O2) = 584;
+    (DI0    => O2) = 556;
+    (DI1    => O2) = 537;
+    (S0     => O2) = 523;
+    (S1     => O2) = 558;
+    (S2     => O2) = 226;
+    (CIN    => O2) = 239;
+    (CYINIT => O3) = 642;
+    (DI0    => O3) = 615;
+    (DI1    => O3) = 596;
+    (DI2    => O3) = 438;
+    (S0     => O3) = 582;
+    (S1     => O3) = 618;
+    (S2     => O3) = 330;
+    (S3     => O3) = 227;
+    (CIN    => O3) = 313;
+    (CYINIT => CO0) = 536;
+    (DI0    => CO0) = 379;
+    (S0     => CO0) = 340;
+    (CIN    => CO0) = 271;
+    (CYINIT => CO1) = 494;
+    (DI0    => CO1) = 465;
+    (DI1    => CO1) = 445;
+    (S0     => CO1) = 433;
+    (S1     => CO1) = 469;
+    (CIN    => CO1) = 157;
+    (CYINIT => CO2) = 592;
+    (DI0    => CO2) = 540;
+    (DI1    => CO2) = 520;
+    (DI2    => CO2) = 356;
+    (S0     => CO2) = 512;
+    (S1     => CO2) = 548;
+    (S2     => CO2) = 292;
+    (CIN    => CO2) = 228;
+    (CYINIT => CO3) = 580;
+    (DI0    => CO3) = 526;
+    (DI1    => CO3) = 507;
+    (DI2    => CO3) = 398;
+    (DI3    => CO3) = 385;
+    (S0     => CO3) = 508;
+    (S1     => CO3) = 528;
+    (S2     => CO3) = 378;
+    (S3     => CO3) = 380;
+    (CIN    => CO3) = 114;
+  endspecify
 endmodule
 
 // ============================================================================

--- a/xc/xc7/techmap/clean_carry_map.v
+++ b/xc/xc7/techmap/clean_carry_map.v
@@ -1,0 +1,98 @@
+// Output CO directly
+module CARRY_CO_DIRECT(input CO, input O, input S, input DI, output OUT);
+
+parameter TOP_OF_CHAIN = 1'b0;
+
+assign OUT = CO;
+
+endmodule
+
+// Compute CO from S, DI, O.
+module CARRY_CO_LUT(input CO, input O, input S, input DI, output OUT);
+
+parameter TOP_OF_CHAIN = 1'b0;
+
+generate if(TOP_OF_CHAIN)
+    // S == S[i]
+    // DI == DI[i]
+    // O == O[i]
+    // CO == CO[i]
+    //
+    // Need to replicate both MUXCY and XORCY to get CO[i].
+    //
+    // Equations:
+    //   1) CO[i] = S[i] ? CO[i-1] : DI[i]
+    //   2) O[i] = S[i] ^ CO[i-1]
+    //
+    //   -- Add "S[i] ^" to the front of both sides of eq 2 --
+    //
+    //   3) S[i] ^ O[i] = S[i] ^ S[i] ^ CO[i-1]
+    //
+    //   -- Apply A ^ A = 0 to eq 3 --
+    //
+    //   4) S[i] ^ O[i] = 0 ^ CO[i-1]
+    //
+    //   -- Apply A ^ B = B ^ A to eq 4
+    //
+    //   5) S[i] ^ O[i] = CO[i-1] ^ 0
+    //
+    //   -- Apply A ^ 0 = A to eq 5
+    //
+    //   6) S[i] ^ O[i] = CO[i-1]
+    //
+    //   -- subsititude CO[i-1] from eq 6 into equation 1 --
+    //
+    //   7) CO[i] = S[i] ? (S[i] ^ O[i]) : DI[i]
+    //
+    // DI, S, O (0, 0, 0) = 0 => OUT = DI => 0
+    // DI, S, O (0, 0, 1) = 1 => OUT = DI => 0
+    // DI, S, O (0, 1, 0) = 2 => OUT = S ^ O => 1
+    // DI, S, O (0, 1, 1) = 3 => OUT = S ^ O => 0
+    // DI, S, O (1, 0, 0) = 4 => OUT = DI => 1
+    // DI, S, O (1, 0, 1) = 5 => OUT = DI => 1
+    // DI, S, O (1, 1, 0) = 6 => OUT = S ^ O => 1
+    // DI, S, O (1, 1, 1) = 7 => OUT = S ^ O => 0
+    //
+    LUT3 #(.INIT(8'b01110100)) mux_and_xor_lut (.I0(O), .I1(S), .I2(DI), .O(OUT));
+else
+    // S == S[i+1]
+    // O == O[i+1]
+    // CO == CO[i]
+    //
+    // Because S/O from next level is available, equation is simply:
+    //
+    // CO[i] = S[i+1] ^ O[i+1]
+    //
+    // S, O (0, 0) = 0 => 0
+    // S, O (0, 1) = 1 => 1
+    // S, O (1, 0) = 2 => 1
+    // S, O (1, 1) = 3 => 0
+    //
+    LUT2 #(.INIT(4'b0110)) xor_lut (.I0(O), .I1(S), .O(OUT));
+endgenerate
+
+endmodule
+
+module CARRY_CO_TOP_POP(input CO, input O, input S, input DI, output OUT);
+// Add 1 dummy layer to the carry chain to get the CO, this can only be used
+// at the top of the carry chain when CO[3] was needed.
+
+parameter TOP_OF_CHAIN = 1'b0;
+
+wire cin_from_below;
+CARRY_COUT_PLUG cin_plug(
+    .CIN(CO),
+    .COUT(cin_from_below)
+);
+
+CARRY4_VPR #(
+    .CYINIT_AX(1'b0),
+    .CYINIT_C0(1'b0),
+    .CYINIT_C1(1'b0)
+) dummy (
+    .CIN(cin_from_below),
+    .O0(OUT),
+    .S0(1'b0)
+);
+
+endmodule

--- a/xc/xc7/techmap/fix_carry.py
+++ b/xc/xc7/techmap/fix_carry.py
@@ -1,0 +1,380 @@
+""" Script for addressing CARRY4 output congestion in elaborated netlists.
+
+Usage:
+
+    python3 fix_carry.py < input-netlist-json > output-netlist-json
+
+Description:
+
+    In the 7-series SLICEL (and SLICEM) sites, there can be output congestion
+    if both the CO and O of the CARRY4 are used.  This congestion can be
+    avoided if transparent/open latches or registers on the output of the
+    CARRY4.
+
+    VPR does not currently support either of those options, so for now, if
+    both CO and O are used, the CO output is converted into a LUT equation to
+    recompute the CO output from O, DI and S.  See carry_map.v and
+    clean_carry_map.v for details.
+
+    This script identifies CARRY4 chains in the netlist, identifies if there
+    is output congestion on the O and CO ports, and marks the congestion by
+    changing CARRY_CO_DIRECT (e.g. directly use the CO port) to CARRY_CO_LUT
+    (compute the CO value using a LUT equation).
+
+"""
+import json
+import sys
+
+
+def find_top_module(design):
+    """
+    Looks for the top-level module in the design. Returns its name. Throws
+    an exception if none was found.
+    """
+
+    for name, module in design["modules"].items():
+        attrs = module["attributes"]
+        if "top" in attrs and int(attrs["top"]) == 1:
+            return name
+
+    raise RuntimeError("No top-level module found in the design!")
+
+
+def find_carry4_chains(design, top_module, bit_to_cells):
+    """ Identify CARRY4 carry chains starting from the root CARRY4.
+
+    All non-root CARRY4 cells should end up as part of a chain, otherwise
+    an assertion is raised.
+
+    Arguments:
+     design (dict) - "design" field from Yosys JSON format
+     top_module (str) - Name of top module.
+     bit_to_cells (dict) - Map of net bit identifier and cell information.
+        Computes in "create_bit_to_cell_map".
+
+    Returns:
+        list of list of strings - List of CARRY4 chains.  Each chain is a list
+            of cellnames.  The cells are listed in chain order, starting from
+            the root.
+
+    """
+    cells = design["modules"][top_module]["cells"]
+
+    used_carry4s = set()
+    root_carry4s = []
+    nonroot_carry4s = {}
+    for cellname in cells:
+        cell = cells[cellname]
+        if cell["type"] != "CARRY4_VPR":
+            continue
+        connections = cell["connections"]
+
+        if "CIN" in connections:
+            cin_connections = connections["CIN"]
+            assert len(cin_connections) == 1
+
+            # Goto driver of CIN, should be a CARRY_COUT_PLUG.
+            plug_cellname, port, bit_idx = bit_to_cells[cin_connections[0]][0]
+            plug_cell = cells[plug_cellname]
+            assert plug_cell["type"] == "CARRY_COUT_PLUG", plug_cellname
+            assert port == "COUT"
+
+            plug_connections = plug_cell["connections"]
+
+            cin_connections = plug_connections["CIN"]
+            assert len(cin_connections) == 1
+
+            # Goto driver of CIN, should be a CARRY_CO_DIRECT.
+            direct_cellname, port, bit_idx = bit_to_cells[cin_connections[0]
+                                                          ][0]
+            direct_cell = cells[direct_cellname]
+            assert direct_cell["type"] == "CARRY_CO_DIRECT", direct_cellname
+            assert port == "OUT"
+
+            direct_connections = direct_cell["connections"]
+
+            co_connections = direct_connections["CO"]
+            assert len(co_connections) == 1
+
+            nonroot_carry4s[co_connections[0]] = cellname
+        else:
+            used_carry4s.add(cellname)
+            root_carry4s.append(cellname)
+
+    # Walk from each root CARRY4 to each child CARRY4 module.
+    chains = []
+    for cellname in root_carry4s:
+        chain = [cellname]
+
+        while True:
+            # Follow CO3 to the next CARRY4, if any.
+            cell = cells[cellname]
+            connections = cell["connections"]
+
+            co3_connections = connections.get("CO3", None)
+            if co3_connections is None:
+                # No next CARRY4, stop here.
+                break
+
+            found_next_link = False
+            for connection in co3_connections:
+                next_cellname = nonroot_carry4s.get(connection, None)
+                if next_cellname is not None:
+                    cellname = next_cellname
+                    used_carry4s.add(cellname)
+                    chain.append(cellname)
+                    found_next_link = True
+                    break
+
+            if not found_next_link:
+                break
+
+        chains.append(chain)
+
+    # Make sure all non-root CARRY4's got used.
+    for bit, cellname in nonroot_carry4s.items():
+        assert cellname in used_carry4s, (bit, cellname)
+
+    return chains
+
+
+def create_bit_to_cell_map(design, top_module):
+    """ Create map from net bit identifier to cell information.
+
+    Arguments:
+     design (dict) - "design" field from Yosys JSON format
+     top_module (str) - Name of top module.
+
+    Returns:
+     bit_to_cells (dict) - Map of net bit identifier and cell information.
+
+    The map keys are the net bit identifier used to mark which net a cell port
+    is connected too.  The map values are a list of cell ports that are in the
+    net.  The first element of the list is the driver port, and the remaining
+    elements are sink ports.
+
+    The list elements are 3-tuples with:
+      cellname (str) - The name of the cell this port belongs too
+      port (str) - The name of the port this element is connected too.
+      bit_idx (int) - For multi bit ports, a 0-based index into the port.
+
+    """
+    bit_to_cells = {}
+
+    cells = design["modules"][top_module]["cells"]
+
+    for cellname in cells:
+        cell = cells[cellname]
+        port_directions = cell["port_directions"]
+        for port, connections in cell["connections"].items():
+            is_output = port_directions[port] == "output"
+            for bit_idx, bit in enumerate(connections):
+
+                list_of_cells = bit_to_cells.get(bit, None)
+                if list_of_cells is None:
+                    list_of_cells = [None]
+                    bit_to_cells[bit] = list_of_cells
+
+                if is_output:
+                    # First element of list of cells is net driver.
+                    assert list_of_cells[0] is None, (
+                        bit, list_of_cells[0], cellname
+                    )
+                    list_of_cells[0] = (cellname, port, bit_idx)
+                else:
+                    list_of_cells.append((cellname, port, bit_idx))
+
+    return bit_to_cells
+
+
+def is_bit_used(bit_to_cells, bit):
+    """ Is the net bit specified used by any sinks? """
+    list_of_cells = bit_to_cells[bit]
+
+    return len(list_of_cells) > 1
+
+
+def is_bit_used_other_than_carry4_cin(design, top_module, bit, bit_to_cells):
+    """ Is the net bit specified used by any sinks other than a carry chain? """
+    cells = design["modules"][top_module]["cells"]
+    list_of_cells = bit_to_cells[bit]
+    assert len(list_of_cells) == 2, bit
+
+    direct_cellname, port, _ = list_of_cells[1]
+    direct_cell = cells[direct_cellname]
+    assert direct_cell['type'] == "CARRY_CO_DIRECT"
+    assert port == "CO"
+
+    # Follow to output
+    connections = direct_cell["connections"]["OUT"]
+    assert len(connections) == 1
+
+    for cellname, port, bit_idx in bit_to_cells[connections[0]][1:]:
+        cell = cells[cellname]
+        if cell["type"] == "CARRY_COUT_PLUG" and port == "CIN":
+            continue
+        else:
+            return True, direct_cellname
+
+    return False, direct_cellname
+
+
+def create_bit_to_net_map(design, top_module):
+    """ Create map from net bit identifier to net information.
+
+    Arguments:
+     design (dict) - "design" field from Yosys JSON format
+     top_module (str) - Name of top module.
+
+    Returns:
+     bit_to_nets (dict) - Map of net bit identifier to net information.
+    """
+    bit_to_nets = {}
+
+    nets = design["modules"][top_module]["netnames"]
+
+    for net in nets:
+        for bit_idx, bit in enumerate(nets[net]["bits"]):
+            bit_to_nets[bit] = (net, bit_idx)
+
+    return bit_to_nets
+
+
+def fixup_cin(design, top_module, bit_to_cells, co_bit, direct_cellname):
+    """ Move connection from CARRY_CO_LUT.OUT -> CARRY_COUT_PLUG.CIN to
+        directly to preceeding CARRY4.
+    """
+    cells = design["modules"][top_module]["cells"]
+
+    direct_cell = cells[direct_cellname]
+    assert direct_cell["type"] == "CARRY_CO_LUT"
+
+    # Follow to output
+    connections = direct_cell["connections"]["OUT"]
+    assert len(connections) == 1
+
+    for cellname, port, bit_idx in bit_to_cells[connections[0]][1:]:
+        cell = cells[cellname]
+        if cell["type"] == "CARRY_COUT_PLUG" and port == "CIN":
+            assert bit_idx == 0
+
+            cells[cellname]["connections"]["CIN"][0] = co_bit
+
+
+def fixup_congested_rows(design, top_module, bit_to_cells, bit_to_nets, chain):
+    """ Walk the specified carry chain, and identify if any outputs are congested.
+
+    Arguments:
+     design (dict) - "design" field from Yosys JSON format
+     top_module (str) - Name of top module.
+     bit_to_cells (dict) - Map of net bit identifier and cell information.
+        Computes in "create_bit_to_cell_map".
+     bit_to_nets (dict) - Map of net bit identifier to net information.
+        Computes in "create_bit_to_net_map".
+     chain (list of str) - List of cells in the carry chain.
+
+    """
+    cells = design["modules"][top_module]["cells"]
+
+    O_ports = ["O0", "O1", "O2", "O3"]
+    CO_ports = ["CO0", "CO1", "CO2", "CO3"]
+
+    def check_if_rest_of_carry4_is_unused(cellname, cell_idx):
+        assert cell_idx < len(O_ports) - 1
+
+        cell = cells[cellname]
+        connections = cell["connections"]
+
+        for o, co in zip(O_ports[cell_idx:], CO_ports[cell_idx:]):
+            o_conns = connections[o]
+            assert len(o_conns) == 1
+            o_bit = o_conns[0]
+            if is_bit_used(bit_to_cells, o_bit):
+                return False
+
+            co_conns = connections[co]
+            assert len(co_conns) == 1
+            co_bit = co_conns[0]
+            if is_bit_used(bit_to_cells, co_bit):
+                return False
+
+        return True
+
+    # Carry chain is congested if both O and CO is used at the same level.
+    # CO to next element in the chain is fine.
+    for chain_idx, cellname in enumerate(chain):
+        cell = cells[cellname]
+        connections = cell["connections"]
+        for cell_idx, (o, co) in enumerate(zip(O_ports, CO_ports)):
+            o_conns = connections[o]
+            assert len(o_conns) == 1
+            o_bit = o_conns[0]
+
+            co_conns = connections[co]
+            assert len(co_conns) == 1
+            co_bit = co_conns[0]
+
+            is_o_used = is_bit_used(bit_to_cells, o_bit)
+            is_co_used, direct_cellname = is_bit_used_other_than_carry4_cin(
+                design, top_module, co_bit, bit_to_cells
+            )
+
+            if is_o_used and is_co_used:
+                # Output at this row is congested.
+                direct_cell = cells[direct_cellname]
+
+                if co == 'CO3' and chain_idx == len(chain) - 1:
+                    # This congestion is on the top of the carry chain,
+                    # emit a dummy layer to the chain.
+                    direct_cell["type"] = "CARRY_CO_TOP_POP"
+                    assert int(direct_cell["parameters"]["TOP_OF_CHAIN"]) == 1
+                # If this is the last CARRY4 in the chain, see if the
+                # remaining part of the chain is idle.
+                elif chain_idx == len(chain) - 1 and \
+                    check_if_rest_of_carry4_is_unused(cellname, cell_idx + 1):
+
+                    # Because the rest of the CARRY4 is idle, it is safe to
+                    # use the next row up to output the top of the carry.
+                    connections["S{}".format(cell_idx + 1)] = ["1'b0"]
+
+                    next_o_conns = connections[O_ports[cell_idx + 1]]
+                    assert len(next_o_conns) == 1
+                    direct_cell["connections"]["CO"][0] = next_o_conns[0]
+
+                    netname, bit_idx = bit_to_nets[next_o_conns[0]]
+                    assert bit_idx == 0
+
+                    # Update annotation that this net is now in use.
+                    net = design["module"][top_module]["netnames"][netname]
+                    assert net["attributes"].get("unused_bits", None) == "0 "
+                    del net["attributes"]["unused_bits"]
+                else:
+                    # The previous two stragies (use another layer of carry)
+                    # only work for the top of the chain.  This appears to be
+                    # in the middle of the chain, so just spill it out to a
+                    # LUT, and fixup the direct carry chain (if any).
+                    direct_cell["type"] = "CARRY_CO_LUT"
+
+                    fixup_cin(
+                        design, top_module, bit_to_cells, co_bit,
+                        direct_cellname
+                    )
+
+
+def main():
+    design = json.load(sys.stdin)
+    top_module = find_top_module(design)
+
+    bit_to_cells = create_bit_to_cell_map(design, top_module)
+    bit_to_nets = create_bit_to_net_map(design, top_module)
+
+    for chain in find_carry4_chains(design, top_module, bit_to_cells):
+        fixup_congested_rows(
+            design, top_module, bit_to_cells, bit_to_nets, chain
+        )
+
+    json.dump(design, sys.stdout, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/xc/xc7/tests/soc/litex/base/baselitex_arty.xdc
+++ b/xc/xc7/tests/soc/litex/base/baselitex_arty.xdc
@@ -1,4 +1,4 @@
-# ### serial:0.tx
+### serial:0.tx
 ##set_property LOC D10 [get_ports serial_tx]
 set_property IOSTANDARD LVCMOS33 [get_ports serial_tx]
 # ### serial:0.rx
@@ -74,6 +74,9 @@ set_property IOSTANDARD SSTL135 [get_ports {ddram_a[13]} ]
 set_property SLEW FAST [get_ports {ddram_ba[0]} ]
 set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[0]} ]
 # ### ddram:0.ba
+##set_property LOC P4 [get_ports {ddram_ba[1]} ]
+set_property SLEW FAST [get_ports {ddram_ba[1]} ]
+set_property IOSTANDARD SSTL135 [get_ports {ddram_ba[1]} ]
 # ### ddram:0.ba
 ##set_property LOC P2 [get_ports {ddram_ba[2]} ]
 set_property SLEW FAST [get_ports {ddram_ba[2]} ]

--- a/xc/xc7/toolchain_wrappers/symbiflow_synth
+++ b/xc/xc7/toolchain_wrappers/symbiflow_synth
@@ -8,7 +8,8 @@ export TECHMAP_PATH=`realpath ${MYPATH}/../share/symbiflow/techmaps/xc7_vpr/tech
 
 SYNTH_TCL_PATH=`realpath ${MYPATH}/../share/symbiflow/scripts/xc7/synth.tcl`
 CONV_TCL_PATH=`realpath ${MYPATH}/../share/symbiflow/scripts/xc7/conv.tcl`
-SPLIT_INOUTS=`realpath ${MYPATH}/python/split_inouts.py`
+export UTILS_PATH=`realpath ${MYPATH}/python`
+SPLIT_INOUTS=${UTILS_PATH}/split_inouts.py
 
 VERILOG_FILES=()
 XDC_FILES=()

--- a/xc/xc7/toolchain_wrappers/symbiflow_synth
+++ b/xc/xc7/toolchain_wrappers/symbiflow_synth
@@ -98,6 +98,7 @@ export OUT_SYNTH_V=${TOP}_synth.v
 export OUT_EBLIF=${TOP}.eblif
 export PART_JSON=`realpath ${DATABASE_DIR}/$DEVICE/$PART/part.json`
 export OUT_FASM_EXTRA=${TOP}_fasm_extra.fasm
+export PYTHON3=${PYTHON3:=$(which python3)}
 LOG=${TOP}_synth.log
 
 yosys -p "tcl ${SYNTH_TCL_PATH}" -l $LOG ${VERILOG_FILES[*]}

--- a/xc/xc7/yosys/synth.tcl
+++ b/xc/xc7/yosys/synth.tcl
@@ -16,10 +16,10 @@ source [file join [file normalize [info script]] .. utils.tcl]
 #
 # Do not infer IOBs for targets that use a ROI.
 if { $::env(USE_ROI) == "TRUE" } {
-    synth_xilinx -vpr -flatten -abc9 -nosrl -noclkbuf -nodsp -noiopad -nowidelut
+    synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -noiopad -nowidelut
 } else {
     # Read Yosys baseline library first.
-    read_verilog -lib -specify -D_EXPLICIT_CARRY +/xilinx/cells_sim.v
+    read_verilog -lib -specify +/xilinx/cells_sim.v
     read_verilog -lib +/xilinx/cells_xtra.v
 
     # Overwrite some models (e.g. IBUF with more parameters)
@@ -28,7 +28,7 @@ if { $::env(USE_ROI) == "TRUE" } {
     hierarchy -check -auto-top
 
     # Start flow after library reading
-    synth_xilinx -vpr -flatten -abc9 -nosrl -nodsp -iopad -nowidelut -noclkbuf -run prepare:check
+    synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -iopad -nowidelut -run prepare:check
 }
 
 # Check that post-synthesis cells match libraries.
@@ -52,7 +52,45 @@ select -set obufds t:OSERDESE2 %co2:+\[OQ,I\] t:OBUFDS t:OBUFTDS %u  %i
 setparam -set HAS_OSERDES 1 @obufds
 
 # Map Xilinx tech library to 7-series VPR tech library.
-read_verilog -lib $::env(TECHMAP_PATH)/cells_sim.v
+read_verilog -specify -lib $::env(TECHMAP_PATH)/cells_sim.v
+
+# Convert congested CARRY4 outputs to LUTs.
+techmap -map  $::env(TECHMAP_PATH)/carry_map.v
+write_json $::env(OUT_JSON).carry_fixup.json
+exec $::env(PYTHON3) $::env(TECHMAP_PATH)/fix_carry.py < $::env(OUT_JSON).carry_fixup.json > $::env(OUT_JSON).carry_fixup_out.json
+design -push
+read_json $::env(OUT_JSON).carry_fixup_out.json
+
+techmap -map  $::env(TECHMAP_PATH)/clean_carry_map.v
+
+# Re-read baseline libraries
+read_verilog -lib -specify +/xilinx/cells_sim.v
+read_verilog -lib +/xilinx/cells_xtra.v
+read_verilog -specify -lib $::env(TECHMAP_PATH)/cells_sim.v
+if { $::env(USE_ROI) != "TRUE" } {
+    read_verilog -lib $::env(TECHMAP_PATH)/iobs.v
+}
+
+# Re-run optimization flow to absorb carry modifications
+hierarchy -check -auto-top
+
+write_ilang $::env(OUT_JSON).pre_abc9.ilang
+if { $::env(USE_ROI) == "TRUE" } {
+    synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -noiopad -nowidelut -run map_ffs:check
+} else {
+    synth_xilinx -flatten -abc9 -nosrl -noclkbuf -nodsp -iopad -nowidelut -run map_ffs:check
+}
+
+write_ilang $::env(OUT_JSON).post_abc9.ilang
+
+# Either the JSON bounce or ABC9 pass causes the CARRY4_VPR CIN/CYINIT pins
+# to have 0's when unused.  As a result VPR will attempt to route a 0 to those
+# ports. However this is not generally possible or desirable.
+#
+# $::env(TECHMAP_PATH)/cells_map.v has a simple techmap pass where these
+# unused ports are removed.  In theory yosys's "rmports" would work here, but
+# it does not.
+chtype -map CARRY4_VPR CARRY4_FIX
 techmap -map  $::env(TECHMAP_PATH)/cells_map.v
 
 # opt_expr -undriven makes sure all nets are driven, if only by the $undef

--- a/xc/xc7/yosys/synth.tcl
+++ b/xc/xc7/yosys/synth.tcl
@@ -44,6 +44,13 @@ if { [info exists ::env(INPUT_XDC_FILE)] && $::env(INPUT_XDC_FILE) != "" } {
 
 update_pll_params
 
+# Write the SDC file
+#
+# Note that write_sdc and the SDC plugin holds live pointers to RTLIL objects.
+# If Yosys mutates those objects (e.g. destroys them), the SDC plugin will
+# segfault.
+write_sdc $::env(OUT_SDC)
+
 write_verilog $::env(OUT_SYNTH_V).premap.v
 
 # Look for connections OSERDESE2.OQ -> OBUFDS.I. Annotate OBUFDS with a parameter
@@ -62,18 +69,18 @@ read_verilog -specify -lib $::env(TECHMAP_PATH)/cells_sim.v
 #
 # Ideally VPR would resolve the congestion in one of the following ways:
 #
-#  - If either O or CO are registered in a FF, then no output 
-#    congestion exists if the O or CO FF is packed into the same cluster.  
-#    The register output will used the [ABCD]Q output, and the unregistered 
+#  - If either O or CO are registered in a FF, then no output
+#    congestion exists if the O or CO FF is packed into the same cluster.
+#    The register output will used the [ABCD]Q output, and the unregistered
 #    output will used the [ABCD]MUX.
 #
-#  - If neither the O or CO are registered in a FF, then the [ABCD]Q output 
+#  - If neither the O or CO are registered in a FF, then the [ABCD]Q output
 #    can still be used if the FF is placed into "transparent latch" mode.
 #    VPR can express this edge, but because using a FF in "transparent latch"
 #    mode requires running specific CE and SR signals connected to constants,
 #    VPR cannot easily (or at all) express this packing situation.
 #
-#    VPR's packer in theory could be expanded to express this kind of 
+#    VPR's packer in theory could be expanded to express this kind of
 #    situation.
 #
 #                                   CLE Row
@@ -116,7 +123,6 @@ read_verilog -specify -lib $::env(TECHMAP_PATH)/cells_sim.v
 # |                                                                          |
 # +--------------------------------------------------------------------------+
 #
-
 
 techmap -map  $::env(TECHMAP_PATH)/carry_map.v
 write_json $::env(OUT_JSON).carry_fixup.json
@@ -171,5 +177,3 @@ attrmap -remove hdlname
 write_json $::env(OUT_JSON)
 # Write the design in Verilog format.
 write_verilog $::env(OUT_SYNTH_V)
-#Write the SDC file
-write_sdc $::env(OUT_SDC)


### PR DESCRIPTION
This PR attempts to fix #1597 by change the strategy used to decongest SLICEL CARRY4 outputs.  Previously, all ALU CO uses were modeled as a `O ^ S`, but yosys's abc9 pass is now good enough to undo this change.  So rather than continue to try to fight abc9 as it gets better at merging logic, this PR uses a new CARRY4 congestion avoidance strategy.

Changes:
 - Yosys arith mapping using upstream CARRY4 mapping
 - New pass (implemented as a Python3 script) de-congests O + CO carry rows by using a LUT equation from the inputs
 - CARRY4_VPR is modelled as a blackbox instead of a whitebox to prevent abc9 from modifying/swapping outputs during cleanup optimization