### PR TITLE
Fix missing CLKFBOUT_PHASE update

### DIFF
--- a/xc/xc7/tests/soc/ibex/ibex.patch
+++ b/xc/xc7/tests/soc/ibex/ibex.patch
@@ -12,21 +12,9 @@ index c26ca45..be19828 100644
    logic clk_sys, rst_sys_n;
  
 diff --git a/shared/rtl/fpga/xilinx/clkgen_xil7series.sv b/shared/rtl/fpga/xilinx/clkgen_xil7series.sv
-index e41b4b0..e080de7 100644
+index e41b4b0..f253c07 100644
 --- a/shared/rtl/fpga/xilinx/clkgen_xil7series.sv
 +++ b/shared/rtl/fpga/xilinx/clkgen_xil7series.sv
-@@ -27,9 +27,9 @@ module clkgen_xil7series (
-     .STARTUP_WAIT         ("FALSE"),
-     .DIVCLK_DIVIDE        (1),
-     .CLKFBOUT_MULT        (12),
--    .CLKFBOUT_PHASE       (0.000),
-+    .CLKFBOUT_PHASE       (0),
-     .CLKOUT0_DIVIDE       (24),
--    .CLKOUT0_PHASE        (0.000),
-+    .CLKOUT0_PHASE        (0),
-     .CLKOUT0_DUTY_CYCLE   (0.500)
-   ) pll (
-     .CLKFBOUT            (clk_fb_unbuf),
 @@ -40,7 +40,7 @@ module clkgen_xil7series (
      .CLKOUT4             (),
      .CLKOUT5             (),

--- a/xc/xc7/yosys/utils.tcl
+++ b/xc/xc7/yosys/utils.tcl
@@ -5,17 +5,18 @@
 proc multiply_param { cell param_name multiplier } {
     set param_value [getparam $param_name $cell]
     if {$param_value ne ""} {
-	set new_param_value [expr int(round($param_value * $multiplier))]
-	setparam -set $param_name $new_param_value $cell
-	puts "Updated parameter $param_name of cell $cell from $param_value to $new_param_value"
+        set new_param_value [expr int(round($param_value * $multiplier))]
+        setparam -set $param_name $new_param_value $cell
+        puts "Updated parameter $param_name of cell $cell from $param_value to $new_param_value"
     }
 }
 
 proc update_pll_params {} {
     foreach cell [selection_to_tcl_list "t:PLLE2_ADV"] {
-	for {set output 0} {$output < 6} {incr output} {
-	    multiply_param $cell "CLKOUT${output}_PHASE" 1000
-	    multiply_param $cell "CLKOUT${output}_DUTY_CYCLE" 100000
-	}
+        multiply_param $cell "CLKFBOUT_PHASE" 1000
+        for {set output 0} {$output < 6} {incr output} {
+            multiply_param $cell "CLKOUT${output}_PHASE" 1000
+            multiply_param $cell "CLKOUT${output}_DUTY_CYCLE" 100000
+        }
     }
 }


### PR DESCRIPTION
This PR:
- adds the `CLKFBOUT_PHASE` parameter to the list of updated PLL parameters.
- improves formatting in the `utils.tcl` script (previously mix of tabs and spaces)
- updates the ibex.patch

After the update, Ibex works on HW.

This issue has been tracked on our burndown list. After merging, I will update the list.
