### PR TITLE
toolchain_wrappers: add additional_vpr_options option

### DIFF
--- a/xc/xc7/tests/install_test/Makefile
+++ b/xc/xc7/tests/install_test/Makefile
@@ -9,6 +9,7 @@ VERILOG:=${current_dir}/counter_${BOARD}.v
 PCF=${current_dir}/${BOARD}.pcf
 XDC=${current_dir}/counter_${BOARD}.xdc
 BUILDDIR:=build
+ADDITIONAL_VPR_OPTIONS="--seed 1024 --astar_fac 1.3"
 
 all: ${BUILDDIR}/${TOP}.bit
 
@@ -23,16 +24,16 @@ else
 endif
 
 ${BUILDDIR}/${TOP}.net: ${BUILDDIR}/${TOP}.eblif
-	cd ${BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE}
+	cd ${BUILDDIR} && symbiflow_pack -e ${TOP}.eblif -d ${DEVICE} -a ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.place: ${BUILDDIR}/${TOP}.net
-	cd ${BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME}
+	cd ${BUILDDIR} && symbiflow_place -e ${TOP}.eblif -d ${DEVICE} -p ${PCF} -n ${TOP}.net -P ${PARTNAME} -a ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.route: ${BUILDDIR}/${TOP}.place
-	cd ${BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE}
+	cd ${BUILDDIR} && symbiflow_route -e ${TOP}.eblif -d ${DEVICE} -a ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.fasm: ${BUILDDIR}/${TOP}.route
-	cd ${BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE}
+	cd ${BUILDDIR} && symbiflow_write_fasm -e ${TOP}.eblif -d ${DEVICE} --additional_vpr_options ${ADDITIONAL_VPR_OPTIONS}
 
 ${BUILDDIR}/${TOP}.bit: ${BUILDDIR}/${TOP}.fasm
 	cd ${BUILDDIR} && symbiflow_write_bitstream -d ${BITSTREAM_DEVICE} -f ${TOP}.fasm -p ${PARTNAME} -b ${TOP}.bit

--- a/xc/xc7/toolchain_wrappers/symbiflow_pack
+++ b/xc/xc7/toolchain_wrappers/symbiflow_pack
@@ -7,7 +7,7 @@ MYPATH=`dirname ${MYPATH}`
 source ${MYPATH}/env
 source ${VPRPATH}/vpr_common
 
-parse_args $@
+parse_args "$@"
 
 export OUT_NOISY_WARNINGS=noisy_warnings-${DEVICE}_pack.log
 

--- a/xc/xc7/toolchain_wrappers/symbiflow_place
+++ b/xc/xc7/toolchain_wrappers/symbiflow_place
@@ -7,7 +7,7 @@ MYPATH=`dirname ${MYPATH}`
 source ${MYPATH}/env
 source ${MYPATH}/vpr_common
 
-parse_args $@
+parse_args "$@"
 
 if [ -z $PCF ]; then
     PCF=""

--- a/xc/xc7/toolchain_wrappers/symbiflow_route
+++ b/xc/xc7/toolchain_wrappers/symbiflow_route
@@ -7,7 +7,7 @@ MYPATH=`dirname ${MYPATH}`
 source ${MYPATH}/env
 source ${VPRPATH}/vpr_common
 
-parse_args $@
+parse_args "$@"
 
 export OUR_NOISY_WARNINGS=noisy_warnings-${DEVICE}_pack.log
 

--- a/xc/xc7/toolchain_wrappers/symbiflow_write_fasm
+++ b/xc/xc7/toolchain_wrappers/symbiflow_write_fasm
@@ -7,7 +7,7 @@ MYPATH=`dirname ${MYPATH}`
 source ${MYPATH}/env
 source ${VPRPATH}/vpr_common
 
-parse_args $@
+parse_args "$@"
 
 TOP="${EBLIF%.*}"
 FASM_EXTRA=${TOP}_fasm_extra.fasm

--- a/xc/xc7/toolchain_wrappers/symbiflow_write_xml_rr_graph
+++ b/xc/xc7/toolchain_wrappers/symbiflow_write_xml_rr_graph
@@ -7,7 +7,7 @@ MYPATH=`dirname ${MYPATH}`
 source ${MYPATH}/env
 source ${MYPATH}/vpr_common
 
-parse_args $@
+parse_args "$@"
 
 OUT_NOISY_WARNINGS=noisy_warnings-${DEVICE}_place.log
 

--- a/xc/xc7/toolchain_wrappers/vpr_common
+++ b/xc/xc7/toolchain_wrappers/vpr_common
@@ -7,11 +7,11 @@ fi
 
 function parse_args {
 
-     OPTS=d:e:p:n:P:s:
-     LONGOPTS=device:,eblif:,pcf:,net:,part:,sdc:
+     OPTS=d:e:p:n:P:s:a:
+     LONGOPTS=device:,eblif:,pcf:,net:,part:,sdc:,additional_vpr_options:
 
-     PARSED_OPTS=`getopt --options=${OPTS} --longoptions=${LONGOPTS} --name $0 -- $@`
-     eval set -- ${PARSED_OPTS}
+     PARSED_OPTS=`getopt --options=${OPTS} --longoptions=${LONGOPTS} --name $0 -- "$@"`
+     eval set -- "${PARSED_OPTS}"
 
      DEVICE=""
      DEVICE_NAME=""
@@ -20,6 +20,7 @@ function parse_args {
      PCF=""
      NET=""
      SDC=""
+     ADDITIONAL_VPR_OPTIONS=""
 
      while true; do
           case "$1" in
@@ -47,6 +48,10 @@ function parse_args {
                     SDC=$2
                     shift 2
                     ;;
+               -a|--additional_vpr_options)
+                    ADDITIONAL_VPR_OPTIONS="$2"
+                    shift 2
+		    ;;
                --)
                     break
                     ;;
@@ -75,6 +80,7 @@ function parse_args {
      export PCF=$PCF
      export NET=$NET
      export SDC=$SDC
+     export VPR_OPTIONS="$VPR_OPTIONS $ADDITIONAL_VPR_OPTIONS"
 
      export ARCH_DIR=`realpath ${MYPATH}/../share/symbiflow/arch/$DEVICE`
      export ARCH_DEF=${ARCH_DIR}/arch.timing.xml
@@ -98,7 +104,6 @@ function run_vpr {
          ${EBLIF} \
          --device ${DEVICE_NAME} \
          ${VPR_OPTIONS} \
-         ${VPR_SEED} \
          --read_rr_graph ${RR_GRAPH} \
          --read_router_lookahead ${LOOKAHEAD} \
          --read_placement_delay_lookup ${PLACE_DELAY} \


### PR DESCRIPTION
This PR replaces usage of environment variable ``${VPR_SEED}`` to set vpr seed with ``-a``/``--additional_vpr_options`` options added to vpr argument parser. This will allow to add, not only vpr seed, but also another vpr options to the default vpr options.

Signed-off-by: Kamil Rakoczy <krakoczy@antmicro.com>