### PR TITLE
Remove penalty cost for undesirable connections

### DIFF
--- a/utils/lib/connection_database.py
+++ b/utils/lib/connection_database.py
@@ -25,10 +25,10 @@ def create_tables(conn):
     c.execute(
         """
 INSERT INTO
-    switch(name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, switch_type)
+    switch(name, internal_capacitance, drive_resistance, intrinsic_delay, switch_type)
 VALUES
-    ("__vpr_delayless_switch__", 0.0, 0.0, 0.0, 0.0, "mux"),
-    ("short", 0.0, 0.0, 0.0, 0.0, "short")
+    ("__vpr_delayless_switch__", 0.0, 0.0, 0.0, "mux"),
+    ("short", 0.0, 0.0, 0.0, "short")
 """
     )
     conn.commit()

--- a/utils/lib/connection_database.sql
+++ b/utils/lib/connection_database.sql
@@ -189,7 +189,6 @@ CREATE TABLE switch(
   internal_capacitance REAL,
   drive_resistance REAL,
   intrinsic_delay REAL,
-  penalty_cost REAL,
   switch_type TEXT
 );
 

--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -68,7 +68,7 @@ class Channels(namedtuple(
 
 
 class SwitchTiming(namedtuple('SwitchTiming',
-                              'r c_in c_out c_internal t_del p_cost')):
+                              'r c_in c_out c_internal t_del')):
     """Encapsulation for timing attributes of a VPR switch
     see: https://vtr-verilog-to-routing.readthedocs.io/en/latest/arch/reference.html#switches
     """

--- a/utils/lib/rr_graph/tests/test_graph2.py
+++ b/utils/lib/rr_graph/tests/test_graph2.py
@@ -12,7 +12,7 @@ from ..tracks import Track, Direction
 class Graph2Tests(unittest.TestCase):
     def setUp(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         delayless = Switch(
@@ -27,7 +27,7 @@ class Graph2Tests(unittest.TestCase):
 
     def test_init(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         self.switches = [
@@ -244,7 +244,7 @@ class Graph2Tests(unittest.TestCase):
 class Graph2MediumTests(unittest.TestCase):
     def setUp(self):
         switch_timing = SwitchTiming(
-            r=0, c_in=1, c_out=2, t_del=0, c_internal=0, p_cost=0
+            r=0, c_in=1, c_out=2, t_del=0, c_internal=0
         )
         switch_sizing = SwitchSizing(mux_trans_size=0, buf_size=1)
         self.switches = [

--- a/utils/lib/rr_graph_capnp/graph2.py
+++ b/utils/lib/rr_graph_capnp/graph2.py
@@ -107,7 +107,6 @@ def read_switch(sw):
             c_out=timing.cout,
             c_internal=timing.cinternal,
             t_del=timing.tdel,
-            p_cost=timing.penaltyCost,
         ),
         sizing=graph2.SwitchSizing(
             buf_size=sizing.bufSize,
@@ -488,7 +487,6 @@ class Graph(object):
                 timing.cout = switch.timing.c_out
                 timing.r = switch.timing.r
                 timing.tdel = switch.timing.t_del
-                timing.penaltyCost = switch.timing.p_cost
 
             if switch.sizing:
                 sizing = out_switch.sizing

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -98,7 +98,6 @@ def graph_from_xml(
                 c_out=float(element.attrib.get('Cout', 0)),
                 c_internal=float(element.attrib.get('Cinternal', 0)),
                 t_del=float(element.attrib.get('Tdel', 0)),
-                p_cost=float(element.attrib.get('penalty_cost', 0)),
             )
 
         # Switch sizing
@@ -556,7 +555,6 @@ class Graph(object):
                     "Cin": switch.timing.c_in,
                     "Cout": switch.timing.c_out,
                     "Tdel": switch.timing.t_del,
-                    "penalty_cost": switch.timing.p_cost,
                 }
 
                 if VPR_HAS_C_INTERNAL_SUPPORT:

--- a/xc/common/utils/prjxray_arch_import.py
+++ b/xc/common/utils/prjxray_arch_import.py
@@ -1154,14 +1154,13 @@ def main():
 
         switchlist_xml = ET.SubElement(arch_xml, 'switchlist')
 
-        for name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, \
+        for name, internal_capacitance, drive_resistance, intrinsic_delay, \
                 switch_type in c.execute("""
 SELECT
     name,
     internal_capacitance,
     drive_resistance,
     intrinsic_delay,
-    penalty_cost,
     switch_type
 FROM
     switch
@@ -1174,7 +1173,6 @@ WHERE
                 "R": str(drive_resistance),
                 "Cin": str(0),
                 "Cout": str(0),
-                "penalty_cost": str(penalty_cost),
                 "Tdel": str(intrinsic_delay),
             }
 

--- a/xc/common/utils/prjxray_arch_import.py
+++ b/xc/common/utils/prjxray_arch_import.py
@@ -1319,27 +1319,31 @@ WHERE
         if direct['x_offset'] == 0 and direct['y_offset'] == 0:
             continue
 
-        ET.SubElement(
-            directlist_xml, 'direct', {
-                'name':
-                    '{}_to_{}_dx_{}_dy_{}'.format(
-                        direct['from_pin'], direct['to_pin'],
-                        direct['x_offset'], direct['y_offset']
-                    ),
-                'from_pin':
-                    add_vpr_tile_prefix(direct['from_pin']),
-                'to_pin':
-                    add_vpr_tile_prefix(direct['to_pin']),
-                'x_offset':
-                    str(direct['x_offset']),
-                'y_offset':
-                    str(direct['y_offset']),
-                'z_offset':
-                    '0',
-                'switch_name':
-                    direct['switch_name'],
-            }
-        )
+        direct_dict = {
+            'name':
+                '{}_to_{}_dx_{}_dy_{}'.format(
+                    direct['from_pin'], direct['to_pin'], direct['x_offset'],
+                    direct['y_offset']
+                ),
+            'from_pin':
+                add_vpr_tile_prefix(direct['from_pin']),
+            'to_pin':
+                add_vpr_tile_prefix(direct['to_pin']),
+            'x_offset':
+                str(direct['x_offset']),
+            'y_offset':
+                str(direct['y_offset']),
+            'z_offset':
+                '0',
+        }
+
+        # If the switch is a delayless_switch, the switch name
+        # needs to be avoided as VPR automatically assigns
+        # the delayless switch to this direct connection
+        if direct['switch_name'] != '__vpr_delayless_switch__':
+            direct_dict['switch_name'] = direct['switch_name']
+
+        ET.SubElement(directlist_xml, 'direct', direct_dict)
 
     arch_xml_str = ET.tostring(arch_xml, pretty_print=True).decode('utf-8')
     args.output_arch.write(arch_xml_str)

--- a/xc/common/utils/prjxray_form_channels.py
+++ b/xc/common/utils/prjxray_form_channels.py
@@ -99,11 +99,7 @@ def create_get_switch(conn):
     pip_cache[(False, 0.0, 0.0, 0.0)] = write_cur.fetchone()[0]
 
     def get_switch_timing(
-            is_pass_transistor,
-            delay,
-            internal_capacitance,
-            drive_resistance,
-            penalty_cost=0.0
+            is_pass_transistor, delay, internal_capacitance, drive_resistance
     ):
         """ Return a switch that matches provided timing.
 
@@ -121,9 +117,6 @@ def create_get_switch(conn):
         drive_resistance : float or convertable to float
             Drive resistance from switch (Ohms).
 
-        penalty_cost : float or convertable to float
-            Penalty Cost assigned through this switch
-
         Returns
         -------
         switch_pkey : int
@@ -132,7 +125,7 @@ def create_get_switch(conn):
         """
         key = (
             bool(is_pass_transistor), float(delay), float(drive_resistance),
-            float(internal_capacitance), float(penalty_cost)
+            float(internal_capacitance)
         )
 
         if key not in pip_cache:
@@ -142,21 +135,20 @@ def create_get_switch(conn):
                 name = 'pass_transistor'
                 switch_type = 'pass_gate'
 
-            name = '{}_R{}_C{}_Tdel{}_Pcost{}'.format(
-                name, drive_resistance, internal_capacitance, delay,
-                penalty_cost
+            name = '{}_R{}_C{}_Tdel{}'.format(
+                name, drive_resistance, internal_capacitance, delay
             )
 
             write_cur.execute(
                 """
 INSERT INTO
     switch(
-        name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, switch_type
+        name, internal_capacitance, drive_resistance, intrinsic_delay, switch_type
     )
 VALUES
-    (?, ?, ?, ?, ?, ?)""", (
+    (?, ?, ?, ?, ?)""", (
                     name, internal_capacitance, drive_resistance, delay,
-                    penalty_cost, switch_type
+                    switch_type
                 )
             )
             pip_cache[key] = write_cur.lastrowid
@@ -184,7 +176,6 @@ VALUES
         delay = 0.0
         drive_resistance = 0.0
         internal_capacitance = 0.0
-        penalty_cost = 0.0
 
         if pip_timing is not None:
             if pip_timing.delays is not None:
@@ -204,7 +195,7 @@ VALUES
 
         return get_switch_timing(
             pip.is_pass_transistor, delay, internal_capacitance,
-            drive_resistance, penalty_cost
+            drive_resistance
         )
 
     return get_switch, get_switch_timing

--- a/xc/common/utils/prjxray_form_channels.py
+++ b/xc/common/utils/prjxray_form_channels.py
@@ -202,19 +202,6 @@ VALUES
                 # milliOhms -> Ohms
                 drive_resistance = pip_timing.drive_resistance / 1e3
 
-        if "GCLK" in pip.net_from and "GFAN" in pip.net_to:
-            penalty_cost = 1e-6
-
-        # HCLK_CMT_CK_BUFHCLK -> HCLK_CMT_CK_IN and -> HCLK_CMT_MUX_CLK_
-        # are both BUFH -> BUFH edges.  In general it doesn't make sense for
-        # the router to follow these paths unless required, so make them more
-        # undesirable.
-        if 'HCLK_CMT_CK_BUFHCLK' in pip.net_from and 'HCLK_CMT_CK_IN' in pip.net_to:
-            penalty_cost = 1e-6
-
-        if 'HCLK_CMT_CK_BUFHCLK' in pip.net_from and 'HCLK_CMT_MUX_CLK_' in pip.net_to:
-            penalty_cost = 1e-6
-
         return get_switch_timing(
             pip.is_pass_transistor, delay, internal_capacitance,
             drive_resistance, penalty_cost

--- a/xc/common/utils/prjxray_routing_import.py
+++ b/xc/common/utils/prjxray_routing_import.py
@@ -1389,14 +1389,13 @@ def main():
         populate_bufg_rebuf_map(conn)
 
         cur = conn.cursor()
-        for name, internal_capacitance, drive_resistance, intrinsic_delay, penalty_cost, \
+        for name, internal_capacitance, drive_resistance, intrinsic_delay, \
                 switch_type in cur.execute("""
 SELECT
     name,
     internal_capacitance,
     drive_resistance,
     intrinsic_delay,
-    penalty_cost,
     switch_type
 FROM
     switch;"""):
@@ -1422,7 +1421,6 @@ FROM
                             c_out=0.0,
                             c_internal=internal_capacitance,
                             t_del=intrinsic_delay,
-                            p_cost=penalty_cost,
                         ),
                         sizing=graph2.SwitchSizing(
                             mux_trans_size=0,


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to test whether the absence of the penalty cost still produces issues in routing clocks outside the clock regions through the general interconnect.

Local builds succeeded in the vivado_diff_fasm test, meaning that no violation of clock routing was generated by VPR