### PR TITLE
Remove conda-forge.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: symbiflow_arch_def_base
 channels:
   - defaults
   - symbiflow
-  - conda-forge
 dependencies:
   - symbiflow-yosys=0.8_6021_gd8b2d1a2=20200708_083630
   - symbiflow-yosys-plugins=1.0.0.7_0060_g7454cd6=20200902_114536


### PR DESCRIPTION
Now that capnproto is in the symbiflow conda repo, conda-forge can be remove
from the channel list again.