### PR TITLE
Add never prune idelayctrl

### DIFF
--- a/xc/common/primitives/idelayctrl/idelayctrl.model.xml
+++ b/xc/common/primitives/idelayctrl/idelayctrl.model.xml
@@ -1,5 +1,5 @@
 <models>
-  <model name="IDELAYCTRL">
+  <model name="IDELAYCTRL" never_prune="true">
     <input_ports>
       <!-- synchronous control inputs -->
       <port is_clock="1" name="REFCLK"/>

--- a/xc/xc7/tests/ddr/ddr_uart.v
+++ b/xc/xc7/tests/ddr/ddr_uart.v
@@ -27,7 +27,7 @@ module top(
 wire [3:0] led;
 
 assign led[0] = main_locked;
-assign led[1] = idelayctl_rdy;
+assign led[1] = 0;
 assign led[2] = 0;
 assign led[3] = 0;
 
@@ -9734,8 +9734,7 @@ BUFG BUFG_5(
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(clk200_clk),
-	.RST(main_ic_reset),
-	.RDY(idelayctl_rdy)
+	.RST(main_ic_reset)
 );
 
 wire tq;

--- a/xc/xc7/tests/ddr/ddr_uart_100t.v
+++ b/xc/xc7/tests/ddr/ddr_uart_100t.v
@@ -27,7 +27,7 @@ module top(
 wire [3:0] led;
 
 assign led[0] = main_locked;
-assign led[1] = idelayctl_rdy;
+assign led[1] = 0;
 assign led[2] = 0;
 assign led[3] = 0;
 
@@ -9734,8 +9734,7 @@ BUFG BUFG_5(
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(clk200_clk),
-	.RST(main_ic_reset),
-	.RDY(idelayctl_rdy)
+	.RST(main_ic_reset)
 );
 
 wire tq;

--- a/xc/xc7/tests/idelayctrl/idelayctrl.v
+++ b/xc/xc7/tests/idelayctrl/idelayctrl.v
@@ -81,21 +81,16 @@ BUFG bufg_clk(.I(PRE_BUFG_SYSCLK), .O(SYSCLK));
 BUFG bufg_clkdiv(.I(PRE_BUFG_CLKDIV), .O(CLKDIV));
 BUFG bufg_refclk(.I(PRE_BUFG_REFCLK), .O(REFCLK));
 
-wire RDY_1;
-wire RDY_2;
-
 IDELAYCTRL idelayctrl_1 (
-    .REFCLK(REFCLK),
-    .RDY(RDY_1)
+    .REFCLK(REFCLK)
 );
 
 IDELAYCTRL idelayctrl_2 (
-    .REFCLK(REFCLK),
-    .RDY(RDY_2)
+    .REFCLK(REFCLK)
 );
 
-assign led[0] = RDY_1;
-assign led[1] = RDY_2;
+assign led[0] = 0;
+assign led[1] = 0;
 
 wire OUTPUTS[7:0];
 

--- a/xc/xc7/tests/serdes/serdes_basys3_idelay.v
+++ b/xc/xc7/tests/serdes/serdes_basys3_idelay.v
@@ -110,7 +110,6 @@ wire [7:0] MASKED_INPUTS = INPUTS & MASK;
 wire I_DAT;
 wire O_DAT;
 wire T_DAT;
-wire RDY;
 
 IOBUF iobuf(.I(O_DAT), .O(I_DAT), .T(T_DAT), .IO(io));
 
@@ -131,8 +130,7 @@ serdes_test
 
 .I_DAT      (I_DAT),
 .O_DAT      (O_DAT),
-.T_DAT      (T_DAT),
-.RDY        (RDY)
+.T_DAT      (T_DAT)
 );
 
 wire [7:0] MASKED_OUTPUTS = OUTPUTS & MASK;
@@ -148,6 +146,5 @@ always @(posedge SYSCLK)
 
 assign led[0] = heartbeat_cnt[22];
 assign led[8:1] = MASKED_OUTPUTS;
-assign led[9] = RDY;
 
 endmodule

--- a/xc/xc7/tests/serdes/serdes_test_idelay.v
+++ b/xc/xc7/tests/serdes/serdes_test_idelay.v
@@ -16,7 +16,6 @@ input  wire RST,
 input  wire I_DAT,
 output wire O_DAT,
 output wire T_DAT,
-output wire RDY,
 
 input  wire [7:0] INPUTS,
 output wire [7:0] OUTPUTS
@@ -71,8 +70,7 @@ oserdes
 wire DDLY;
 
 IDELAYCTRL idelayctrl (
-    .REFCLK(REFCLK),
-    .RDY(RDY)
+    .REFCLK(REFCLK)
 );
 
 // IDELAY

--- a/xc/xc7/tests/soc/litex/base/baselitex_arty.v
+++ b/xc/xc7/tests/soc/litex/base/baselitex_arty.v
@@ -39,8 +39,8 @@ module top(
 
 wire [3:0] led;
 
-assign led[0] = idelayctl_rdy;
-assign led[1] = soc_pll_locked;
+assign led[0] = soc_pll_locked;
+assign led[1] = 0;
 assign led[2] = 0;
 assign led[3] = 0;
 
@@ -89,7 +89,6 @@ OBUF #(.IOSTANDARD("SSTL135"), .SLEW("FAST")) obuf_rst (.I(ddram_reset_n_iob),.O
 
 // End manually inserted OBUFs
 
-wire idelayctl_rdy;
 wire soc_netsoc_ctrl_reset_reset_re;
 wire soc_netsoc_ctrl_reset_reset_r;
 wire soc_netsoc_ctrl_reset_reset_we;
@@ -13456,8 +13455,7 @@ OBUF clk_eth_buf(.I(eth_ref_clk_obuf), .O(eth_ref_clk));
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(clk200_clk),
-	.RST(soc_ic_reset),
-	.RDY(idelayctl_rdy)
+	.RST(soc_ic_reset)
 );
 
 reg [31:0] mem_3[0:4095];

--- a/xc/xc7/tests/soc/litex/base/baselitex_arty100t.v
+++ b/xc/xc7/tests/soc/litex/base/baselitex_arty100t.v
@@ -39,8 +39,8 @@ module top(
 
 wire [3:0] led;
 
-assign led[0] = idelayctl_rdy;
-assign led[1] = soc_pll_locked;
+assign led[0] = soc_pll_locked;
+assign led[1] = 0;
 assign led[2] = 0;
 assign led[3] = 0;
 
@@ -89,7 +89,6 @@ OBUF #(.IOSTANDARD("SSTL135"), .SLEW("FAST")) obuf_rst (.I(ddram_reset_n_iob),.O
 
 // End manually inserted OBUFs
 
-wire idelayctl_rdy;
 wire soc_netsoc_ctrl_reset_reset_re;
 wire soc_netsoc_ctrl_reset_reset_r;
 wire soc_netsoc_ctrl_reset_reset_we;
@@ -13457,8 +13456,7 @@ OBUF clk_eth_buf(.I(eth_ref_clk_obuf), .O(eth_ref_clk));
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(clk200_clk),
-	.RST(soc_ic_reset),
-	.RDY(idelayctl_rdy)
+	.RST(soc_ic_reset)
 );
 
 reg [31:0] mem_3[0:4095];

--- a/xc/xc7/tests/soc/litex/mini_ddr/minilitex_ddr_arty.v
+++ b/xc/xc7/tests/soc/litex/mini_ddr/minilitex_ddr_arty.v
@@ -27,7 +27,7 @@ module top(
 wire [3:0] led;
 
 assign led[0] = main_locked;
-assign led[1] = idelayctl_rdy;
+assign led[1] = 0;
 assign led[2] = 0;
 assign led[3] = 0;
 
@@ -76,7 +76,6 @@ OBUF #(.IOSTANDARD("SSTL135"), .SLEW("FAST")) obuf_rst (.I(ddram_reset_n_iob),.O
 
 // End manually inserted OBUFs
 
-wire idelayctl_rdy;
 reg main_minsoc_ctrl_reset_storage = 1'd0;
 reg main_minsoc_ctrl_reset_re = 1'd0;
 reg [31:0] main_minsoc_ctrl_scratch_storage = 32'd305419896;
@@ -10149,8 +10148,7 @@ BUFG BUFG_4(
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(clk200_clk),
-	.RST(main_ic_reset),
-	.RDY(idelayctl_rdy)
+	.RST(main_ic_reset)
 );
 
 wire tq;

--- a/xc/xc7/tests/soc/litex/mini_ddr/minilitex_ddr_arty100t.v
+++ b/xc/xc7/tests/soc/litex/mini_ddr/minilitex_ddr_arty100t.v
@@ -27,7 +27,7 @@ module top(
 wire [3:0] led;
 
 assign led[0] = main_locked;
-assign led[1] = idelayctl_rdy;
+assign led[1] = 0;
 assign led[2] = 0;
 assign led[3] = 0;
 
@@ -76,7 +76,6 @@ OBUF #(.IOSTANDARD("SSTL135"), .SLEW("FAST")) obuf_rst (.I(ddram_reset_n_iob),.O
 
 // End manually inserted OBUFs
 
-wire idelayctl_rdy;
 reg main_minsoc_ctrl_reset_storage = 1'd0;
 reg main_minsoc_ctrl_reset_re = 1'd0;
 reg [31:0] main_minsoc_ctrl_scratch_storage = 32'd305419896;
@@ -10149,8 +10148,7 @@ BUFG BUFG_4(
 
 IDELAYCTRL IDELAYCTRL(
 	.REFCLK(clk200_clk),
-	.RST(main_ic_reset),
-	.RDY(idelayctl_rdy)
+	.RST(main_ic_reset)
 );
 
 wire tq;


### PR DESCRIPTION
This PR enables the never_prune attribute to the IDELAYCTRL so that it does not get pruned by VPR if no output signal is provided.