### PR TITLE
Generalize libxml2 package spec now that 2.9.10 is released.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,7 +14,8 @@ dependencies:
   - nodejs
   - libiconv
   - iverilog
-  - libxml2=2.9.10=20200629_180127
+  # libxml2 2.9.10 contains an integer overflow fix required for arch-defs.
+  - libxml2>=2.9.10
   - icestorm
   - capnproto-java
   - pip


### PR DESCRIPTION
This allows using the libxml2 package from anaconda rather than from
symbiflow.

After this is merged, we can remove the libxml2 job from https://github.com/SymbiFlow/conda-packages