### PR TITLE
Fix unroutability issues with new VPR

### DIFF
--- a/.github/kokoro/steps/rapidwright.sh
+++ b/.github/kokoro/steps/rapidwright.sh
@@ -2,7 +2,9 @@
 
 export RAPIDWRIGHT_PATH=$(pwd)/github/$KOKORO_DIR/env/RapidWright
 mkdir -p "${RAPIDWRIGHT_PATH}"
-git clone https://github.com/Xilinx/RapidWright.git "${RAPIDWRIGHT_PATH}"
+
+# Using SymbiFlow/RapidWright fork to control ingestion of upstream merges.
+git clone https://github.com/SymbiFlow/RapidWright.git "${RAPIDWRIGHT_PATH}"
 pushd "${RAPIDWRIGHT_PATH}"
 git checkout interchange
 make update_jars


### PR DESCRIPTION
The newest VPR has fixed an issue with IPIN/OPIN RR nodes for which multiple RR nodes were emitted for the same site pin, due to the possible multiple side locations of the pin.

Therefore, with the new VPR, we cannot count on the presence of multiple nodes for the same pin during the routing import, to create the correct connections between the interconnection nodes and the site nodes.

This PR fixes this issue, assigning the same node ID to the directional graph nodes allowing to have multiple CHAN nodes connected to an IPIN/OPIN.

The corresponding VPR issue is the following one: https://github.com/verilog-to-routing/vtr-verilog-to-routing/issues/1571.

This PR is expected to fail as with the current version of VPR, multiple nodes corresponding to the same site pin are emitted during the creation of the virtual RR graph.