### PR TITLE
Revert "CI: fix latest package URL getter tool name"

### DIFF
--- a/.github/workflows/checkstatus.yml
+++ b/.github/workflows/checkstatus.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install STDM
       run: pip install git+https://github.com/SymbiFlow/symbiflow-tools-data-manager#egg=stdm
     - name: Get latest artifact name
-      run: mkdir install && symbiflow_get_latest_artifact_url > install/latest
+      run: mkdir install && get_latest_artifact_url > install/latest
     - name: Upload artifact URL file
       uses: weslenng/gcp-storage-sync@master
       env:


### PR DESCRIPTION
This reverts commit 9c42f14cc37c4cb3665a51634fdc0f0c5dc6d45d.

Signed-off-by: Karol Gugala <kgugala@antmicro.com>