### PR TITLE
ci/check-status: set-output name=skip

### DIFF
--- a/.github/workflows/checkstatus.yml
+++ b/.github/workflows/checkstatus.yml
@@ -4,26 +4,41 @@ on:
   status:
 
 jobs:
+
   Check-statuses:
     runs-on: ubuntu-latest
-
     steps:
+
     - name: Check status
-      run: |
-        curl -s --url https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.sha }}/status \
-        --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' | head -n 2 | tail -n 1 | grep "success"
+      id: check
+      run: >-
+        curl -fsSL
+        -H 'Accept: application/vnd.github.v3+json'
+        -H 'authorization: Bearer ${{ github.token }}'
+        https://api.github.com/repos/${{ github.repository }}/commits/${{ github.event.sha }}/status
+        | head -n 2
+        | tail -n 1
+        | grep "success"
+        || echo '::set-output name=skip::true'
+
     - name: Set up Python
+      if: steps.check.outputs.skip != 'true'
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
+
     - name: Install STDM
+      if: steps.check.outputs.skip != 'true'
       run: pip install git+https://github.com/SymbiFlow/symbiflow-tools-data-manager#egg=stdm
+
     - name: Get latest artifact name
+      if: steps.check.outputs.skip != 'true'
       run: mkdir install && symbiflow_get_latest_artifact_url > install/latest
+
     - name: Upload artifact URL file
+      if: steps.check.outputs.skip != 'true'
       uses: weslenng/gcp-storage-sync@master
       env:
-        GCP_SERVICE_ACCOUNT_KEY_FILE: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_FILE  }}
-        GCP_STORAGE_BUCKET: ${{ secrets.GCP_STORAGE_BUCKET  }}
+        GCP_SERVICE_ACCOUNT_KEY_FILE: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_FILE }}
+        GCP_STORAGE_BUCKET: ${{ secrets.GCP_STORAGE_BUCKET }}
         SOURCE_DIR: "install"
-


### PR DESCRIPTION
Close #1741

This is a small enhancement to #1719. Currently, if step 'Check status' fails, the CI run is reported as a failure. This PR sets an output variable (`skip`) instead. That variable is used as the `if` condition in all the remaining steps. As a result, CI runs will all be green, unless there is some issue with any of the steps after the first one.