### PR TITLE
gh-actions: run check status only if commit is on master

### DIFF
--- a/.github/workflows/checkstatus.yml
+++ b/.github/workflows/checkstatus.yml
@@ -6,12 +6,14 @@ on:
 jobs:
 
   Check-statuses:
+    if: ${{ contains(github.event.branches.*.name, 'master') == 1 }}
     runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v2
 
     - uses: ./.github/check-status
+      id: check
       with:
         token: ${{ github.token }}
         sha: ${{ github.event.sha }}


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

I have noticed that the check-status workflow is executed also on commits that are not on the master branch: 

```
Run curl -fsSL -H 'Accept: application/vnd.github.v3+json' -H 'authorization: Bearer ***' https://api.github.com/repos/SymbiFlow/symbiflow-arch-defs/commits/bc7fc375e24546994db346a7d0b1921740e2c480/status | head -n 2 | tail -n 1 | grep "success" || echo '::set-output name=skip::true'
  curl -fsSL -H 'Accept: application/vnd.github.v3+json' -H 'authorization: Bearer ***' https://api.github.com/repos/SymbiFlow/symbiflow-arch-defs/commits/bc7fc375e24546994db346a7d0b1921740e2c480/status | head -n 2 | tail -n 1 | grep "success" || echo '::set-output name=skip::true'
  shell: /bin/bash -e ***0***
curl: (23) Failed writing body (1125 != 1370)
```

In this example, `bc7fc375e24546994db346a7d0b1921740e2c480` is a commit from https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1744, which should not trigger the GH action workflow.