### PR TITLE
Add Vivado logs to captured results for debugging purposes.

### DIFF
--- a/.github/kokoro/continuous-docs.cfg
+++ b/.github/kokoro/continuous-docs.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-docs/"
   }
 }

--- a/.github/kokoro/continuous-ice40.cfg
+++ b/.github/kokoro/continuous-ice40.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-ice40/"
   }
 }

--- a/.github/kokoro/continuous-ql.cfg
+++ b/.github/kokoro/continuous-ql.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-ql/"
   }
 }

--- a/.github/kokoro/continuous-testarch.cfg
+++ b/.github/kokoro/continuous-testarch.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-testarch/"
   }
 }

--- a/.github/kokoro/continuous-tests.cfg
+++ b/.github/kokoro/continuous-tests.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-tests/"
   }
 }

--- a/.github/kokoro/continuous-xc7-vendor.cfg
+++ b/.github/kokoro/continuous-xc7-vendor.cfg
@@ -19,6 +19,7 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
     regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-xc7-vendor/"
   }

--- a/.github/kokoro/continuous-xc7.cfg
+++ b/.github/kokoro/continuous-xc7.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-xc7/"
   }
 }

--- a/.github/kokoro/continuous-xc7a200t-vendor.cfg
+++ b/.github/kokoro/continuous-xc7a200t-vendor.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-xc7a200t-vendor/"
   }
 }

--- a/.github/kokoro/continuous-xc7a200t.cfg
+++ b/.github/kokoro/continuous-xc7a200t.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-continuous-xc7a200t/"
   }
 }

--- a/.github/kokoro/kokoro-cfg.py
+++ b/.github/kokoro/kokoro-cfg.py
@@ -3,7 +3,28 @@
 Generates kokoro config files based on template.
 """
 
-db_full = """\
+DEFAULT_ARTIFACTS = """\
+    regex: "**/*result*.xml"
+    regex: "**/*sponge_log.xml"
+    regex: "**/.ninja_log"
+    regex: "**/pack.log"
+    regex: "**/place.log"
+    regex: "**/route.log"
+    regex: "**/*_sv2v.v.log"
+    regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"\
+"""
+
+INSTALL = """\
+    regex: "**/symbiflow-arch-defs-install*.tar.xz"\
+"""
+
+INSTALL_200T = """\
+    regex: "**/symbiflow-arch-defs-install-200t*.tar.xz"\
+"""
+
+DB_FULL = """\
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Generated from .github/kokoro/kokoro-cfg.py
@@ -17,14 +38,7 @@ timeout_mins: 4320
 action {
   define_artifacts {
     # File types
-    regex: "**/*result*.xml"
-    regex: "**/*sponge_log.xml"
-    regex: "**/.ninja_log"
-    regex: "**/pack.log"
-    regex: "**/place.log"
-    regex: "**/route.log"
-    regex: "**/*_sv2v.v.log"
-    regex: "**/*_qor.csv"
+%(artifacts)s
     strip_prefix: "github/symbiflow-arch-defs-%(kokoro_type)s-%(arch)s/"
   }
 }
@@ -47,14 +61,27 @@ env_vars {
 
 for type in ['tests', 'docs', 'ice40', 'testarch', 'xc7', 'xc7-vendor',
              'xc7a200t', 'xc7a200t-vendor', 'ql', 'install', 'install-200t']:
+    if type == 'install':
+        artifacts = INSTALL
+    elif type == 'install-200t':
+        artifacts = INSTALL_200T
+    else:
+        artifacts = DEFAULT_ARTIFACTS
+
     with open("continuous-%s.cfg" % type, "w") as f:
-        f.write(db_full % {
-            'arch': type,
-            'kokoro_type': 'continuous',
-        })
+        f.write(
+            DB_FULL % {
+                'arch': type,
+                'artifacts': artifacts,
+                'kokoro_type': 'continuous',
+            }
+        )
 
     with open("presubmit-%s.cfg" % type, "w") as f:
-        f.write(db_full % {
-            'arch': type,
-            'kokoro_type': 'presubmit',
-        })
+        f.write(
+            DB_FULL % {
+                'arch': type,
+                'artifacts': artifacts,
+                'kokoro_type': 'presubmit',
+            }
+        )

--- a/.github/kokoro/package_results.sh
+++ b/.github/kokoro/package_results.sh
@@ -7,7 +7,7 @@ echo "========================================"
 echo "Packing results"
 echo "----------------------------------------"
 date
-cd build
+pushd build
 find -name "*result*.xml" \
     -o -name "*sponge_log.xml" \
     -o -name ".ninja_log" \
@@ -19,9 +19,22 @@ find -name "*result*.xml" \
     -o -name "*_qor.csv" \
     -o -name "vivado.log" \
     | xargs tar -cvf ../results.tar
-cd ..
+popd
 rm -r build
 mkdir build
-cd build
+pushd build
 tar -xf ../results.tar
 rm ../results.tar
+
+popd
+# Cleanup conda/RapidWright/etc.
+rm -r env
+# Cleanup .git and third_party before artifact collection.
+rm -r third_party .git
+
+# Make sure working directory doesn't exceed disk space limit!
+echo "Working directory size: $(du -sh)"
+if [[ $(du -s | cut -d $'\t' -f 1) -gt $(expr 1024 \* 1024 \* 45) ]]; then
+    echo "Working directory too large!"
+    exit 1
+fi

--- a/.github/kokoro/package_results.sh
+++ b/.github/kokoro/package_results.sh
@@ -17,6 +17,7 @@ find -name "*result*.xml" \
     -o -name "*_sv2v.v.log" \
     -o -name "*.bit" \
     -o -name "*_qor.csv" \
+    -o -name "vivado.log" \
     | xargs tar -cvf ../results.tar
 cd ..
 rm -r build

--- a/.github/kokoro/presubmit-docs.cfg
+++ b/.github/kokoro/presubmit-docs.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-docs/"
   }
 }

--- a/.github/kokoro/presubmit-ice40.cfg
+++ b/.github/kokoro/presubmit-ice40.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-ice40/"
   }
 }

--- a/.github/kokoro/presubmit-ql.cfg
+++ b/.github/kokoro/presubmit-ql.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-ql/"
   }
 }

--- a/.github/kokoro/presubmit-testarch.cfg
+++ b/.github/kokoro/presubmit-testarch.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-testarch/"
   }
 }

--- a/.github/kokoro/presubmit-tests.cfg
+++ b/.github/kokoro/presubmit-tests.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-tests/"
   }
 }

--- a/.github/kokoro/presubmit-xc7-vendor.cfg
+++ b/.github/kokoro/presubmit-xc7-vendor.cfg
@@ -19,6 +19,7 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
     regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7-vendor/"
   }

--- a/.github/kokoro/presubmit-xc7.cfg
+++ b/.github/kokoro/presubmit-xc7.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7/"
   }
 }

--- a/.github/kokoro/presubmit-xc7a200t-vendor.cfg
+++ b/.github/kokoro/presubmit-xc7a200t-vendor.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7a200t-vendor/"
   }
 }

--- a/.github/kokoro/presubmit-xc7a200t.cfg
+++ b/.github/kokoro/presubmit-xc7a200t.cfg
@@ -19,6 +19,8 @@ action {
     regex: "**/route.log"
     regex: "**/*_sv2v.v.log"
     regex: "**/*_qor.csv"
+    regex: "**/vivado.log"
+    regex: "**/*.bit"
     strip_prefix: "github/symbiflow-arch-defs-presubmit-xc7a200t/"
   }
 }


### PR DESCRIPTION
Also fixes script when generating install collection lists.

Cleans up `third_party`, `.git` and `env` directories prior to kokoro doing artifact collection.