### PR TITLE
Update SymbiFlow/RapidWright fork instead of directly ingesting upstream

### DIFF
--- a/.github/kokoro/steps/rapidwright.sh
+++ b/.github/kokoro/steps/rapidwright.sh
@@ -2,7 +2,9 @@
 
 export RAPIDWRIGHT_PATH=$(pwd)/github/$KOKORO_DIR/env/RapidWright
 mkdir -p "${RAPIDWRIGHT_PATH}"
-git clone https://github.com/Xilinx/RapidWright.git "${RAPIDWRIGHT_PATH}"
+
+# Using SymbiFlow/RapidWright fork to control ingestion of upstream merges.
+git clone https://github.com/SymbiFlow/RapidWright.git "${RAPIDWRIGHT_PATH}"
 pushd "${RAPIDWRIGHT_PATH}"
 git checkout interchange
 make update_jars


### PR DESCRIPTION
A change on upstream RapidWright was added that depended on a new version of the closed portion of RapidWright, which is resulting in build failures.  For now, fork RapidWright and move the branch point back until the closed portion of RapidWright is updated.