### PR TITLE
Make Ibex sv2v conversion deterministic

### DIFF
--- a/xc/xc7/tests/soc/ibex/generate.py
+++ b/xc/xc7/tests/soc/ibex/generate.py
@@ -65,7 +65,7 @@ def get_fusesoc_sources(root_dir, eda_yaml_path, f_log):
         eda_yaml_path=eda_yaml_path
     )
 
-    return set(
+    return list(
         s.decode() for s in
         subprocess.check_output(get_sources_invocation, shell=True).split()
     )


### PR DESCRIPTION
This PR ensures that Ibex sv2v conversion is deterministic, by enforcing the original input file order (used in synthesis).

A file order during the sv2v conversion is important. When a file is provided earlier, it can force sv2v to generate additional
wrappers or resolve some advanced SystemVerilog syntax correctly (i.e., wildcards)