### PR TITLE
litex: do not output timestamp in BIOS

### DIFF
--- a/xc/xc7/tests/soc/litex/generate.py
+++ b/xc/xc7/tests/soc/litex/generate.py
@@ -33,7 +33,7 @@ class BaseSoC(SoCCore):
             platform,
             sys_clk_freq,
             ident="LiteX SoC on Arty A7",
-            ident_version=True,
+            ident_version=False,
             **kwargs
         )
 


### PR DESCRIPTION
This PR prevents LiteX designs to incur in non-deterministic P&R due to changes in the BIOS (details in https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1788).

With this PR the Build time timestamp is not being added to the mem.init files, but it requires using the latest versions of LiteX, which insert FD primitives in the design.

The FD have been retargeted with a techmap pass in the synth.tcl script as a temporary workaround, as this should rather be a fix to yosys upstream.