### PR TITLE
prjxray: use conda package instead of third_party dir

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "third_party/prjxray"]
 	path = third_party/prjxray
 	url = https://github.com/SymbiFlow/prjxray.git
-[submodule "third_party/prjxray-db"]
-	path = third_party/prjxray-db
-	url = https://github.com/SymbiFlow/prjxray-db.git
 [submodule "third_party/icestorm"]
 	path = third_party/icestorm
 	url = https://github.com/cliffordwolf/icestorm.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,6 @@ get_target_property_required(PYTHON3 env PYTHON3)
 include(common/cmake/image_gen.cmake)
 include(common/cmake/gen.cmake)
 
-add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/third_party/prjxray)
-
 # Target for all check tests.
 add_custom_target(all_check_tests)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ add_env_executable(EXE flake8 REQUIRED)
 add_env_executable(EXE vvp REQUIRED)
 add_env_executable(EXE iverilog REQUIRED)
 add_env_executable(EXE xcfasm REQUIRED)
+add_env_executable(EXE xc7frames2bit REQUIRED)
+add_env_executable(EXE bitread REQUIRED)
+add_env_executable(EXE prjxray-config)
 
 get_target_property_required(PYTHON3 env PYTHON3)
 

--- a/common/cmake/env.cmake
+++ b/common/cmake/env.cmake
@@ -76,6 +76,7 @@ function(ADD_ENV_EXECUTABLE)
 
   set(binary ${ADD_ENV_EXECUTABLE_EXE})
   string(TOUPPER ${binary} binary_upper)
+  string(REPLACE "-" "_" binary_upper ${binary_upper})
   if(DEFINED ENV{${binary_upper}})
     set(${binary_upper} $ENV{${binary_upper}})
   else()

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - symbiflow::symbiflow-yosys=0.8_6021_gd8b2d1a2=20200708_083630
   - symbiflow::symbiflow-yosys-plugins=1.0.0.7_0174_g5e6370a=20201012_171341
   - symbiflow::symbiflow-vtr=8.0.0.rc2_5415_gd6d69ff92=20201120_180018
+  - symbiflow::prjxray-tools=0.1_2697_g0f939808=20201120_091524
   - symbiflow::prjxray-db=0.0_0236_g2ddf99b=20201105_181012
   - symbiflow::zachjs-sv2v=0.0.5_0018_ga170536
   - symbiflow::openocd

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - symbiflow::symbiflow-yosys=0.8_6021_gd8b2d1a2=20200708_083630
   - symbiflow::symbiflow-yosys-plugins=1.0.0.7_0174_g5e6370a=20201012_171341
   - symbiflow::symbiflow-vtr=8.0.0.rc2_5415_gd6d69ff92=20201120_180018
+  - symbiflow::prjxray-db=0.0_0236_g2ddf99b=20201105_181012
   - symbiflow::zachjs-sv2v=0.0.5_0018_ga170536
   - symbiflow::openocd
   - symbiflow::iverilog

--- a/xc/common/cmake/arch_define.cmake
+++ b/xc/common/cmake/arch_define.cmake
@@ -110,6 +110,8 @@ function(ADD_XC_ARCH_DEFINE)
   endif ()
 
   get_target_property_required(XCFASM env XCFASM)
+  get_target_property_required(XC7FRAMES2BIT env XC7FRAMES2BIT)
+  get_target_property_required(BITREAD env BITREAD)
 
 
   get_target_property_required(RAPIDWRIGHT_INSTALLED rapidwright RAPIDWRIGHT_INSTALLED)
@@ -178,9 +180,9 @@ function(ADD_XC_ARCH_DEFINE)
         --emit_pudc_b_pullup \
         --fn_in \${OUT_FASM} \
         --bit_out \${OUT_BITSTREAM} \
-        --frm2bit $<TARGET_FILE:xc7frames2bit> \
+        --frm2bit ${XC7FRAMES2BIT} \
         \${FASM_TO_BIT_EXTRA_ARGS}"
-    BIT_TO_V bitread
+    BIT_TO_V ${BITREAD}
     BIT_TO_V_CMD "${CMAKE_COMMAND} -E env \
     PYTHONPATH=${symbiflow-arch-defs_BINARY_DIR}/env/conda/lib/python3.7/site-packages:${PRJRAY_DIR}:${PRJRAY_DIR}/third_party/fasm:${symbiflow-arch-defs_SOURCE_DIR}/utils \
         \${PYTHON3} -mfasm2bels \
@@ -189,7 +191,7 @@ function(ADD_XC_ARCH_DEFINE)
         --rr_graph \${OUT_RRBIN_REAL_LOCATION} \
         --vpr_capnp_schema_dir ${VPR_CAPNP_SCHEMA_DIR} \
         --route \${OUT_ROUTE} \
-        --bitread $<TARGET_FILE:bitread> \
+        --bitread ${BITREAD} \
         --bit_file \${OUT_BITSTREAM} \
         --fasm_file \${OUT_BITSTREAM}.fasm \
         --iostandard ${DEFAULT_IOSTANDARD} \

--- a/xc/common/cmake/vivado.cmake
+++ b/xc/common/cmake/vivado.cmake
@@ -34,6 +34,7 @@ function(COMMON_VIVADO_TARGETS)
   )
 
   get_target_property_required(PYTHON3 env PYTHON3)
+  get_target_property_required(BITREAD env BITREAD)
 
   set(NAME ${COMMON_VIVADO_TARGETS_NAME})
   set(WORK_DIR ${COMMON_VIVADO_TARGETS_WORK_DIR})
@@ -111,7 +112,7 @@ function(COMMON_VIVADO_TARGETS)
         ${PYTHON3} ${PRJRAY_DIR}/utils/bit2fasm.py
           --part ${PART}
           --db-root ${PRJRAY_DB_DIR}/${PRJRAY_ARCH}
-          --bitread $<TARGET_FILE:bitread>
+          --bitread ${BITREAD}
           --verbose
           ${CMAKE_CURRENT_BINARY_DIR}/${WORK_DIR}/design_${NAME}.bit
           > ${CMAKE_CURRENT_BINARY_DIR}/${WORK_DIR}/design_${NAME}.bit.fasm
@@ -579,6 +580,8 @@ function(CREATE_DCP_BY_INTERCHANGE)
   set(NAME ${CREATE_DCP_NAME})
   set(WORK_DIR ${CREATE_DCP_WORK_DIR})
 
+  get_target_property_required(BITREAD env BITREAD)
+
   get_target_property_required(BITSTREAM ${CREATE_DCP_PARENT_NAME} BIT)
   get_target_property_required(BIT_VERILOG ${CREATE_DCP_PARENT_NAME} BIT_V)
   get_target_property_required(BOARD ${CREATE_DCP_PARENT_NAME} BOARD)
@@ -672,7 +675,7 @@ function(CREATE_DCP_BY_INTERCHANGE)
         ${PYTHON3} ${PRJRAY_DIR}/utils/bit2fasm.py
           --part ${PART}
           --db-root ${PRJRAY_DB_DIR}/${PRJRAY_ARCH}
-          --bitread $<TARGET_FILE:bitread>
+          --bitread ${BITREAD}
           --verbose
           ${CMAKE_CURRENT_BINARY_DIR}/${WORK_DIR}/${NAME}.bit
           > ${CMAKE_CURRENT_BINARY_DIR}/${WORK_DIR}/${NAME}.bit.fasm

--- a/xc/xc7/CMakeLists.txt
+++ b/xc/xc7/CMakeLists.txt
@@ -2,13 +2,25 @@ set(XC7_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(PRJXRAY_DIR ${symbiflow-arch-defs_SOURCE_DIR}/third_party/prjxray
   CACHE PATH "Path to prjxray library")
 
-execute_process(
-  COMMAND
-    prjxray-config
-  OUTPUT_VARIABLE PRJXRAY_DB_DIR
-)
+get_target_property_required(PRJXRAY_CONFIG env PRJXRAY_CONFIG)
 
-string(STRIP "${PRJXRAY_DB_DIR}" PRJXRAY_DB_DIR)
+if (NOT ${PRJXRAY_CONFIG} STREQUAL "PRJXRAY_CONFIG-NOTFOUND")
+  execute_process(
+    COMMAND
+      bash ${PRJXRAY_CONFIG}
+      OUTPUT_VARIABLE PRJXRAY_DB_DIR
+  )
+  string(STRIP "${PRJXRAY_DB_DIR}" PRJXRAY_DB_DIR)
+else ()
+  set(PRJXRAY_DB_DIR "PRJXRAY_DB_DIR-NOTFOUND")
+endif ()
+
+set(PRJXRAY_DB_DIR "${PRJXRAY_DB_DIR}"
+  CACHE PATH "Path to prjxray database directory")
+
+if (${PRJXRAY_DB_DIR} STREQUAL "PRJXRAY_DB_DIR-NOTFOUND")
+  message(FATAL_ERROR "Could not find the project xray database directory! Please provide it with the PRJXRAY_DB_DIR variable")
+endif ()
 
 set(ARCH_IMPORT_TIMING ${symbiflow-arch-defs_SOURCE_DIR}/utils/update_arch_timings.py)
 add_custom_target(

--- a/xc/xc7/CMakeLists.txt
+++ b/xc/xc7/CMakeLists.txt
@@ -1,9 +1,14 @@
 set(XC7_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(PRJXRAY_DIR ${symbiflow-arch-defs_SOURCE_DIR}/third_party/prjxray
   CACHE PATH "Path to prjxray library")
-set(PRJXRAY_DB_DIR
-  ${symbiflow-arch-defs_SOURCE_DIR}/third_party/prjxray-db
-  CACHE PATH "Path to prjxray database files")
+
+execute_process(
+  COMMAND
+    prjxray-config
+  OUTPUT_VARIABLE PRJXRAY_DB_DIR
+)
+
+string(STRIP "${PRJXRAY_DB_DIR}" PRJXRAY_DB_DIR)
 
 set(ARCH_IMPORT_TIMING ${symbiflow-arch-defs_SOURCE_DIR}/utils/update_arch_timings.py)
 add_custom_target(

--- a/xc/xc7/tests/install_test/CMakeLists.txt
+++ b/xc/xc7/tests/install_test/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(INSTALLATION_DIR_BIN "${CMAKE_INSTALL_PREFIX}/bin")
 
+get_target_property_required(XC7FRAMES2BIT env XC7FRAMES2BIT)
+
 function(add_binary_test test_name part_name device board)
 	add_test(NAME ${test_name}
 		COMMAND ${CMAKE_COMMAND} -E env
@@ -7,7 +9,7 @@ function(add_binary_test test_name part_name device board)
 		${CMAKE_COMMAND} -E env
 		PYTHONPATH=${PRJXRAY_DIR}:${PRJXRAY_DIR}/third_party/fasm
 		DATABASE_DIR=${PRJXRAY_DB_DIR}
-		FRAMES2BIT=$<TARGET_FILE:xc7frames2bit>
+		FRAMES2BIT=${XC7FRAMES2BIT}
 		make PARTNAME=${part_name} DEVICE=${device} BOARD=${board}
 		WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endfunction()


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is intended to use the conda packages for the prjxray-tools and prjxray-db:

- prjxray-db: instead of the third party dir, it gets the database from the conda-package
- prjxray-tools: locally conflicts with the riscv64-gcc-newlib package from `litex-hub`. The conflicts are being fixes, and once it's done, I will ad the prjxray-tools conda package as well

The reason behind using the conda packages is that both symbiflow-examples and fpga-perf-tool use them, so, to use the same environment.yml file as used in symbiflow-arch-defs, we require having the prjxray packages here as well.