### PR TITLE
check-status: move stdm library call within the check-status script

### DIFF
--- a/.github/check-status/check-status.py
+++ b/.github/check-status/check-status.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-from os import environ
+from os import environ, path
 from github import Github
+from stdm import get_latest_artifact_url
 
 gh_ref = environ['GITHUB_REPOSITORY']
 gh_sha = environ['INPUT_SHA']
@@ -17,3 +18,19 @@ for item in status.statuses:
 if status.state != 'success':
     print('Status not successful. Skipping...')
     exit(1)
+
+artifacts, _ = get_latest_artifact_url()
+
+for artifact in artifacts:
+    name = artifact["name"].split(".")[0]
+    url = artifact["url"]
+
+    if name.startswith("symbiflow-arch-defs-install"):
+        file_name = "symbiflow-toolchain-latest"
+    elif name.startswith("symbiflow-arch-defs-benchmarks"):
+        file_name = "symbiflow-benchmarks-latest"
+    else:
+        file_name = name + "-latest"
+
+    with open(path.join("install", file_name), "w") as f:
+        f.write(url)

--- a/.github/check-status/entrypoint.sh
+++ b/.github/check-status/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-/check-status.py && mkdir install && symbiflow_get_latest_artifact_url > install/latest || echo '::set-output name=skip::true'
+mkdir install && /check-status.py || echo '::set-output name=skip::true'


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR changes the way the check status GH action gets the latest link.

This requires https://github.com/SymbiFlow/symbiflow-tools-data-manager/pull/11 to be merged.

There will be one sym-link-like file for each package produced by symbiflow-arch-defs install CI.