### PR TITLE
Use `read_xdc -no_add` to avoid write-back.

### DIFF
--- a/xc/common/cmake/vivado.cmake
+++ b/xc/common/cmake/vivado.cmake
@@ -628,7 +628,7 @@ function(CREATE_DCP_BY_INTERCHANGE)
   set(XDC_EXTRA_ARGS "")
   if(NOT "${CREATE_DCP_XDC}" STREQUAL "")
       get_file_location(XDC_LOCATION ${CREATE_DCP_XDC})
-      set(XDC_EXTRA_ARGS "source ${XDC_LOCATION}")
+      set(XDC_EXTRA_ARGS "read_xdc -no_add ${XDC_LOCATION}")
       append_file_dependency(RUNME_DEPS ${CREATE_DCP_XDC})
   endif()
 

--- a/xc/common/utils/vivado_create_runme.py
+++ b/xc/common/utils/vivado_create_runme.py
@@ -14,7 +14,7 @@ synth_design -top {top}
 
 write_checkpoint -force design_{name}_pre_source.dcp
 
-read_xdc {bit_xdc}
+read_xdc -no_add {bit_xdc}
 """.format(
             name=args.name,
             bit_v=args.verilog,


### PR DESCRIPTION
`read_xdc` by default will write back the XDC if it's different.  This is suprising, so add `-no_add` to prevent this.