### PR TITLE
oddr: fix inv and zinv techmaps

### DIFF
--- a/xc/xc7/techmap/cells_map.v
+++ b/xc/xc7/techmap/cells_map.v
@@ -3252,6 +3252,8 @@ module ODDR (
 
   ODDR_VPR # (
     .ZINV_CLK       (!IS_C_INVERTED),
+    .INV_D1         (!ZINV_D1),
+    .INV_D2         (!ZINV_D2),
     .ZINV_D1        (ZINV_D1),
     .ZINV_D2        (ZINV_D2),
     .SRTYPE_SYNC    ( SRTYPE == "SYNC"),

--- a/xc/xc7/techmap/cells_sim.v
+++ b/xc/xc7/techmap/cells_sim.v
@@ -1226,6 +1226,9 @@ module ODDR_VPR (
   parameter [0:0] ZINV_CLK = 1'b1;
   parameter [0:0] ZINV_D1  = 1'b1;
   parameter [0:0] ZINV_D2  = 1'b1;
+  
+  parameter [0:0] INV_D1  = 1'b0;
+  parameter [0:0] INV_D2  = 1'b0;
 
   parameter [0:0] SRTYPE_SYNC = 1'b0;
   parameter [0:0] SAME_EDGE   = 1'b1;


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This is a follow-up to https://github.com/SymbiFlow/symbiflow-arch-defs/pull/1813 and fixes one more issue related to the inverted pins of the ODDR.

In fact, depending on which type of the ODDR (`TDDR` or `ODDR`), the inverted pins should have different features:

- TDDR: `ZINV_T`
- ODDR: `IS_D_INVERTED`