### PR TITLE
bump vtr package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - litex-hub::symbiflow-yosys-plugins=1.0.0_7_g59ff1e6_23_g3a95697_17_g00b887b_0194_g40efa51=20201120_145821
   - litex-hub::prjxray-tools=0.1_2697_g0f939808=20201120_145821
   - litex-hub::prjxray-db=0.0_0239_gd87c844=20201120_145821
-  - litex-hub::vtr=v8.0.0_3011_gb0223dc59=20201202_112618
+  - litex-hub::vtr=v8.0.0_3015_gd912bdb88=20201210_100534
   - litex-hub::yosys=0.9_5007_g2116c585=20201202_112618
   - litex-hub::zachjs-sv2v=0.0.5_0025_ge9f9696=20201120_205532
   - cmake


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR is to update the VTR package that contains the capnp-schema-dir binary to get the location of the schemas.

Fix merged here: https://github.com/litex-hub/litex-conda-eda/pull/58