### PR TITLE
Add bot locking and updating Conda and Pip packages

### DIFF
--- a/.github/workflows/update_conda_lock.yml
+++ b/.github/workflows/update_conda_lock.yml
@@ -1,0 +1,29 @@
+name: update_conda_lock
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  update-locks:
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        submodules:  'recursive'
+        ref:         'master'    # It will be the PR's base
+
+    - name: Update Lock and Issue a Pull Request
+      uses: SymbiFlow/actions/update_conda_lock@7a34d4c1a27dc369cfc618ae0902fcfaf1a36c59
+      with:
+        branch_name_core: 'update_conda_lock'
+        conda_lock_file:  'conda_lock.yml'
+        environment_file: 'environment.yml'
+        gh_access_token:  ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update_conda_lock.yml
+++ b/.github/workflows/update_conda_lock.yml
@@ -1,7 +1,6 @@
 name: update_conda_lock
 
 on:
-  pull_request:
   push:
   schedule:
     - cron: '0 3 * * *'
@@ -21,6 +20,7 @@ jobs:
         ref:         'master'    # It will be the PR's base
 
     - name: Update Lock and Issue a Pull Request
+      if: ${{ github.ref == 'refs/heads/master' }}
       uses: SymbiFlow/actions/update_conda_lock@7a34d4c1a27dc369cfc618ae0902fcfaf1a36c59
       with:
         branch_name_core: 'update_conda_lock'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile
 TOP_DIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 REQUIREMENTS_FILE := requirements.txt
-ENVIRONMENT_FILE := environment.yml
+ENVIRONMENT_FILE := conda_lock.yml
 
 third_party/make-env/conda.mk:
 	git submodule init
@@ -23,6 +23,9 @@ all: env
 clean::
 	rm -rf build
 
+# Conda Lock contains all dependencies. PIP often fails if a package is both
+# specified to be installed directly and as a dependency of another package.
+env:: export PIP_NO_DEPS = true
 env:: | $(CONDA_ENV_PYTHON)
 	git submodule init
 	git submodule update --init --recursive

--- a/conda_lock.yml
+++ b/conda_lock.yml
@@ -1,0 +1,180 @@
+name: symbiflow_arch_def_base
+channels:
+  - litex-hub
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - _openmp_mutex=4.5=1_gnu
+  - binutils-riscv64-elf=2.34=20210513_184432
+  - bison=3.7.5=h2531618_1
+  - bzip2=1.0.8=h7b6447c_0
+  - c-ares=1.17.1=h27cfd23_0
+  - ca-certificates=2021.7.5=h06a4308_1
+  - capnproto=0.8.0=20210316_201220
+  - capnproto-java=0.1.5_0012_g44a8c1e=20201104_165332
+  - certifi=2021.5.30=py37h06a4308_0
+  - cloog=0.18.0=0
+  - cmake=3.19.6=h973ab73_0
+  - cython=0.29.24=py37h295c915_0
+  - expat=2.4.1=h2531618_2
+  - flake8=3.9.2=pyhd3eb1b0_0
+  - flex=2.6.4=ha10e3a4_1
+  - gcc-riscv64-elf-newlib=9.2.0=20201119_154229
+  - gcc-riscv64-elf-nostdc=9.2.0=20210513_184432
+  - gmp=6.2.1=h2531618_2
+  - icestorm=0.0_0719_g792cef0=20201120_145821
+  - icu=58.2=he6710b0_3
+  - importlib-metadata=3.10.0=py37h06a4308_0
+  - isl=0.21=20210513_184432
+  - iverilog=s20150603_0957_gad862020=20201120_145821
+  - krb5=1.19.2=hac12032_0
+  - ld_impl_linux-64=2.35.1=h7274673_9
+  - libcurl=7.78.0=h0b77cf5_0
+  - libedit=3.1.20210216=h27cfd23_1
+  - libev=4.33=h7b6447c_0
+  - libffi=3.3=he6710b0_2
+  - libftdi=1.3=20210517_190633
+  - libgcc-ng=9.3.0=h5101ec6_17
+  - libgomp=9.3.0=h5101ec6_17
+  - libiconv=1.15=h63c8f33_5
+  - libnghttp2=1.41.0=hf8bcb03_2
+  - libssh2=1.9.0=h1ba5d50_1
+  - libstdcxx-ng=9.3.0=hd4cf53a_17
+  - libusb=1.0.20=20210517_190633
+  - libuuid=1.0.3=h1bed415_2
+  - libuv=1.40.0=h7b6447c_0
+  - libxml2=2.9.12=h03d6c58_0
+  - lz4-c=1.9.3=h295c915_1
+  - m4=1.4.18=h4e445db_0
+  - make=4.2.1=h1bed415_1
+  - mccabe=0.6.1=py37_1
+  - mpc=1.1.0=h10f8cd9_1
+  - mpfr=4.0.2=hb69a4c5_1
+  - ncurses=6.2=he6710b0_1
+  - nodejs=10.13.0=he6710b0_0
+  - openjdk=8.0.152=h7b6447c_3
+  - openocd=0.10.0_1514_ga8edbd020=20201119_154304
+  - openssl=1.1.1k=h27cfd23_0
+  - pcre=8.45=h295c915_0
+  - pip=21.2.2=py37h06a4308_0
+  - pkg-config=0.29.2=h1bed415_8
+  - prjxray-db=0.0_248_g2e51ad3=20210312_125539
+  - prjxray-tools=0.1_2842_g6867429c=20210301_104249
+  - pycodestyle=2.7.0=pyhd3eb1b0_0
+  - pyflakes=2.3.1=pyhd3eb1b0_0
+  - python=3.7.11=h12debd9_0
+  - readline=8.1=h27cfd23_0
+  - rhash=1.4.1=h3c74f83_1
+  - setuptools=52.0.0=py37h06a4308_0
+  - sqlite=3.36.0=hc218d9a_0
+  - swig=4.0.2=h2531618_3
+  - symbiflow-yosys-plugins=1.0.0_7_375_ge9e412b=20210813_070938
+  - tbb=2020.3=hfd86e86_0
+  - tk=8.6.10=hbc83047_0
+  - typing_extensions=3.10.0.0=pyh06a4308_0
+  - vtr-optimized=8.0.0_4118_g06317d042=20210813_070938
+  - wheel=0.37.0=pyhd3eb1b0_0
+  - xz=5.2.5=h7b6447c_0
+  - yosys=0.9_5567_g539d4ee9=20210813_070938_py37
+  - zachjs-sv2v=0.0.5_0025_ge9f9696=20201120_205532
+  - zipp=3.5.0=pyhd3eb1b0_0
+  - zlib=1.2.11=h7b6447c_3
+  - zstd=1.4.9=haebb681_0
+  - pip:
+    - Arpeggio==1.10.2
+    - attrs==21.2.0
+    - cairocffi==1.2.0
+    - CairoSVG==2.5.2
+    - certifi==2021.5.30
+    - cffi==1.14.6
+    - chardet==4.0.0
+    - charset-normalizer==2.0.4
+    - colorama==0.4.4
+    - cryptography==3.4.7
+    - cssselect2==0.4.1
+    - cycler==0.10.0
+    - defusedxml==0.7.1
+    - edalize @ git+https://github.com/lowRISC/edalize.git@ee5f9f71c7eedbf7d04f551753e827966c3fd6c5
+    - fasm==0.0.2.post70
+    - fasm-utils @ git+https://github.com/QuickLogic-Corp/quicklogic-fasm-utils@3d6a375ddb6b55aaa5a59d99e44a207d4c18709f
+    - fusesoc @ git+https://github.com/lowRISC/fusesoc.git@1fb8c939a0fb165bb1ca96233bcc7fc9b6e78369
+    - gitdb==4.0.7
+    - GitPython==3.1.18
+    - hilbertcurve==1.0.5
+    - idna==3.2
+    - iniconfig==1.1.1
+    - intelhex==2.3.0
+    - intervaltree==3.1.0
+    - ipyxact==0.2.4
+    - Jinja2==3.0.1
+    - jsonmerge==1.8.0
+    - jsonschema==3.2.0
+    - kiwisolver==1.3.1
+    - lxml==4.6.3
+    - Mako==1.1.4
+    - MarkupSafe==2.0.1
+    - matplotlib==3.4.3
+    - mccabe==0.6.1
+    - numpy==1.21.2
+    - okonomiyaki==1.3.2
+    - packaging==21.0
+    - parameterized==0.8.1
+    - pdfminer.six==20201018
+    - Pillow==8.3.1
+    - pluggy==0.13.1
+    - ply==3.11
+    - progressbar2==3.53.1
+    - py==1.10.0
+    - pycapnp==1.0.0b1
+    - pycparser==2.20
+    - pyjson==1.3.0
+    - pyjson5==1.5.2
+    - pyparsing==2.4.7
+    - pyrsistent==0.18.0
+    - pyserial==3.5
+    - pytest==6.2.4
+    - python-constraint==1.4.0
+    - python-dateutil==2.8.2
+    - python-fpga-interchange @ git+https://github.com/SymbiFlow/python-fpga-interchange.git@4509be707b12be049b2d7a101fd0683c5d15ae70
+    - python-sat==0.1.7.dev10
+    - python-utils==2.5.6
+    - pyusb==1.2.1
+    - PyYAML==5.4.1
+    - quicklogic-fasm @ git+https://github.com/QuickLogic-Corp/quicklogic-fasm.git@57b6e60574a9d483dc94710d0d3ff42a62b4ec41
+    - requests==2.26.0
+    - rr-graph @ git+https://github.com/SymbiFlow/symbiflow-rr-graph.git@f0c41b77ad25b3afc438f4a7bff4c2297f6587d5
+    - scipy==1.7.1
+    - simplejson==3.17.3
+    - simplesat==0.8.2
+    - six==1.16.0
+    - smmap==4.0.0
+    - sortedcontainers==2.4.0
+    - svgwrite==1.4.1
+    - termcolor==1.1.0
+    - textX==2.3.0
+    - tinycss2==1.1.0
+    - tinyfpgab==1.1.0
+    - tinyprog==1.0.21
+    - toml==0.10.2
+    - tqdm==4.62.1
+    - urllib3==1.26.6
+    - webencodings==0.5.1
+    - yapf==0.26.0
+    - zipfile2==0.0.12
+    - -e third_party/prjxray
+    - -e third_party/xc-fasm
+    - -e third_party/qlf-fasm
+    - -e third_party/python-sdf-timing
+    - -e third_party/python-symbiflow-v2x
+    - -e third_party/vtr-xml-utils
+    - -e third_party/symbiflow-xc-fasm2bels
+    - -e third_party/litex
+    - -e third_party/litex-boards
+    - -e third_party/litedram
+    - -e third_party/liteeth
+    - -e third_party/liteiclink
+    - -e third_party/migen
+    - -e quicklogic/common/utils/quicklogic-timings-importer
+    - third_party/pythondata-cpu-vexriscv
+    - third_party/pythondata-software-compiler_rt
+

--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,9 @@ dependencies:
   - litex-hub::openocd=0.10.0_1514_ga8edbd020=20201119_154304
   - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
   - litex-hub::prjxray-db=0.0_248_g2e51ad3=20210312_125539
-  - litex-hub::vtr-optimized=8.0.0_4118_g06317d042=20210813_070938
-  - litex-hub::yosys=0.9_5567_g539d4ee9=20210813_070938_py37
-  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_375_ge9e412b=20210813_070938
+  - litex-hub::vtr-optimized
+  - litex-hub::yosys
+  - litex-hub::symbiflow-yosys-plugins
   - litex-hub::zachjs-sv2v=0.0.5_0025_ge9f9696=20201120_205532
   - cmake
   - make

--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,8 @@ dependencies:
   - litex-hub::icestorm=0.0_0719_g792cef0=20201120_145821
   - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
   - litex-hub::openocd=0.10.0_1514_ga8edbd020=20201119_154304
-  - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
-  - litex-hub::prjxray-db=0.0_248_g2e51ad3=20210312_125539
+  - litex-hub::prjxray-tools
+  - litex-hub::prjxray-db
   - litex-hub::vtr-optimized
   - litex-hub::yosys
   - litex-hub::symbiflow-yosys-plugins


### PR DESCRIPTION
This PR adds a bot for creating and updating locks for Conda and Pip packages. It consists of a GitHub Actions workflow which handles `git` and creates a Pull Request and `update_conda_lock.py` script, which creates or updates locks.

Basically, it creates Conda environment based on `environment.yml` (which shouldn't be locked, but locked will work too) and creates locks based on Conda and Pip packages installed.

Currently the workflow added can only be run manually and that's how I tested it. It can be easily modified to work regularly on schedule of course. For now there are some simple constants used for PR title, user creating commit and commit title but these are easily configurable. For testing purposes I set them to be set as an input of the manual workflow.

To to use locks during building the scripts will need to be slightly modified. Instead of using `conda env create --file environment.yml` it needs to be `conda create --file conda.lock -n env` followed by installing pip packages by the pip from such environment, eg. `conda run -n env python -m pip install -r pip.lock`.

The script `update_conda_lock.py` can be tested locally after setting required environment variables:
* `BOT_ENV_NAME` -- custom name for the temporarily created environment (such environment cannot exist),
* `BOT_ENV_YML` -- path of `environment.yml` file, relative to the current directory (in CI it's repository root),
* `BOT_CONDA_LOCK` -- path of the conda lock being updated or created, eg. `conda.lock`,
* `BOT_PIP_LOCK` -- path of the pip lock being updated or created, eg. `pip.lock`.

It doesn't call git or create a PR so it's safe to use locally. Of course its requirement is that `conda` command is available.