### PR TITLE
Lower timeout to workaround Vivado 2019.2 hang.

### DIFF
--- a/.github/kokoro/continuous-docs.cfg
+++ b/.github/kokoro/continuous-docs.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-docs/.github/kokoro/docs.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-ice40.cfg
+++ b/.github/kokoro/continuous-ice40.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-ice40/.github/kokoro/ice40.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-install-200t.cfg
+++ b/.github/kokoro/continuous-install-200t.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-install-200t/.github/kokoro/install-200t.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-install.cfg
+++ b/.github/kokoro/continuous-install.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-install/.github/kokoro/install.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-ql.cfg
+++ b/.github/kokoro/continuous-ql.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-ql/.github/kokoro/ql.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-testarch.cfg
+++ b/.github/kokoro/continuous-testarch.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-testarch/.github/kokoro/testarch.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-tests.cfg
+++ b/.github/kokoro/continuous-tests.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-tests/.github/kokoro/tests.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-xc7-vendor.cfg
+++ b/.github/kokoro/continuous-xc7-vendor.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-xc7-vendor/.github/kokoro/xc7-vendor.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-xc7.cfg
+++ b/.github/kokoro/continuous-xc7.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-xc7/.github/kokoro/xc7.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-xc7a200t-vendor.cfg
+++ b/.github/kokoro/continuous-xc7a200t-vendor.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-xc7a200t-vendor/.github/kokoro/xc7a200t-vendor.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/continuous-xc7a200t.cfg
+++ b/.github/kokoro/continuous-xc7a200t.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-continuous-xc7a200t/.github/kokoro/xc7a200t.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/kokoro-cfg.py
+++ b/.github/kokoro/kokoro-cfg.py
@@ -30,7 +30,7 @@ DB_FULL = """\
 
 build_file: "symbiflow-arch-defs-%(kokoro_type)s-%(arch)s/.github/kokoro/%(arch)s.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-docs.cfg
+++ b/.github/kokoro/presubmit-docs.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-docs/.github/kokoro/docs.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-ice40.cfg
+++ b/.github/kokoro/presubmit-ice40.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-ice40/.github/kokoro/ice40.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-install-200t.cfg
+++ b/.github/kokoro/presubmit-install-200t.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-install-200t/.github/kokoro/install-200t.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-install.cfg
+++ b/.github/kokoro/presubmit-install.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-install/.github/kokoro/install.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-ql.cfg
+++ b/.github/kokoro/presubmit-ql.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-ql/.github/kokoro/ql.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-testarch.cfg
+++ b/.github/kokoro/presubmit-testarch.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-testarch/.github/kokoro/testarch.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-tests.cfg
+++ b/.github/kokoro/presubmit-tests.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-tests/.github/kokoro/tests.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-xc7-vendor.cfg
+++ b/.github/kokoro/presubmit-xc7-vendor.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-xc7-vendor/.github/kokoro/xc7-vendor.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-xc7.cfg
+++ b/.github/kokoro/presubmit-xc7.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-xc7/.github/kokoro/xc7.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-xc7a200t-vendor.cfg
+++ b/.github/kokoro/presubmit-xc7a200t-vendor.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-xc7a200t-vendor/.github/kokoro/xc7a200t-vendor.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {

--- a/.github/kokoro/presubmit-xc7a200t.cfg
+++ b/.github/kokoro/presubmit-xc7a200t.cfg
@@ -6,7 +6,7 @@
 
 build_file: "symbiflow-arch-defs-presubmit-xc7a200t/.github/kokoro/xc7a200t.sh"
 
-timeout_mins: 4320
+timeout_mins: 1200
 
 action {
   define_artifacts {


### PR DESCRIPTION
This is ~3x current maximum runtime.