### PR TITLE
Bump yosys plugins

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - litex-hub::icestorm=0.0_0719_g792cef0=20201120_145821
   - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
   - litex-hub::openocd=0.10.0_1514_ga8edbd020=20201119_154304
-  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_g59ff1e6_23_g3a95697_17_g00b887b_0194_g40efa51=20201120_145821
+  - litex-hub::symbiflow-yosys-plugins=v1.0.0_7_226_gdd84a47=20201216_065815
   - litex-hub::prjxray-tools=0.1_2697_g0f939808=20201120_145821
   - litex-hub::prjxray-db=0.0_0239_gd87c844=20201120_145821
   - litex-hub::vtr=v8.0.0_3015_gd912bdb88=20201210_100534

--- a/xc/common/utils/prjxray_create_place_constraints.py
+++ b/xc/common/utils/prjxray_create_place_constraints.py
@@ -786,9 +786,9 @@ def main():
 
     idelayctrl_instances = place_constraints.get_used_instances("IDELAYCTRL")
 
-    assert len(idelayctrl_cmts) == len(
+    assert len(idelayctrl_cmts) <= len(
         idelayctrl_instances
-    ), "The number of IDELAYCTRL blocks and IO banks with IDELAYs used do not match."
+    ), "Not enough IDELAYCTRL blocks to cover all the IO banks with IDELAYs."
 
     idelayctrl_sites = dict()
     for site_name, _, clk_region in vpr_grid.get_site_type_dict(

--- a/xc/xc7/tests/soc/litex/mini/CMakeLists.txt
+++ b/xc/xc7/tests/soc/litex/mini/CMakeLists.txt
@@ -2,8 +2,7 @@ add_file_target(FILE arty_clocks.xdc)
 
 set(SOURCES
   top.v
-  top.pcf
-  top.sdc
+  top.xdc
   mem.init
   mem_1.init
   mem_2.init
@@ -18,10 +17,10 @@ add_litex_test(
   BOARD arty-full
   GENERATE_SCRIPT ${GENERATE_LITEX}
   FIXUP_SCRIPT ${FIXUP_XDC}
+  USE_XDC
   FLAGS
     --integrated-rom-size 0x10000
     --uart-baudrate 1000000
-    --toolchain symbiflow
   VIVADO_XDC arty_clocks.xdc
 )
 
@@ -34,9 +33,9 @@ add_litex_test(
   BOARD arty100t-full
   GENERATE_SCRIPT ${GENERATE_LITEX}
   FIXUP_SCRIPT ${FIXUP_XDC}
+  USE_XDC
   FLAGS
     --integrated-rom-size 0x10000
     --uart-baudrate 1000000
-    --toolchain symbiflow
   VIVADO_XDC arty_clocks.xdc
 )

--- a/xc/xc7/yosys/synth.tcl
+++ b/xc/xc7/yosys/synth.tcl
@@ -53,7 +53,7 @@ update_pll_params
 # Note that write_sdc and the SDC plugin holds live pointers to RTLIL objects.
 # If Yosys mutates those objects (e.g. destroys them), the SDC plugin will
 # segfault.
-write_sdc $::env(OUT_SDC)
+write_sdc -include_propagated_clocks $::env(OUT_SDC)
 
 write_verilog $::env(OUT_SYNTH_V).premap.v
 


### PR DESCRIPTION
This PR does the following:

- updates yosys-plugins
- removes the symbiflow workaround from minilitex test (fixes https://github.com/SymbiFlow/symbiflow-arch-defs/issues/1753)