### PR TITLE
Add fasm dependencies to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,6 +21,12 @@ dependencies:
   - libiconv
   # libxml2 2.9.10 contains an integer overflow fix required for arch-defs.
   - libxml2>=2.9.10
+  # openjdk, libuuid, pkg-config, and cython are required to build the fasm package's ANTLR backend.
+  # They can be removed if fasm is packaged as a binary e.g. a wheel or Conda package.
+  - openjdk
+  - libuuid
+  - pkg-config
+  - cython
   - pip
   - pip:
     - -r file:requirements.txt


### PR DESCRIPTION
Add dependencies for fasm ANTLR parser to Conda environment.yml, so that `make env` will install these.