### PR TITLE
Define DBROOT after DEVICE is set

### DIFF
--- a/xc/xc7/toolchain_wrappers/symbiflow_write_bitstream
+++ b/xc/xc7/toolchain_wrappers/symbiflow_write_bitstream
@@ -48,7 +48,6 @@ while true; do
 done
 
 DATABASE_DIR=${DATABASE_DIR:=$(prjxray-config)}
-DBROOT=`realpath ${DATABASE_DIR}/${DEVICE}`
 
 if [ -z $DEVICE ]; then
 	# Try to find device name. Accept only when exactly one is found
@@ -60,6 +59,8 @@ if [ -z $DEVICE ]; then
 		exit 1
 	fi
 fi
+
+DBROOT=`realpath ${DATABASE_DIR}/${DEVICE}`
 
 if [ -z $FASM ]; then
 	echo "Please provide fasm file name"


### PR DESCRIPTION
DBROOT depends on the DEVICE variable, so we need to be past any code
that set DEVICE before settting DBROOT.

This cause nmigen fail when using the symbiflow toolchain. See:
https://github.com/SymbiFlow/symbiflow-examples/issues/123

This regression was caused in b35514859f7f02c289c2f6bc058fd3ca1c00143b
