### PR TITLE
Updated dependencies to include swig

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,9 @@ dependencies:
   - flake8
   - nodejs
   - libiconv
+  # swig is required to build the rapidyaml package
+  # It can be removed once that is available in PyPi
+  - swig
   # libxml2 2.9.10 contains an integer overflow fix required for arch-defs.
   - libxml2>=2.9.10
   # openjdk, libuuid, pkg-config, and cython are required to build the fasm package's ANTLR backend.


### PR DESCRIPTION
Due to the fact rapidyaml now has to be build locally, the build fails without the swig package installed. I added this as a dependency for now to make it easier to have the install process work automatically without having to manually install this package.