### PR TITLE
Mark CARRY4_VPR as lib_whitebox

### DIFF
--- a/xc/xc7/techmap/cells_sim.v
+++ b/xc/xc7/techmap/cells_sim.v
@@ -85,7 +85,6 @@ assign COUT = CIN;
 
 endmodule
 
-(* abc9_box, blackbox *)
 module CARRY4_VPR(O0, O1, O2, O3, CO0, CO1, CO2, CO3, CYINIT, CIN, DI0, DI1, DI2, DI3, S0, S1, S2, S3);
   parameter CYINIT_AX = 1'b0;
   parameter CYINIT_C0 = 1'b0;


### PR DESCRIPTION
`CARRY4_VPR` is parametric, but also marked as a `blackbox`; this confuses ABC9 because you can't monomorphise blackboxes, and so it has no way of knowing if the timings it computes are accurate. I believe it is correct to instead mark it as `lib_whitebox` so that ABC9 can monomorphise it properly.