### PR TITLE
Update retarget.v to fix TECHMAP_REPLACE typo

### DIFF
--- a/xc/xc7/techmap/retarget.v
+++ b/xc/xc7/techmap/retarget.v
@@ -2,6 +2,6 @@ module FD (output reg Q, input C, D);
 
 parameter [0:0] INIT = 1'b0;
 
-FDRE #(.INIT(INIT)) __TECHMAP_REPLACE__ (.Q(Q), .C(C), .D(D), .CE(1'b1), .R(1'b0));
+FDRE #(.INIT(INIT)) _TECHMAP_REPLACE_ (.Q(Q), .C(C), .D(D), .CE(1'b1), .R(1'b0));
 
 endmodule


### PR DESCRIPTION
Per discussion in slack, fixing a typo in this arch definition. @Ravenslofty