### PR TITLE
Added loading rr graph nodes directions

### DIFF
--- a/utils/lib/rr_graph/graph2.py
+++ b/utils/lib/rr_graph/graph2.py
@@ -278,14 +278,14 @@ class Graph(object):
             assert key not in self.loc_map
             self.loc_map[key] = loc
 
+            # Skip building IPIN -> SINK and OPIN -> SOURCE graph if edges
+            # are not required.
+            if not build_pin_edges:
+                continue
+
             for pin_class_idx, pin_class in enumerate(block_type.pin_class):
                 pin_class_node = self.loc_pin_class_map[
                     (loc.x, loc.y, pin_class_idx)]
-
-                # Skip building IPIN -> SINK and OPIN -> SOURCE graph if edges
-                # are not required.
-                if not build_pin_edges:
-                    continue
 
                 for pin in pin_class.pin:
                     for pin_node, _ in self.loc_pin_map[(loc.x, loc.y,

--- a/utils/lib/rr_graph_xml/graph2.py
+++ b/utils/lib/rr_graph_xml/graph2.py
@@ -73,6 +73,14 @@ def graph_from_xml(
     nodes = []
     edges = []
 
+    # Node direction map
+    node_direction_map = {
+        None: graph2.NodeDirection.NO_DIR,
+        "INC_DIR": graph2.NodeDirection.INC_DIR,
+        "DEC_DIR": graph2.NodeDirection.DEC_DIR,
+        "BI_DIR": graph2.NodeDirection.BI_DIR,
+    }
+
     # Itertate over XML elements
     switch_timing = None
     switch_sizing = None
@@ -232,6 +240,9 @@ def graph_from_xml(
             ]:
                 continue
 
+            direction = element.get("direction", None)
+            direction = node_direction_map[direction]
+
             # Dropping metadata for now
             metadata = None
 
@@ -239,7 +250,7 @@ def graph_from_xml(
                 graph2.Node(
                     id=int(element.attrib['id']),
                     type=node_type,
-                    direction=graph2.NodeDirection.NO_DIR,
+                    direction=direction,
                     capacity=int(element.attrib['capacity']),
                     loc=node_loc,
                     timing=node_timing,
@@ -284,6 +295,7 @@ class Graph(object):
             build_pin_edges=True,
             rebase_nodes=True,
             filter_nodes=True,
+            load_edges=False,
     ):
         if progressbar is None:
             progressbar = lambda x: x  # noqa: E731
@@ -293,7 +305,10 @@ class Graph(object):
         self.output_file_name = output_file_name
 
         graph_input = graph_from_xml(
-            input_file_name, progressbar, filter_nodes=filter_nodes
+            input_file_name,
+            progressbar,
+            filter_nodes=filter_nodes,
+            load_edges=load_edges,
         )
         graph_input['build_pin_edges'] = build_pin_edges
 


### PR DESCRIPTION
This PR adds reading of VPR node directions to the rr graph XML handling library. It also exposes the `load_edges` option.