### PR TITLE
QuickLogic qlf_k4n8 repacker

### DIFF
--- a/.github/kokoro/ql.sh
+++ b/.github/kokoro/ql.sh
@@ -22,12 +22,15 @@ set +e
 	pushd build
 	export VPR_NUM_WORKERS=${CORES}
 	set +e
+
+    # Run tests
 	ninja -j${MAX_CORES} all_quicklogic_tests
+	# If successful install the toolchain
+	if [ $? -eq 0 ]; then
+		ninja -j${MAX_CORES} install
+	fi
+
 	BUILD_RESULT=$?
-	# FIXME: Not sure if the below will work for QuickLogic now.
-	#ninja print_qor > ql_openfpga_qor.csv
-	# Installing devices and toolchain
-	ninja -j${MAX_CORES} install
 	popd
 	exit ${BUILD_RESULT}
 )

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -521,6 +521,7 @@ function(DEFINE_DEVICE)
   #   [NO_INSTALL]
   #   [NET_PATCH_DEPS <list of dependencies>]
   #   [NET_PATCH_EXTRA_ARGS <extra args for .net patching>]
+  #   [EXTRA_INSTALL_FILES <file1> <file2> ... <fileN>]
   #   )
   # ~~~
   #
@@ -554,7 +555,7 @@ function(DEFINE_DEVICE)
   #
   set(options CACHE_LOOKAHEAD CACHE_PLACE_DELAY NO_INSTALL NO_RR_PATCHING)
   set(oneValueArgs DEVICE ARCH PART DEVICE_TYPE PACKAGES WIRE_EBLIF ROUTE_CHAN_WIDTH EXT_RR_GRAPH)
-  set(multiValueArgs RR_PATCH_DEPS RR_PATCH_EXTRA_ARGS NET_PATCH_DEPS NET_PATCH_EXTRA_ARGS CACHE_ARGS)
+  set(multiValueArgs RR_PATCH_DEPS RR_PATCH_EXTRA_ARGS NET_PATCH_DEPS NET_PATCH_EXTRA_ARGS CACHE_ARGS EXTRA_INSTALL_FILES)
   cmake_parse_arguments(
     DEFINE_DEVICE
     "${options}"
@@ -903,11 +904,12 @@ function(DEFINE_DEVICE)
           DEVICES "${DEVICES}"
     )
 
-    # Set the NO_INSTALL property
+    # Set the NO_INSTALL property and the list of extra files to be installed
     set_target_properties(
       ${DEFINE_DEVICE_DEVICE}
       PROPERTIES
         NO_INSTALL ${NO_INSTALL}
+        EXTRA_INSTALL_FILES "${DEFINE_DEVICE_EXTRA_INSTALL_FILES}"
     )
 
     # Install device files. The function checks internally whether the files need to be installed

--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -1659,7 +1659,10 @@ function(ADD_FPGA_TARGET)
     VPR_CMD
     ${QUIET_CMD} ${VPR}
     ${DEVICE_MERGED_FILE_LOCATION}
-    ${OUT_EBLIF}
+  )
+
+  set(
+    VPR_ARGS
     --device ${DEVICE_FULL}
     --read_rr_graph ${OUT_RRBIN_REAL_LOCATION}
     ${VPR_BASE_ARGS_LIST}
@@ -1678,7 +1681,7 @@ function(ADD_FPGA_TARGET)
       )
     append_file_dependency(VPR_DEPS ${LOOKAHEAD_FILE})
     get_file_location(LOOKAHEAD_LOCATION ${LOOKAHEAD_FILE})
-    list(APPEND VPR_CMD --read_router_lookahead ${LOOKAHEAD_LOCATION})
+    list(APPEND VPR_ARGS --read_router_lookahead ${LOOKAHEAD_LOCATION})
   endif()
 
   get_target_property_required(
@@ -1690,7 +1693,7 @@ function(ADD_FPGA_TARGET)
       )
     append_file_dependency(VPR_DEPS ${PLACE_DELAY_FILE})
     get_file_location(PLACE_DELAY_LOCATION ${PLACE_DELAY_FILE})
-    list(APPEND VPR_CMD --read_placement_delay_lookup ${PLACE_DELAY_LOCATION})
+    list(APPEND VPR_ARGS --read_placement_delay_lookup ${PLACE_DELAY_LOCATION})
   endif()
 
   list(APPEND VPR_DEPS ${VPR} ${QUIET_CMD})
@@ -1704,7 +1707,7 @@ function(ADD_FPGA_TARGET)
   add_custom_command(
     OUTPUT ${OUT_NET} ${OUT_LOCAL}/pack.log
     DEPENDS ${VPR_DEPS}
-    COMMAND ${VPR_CMD} --pack
+    COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} --pack
     COMMAND
       ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log ${OUT_LOCAL}/pack.log
     WORKING_DIRECTORY ${OUT_LOCAL}
@@ -1728,7 +1731,7 @@ function(ADD_FPGA_TARGET)
     OUTPUT ${ECHO_OUT_NET}
     DEPENDS ${VPR_DEPS}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${OUT_LOCAL}/echo
-    COMMAND cd ${OUT_LOCAL}/echo && ${VPR_CMD} --pack_verbosity 3 --echo_file on --pack
+    COMMAND cd ${OUT_LOCAL}/echo && ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} --pack_verbosity 3 --echo_file on --pack
     COMMAND
       ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/echo/vpr_stdout.log ${OUT_LOCAL}/echo/pack.log
     )
@@ -1884,7 +1887,7 @@ function(ADD_FPGA_TARGET)
   add_custom_command(
     OUTPUT ${OUT_PLACE}
     DEPENDS ${OUT_NET} ${VPR_DEPS}
-    COMMAND ${VPR_CMD} ${FIX_CLUSTERS_ARG} --place
+    COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} ${FIX_CLUSTERS_ARG} --place
     COMMAND
       ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
       ${OUT_LOCAL}/place.log
@@ -1895,7 +1898,7 @@ function(ADD_FPGA_TARGET)
   add_custom_command(
     OUTPUT ${ECHO_OUT_PLACE}
     DEPENDS ${ECHO_OUT_NET} ${VPR_DEPS}
-    COMMAND ${VPR_CMD} ${FIX_CLUSTERS_ARG} --echo_file on --place
+    COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} ${FIX_CLUSTERS_ARG} --echo_file on --place
     COMMAND
       ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/echo/vpr_stdout.log
         ${OUT_LOCAL}/echo/place.log
@@ -1905,13 +1908,75 @@ function(ADD_FPGA_TARGET)
   add_custom_target(${NAME}_place DEPENDS ${OUT_PLACE})
   add_dependencies(all_${BOARD}_place ${NAME}_place)
 
+  # Process packed netlist and circuit netlist
+  # -------------------------------------------------------------------------
+  get_target_property(NET_PATCH_TOOL     ${ARCH} NET_PATCH_TOOL)
+  get_target_property(NET_PATCH_TOOL_CMD ${ARCH} NET_PATCH_TOOL_CMD)
+
+  if (NOT "${NET_PATCH_TOOL}" MATCHES ".*NOTFOUND")
+
+    # Set variables for the configure statement below
+    set(VPR_ARCH ${DEVICE_MERGED_FILE_LOCATION})
+
+    set(IN_NET ${OUT_NET})
+    set(IN_EBLIF ${OUT_EBLIF})
+    set(IN_PLACE ${OUT_PLACE})
+
+    set(OUT_NET ${OUT_LOCAL}/${TOP}.patched.net)
+    set(OUT_NET_REL ${OUT_LOCAL_REL}/${TOP}.patched.net)
+
+    set(OUT_EBLIF ${OUT_LOCAL}/${TOP}.patched.eblif)
+    set(OUT_EBLIF_REL ${OUT_LOCAL_REL}/${TOP}.patched.eblif)
+
+    set(OUT_PLACE ${OUT_LOCAL}/${TOP}.patched.place)
+    set(OUT_PLACE_REL ${OUT_LOCAL_REL}/${TOP}.patched.place)
+
+    # Configure the base command
+    string(CONFIGURE ${NET_PATCH_TOOL_CMD} NET_PATCH_TOOL_CMD_FOR_TARGET)
+    separate_arguments(
+      NET_PATCH_TOOL_CMD_FOR_TARGET_LIST UNIX_COMMAND ${NET_PATCH_TOOL_CMD_FOR_TARGET}
+    )
+
+    # Configure and append extra args
+    get_target_property(NET_PATCH_EXTRA_ARGS ${DEVICE} NET_PATCH_EXTRA_ARGS)
+    if (NOT "${NET_PATCH_EXTRA_ARGS}" MATCHES ".*NOTFOUND")
+      string(CONFIGURE ${NET_PATCH_EXTRA_ARGS} NET_PATCH_EXTRA_ARGS_FOR_TARGET)
+      separate_arguments(
+        NET_PATCH_EXTRA_ARGS_FOR_TARGET_LIST UNIX_COMMAND ${NET_PATCH_EXTRA_ARGS_FOR_TARGET}
+      )
+    else()
+      set(NET_PATCH_EXTRA_ARGS_FOR_TARGET_LIST)
+    endif()
+
+    # Extra dependencies
+    get_target_property(NET_PATCH_DEPS ${DEVICE} NET_PATCH_DEPS)
+    if ("${NET_PATCH_DEPS}" MATCHES ".*NOTFOUND")
+      set(NET_PATCH_DEPS)
+    endif ()
+
+    # Add targets for patched EBLIF and .net
+    add_custom_command(
+      OUTPUT ${OUT_NET} ${OUT_EBLIF} ${OUT_PLACE}
+      DEPENDS ${IN_NET} ${IN_EBLIF} ${IN_PLACE} ${NET_PATCH_TOOL} ${NET_PATCH_DEPS}
+      COMMAND ${NET_PATCH_TOOL_CMD_FOR_TARGET_LIST} ${NET_PATCH_EXTRA_ARGS_FOR_TARGET_LIST}
+      WORKING_DIRECTORY ${OUT_LOCAL}
+    )
+
+    add_output_to_fpga_target(${NAME} PATCHED_NET ${OUT_NET_REL})
+    add_output_to_fpga_target(${NAME} PATCHED_EBLIF ${OUT_EBLIF_REL})
+    add_output_to_fpga_target(${NAME} PATCHED_PLACE ${OUT_PLACE_REL})
+
+    add_custom_target(${NAME}_patch_net DEPENDS ${OUT_NET} ${OUT_EBLIF} ${OUT_PLACE})
+
+  endif ()
+
 
   # Generate routing.
   # -------------------------------------------------------------------------
   add_custom_command(
     OUTPUT ${OUT_ROUTE}
-    DEPENDS ${OUT_PLACE} ${VPR_DEPS}
-    COMMAND ${VPR_CMD} --route
+    DEPENDS ${OUT_NET} ${OUT_PLACE} ${VPR_DEPS}
+    COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} --route
     COMMAND
       ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
         ${OUT_LOCAL}/route.log
@@ -1925,7 +1990,7 @@ function(ADD_FPGA_TARGET)
   add_custom_command(
     OUTPUT ${ECHO_ATOM_NETLIST_ORIG} ${ECHO_ATOM_NETLIST_CLEANED}
     DEPENDS ${ECHO_OUT_PLACE} ${VPR_DEPS} ${ECHO_DIRECTORY_TARGET}
-    COMMAND ${VPR_CMD} --echo_file on --route
+    COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} --echo_file on --route
     COMMAND
       ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/echo/vpr_stdout.log
         ${OUT_LOCAL}/echo/route.log
@@ -2015,7 +2080,7 @@ function(ADD_FPGA_TARGET)
   add_custom_command(
     OUTPUT ${OUT_ANALYSIS} ${OUT_POST_SYNTHESIS_V} ${OUT_POST_SYNTHESIS_BLIF}
     DEPENDS ${OUT_ROUTE} ${VPR_DEPS}
-    COMMAND ${VPR_CMD} --analysis --gen_post_synthesis_netlist on
+    COMMAND ${VPR_CMD} ${OUT_EBLIF} ${VPR_ARGS} --analysis --gen_post_synthesis_netlist on
     COMMAND ${CMAKE_COMMAND} -E copy ${OUT_LOCAL}/vpr_stdout.log
         ${OUT_LOCAL}/analysis.log
     WORKING_DIRECTORY ${OUT_LOCAL}

--- a/common/cmake/install.cmake
+++ b/common/cmake/install.cmake
@@ -356,6 +356,12 @@ function(INSTALL_DEVICE_FILES)
     list(APPEND INSTALL_FILES ${VPR_GRID_MAP_FILE})
   endif()
 
+  # Extra files for the device (common to all packages)
+  get_target_property(EXTRA_FILES ${DEVICE} EXTRA_INSTALL_FILES)
+  if(NOT ${EXTRA_FILES} MATCHES ".*-NOTFOUND" AND NOT ${EXTRA_FILES} STREQUAL "")
+    list(APPEND INSTALL_FILES ${EXTRA_FILES})
+  endif()
+
   # Generate installation target for the files
   foreach(FILE ${INSTALL_FILES})
     get_file_location(SRC_FILE ${FILE})

--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -57,9 +57,15 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
           DESTINATION share/symbiflow/scripts/${FAMILY})
 
   # Example design to run through the flow
-  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/tests/counter_16bit/*.v
-	  DESTINATION share/symbiflow/tests/counter_16bit
-	   PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/tests/counter_16bit/counter_16bit.v
+          DESTINATION share/symbiflow/tests/counter_16bit
+          PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/tests/counter_16bit/counter_16bit_tb.v
+          DESTINATION share/symbiflow/tests/counter_16bit
+          PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+  install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/tests/counter_16bit/counter_16bit.sdc
+          DESTINATION share/symbiflow/tests/counter_16bit
+          PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
   
   # install python scripts
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/split_inouts.py

--- a/quicklogic/common/cmake/quicklogic_install.cmake
+++ b/quicklogic/common/cmake/quicklogic_install.cmake
@@ -23,7 +23,7 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
     return()
   endif ()
 
-  set(WRAPPERS env symbiflow_generate_constraints symbiflow_pack symbiflow_place symbiflow_route symbiflow_synth ql_symbiflow symbiflow_analysis)
+  set(WRAPPERS env symbiflow_generate_constraints symbiflow_pack symbiflow_place symbiflow_route symbiflow_synth ql_symbiflow symbiflow_analysis symbiflow_repack)
 
   # Export VPR arguments
   list(JOIN VPR_BASE_ARGS " " VPR_BASE_ARGS)
@@ -85,6 +85,25 @@ function(DEFINE_QL_TOOLCHAIN_TARGET)
   install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/utils/lib/parse_pcf.py
           DESTINATION bin/python/lib
           PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+
+  # install the repacker
+  set(REPACKER_FILES
+    arch_xml_utils.py
+    block_path.py
+    eblif_netlist.py
+    netlist_cleaning.py
+    packed_netlist.py
+    pb_rr_graph_netlist.py
+    pb_rr_graph.py
+    pb_rr_graph_router.py
+    pb_type.py
+    repack.py
+  )
+  foreach(NAME ${REPACKER_FILES})
+    install(FILES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/utils/repacker/${NAME}
+            DESTINATION bin/python/repacker
+            PERMISSIONS WORLD_READ OWNER_WRITE OWNER_READ GROUP_READ)
+  endforeach()
 
   # install techmap
   install(DIRECTORY ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/${FAMILY}/techmap/.

--- a/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
@@ -54,6 +54,20 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
     NO_TEST_PINS
     NO_PLACE_CONSTR
 
+    NET_PATCH_TOOL
+      ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/qlf_k4n8/utils/repacker/repack.py
+    NET_PATCH_TOOL_CMD "${CMAKE_COMMAND} -E env \
+     PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils \
+     \${PYTHON3} \${NET_PATCH_TOOL} \
+         --net-in \${IN_NET} \
+         --eblif-in \${IN_EBLIF} \
+         --place-in \${IN_PLACE} \
+         --net-out \${OUT_NET} \
+         --eblif-out \${OUT_EBLIF} \
+         --place-out \${OUT_PLACE} \
+         --vpr-arch \${VPR_ARCH} \
+         --absorb_buffer_luts on"
+
     # With the current support there is no bitstream generation support yet.
     # A FASM file can be generated though but FASM annotation is also a subject
     # to change.

--- a/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
@@ -57,8 +57,8 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
     NET_PATCH_TOOL
       ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/qlf_k4n8/utils/repacker/repack.py
     NET_PATCH_TOOL_CMD "${CMAKE_COMMAND} -E env \
-     PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils \
-     \${PYTHON3} \${NET_PATCH_TOOL} \
+      PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils \
+      \${QUIET_CMD} \${PYTHON3} \${NET_PATCH_TOOL} \
          --net-in \${IN_NET} \
          --eblif-in \${IN_EBLIF} \
          --place-in \${IN_PLACE} \
@@ -66,6 +66,8 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
          --eblif-out \${OUT_EBLIF} \
          --place-out \${OUT_PLACE} \
          --vpr-arch \${VPR_ARCH} \
+         --log \${OUT_NET}.log \
+         --log-level DEBUG \
          --absorb_buffer_luts on"
 
     # With the current support there is no bitstream generation support yet.

--- a/quicklogic/common/cmake/quicklogic_qlf_device.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_device.cmake
@@ -146,6 +146,11 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
   set(DEVICE_NET_PATCH_DEPS ${REPACKING_RULES_TARGET})
   set(DEVICE_NET_PATCH_EXTRA_ARGS "--repacking-rules ${CMAKE_CURRENT_BINARY_DIR}/${REPACKING_RULES_NAME}")
 
+  # Add the repacking rules as an extra file to be installed
+  set(EXTRA_INSTALL_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/${REPACKING_RULES_NAME}
+  )
+
   # Define the device
   define_device(
     DEVICE ${DEVICE}
@@ -169,6 +174,8 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
       --place_delta_delay_matrix_calculation_method dijkstra
       --router_lookahead extended_map
       --route_chan_width ${ROUTE_CHAN_WIDTH}
+
+    EXTRA_INSTALL_FILES ${EXTRA_INSTALL_FILES}
   )
 
   # .......................................................

--- a/quicklogic/common/cmake/quicklogic_qlf_device.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_device.cmake
@@ -8,10 +8,11 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
   #   LAYOUT <layout name>
   #   RR_GRAPH <rr_graph>
   #   [ROUTE_CHAN_WIDTH <route channel width>]
+  #   REPACKING_RULES <repacking_rules.json>
   #   )
   # ~~~
   set(options)
-  set(oneValueArgs NAME FAMILY ARCH ARCH_XML LAYOUT RR_GRAPH ROUTE_CHAN_WIDTH)
+  set(oneValueArgs NAME FAMILY ARCH ARCH_XML LAYOUT RR_GRAPH ROUTE_CHAN_WIDTH REPACKING_RULES)
   set(multiValueArgs)
   cmake_parse_arguments(
     QUICKLOGIC_DEFINE_QLF_DEVICE
@@ -28,6 +29,8 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
   set(ARCH_XML ${QUICKLOGIC_DEFINE_QLF_DEVICE_ARCH_XML})
   set(LAYOUT   ${QUICKLOGIC_DEFINE_QLF_DEVICE_LAYOUT})
   set(RR_GRAPH ${QUICKLOGIC_DEFINE_QLF_DEVICE_RR_GRAPH})
+
+  set(REPACKING_RULES ${QUICKLOGIC_DEFINE_QLF_DEVICE_REPACKING_RULES})
 
   # If ROUTE_CHAN_WIDTH is not given then use the value from the architecture
   if("${QUICKLOGIC_DEFINE_QLF_DEVICE_ROUTE_CHAN_WIDTH}" STREQUAL "")
@@ -102,6 +105,24 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
 
   # .......................................................
 
+  # Copy repacking rules
+  set(REPACKING_RULES_NAME ${DEVICE}.repacking_rules.json)
+
+  add_custom_command(
+    OUTPUT
+      ${CMAKE_CURRENT_BINARY_DIR}/${REPACKING_RULES_NAME}
+    DEPENDS
+      ${ARCH_XML}
+    COMMAND
+      ${CMAKE_COMMAND} -E copy
+        ${REPACKING_RULES}
+        ${CMAKE_CURRENT_BINARY_DIR}/${REPACKING_RULES_NAME}
+  )
+
+  add_file_target(FILE ${REPACKING_RULES_NAME} GENERATED)
+
+  # .......................................................
+
   add_custom_target(
     ${DEVICE_TYPE}
   )
@@ -120,6 +141,11 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
 
   # .......................................................
 
+  get_file_target(REPACKING_RULES_TARGET ${REPACKING_RULES_NAME})
+
+  set(DEVICE_NET_PATCH_DEPS ${REPACKING_RULES_TARGET})
+  set(DEVICE_NET_PATCH_EXTRA_ARGS "--repacking-rules ${CMAKE_CURRENT_BINARY_DIR}/${REPACKING_RULES_NAME}")
+
   # Define the device
   define_device(
     DEVICE ${DEVICE}
@@ -130,6 +156,9 @@ function(QUICKLOGIC_DEFINE_QLF_DEVICE)
 
     EXT_RR_GRAPH ${CMAKE_CURRENT_BINARY_DIR}/${RR_GRAPH_FOR_DEVICE}
     NO_RR_PATCHING
+
+    NET_PATCH_DEPS ${DEVICE_NET_PATCH_DEPS}
+    NET_PATCH_EXTRA_ARGS ${DEVICE_NET_PATCH_EXTRA_ARGS}
 
     CACHE_PLACE_DELAY
     CACHE_LOOKAHEAD

--- a/quicklogic/common/toolchain_wrappers/ql_symbiflow
+++ b/quicklogic/common/toolchain_wrappers/ql_symbiflow
@@ -348,6 +348,13 @@ else
     HAVE_FASM2BELS=1
 fi
 
+# For some devices do repacking between place and route
+if [[ "$DEVICE" =~ ^(qlf_k4n8.*)$ ]]; then
+    TOP_FINAL=${TOP}.repacked
+else
+    TOP_FINAL=${TOP}
+fi
+
 export PCF_FILE=$PCF
 export TOP_F=$TOP
 export PINMAP_FILE=$PINMAPCSV
@@ -396,6 +403,7 @@ fi
 echo -e ".PHONY:\${BUILDDIR}\n 
 current_dir := $CURR_DIR\n\
 TOP := $TOP\n\
+TOP_FINAL := $TOP_FINAL\n\
 VERILOG := $VERILOG_LIST \n\
 PARTNAME := $PART\n\
 DEVICE  := $DEVICE\n\
@@ -404,7 +412,7 @@ PCF := $PCF_MAKE\n\
 SDC := $SDC_MAKE\n\
 BUILDDIR := build\n\n\
 
-all: \${BUILDDIR}/\${TOP}.route\n\
+all: \${BUILDDIR}/\${TOP_FINAL}.route\n\
 \n\
 \${BUILDDIR}/\${TOP}.eblif: \${VERILOG} \${PCF}\n\
   ifneq (\"\$(wildcard \$(HEX_FILES))\",\"\")\n\
@@ -417,12 +425,21 @@ all: \${BUILDDIR}/\${TOP}.route\n\
 \n\
 \${BUILDDIR}/\${TOP}.place: \${BUILDDIR}/\${TOP}.net \${PCF}\n\
 	cd \${BUILDDIR} && symbiflow_place -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -p \${PCF} -n \${TOP}.net -P \${PARTNAME} -s \${SDC} 2>&1 > $LOG_FILE\n\
-\n\
-\${BUILDDIR}/\${TOP}.route: \${BUILDDIR}/\${TOP}.place\n\
-	cd \${BUILDDIR} && symbiflow_route -e \${TOP}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
+" >$MAKE_FILE
+
+if [ "$TOP" != "$TOP_FINAL" ]; then
+    echo -e "\
+\${BUILDDIR}/\${TOP_FINAL}.place: \${BUILDDIR}/\${TOP}.eblif \${BUILDDIR}/\${TOP}.net \${BUILDDIR}/\${TOP}.place\n\
+	cd \${BUILDDIR} && symbiflow_repack -e \${TOP}.eblif -n \${TOP}.net -f \${FAMILY} -d \${DEVICE} 2>&1 > $LOG_FILE\n\
+    " >>$MAKE_FILE
+fi
+
+    echo -e "\
+\${BUILDDIR}/\${TOP_FINAL}.route: \${BUILDDIR}/\${TOP_FINAL}.place\n\
+	cd \${BUILDDIR} && symbiflow_route -e \${TOP_FINAL}.eblif -f \${FAMILY} -d \${DEVICE} -s \${SDC} 2>&1 > $LOG_FILE\n\
 \n\
 \${BUILDDIR}/\${TOP}.post_v: \${BUILDDIR}/\${TOP}.route\n\
-" >$MAKE_FILE
+" >>$MAKE_FILE
 
 if [ "$HAVE_FASM2BELS" != 0 ]; then
     echo -e "\
@@ -449,9 +466,9 @@ elif [ $1 == "-compile" ]; then
 
   # FIXME: No bitstream for qlf_k4n8
   if [ "${FAMILY}" == "qlf_k4n8" ]; then
-    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.route  || exit
+    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP_FINAL}.route  || exit
   else
-    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP}.bit  || exit
+    cd $SOURCE;make -f Makefile.symbiflow ${BUILDDIR}/${TOP_FINAL}.bit  || exit
   fi
 
   if [ ! -z "$OUT" ]; then

--- a/quicklogic/common/toolchain_wrappers/symbiflow_repack
+++ b/quicklogic/common/toolchain_wrappers/symbiflow_repack
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+MYPATH=`realpath $0`
+MYPATH=`dirname ${MYPATH}`
+
+source ${MYPATH}/env
+source ${VPRPATH}/vpr_common
+
+parse_args $@
+
+REPACK=`realpath ${MYPATH}/python/repacker/repack.py`
+
+DESIGN=${EBLIF/.eblif/}
+RULES=${ARCH_DIR}/${DEVICE_1}.repacking_rules.json
+
+python3 ${REPACK} \
+  --vpr-arch ${ARCH_DEF} \
+  --repacking-rules ${RULES} \
+  --eblif-in ${DESIGN}.eblif \
+  --net-in ${DESIGN}.net \
+  --place-in ${DESIGN}.place \
+  --eblif-out ${DESIGN}.repacked.eblif \
+  --net-out ${DESIGN}.repacked.net \
+  --place-out ${DESIGN}.repacked.place \
+  --absorb_buffer_luts on \
+  >repack.log 2>&1

--- a/quicklogic/common/toolchain_wrappers/vpr_common
+++ b/quicklogic/common/toolchain_wrappers/vpr_common
@@ -79,7 +79,8 @@ function parse_args {
 
      export ARCH_DIR=`realpath ${MYPATH}/../share/symbiflow/arch/${DEVICE_1}_${DEVICE_1}`
      export ARCH_DEF=${ARCH_DIR}/arch_${DEVICE_1}_${DEVICE_1}.xml
-     export RR_GRAPH=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.rr_graph.real.bin
+#     export RR_GRAPH=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.rr_graph.real.bin
+     export RR_GRAPH=${ARCH_DIR}/${DEVICE_1}.rr_graph.bin
      export PLACE_DELAY=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.place_delay.bin
      export ROUTE_DELAY=${ARCH_DIR}/rr_graph_${DEVICE_1}_${DEVICE_1}.lookahead.bin
 

--- a/quicklogic/qlf_k4n8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/CMakeLists.txt
@@ -48,3 +48,5 @@ define_ql_toolchain_target(
   SYNTH_SCRIPT ${FAMILY_DIR}/yosys/synth.tcl
   CONV_SCRIPT ${FAMILY_DIR}/yosys/conv.tcl
 )
+
+add_subdirectory(utils)

--- a/quicklogic/qlf_k4n8/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/CMakeLists.txt
@@ -18,7 +18,8 @@ set(VPR_ARCH_ARGS "\
     --clock_modeling ideal \
     --place_delta_delay_matrix_calculation_method dijkstra \
     --place_delay_model delta_override \
-    --router_lookahead extended_map "
+    --router_lookahead extended_map \
+    --allow_dangling_combinational_nodes on "
 )
 
 # Define the architecture

--- a/quicklogic/qlf_k4n8/devices/umc22/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/devices/umc22/CMakeLists.txt
@@ -6,7 +6,7 @@ quicklogic_define_qlf_device (
   ARCH_XML ${symbiflow-arch-defs_SOURCE_DIR}/third_party/qlfpga-symbiflow-plugins/qlf_k4n8/vpr_arch/UMC22nm_vpr.xml
   RR_GRAPH ${symbiflow-arch-defs_SOURCE_DIR}/third_party/qlfpga-symbiflow-plugins/qlf_k4n8/vpr_rr_graph/UMC22nm_vpr.bin.gz
 
-  REPACKING_RULES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/qlf_k4n8/devices/umc22/repacking_rules.json
+  REPACKING_RULES ${symbiflow-arch-defs_SOURCE_DIR}/third_party/qlfpga-symbiflow-plugins/qlf_k4n8/vpr_arch/repacking_rules.json
 
   ROUTE_CHAN_WIDTH 60
 )

--- a/quicklogic/qlf_k4n8/devices/umc22/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/devices/umc22/CMakeLists.txt
@@ -6,5 +6,7 @@ quicklogic_define_qlf_device (
   ARCH_XML ${symbiflow-arch-defs_SOURCE_DIR}/third_party/qlfpga-symbiflow-plugins/qlf_k4n8/vpr_arch/UMC22nm_vpr.xml
   RR_GRAPH ${symbiflow-arch-defs_SOURCE_DIR}/third_party/qlfpga-symbiflow-plugins/qlf_k4n8/vpr_rr_graph/UMC22nm_vpr.bin.gz
 
+  REPACKING_RULES ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/qlf_k4n8/devices/umc22/repacking_rules.json
+
   ROUTE_CHAN_WIDTH 60
 )

--- a/quicklogic/qlf_k4n8/utils/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/utils/CMakeLists.txt
@@ -1,0 +1,10 @@
+get_target_property_required(PYTHON3 env PYTHON3)
+
+# Add a target that runs tests for Python utils
+add_custom_target(all_python_tests
+    COMMAND
+        ${CMAKE_COMMAND} -E env
+        PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils:${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/common/utils:$PYTHONPATH
+        ${PYTHON3} -m pytest --doctest-modules -vv
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/quicklogic/qlf_k4n8/utils/repacker/README.md
+++ b/quicklogic/qlf_k4n8/utils/repacker/README.md
@@ -1,0 +1,312 @@
+# Netlist repacking utility
+
+## 1. Goal
+
+Provide the same VPR operating mode pb_type into physical mode pb_type
+repacking as implemented in the OpenFPGA project.
+
+https://openfpga.readthedocs.io/en/master/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands/#repack
+
+## 2. Files affected by the repacker
+
+The utility expects a VPR packed netlist, an EBLIF netlist and a VPR placement
+file as input and outputs a similar set of files representing the design after
+repacking. The placement is not altered, just the SHA checksum is updated in
+the file.
+
+### VPR packed netlist (.net)
+
+The packed netlist contains information about the clusters of a packed design.
+It tells which specific pb_type instances (pbs or blocks) are occupied by which
+cells from the circuit netlist. Intra-cluster routing as well as LUT port
+rotation is also stored there.
+
+The repacker discards any existing intra-cluster routing, remaps blocks and
+their port connections according to rules provided by OpenFPGA architecture
+file and re-routes the cluster. The procedure is repeated for each cluster
+independently.
+
+### Circuit netlist (.blif / .eblif)
+
+The circuit netlist holds all nets and cells of a particular design along with
+its attributes and parameters. Repacking a cell from one block instance into
+another usually requires changing its type. All changes introduced to the
+packed netlist must be reflected in the circuit netlist hence it needs to be
+modified by the packer as well.
+
+### VPR placement file (.place)
+
+This file stores cluster placement on the device grid. The file content itself
+is not affected by the packer but its header is. The header stores a checksum
+computed over the packed netlist file to ensure that the two stays in sync.
+Modified packed netlist has a different checksum hence the placement file
+needs to have its header updated.
+
+## 4. Tool operation
+
+### Preparation
+
+The preparation step includes loading and pre-processing all the information
+required for repacking
+
+#### loading of VPR architecture
+
+The VPR architecture XML file is loaded to obtain information about:
+ - pb_type hierarchy
+ - binding of netlist cell types (BLIF models) with pb_types
+ - cell models used in the architecture.
+
+Soon after the architecture file is read an internal representation of the
+pb_type hierarchy for each root pb_type (a.k.a. complex block - CLB) is built.
+For every leaf pb_type of class "lut" another child pb_type is added to the
+hierarchy. This is done to keep the pb_type hierarchy consistent with the packed
+netlist hierarchy where native LUTs contain the one extra level.
+
+Next, all known leaf pb_types are scanned for cell type bindings and internal
+structures that represent known cell types are created. VPR architecture does
+not store port widths along with the model list so to get actual cell types
+both pb_type tree and the model list need to be examined.
+
+#### Loading of repacking rules
+
+Repacking rules may contain port maps. These port maps may or may not
+explicitly specify port pins (bits). For the purpose of the repacker
+implementation port map needs to be known down to each pin. To tell the
+pin-to-pin correspondence each rule is confronted with the pb_type it refers to
+(pb_types store port widths) and direct pin correspondences are created.
+This is called "port map expansion".
+
+#### Loading and pre-processing of circuit netlist
+
+The circuit BLIF/EBLIF netlist is loaded and stored internally.
+
+A netlist contains top-level ports. These ports do not correspond to any cells.
+However, they will have to be represented by explicit netlist cells after
+repacking. To allow for that each top-level port is converted to a virtual cell
+and added to the netlist. This allows the repacking algorithm to operate
+regularly without the need of any special IO handling. Top-level netlist ports
+are removed.
+
+#### Circuit netlist cleaning
+
+Circuit netlist cleaning (for now) includes removal of buffer LUTs. Buffer LUTs
+are 1-bit LUTs configured as pass-through. They are used to stitch different
+nets together while preserving their original names. The implemented buffer LUT
+absorption matches the identical process performed by VPR and should be enabled
+for the repacker if enabled for the VPR flow.
+
+#### Loading of the packed netlist
+
+The packed netlist is loaded, parsed and stored using internal data structures
+
+### Repacking
+
+The repacking is done independently for each cluster. Clusters are processed
+one-by-one, repacked ones replace original ones in the packed netlist. The
+following steps are identical and are done in the same sequence for each
+cluster.
+
+#### Net renaming
+Net renaming is a result of LUT buffer absorption. This is necessary to keep
+the packed netlist and the circuit netlist in sync.
+
+#### Explicit instantiation of route-through LUTs
+In VPR a native LUT (.names) can be configured as an implicit buffer
+(a route-through) by the VPR packer whenever necessary. Such a lut is not
+present in the circuit netlist. However it still needs to be repacked into a
+physical LUT cell.
+
+To achieve this goal all route-though LUTs in the packed netlist of the current
+cluster are identifier and explicit LUT blocks are inserted for them. After
+that corresponding LUT buffers are inserted into the circuit netlist. This
+ensures regularity of the repacking algorithm - no special handling is required
+for such LUTs. They will be subjected to repacking as any other block/cell.
+
+#### Identification of blocks to be repacked and their targets
+
+In the first step all blocks that are to be repacked are identified. For this
+the packed netlist of the cluster is scanned for leaf blocks. Each leaf block
+is compared against all known repacking rules. Whenever its path in the
+hierarchy matches a rule then it is considered to be repacked. Identified
+blocks are stored along with their matching rules on a list.
+
+The second step is identification of target (destination) block(s) for each
+source block for the repacking to take place. To do that a function scans the
+hierarchy of the VPR architecture and identifies pb_types that match the
+destination path as defined by the repacking rule for the given block. A list of
+destination pb_types is created. The list should contain exactly one element.
+Zero elements means that there is no suitable pb_type present in the
+architecture and more than one means that there is an ambiguity. Both cases are
+reported as an error. Finally the destination pb_type is stored along with the
+block to be repacked.
+
+If there are no blocks to be repacked then there is nothing more that can be
+done for this cluster and the algorithm moves to the next one.
+
+#### Circuit netlist cell repacking
+
+For each block to be repacked its corresponding cell instance in the circuit
+netlist and its cell type (model) is found. Cell type (model) of the destination
+pb_type is identified as well. The original cell is removed from the circuit
+netlist and a new one is created based on the destination pb_type model. The new
+cell connectivity is determined by the port map as defined by the repacking rule
+being applied. For LUTs the LUT port rotation is also taken into account here.
+
+In case of a LUT the newly created LUT cell receives a parameter named "LUT"
+which stores the truth table.
+
+If the block being repacked represents a top-level IO port then the port name is
+added to the list of top-level ports to be removed. When a top-level IO is
+repacked into a physical cell, no top-level IO port is needed anymore.
+
+#### Cluster repacking
+
+Repacking of cluster cells (in the packed netlist) is done implicitly via the
+pb_type routing graph. Routes present in the graph imply which blocks are used
+(instanced) and which are not. The advantage of that approach is that the
+repacking and rerouting of the cluster are both done at the same single step.
+
+At the beginning the routing graph for the complex block is created. The graph
+represents all routing resources for a root pb_type (complex block) as defined
+in the VPR architecture. In the graph nodes represent pb_type ports and edges
+connections between them. Nodes may be associated with nets. Edges are
+associated with nets implicitly - if an edge spans two nodes of the same net
+then it also belongs to that net.
+
+Once the graph is built all nodes representing ports of the destination blocks
+of the remapping are associated with net names. Ports are remapped according to
+the repacking rules. This is the step where the actual repacking takes place.
+Together with the repacked blocks the ports of the cluster block are associated
+with nets as well.
+
+Following port and net association there is the routing stage. For each node
+that is a sink a route to the source node of the same net is determined.
+In case when the source node is a cluster block port and there is no route
+available the first cluster block port node that can be reached is taken. This
+works similarly to the VPR packer.
+
+Currently the router is implemented as a greedy depth-first search. No edge
+timing information is used. For the complexity of the current repacking problems
+this implementation is sufficient - most of the routing paths do not have more
+than one or two alternatives.
+
+Finally once the graph is fully routed it is converted back to a packed netlist
+of the cluster. The new cluster replaces the old one in the packed netlist.
+
+#### IO blocks handling
+
+During conversion from packed netlist to a routing graph and back information
+about IO block names is lost. To preserve the names the original ones are stored
+prior to the cluster repacking and are used to rename repacked IO blocks
+afterwards.
+
+### Finishing
+
+At this point all clusters were repacked along with the corresponding cells in
+the circuit netlist. Apart from writing the data to files there are a few
+additional steps that need to be performed.
+
+#### Top-level port removal
+During cluster processing names of blocks representing top-level IO ports were
+stored. Those blocks got repacked into physical IO cells and the top-level IO
+ports are no longer needed so they are removed.
+
+#### Synchronization of cells attributes and parameters
+
+VPR stores cell attributes and parameters read from the circuit (EBLIF) netlist
+with the packed netlist as well. It complains if both don't match. During
+conversion from packed netlist to a routing graph and back block attributes and
+parameters are lost - they are not stored within the graph. So in this step they
+are taken from the circuit netlist and associated with corresponding packed
+netlist blocks again.
+
+#### Circuit netlist cleaning
+
+This step is necessary only if buffer LUT absorption is enabled. Before
+repacking buffer LUTs driving top-level ports cannot be removed as their removal
+would cause top-level IO port renaming. After repacking IO ports are represented
+as cells so the removal is possible.
+
+#### Circuit netlist write back (EBLIF)
+
+The circuit netlist is written to an EBLIF file. The use of the EBLIF format is
+necessary to store LUT truth tables as cell parameters. After repacking LUTs are
+no longer represented by .names hence require a parameter to store the truth
+table.
+
+#### Packed netlist write back
+
+This is an obvious step. The final packed netlist is serialized and written to
+an XML (.net) file.
+
+#### Patching of VPR placement file
+If provided, the VPR placement file receives a patched header containing a new
+SHA256 checksum. The checksum corresponds to the packed netlist file after
+repacking.
+
+## Implementation
+
+The repacker is implemented using a set of Python scripts located under quicklogic/openfpga/utils.
+
+ * repack.py
+
+    This is the main repacking script that implements the core repacking algorithm steps. This one is to be invoked to perform repacking.
+
+ * pb_rr_graph.py
+
+    Utilities for representing and building pb_type routing graph based on VTR architecture
+
+ * pb_rr_graph_router.py
+
+    Implementation of a router which operates on the pb_type routing graph.
+
+ * pb_rr_graph_netlist.py
+
+    A set of utility functions for loading a packed netlist into a pb_type graph as well as for creating a packed netlist from a routed pb_type graph.
+
+ * pb_type.py
+
+    Data structures and utilities for representing the pb_type hierarchy
+
+ * netlist_cleaning.py
+
+    Utilities for cleaning circuit netlist
+
+ * packed_netlist.py
+
+    Utilities for reading and writing VPR packed netlist
+
+ * eblif.py
+
+    Utilities for reading and writing BLIF/EBLIF circuit netlist
+
+ * block_path.py
+
+    Utilities for representing hierarchical path of blocks and pb_types
+
+## Important notes
+
+### Circuit netlist cleaning
+
+VPR can "clean" a circuit netlist and it does that by default.
+The cleaning includes:
+
+ * Buffer LUT absorption
+ * Dangling block removal
+ * Dangling top-level IO removal
+
+The important issue is that normally the cleaned netlist is not written back
+to any file hence it cannot be accessed outside VPR. That cleaned circuit
+netlist must correspond to the packed netlist used. This means equal number of
+blocks and cells and matching names.
+
+The issue is that the circuit netlist input to the repacker is not the actual
+netlist used by VPR that has to match with the packed netlist.
+
+An obvious solution would be to disable all netlist cleaning operations in VPR.
+But that unfortunately leads to huge LUT usage as each buffer LUT is then
+treated by VPR as a regular cell.
+
+An alternative solution, which has been implemented, is to recreate some of
+the netlist cleaning procedures in the repacker so that they both operate on
+the same effective circuit netlist. This is what has been done.

--- a/quicklogic/qlf_k4n8/utils/repacker/arch_xml_utils.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/arch_xml_utils.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""
+A number of utility functions useful for traversing pb_type hierarchy as
+defined in VPR architecture XML file.
+"""
+import re
+
+import lxml.etree as ET
+
+# =============================================================================
+
+
+def is_leaf_pbtype(xml_pbtype):
+    """
+    Returns true when the given pb_type is a leaf.
+    """
+    assert xml_pbtype.tag == "pb_type", xml_pbtype.tag
+    return "blif_model" in xml_pbtype.attrib
+
+
+def get_parent_pb(xml_pbtype):
+    """
+    Returns a parent pb_type of the given one or none if it is a top-level
+    complex block
+    """
+    assert xml_pbtype.tag in ["pb_type", "mode", "interconnect"], xml_pbtype.tag
+
+    # Get immediate parent
+    xml_parent = xml_pbtype.getparent()
+
+    # We've hit the end
+    if xml_parent is None or xml_parent.tag == "complexblocklist":
+        return None
+
+    # The immediate parent is a mode, jump one more level up
+    if xml_parent is not None and xml_parent.tag == "mode":
+        xml_parent = xml_parent.getparent()
+
+    return xml_parent
+
+
+def get_parent_pb_and_mode(xml_pbtype):
+    """
+    Returns a parent pb_type and mode element for the given pb_type. If there
+    are no modes (implicit default mode) then the mode element returned is
+    the same as the pb_type element.
+    """
+    assert xml_pbtype.tag in ["pb_type", "mode"], xml_pbtype.tag
+
+    # Get immediate parent
+    xml_parent = xml_pbtype.getparent()
+
+    # We've hit the end
+    if xml_parent is None or xml_parent.tag == "complexblocklist":
+        return None, None
+
+    assert xml_parent.tag in ["pb_type", "mode"], xml_parent.tag
+
+    # pb_type parent
+    if xml_pbtype.tag == "pb_type":
+
+        if xml_parent.tag == "pb_type":
+            return xml_parent, xml_parent
+
+        elif xml_parent.tag == "mode":
+            return xml_parent.getparent(), xml_parent
+
+    elif xml_pbtype.tag == "mode":
+
+        return xml_parent.getparent(), xml_pbtype
+
+
+def get_pb_by_name(xml_parent, name):
+    """
+    Searches for a pb_type with the given name inside a parent pb_type.
+    Returns either a child or the parent.
+
+    The provided parent may be a mode but a pb_type is always returned.
+    """
+    assert xml_parent.tag in ["pb_type", "mode"], xml_parent.tag
+
+    # Check the parent name. If this is a mode then check its parent name
+    if xml_parent.tag == "mode":
+        xml_parent_pb = get_parent_pb(xml_parent)
+        if xml_parent_pb.attrib["name"] == name:
+            return xml_parent_pb
+
+    else:
+        if xml_parent.attrib["name"] == name:
+            return xml_parent
+
+    # Check children
+    for xml_pbtype in xml_parent.findall("pb_type"):
+        if xml_pbtype.attrib["name"] == name:
+            return xml_pbtype
+
+    # None found
+    return None
+
+# =============================================================================
+
+
+def yield_pb_children(xml_parent):
+    """
+    Yields all child pb_types and their indices taking into account num_pb.
+    """
+    for xml_child in xml_parent.findall("pb_type"):
+        num_pb = int(xml_child.get("num_pb", 1))
+        for i in range(num_pb):
+            yield xml_child, i
+
+# =============================================================================
+
+INTERCONNECT_PORT_SPEC_RE = re.compile(
+    r"((?P<pbtype>[A-Za-z0-9_]+)(\[(?P<indices>[0-9:]+)\])?\.)" \
+    r"(?P<port>[A-Za-z0-9_]+)(\[(?P<bits>[0-9:]+)\])?"
+)
+
+def get_pb_and_port(xml_ic, port_spec):
+    """
+    """
+    assert xml_ic.tag == "interconnect"
+
+    # Match the port name
+    match = INTERCONNECT_PORT_SPEC_RE.fullmatch(port_spec)
+    assert match is not None, port_spec
+
+    # Get the referenced pb_type
+    xml_parent = xml_ic.getparent()
+    xml_pbtype = get_pb_by_name(xml_parent, match.group("pbtype"))
+    assert xml_pbtype is not None, port_spec
+
+    # Find the port
+    port = match.group("port")
+    for xml_port in xml_pbtype:
+        if xml_port.tag in ["input", "output", "clock"]:
+
+            # Got it
+            if xml_port.attrib["name"] == port:
+                return xml_pbtype, xml_port
+    else:
+        assert False, (port_spec, xml_pbtype.attrib["name"], port)
+
+
+def yield_indices(index_spec):
+    """
+    Given an index specification string as "<i1>:<i0>" or "<i>" yields all bits
+    that it is comprised of. The function also supports cases when i0 > i1.
+    """
+
+    # None
+    if index_spec is None:
+        return
+        
+    # Range
+    elif ":" in index_spec:
+        i0, i1 = [int(i) for i in index_spec.split(":")]
+
+        if i0 > i1:
+            for i in range(i1, i0+1):
+                yield i
+
+        elif i0 < i1:
+            for i in range(i0, i1+1):
+                yield i
+
+        else:
+            yield i0
+
+    # Single value
+    else:
+        yield int(index_spec)
+
+
+def yield_pins(xml_ic, port_spec, skip_index=True):
+    """
+    Yields individual port pins as "<pb_type>[<pb_index].<port>[<bit>]" given
+    the port specification.
+    """
+    assert xml_ic.tag == "interconnect"
+
+    # Match the port name
+    match = INTERCONNECT_PORT_SPEC_RE.fullmatch(port_spec)
+    assert match is not None, port_spec
+
+    # Get the referenced pb_type
+    xml_parent = xml_ic.getparent()
+    xml_pbtype = get_pb_by_name(xml_parent, match.group("pbtype"))
+    assert xml_pbtype is not None, port_spec
+
+    # Find the port
+    port = match.group("port")
+    for xml_port in xml_pbtype:
+        if xml_port.tag in ["input", "output", "clock"]:
+            if xml_port.attrib["name"] == port:
+                width = int(xml_port.attrib["num_pins"])
+                break
+    else:
+        assert False, (port_spec, xml_pbtype.attrib["name"], port)
+
+    # Check if we are referencing an upstream parent
+    is_parent_port = get_parent_pb(xml_ic) == xml_pbtype
+
+    # Build a list of pb_type indices
+    if not is_parent_port:
+        num_pb = int(xml_pbtype.get("num_pb", 1))
+        indices = list(yield_indices(match.group("indices")))
+        if not indices:
+            if num_pb > 1:
+                indices = list(range(0, num_pb))    
+            else:
+                indices = [None]
+    else:
+        indices = [None]
+
+    # Build a list of bit indices
+    bits = list(yield_indices(match.group("bits")))
+    if not bits:
+        if width > 1:
+            bits = list(range(0, width))
+        else:
+            bits = [None]
+
+    # Yield individual pin names
+    for i in indices:
+        for j in bits:
+
+            name = match.group("pbtype")
+            if i is not None:
+                name += "[{}]".format(i)
+            elif not skip_index:
+                name += "[0]"
+
+            name += "." + match.group("port")
+            if j is not None:
+                name += "[{}]".format(j)
+            elif not skip_index:
+                name += "[0]"
+
+            yield name
+
+# =============================================================================
+
+
+def append_metadata(xml_item, meta_name, meta_data):
+    """
+    Appends metadata to an element of architecture
+    """
+    assert xml_item.tag in ["pb_type", "mode", "direct", "mux"]
+
+    xml_meta = ET.Element("meta", {"name": meta_name})
+    xml_meta.text = meta_data
+
+    # Use existing metadata section. If not present then create a new one
+    xml_metadata = xml_item.find("metadata")
+    if xml_metadata is None:
+        xml_metadata = ET.Element("metadata")
+
+    # Append meta, check for conflict
+    for item in xml_metadata.findall("meta"):
+        assert item.attrib["name"] != xml_meta.attrib["name"]
+    xml_metadata.append(xml_meta)
+
+    # Append
+    if xml_metadata.getparent() is None:
+        xml_item.append(xml_metadata)

--- a/quicklogic/qlf_k4n8/utils/repacker/arch_xml_utils.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/arch_xml_utils.py
@@ -116,7 +116,7 @@ def yield_pb_children(xml_parent):
 # =============================================================================
 
 INTERCONNECT_PORT_SPEC_RE = re.compile(
-    r"((?P<pbtype>[A-Za-z0-9_]+)(\[(?P<indices>[0-9:]+)\])?\.)" \
+    r"((?P<pbtype>[A-Za-z0-9_]+)(\[(?P<indices>[0-9:]+)\])?\.)"
     r"(?P<port>[A-Za-z0-9_]+)(\[(?P<bits>[0-9:]+)\])?"
 )
 

--- a/quicklogic/qlf_k4n8/utils/repacker/arch_xml_utils.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/arch_xml_utils.py
@@ -23,7 +23,9 @@ def get_parent_pb(xml_pbtype):
     Returns a parent pb_type of the given one or none if it is a top-level
     complex block
     """
-    assert xml_pbtype.tag in ["pb_type", "mode", "interconnect"], xml_pbtype.tag
+    assert xml_pbtype.tag in [
+        "pb_type", "mode", "interconnect"
+    ], xml_pbtype.tag
 
     # Get immediate parent
     xml_parent = xml_pbtype.getparent()
@@ -97,6 +99,7 @@ def get_pb_by_name(xml_parent, name):
     # None found
     return None
 
+
 # =============================================================================
 
 
@@ -109,12 +112,14 @@ def yield_pb_children(xml_parent):
         for i in range(num_pb):
             yield xml_child, i
 
+
 # =============================================================================
 
 INTERCONNECT_PORT_SPEC_RE = re.compile(
     r"((?P<pbtype>[A-Za-z0-9_]+)(\[(?P<indices>[0-9:]+)\])?\.)" \
     r"(?P<port>[A-Za-z0-9_]+)(\[(?P<bits>[0-9:]+)\])?"
 )
+
 
 def get_pb_and_port(xml_ic, port_spec):
     """
@@ -151,17 +156,17 @@ def yield_indices(index_spec):
     # None
     if index_spec is None:
         return
-        
+
     # Range
     elif ":" in index_spec:
         i0, i1 = [int(i) for i in index_spec.split(":")]
 
         if i0 > i1:
-            for i in range(i1, i0+1):
+            for i in range(i1, i0 + 1):
                 yield i
 
         elif i0 < i1:
-            for i in range(i0, i1+1):
+            for i in range(i0, i1 + 1):
                 yield i
 
         else:
@@ -207,7 +212,7 @@ def yield_pins(xml_ic, port_spec, skip_index=True):
         indices = list(yield_indices(match.group("indices")))
         if not indices:
             if num_pb > 1:
-                indices = list(range(0, num_pb))    
+                indices = list(range(0, num_pb))
             else:
                 indices = [None]
     else:
@@ -238,6 +243,7 @@ def yield_pins(xml_ic, port_spec, skip_index=True):
                 name += "[0]"
 
             yield name
+
 
 # =============================================================================
 

--- a/quicklogic/qlf_k4n8/utils/repacker/block_path.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/block_path.py
@@ -8,7 +8,7 @@ import re
 
 # A regular expression for parsing path nodes
 PATH_NODE_RE = re.compile(
-    r"^(?P<name>[^\s\[\]\.]+)(\[(?P<index>[0-9]+)\])?" \
+    r"^(?P<name>[^\s\[\]\.]+)(\[(?P<index>[0-9]+)\])?"
     r"(\[(?P<mode>[^\s\[\]\.]+)\])?$"
 )
 

--- a/quicklogic/qlf_k4n8/utils/repacker/block_path.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/block_path.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+Block hierarchy path utilities.
+"""
+import re
+
+# =============================================================================
+
+# A regular expression for parsing path nodes
+PATH_NODE_RE = re.compile(
+    r"^(?P<name>[^\s\[\]\.]+)(\[(?P<index>[0-9]+)\])?" \
+    r"(\[(?P<mode>[^\s\[\]\.]+)\])?$"
+)
+
+# =============================================================================
+
+
+class PathNode:
+    """
+    A class for representing a single path node.
+
+    A string representation of a path node can have the following formats:
+    - "<name>[<index>][<mode>]"
+    - "<name>[<index>]"
+    - "<name>[<mode>]"
+    - "<name>"
+
+    Differentiation between index and mode is based on the assumption that an
+    index may only contain numbers while a mode any other character as well.
+
+    FIXME: This may lead to ambiguity if a mode is named using digits only.
+    """
+
+    def __init__(self, name, index=None, mode=None):
+        """
+        Generic constructor
+        """
+
+        assert isinstance(name, str) or name is None, name
+        assert isinstance(index, int) or index is None, index
+        assert isinstance(mode, str) or mode is None, mode
+
+        self.name = name
+        self.index = index
+        self.mode = mode
+
+    @staticmethod
+    def from_string(string):
+        """
+        Converts a string representation to a PathNode object
+        """
+
+        # Match the regex
+        match = PATH_NODE_RE.fullmatch(string)
+        assert match is not None, string
+
+        name  = match.group("name")
+        index = match.group("index")
+        mode  = match.group("mode")
+
+        if index is not None:
+            index = int(index)
+
+        return PathNode(name, index, mode)
+
+    def to_string(self):
+        """
+        Converts the node into a string
+        """
+        string = self.name
+
+        if self.index is not None:
+            string += "[{}]".format(self.index)
+
+        if self.mode is not None:
+            string += "[{}]".format(self.mode)
+
+        return string
+
+    def __str__(self):
+        return self.to_string()
+
+    def __repr__(self):
+        return self.to_string()

--- a/quicklogic/qlf_k4n8/utils/repacker/block_path.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/block_path.py
@@ -54,9 +54,9 @@ class PathNode:
         match = PATH_NODE_RE.fullmatch(string)
         assert match is not None, string
 
-        name  = match.group("name")
+        name = match.group("name")
         index = match.group("index")
-        mode  = match.group("mode")
+        mode = match.group("mode")
 
         if index is not None:
             index = int(index)

--- a/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""
+BLIF/EBLIF parsing, writing and manipulation utilities.
+
+BLIF format specification:
+    https://course.ece.cmu.edu/~ee760/760docs/blif.pdf
+
+EBLIF format specification:
+    https://docs.verilogtorouting.org/en/latest/vpr/file_formats/#extended-blif-eblif
+"""
+
+import re
+from collections import OrderedDict
+
+# =============================================================================
+
+
+class Cell:
+    """
+    This class represents a single cell in a netlist
+    """
+
+    def __init__(self, type):
+
+        # Cell name. This one is for reference only. It won't be writteb back
+        # with the .cname attribute. Use the cname field for that.
+        self.name = None
+
+        # Cell type (model)
+        self.type  = type
+
+        # Ports and connections. Indexed by port specificatons
+        # (as <port>[<bit>]), contains net names.
+        self.ports = OrderedDict()
+
+        # For const sources ($const) this is the value of the constant
+        # For luts ($lut) this is a list holding the truth table
+        # For latches this is the initial value of the latch or None
+        self.init = None
+
+        # Extended EBLIF data
+        self.cname = None
+        self.attributes = OrderedDict() # name: value, strings
+        self.parameters = OrderedDict() # name: value, strings
+
+    def __str__(self):
+        return "{} ({})".format(self.type, self.name)
+
+    def __repr__(self):
+        return str(self)
+
+
+class Eblif:
+    """
+    This class represents a top-level module of a BLIF/EBLIF netlist
+
+    The class contains BLIF/EBLIF parser and serialized. The parser support
+    all EBLIF constructs except for .conn statements. It is possible to do a
+    parser -> serializer round trip which should generate identical file as
+    the one provided to the parser.
+
+    Netlist cells are stored using the Cell class (see above).
+
+    Cells defined as ".subckt <type>" are stored along with their type. Native
+    BLIF cells (.names, .latch etc.) are represented via the following
+    "built-in" cell models.
+
+    * $const - A constant generator (0-LUT). The output port is named "out"
+        and the init parameter is set to the constant value generated.
+
+    * $lut - N-input LUT. The input port is named "lut_in" and the output one
+        "lut_out". The init parameter contains the truth table. Log2 of size of
+        the table defines the LUT width.
+
+    * $latch - A generic ff/latch with unknown type. Common ports are named:
+        "D", "Q", and "clock". The init value specifies initial ff/latch state
+        a per BLIF specification.
+
+    * $fe, $re, $ah, $al, $as - A ff/latch of type corresponding to BLIF
+        definitions. Apart from different types these are identical to $latch
+
+    * $input, $output - These are used to represent top-level IO ports. The
+        cells have single port named "inpad" and "outpad" respectively. To
+        create / remove such cells use convert_ports_to_cells() and
+        convert_cells_to_ports() methods.
+    """
+
+    def __init__(self, model):
+
+        # Top-level module name
+        self.model = model
+
+        # Top-level input and output nets
+        self.inputs = []
+        self.outputs = []
+
+        # Cells (by names)
+        self.cells = OrderedDict()
+
+
+    def add_cell(self, cell):
+        """
+        Adds a cell. Generates its name if the cell doesn't have. Returns the
+        name under which the cell is stored.
+        """
+
+        # No cell
+        if cell is None:
+            return None
+
+        # Use the cell name
+        if cell.name:
+            name = cell.name
+
+        # Generate a name
+        else:
+            index = 0
+            while True:
+                name = "{}{}".format(cell.type, index)
+                if name not in self.cells:
+                    cell.name = name
+                    break
+
+        # Add it
+        assert cell.name not in self.cells, cell.name
+        self.cells[cell.name] = cell
+
+        return name
+
+    def find_cell(self, name, use_cname=True):
+        """
+        Finds a cell in the netlist given its name, When use_cname is True
+        then looks also by the cell's cname
+        """
+
+        # Try by name
+        cell = self.cells.get(name, None)
+
+        # Try by cname if allowed
+        if cell is None and use_cname:
+            for c in self.cells.values():
+                if c.cname == name:
+                    cell = c
+                    break
+
+        return cell
+
+    def convert_ports_to_cells(self):
+        """
+        Converts top-level input and output ports to $input and $output cells
+        """
+
+        # Convert inputs
+        for port in self.inputs:
+
+            cell = Cell("$input")
+            cell.name = port
+            cell.ports["inpad"] = port
+
+            self.add_cell(cell)
+
+        # Convert outputs
+        for port in self.outputs:
+
+            cell = Cell("$output")
+            cell.name = "out:" + port
+            cell.cname = cell.name
+            cell.ports["outpad"] = port
+
+            self.add_cell(cell)
+
+        # Clear top-level ports
+        self.inputs = []
+        self.outputs = []
+
+    def convert_cells_to_ports(self):
+        """
+        Converts $input and $output cells into top-level ports
+        """
+        for key in list(self.cells.keys()):
+            cell = self.cells[key]
+
+            # Input
+            if cell.type == "$input":
+                assert "inpad" in cell.ports
+                name = cell.ports["inpad"]
+
+                self.inputs.append(name)
+                del self.cells[key]
+
+            # Output
+            if cell.type == "$output":
+                assert "outpad" in cell.ports
+                name = cell.name.replace("out:", "")
+
+                self.outputs.append(name)
+                del self.cells[key]
+
+                # Insert a buffer if the port name does not match the net name
+                net = cell.ports["outpad"]
+                if name != net:
+
+                    cell = Cell("$lut")
+                    cell.name = name
+                    cell.ports["lut_in[0]"] = net
+                    cell.ports["lut_out"] = name
+                    cell.init = [0, 1]
+
+                    self.add_cell(cell)
+
+    @staticmethod
+    def from_string(string):
+        """
+        Parses a BLIF/EBLIF netlist as a multi-line string. Returns an Eblif
+        class instance.
+        """
+
+        def parse_single_output_cover(parts):
+            """
+            Parses a single output cover of a BLIF truth table.
+            """
+
+            # FIXME: Add support for don't cares
+            if "-" in parts[0]:
+                assert False, "Don't cares ('-') not supported yet!"
+
+            # Assume only single address
+            addr = int(parts[0][::-1], 2)
+            data = int(parts[1])
+
+            yield addr, data
+
+        # Split lines, strip whitespace, remove blank ones
+        lines = string.split("\n")
+        lines = [l.strip() for l in lines]
+        lines = [l for l in lines if l]
+
+        eblif = None
+        cell = None
+
+        # Parse lines
+        for line_no, line in enumerate(lines):
+            fields = line.split()
+
+            # Reject comments
+            for i in range(len(fields)):
+                if fields[i].startswith("#"):
+                    fields = fields[:i]
+                    break
+
+            # Empty line
+            if not fields:
+                continue
+
+            # Look for .model
+            if fields[0] == ".model":
+                eblif = Eblif(fields[1])
+                continue
+
+            # No EBLIF yet
+            if not eblif:
+                continue
+
+            # Input list
+            if fields[0] == ".inputs":
+                assert len(fields) >= 2
+                eblif.inputs = fields[1:]
+
+            # Output list
+            elif fields[0] == ".outputs":
+                assert len(fields) >= 2
+                eblif.outputs = fields[1:]
+
+            # Got a generic cell
+            elif fields[0] == ".subckt":
+                assert len(fields) >= 2
+                eblif.add_cell(cell)
+
+                # Add the new cell
+                cell = Cell(fields[1])
+
+                # Add ports and net connections
+                for conn in fields[2:]:
+                    port, net = conn.split("=", maxsplit=1)
+                    cell.ports[port] = net
+
+            # Got a native flip-flop / latch
+            elif fields[0] == ".latch":
+                assert len(fields) >= 3
+                eblif.add_cell(cell)
+
+                # Add the new cell
+                cell = Cell("$latch")
+
+                # Input and output
+                cell.ports["D"] = fields[1]
+                cell.ports["Q"] = fields[2]
+
+                # Got type and control
+                if len(fields) >= 5:
+                    cell.type = "$" + fields[3]
+                    cell.ports["clock"] = fields[4]
+
+                # Use the output net as cell name
+                cell.name = cell.ports["Q"]
+
+                # Got initial value
+                if len(fields) >= 6:
+                    cell.init = int(fields[5])
+                else:
+                    cell.init = 3 # Unknown
+
+            # Got a native LUT
+            elif fields[0] == ".names":
+                assert len(fields) >= 2
+                eblif.add_cell(cell)
+
+                # Determine LUT width
+                width = len(fields[1:-1])
+
+                # Add the new cell
+                type = "$lut" if width > 0 else "$const"
+                cell = Cell(type)
+
+                # Initialize the truth table
+                if type == "$lut":
+                    cell.init = [0 for i in range(2 ** width)]
+                elif type == "$const":
+                    cell.init = 0
+
+                # Input connections
+                for i, net in enumerate(fields[1:-1]):
+                    port = "lut_in[{}]".format(i)
+                    cell.ports[port] = net
+
+                # Output connection
+                cell.ports["lut_out"] = fields[-1]
+
+                # Use the output net as cell name
+                cell.name = cell.ports["lut_out"]
+
+            # LUT truth table chunk
+            elif all([c in ("0", "1", "-") for c in fields[0]]):
+                assert cell is not None
+                assert cell.type in ["$lut", "$const"]
+
+                # The cell is a LUT
+                if cell.type == "$lut":
+                    assert len(fields) == 2
+                    for addr, data in parse_single_output_cover(fields):
+                        cell.init[addr] = data
+
+                # The cell is a const source
+                elif cell.type == "$const":
+                    assert len(fields) == 1
+                    cell.init = int(fields[0])
+
+            # Cell name
+            elif fields[0] == ".cname":
+                cell.name = fields[1]
+                cell.cname = cell.name
+
+            # Cell attribute
+            elif fields[0] == ".attr":
+                cell.attributes[fields[1]] = fields[2]
+
+            # Cell parameter
+            elif fields[0] == ".param":
+                cell.parameters[fields[1]] = fields[2]
+
+            # End
+            elif fields[0] == ".end":
+                # FIXME: Mark that the end is reached and disregard following
+                # keywords
+                pass
+
+            # Unknown directive
+            else:
+                assert False, line
+
+        # Store the current cell
+        eblif.add_cell(cell)
+
+        return eblif
+
+    @staticmethod
+    def from_file(file_name):
+        """
+        Parses a BLIF/EBLIF file. Returns an Eblif class instance.
+        """
+        with open(file_name, "r") as fp:
+            string = fp.read()
+            return Eblif.from_string(string)
+
+    def to_string(self, cname=True, attr=True, param=True, consts=True):
+        """
+        Formats EBLIF data as a multi-line EBLIF string. Additional parameters
+        control what kind of extended (EBLIF) data will be written.
+        """
+
+        lines = []
+
+        # Header
+        lines.append(".model {}".format(self.model))
+        lines.append(".inputs {}".format(" ".join(self.inputs)))
+        lines.append(".outputs {}".format(" ".join(self.outputs)))
+
+        # Cells
+        for cell in self.cells.values():
+
+            # A constant source
+            if cell.type == "$const":
+
+                # Skip consts
+                if not consts:
+                    continue
+
+                lines.append(".names {}".format(str(cell.ports["lut_out"])))
+                if cell.init != 0:
+                    lines.append(str(cell.init))
+
+            # A LUT
+            elif cell.type == "$lut":
+
+                # Identify LUT input pins and their bind indices
+                nets = {}
+                for port, net in cell.ports.items():
+                    match = re.fullmatch(r"lut_in\[(?P<index>[0-9]+)\]", port)
+                    if match is not None:
+                        index = int(match.group("index"))
+                        nets[index] = net
+
+                # Write the cell header. Sort inputs by their indices
+                keys = sorted(nets.keys())
+                lines.append(".names {} {}".format(
+                    " ".join([nets[k] for k in keys]),
+                    str(cell.ports["lut_out"])
+                ))
+
+                # Write the truth table
+                fmt = "{:0" + str(len(nets)) + "b}"
+                tab = []
+                for addr, data in enumerate(cell.init):
+                    if data != 0:
+                        tab.append(fmt.format(addr)[::-1] + " 1")
+                lines.extend(sorted(tab))
+
+            # A latch
+            elif cell.type in ["$fe", "$re", "$ah", "$al", "$as"]:
+
+                line = ".latch {} {} {} {} {}".format(
+                    str(cell.ports["D"]),
+                    str(cell.ports["Q"]),
+                    cell.type[1:],
+                    str(cell.ports["clock"]),
+                    str(cell.init)
+                )
+                lines.append(line)
+
+            # A generic latch controlled by a single global clock
+            elif cell.type == "$latch":
+
+                line = ".latch {} {} {}".format(
+                    str(cell.ports["D"]),
+                    str(cell.ports["Q"]),
+                    str(cell.init)
+                )
+                lines.append(line)
+
+            # A generic subcircuit
+            else:
+
+                # The subcircuit along with its connections
+                line = ".subckt {}".format(cell.type)
+                for port, net in cell.ports.items():
+                    line += " {}={}".format(port, net)
+                lines.append(line)
+
+                # Cell name
+                if cname and cell.cname:
+                    lines.append(".cname {}".format(cell.cname))
+
+                # Cell attributes
+                if attr:
+                    for k, v in cell.attributes.items():
+                        lines.append(".attr {} {}".format(k ,v))
+
+                # Cell parameters
+                if param:
+                    for k, v in cell.parameters.items():
+                        lines.append(".param {} {}".format(k ,v))
+
+        # Footer
+        lines.append(".end")
+
+        # Join all lines
+        return "\n".join(lines)
+
+    def to_file(self, file_name, **kw):
+        """
+        Writes EBLIF data to a file
+        """
+        with open(file_name, "w") as fp:
+            fp.write(self.to_string(**kw))

--- a/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
@@ -27,7 +27,7 @@ class Cell:
         self.name = None
 
         # Cell type (model)
-        self.type  = type
+        self.type = type
 
         # Ports and connections. Indexed by port specificatons
         # (as <port>[<bit>]), contains net names.
@@ -40,8 +40,8 @@ class Cell:
 
         # Extended EBLIF data
         self.cname = None
-        self.attributes = OrderedDict() # name: value, strings
-        self.parameters = OrderedDict() # name: value, strings
+        self.attributes = OrderedDict()  # name: value, strings
+        self.parameters = OrderedDict()  # name: value, strings
 
     def __str__(self):
         return "{} ({})".format(self.type, self.name)
@@ -96,7 +96,6 @@ class Eblif:
 
         # Cells (by names)
         self.cells = OrderedDict()
-
 
     def add_cell(self, cell):
         """
@@ -308,7 +307,7 @@ class Eblif:
                 if len(fields) >= 6:
                     cell.init = int(fields[5])
                 else:
-                    cell.init = 3 # Unknown
+                    cell.init = 3  # Unknown
 
             # Got a native LUT
             elif fields[0] == ".names":
@@ -324,7 +323,7 @@ class Eblif:
 
                 # Initialize the truth table
                 if type == "$lut":
-                    cell.init = [0 for i in range(2 ** width)]
+                    cell.init = [0 for i in range(2**width)]
                 elif type == "$const":
                     cell.init = 0
 
@@ -432,10 +431,12 @@ class Eblif:
 
                 # Write the cell header. Sort inputs by their indices
                 keys = sorted(nets.keys())
-                lines.append(".names {} {}".format(
-                    " ".join([nets[k] for k in keys]),
-                    str(cell.ports["lut_out"])
-                ))
+                lines.append(
+                    ".names {} {}".format(
+                        " ".join([nets[k] for k in keys]),
+                        str(cell.ports["lut_out"])
+                    )
+                )
 
                 # Write the truth table
                 fmt = "{:0" + str(len(nets)) + "b}"
@@ -449,11 +450,8 @@ class Eblif:
             elif cell.type in ["$fe", "$re", "$ah", "$al", "$as"]:
 
                 line = ".latch {} {} {} {} {}".format(
-                    str(cell.ports["D"]),
-                    str(cell.ports["Q"]),
-                    cell.type[1:],
-                    str(cell.ports["clock"]),
-                    str(cell.init)
+                    str(cell.ports["D"]), str(cell.ports["Q"]), cell.type[1:],
+                    str(cell.ports["clock"]), str(cell.init)
                 )
                 lines.append(line)
 
@@ -461,9 +459,7 @@ class Eblif:
             elif cell.type == "$latch":
 
                 line = ".latch {} {} {}".format(
-                    str(cell.ports["D"]),
-                    str(cell.ports["Q"]),
-                    str(cell.init)
+                    str(cell.ports["D"]), str(cell.ports["Q"]), str(cell.init)
                 )
                 lines.append(line)
 
@@ -483,12 +479,12 @@ class Eblif:
                 # Cell attributes
                 if attr:
                     for k, v in cell.attributes.items():
-                        lines.append(".attr {} {}".format(k ,v))
+                        lines.append(".attr {} {}".format(k, v))
 
                 # Cell parameters
                 if param:
                     for k, v in cell.parameters.items():
-                        lines.append(".param {} {}".format(k ,v))
+                        lines.append(".param {} {}".format(k, v))
 
         # Footer
         lines.append(".end")

--- a/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
@@ -231,8 +231,8 @@ class Eblif:
 
         # Split lines, strip whitespace, remove blank ones
         lines = string.split("\n")
-        lines = [l.strip() for l in lines]
-        lines = [l for l in lines if l]
+        lines = [line.strip() for line in lines]
+        lines = [line for line in lines if line]
 
         eblif = None
         cell = None

--- a/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/eblif_netlist.py
@@ -262,12 +262,10 @@ class Eblif:
 
             # Input list
             if fields[0] == ".inputs":
-                assert len(fields) >= 2
                 eblif.inputs = fields[1:]
 
             # Output list
             elif fields[0] == ".outputs":
-                assert len(fields) >= 2
                 eblif.outputs = fields[1:]
 
             # Got a generic cell

--- a/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
@@ -3,6 +3,8 @@
 Utilities for cleaning circuit netlists
 """
 
+import logging
+
 # =============================================================================
 
 
@@ -72,7 +74,7 @@ def absorb_buffer_luts(netlist):
         # Remove the cell
         del netlist.cells[cell.name]
 
-    print("", "Absorbed {} buffer LUTs".format(len(buffers)))
+    logging.debug(" Absorbed {} buffer LUTs".format(len(buffers)))
     return net_map
 
 

--- a/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Utilities for cleaning circuit netlists
+"""
+
+# =============================================================================
+
+
+def absorb_buffer_luts(netlist):
+    """
+    Performs downstream absorbtion of buffer LUTs. All buffer LUTs are absorbed
+    except for those that drive top-level output ports not to change output
+    net names.
+
+    Returns a net map that defines the final net remapping after some nets
+    got absorbed downstream.
+    """
+
+    INP_PORT = "lut_in[0]"
+    OUT_PORT = "lut_out"
+
+    def is_buffer_lut(cell):
+        """
+        Returns True when a cell is a buffer LUT to be absorbed.
+        """
+
+        # A pass-through LUT
+        if cell.type == "$lut" and cell.init == [0, 1]:
+
+            assert OUT_PORT in cell.ports, cell
+            net_out = cell.ports[OUT_PORT]
+
+            # Must not be driving any top-level outputs
+            if net_out in netlist.outputs:
+                return False
+
+            return True
+
+        return False
+
+    # Identify LUT buffers
+    buffers = {key: cell for key, cell in netlist.cells.items() \
+               if is_buffer_lut(cell) == True}
+
+    # Merge them downstream
+    net_map = {}
+    for cell in buffers.values():
+
+        # Get input and output nets
+        assert INP_PORT in cell.ports, cell
+        net_inp = cell.ports[INP_PORT]
+
+        assert OUT_PORT in cell.ports, cell
+        net_out = cell.ports[OUT_PORT]
+
+        # Replace the output net in all cells with the input one
+        for c in netlist.cells.values():
+            for port, net in c.ports.items():
+                if net == net_out:
+                    c.ports[port] = net_inp
+
+        # Update net map
+        for net in net_map:
+            if net_map[net] == net_out:
+                net_map[net] = net_inp
+
+        net_map[net_out] = net_inp
+
+        # Remove the cell
+        del netlist.cells[cell.name]
+
+    print("", "Absorbed {} buffer LUTs".format(len(buffers)))
+    return net_map
+
+
+def sweep_dangling_cells(netlist):
+    # TODO:
+    pass

--- a/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/netlist_cleaning.py
@@ -39,8 +39,11 @@ def absorb_buffer_luts(netlist):
         return False
 
     # Identify LUT buffers
-    buffers = {key: cell for key, cell in netlist.cells.items() \
-               if is_buffer_lut(cell) == True}
+    buffers = {
+        key: cell
+        for key, cell in netlist.cells.items()
+        if is_buffer_lut(cell)
+    }
 
     # Merge them downstream
     net_map = {}

--- a/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
@@ -512,6 +512,28 @@ class Block:
         # Recurse
         return block.find_net_for_port(conn.port, conn.pin)
 
+    def get_nets(self):
+        """
+        Returns all nets that are present in this block and its children
+        """
+
+        nets = set()
+
+        # Recursive walk function
+        def walk(block):
+
+            # Examine block ports
+            for port in block.ports.values():
+                for pin in range(port.width):
+
+                    net = block.find_net_for_port(port.name, pin)
+                    if net:
+                        nets.add(net)
+
+        # Get the nets
+        walk(self)
+        return nets
+
     def get_block_by_path(self, path):
         """
         Returns a child block given its hierarchical path. The path must not

--- a/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
@@ -259,7 +259,7 @@ class Block:
             block.blocks[sub_block.instance] = sub_block
 
         # Parse attributes and parameters
-        for tag, data in zip(["attributes", "parameters"], \
+        for tag, data in zip(["attributes", "parameters"],
                              [block.attributes, block.parameters]):
 
             # Find the list
@@ -300,7 +300,7 @@ class Block:
 
         # Attributes / parameters
         if self.is_leaf:
-            for tag, data in zip(["attributes", "parameters"], \
+            for tag, data in zip(["attributes", "parameters"],
                                  [self.attributes, self.parameters]):
 
                 xml_list = ET.Element(tag)
@@ -318,7 +318,7 @@ class Block:
             xml_ports = ET.Element(tag)
             port_type = tag[:-1]
 
-            keys = self.ports.keys()  #sorted(list(self.ports[tag].keys()))
+            keys = self.ports.keys()
             for key in keys:
                 port = self.ports[key]
                 if port.type == port_type:
@@ -347,7 +347,7 @@ class Block:
             elem.append(xml_ports)
 
         # Recurse
-        keys = self.blocks.keys()  #sorted(list(self.blocks.keys()))
+        keys = self.blocks.keys()
         for key in keys:
             xml_block = self.blocks[key].to_etree()
             elem.append(xml_block)
@@ -458,7 +458,7 @@ class Block:
          - This block,
          - A child,
          - The parent,
-         - A sibling (the parent's child).         
+         - A sibling (the parent's child).
         """
 
         # Strip index. FIXME: Use a regex here.
@@ -529,7 +529,7 @@ class Block:
                 return None
 
             # Check if operating mode matches
-            if parts[0].mode != None:
+            if parts[0].mode is not None:
                 if block.mode != parts[0].mode:
                     return None
 

--- a/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
@@ -579,6 +579,27 @@ class Block:
         # Find the child
         return walk(self, path)
 
+    def count_leafs(self):
+        """
+        Counts all non-open leaf blocks
+        """
+
+        def walk(block, count=0):
+
+            # This is a non-ope leaf, count it
+            if block.is_leaf and not block.is_open:
+                count += 1
+
+            # This is a non-leaf block. Recurse
+            if not block.is_leaf:
+                for child in block.blocks.values():
+                    count += walk(child)
+
+            return count
+
+        # Recursive walk and count
+        return walk(self)
+
     def __str__(self):
         """
         Returns a user-readable description string

--- a/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
@@ -21,8 +21,10 @@ class Connection:
     """
 
     # A regex for parsing connection specification
-    REGEX = re.compile(r"(?P<driver>\S+)\.(?P<port>\S+)\[(?P<pin>[0-9]+)\]->"
-                       r"(?P<interconnect>\S+)")
+    REGEX = re.compile(
+        r"(?P<driver>\S+)\.(?P<port>\S+)\[(?P<pin>[0-9]+)\]->"
+        r"(?P<interconnect>\S+)"
+    )
 
     def __init__(self, driver, port, pin, interconnect):
         """
@@ -61,10 +63,10 @@ class Connection:
 
         # Extract data
         return Connection(
-            driver = match.group("driver"),
-            port = match.group("port"),
-            pin = int(match.group("pin")),
-            interconnect = match.group("interconnect")
+            driver=match.group("driver"),
+            port=match.group("port"),
+            pin=int(match.group("pin")),
+            interconnect=match.group("interconnect")
         )
 
     def to_string(self):
@@ -72,10 +74,7 @@ class Connection:
         Builds a specification string that can be stored in packed netlist
         """
         return "{}.{}[{}]->{}".format(
-            self.driver,
-            self.port,
-            self.pin,
-            self.interconnect
+            self.driver, self.port, self.pin, self.interconnect
         )
 
     def __str__(self):
@@ -83,6 +82,7 @@ class Connection:
 
     def __repr__(self):
         return self.to_string()
+
 
 # =============================================================================
 
@@ -134,12 +134,12 @@ class Port:
         # Remove open connections
         conn = {i: conn[i] for i in range(width) if conn[i] != "open"}
 
-        # Build connection objects. Do that only for ports that specify a 
+        # Build connection objects. Do that only for ports that specify a
         # connection to another port. Otherwise treat the name as a net name.
         for key in conn.keys():
             if "->" in conn[key]:
-                conn[key] = Connection.from_string(conn[key])    
-        
+                conn[key] = Connection.from_string(conn[key])
+
         return Port(name, type, width, conn)
 
     def to_etree(self):
@@ -165,13 +165,12 @@ class Port:
         Returns a user-readable description string
         """
         return "{}[{}:0] ({})".format(
-            self.name,
-            self.width - 1,
-            self.type[0].upper()
+            self.name, self.width - 1, self.type[0].upper()
         )
 
     def __repr__(self):
         return str(self)
+
 
 # =============================================================================
 
@@ -213,9 +212,9 @@ class Block:
 
         # Create the block with basic attributes
         block = Block(
-            name = elem.attrib["name"],
-            instance = elem.attrib["instance"],
-            mode = elem.get("mode", "default")
+            name=elem.attrib["name"],
+            instance=elem.attrib["instance"],
+            mode=elem.get("mode", "default")
         )
 
         # Parse ports
@@ -269,7 +268,8 @@ class Block:
 
                 # Only a leaf block can have attributes / parameters
                 assert block.is_leaf, "Non-leaf block '{}' with {}".format(
-                    block.instance, tag)
+                    block.instance, tag
+                )
 
                 # Parse
                 sub_tag = tag[:-1]
@@ -318,7 +318,7 @@ class Block:
             xml_ports = ET.Element(tag)
             port_type = tag[:-1]
 
-            keys = self.ports.keys() #sorted(list(self.ports[tag].keys()))
+            keys = self.ports.keys()  #sorted(list(self.ports[tag].keys()))
             for key in keys:
                 port = self.ports[key]
                 if port.type == port_type:
@@ -333,21 +333,21 @@ class Block:
                         # Encode
                         rotation = []
                         for i in range(port.width):
-                            rotation.append(str(
-                                port.rotation_map.get(i, "open"))
+                            rotation.append(
+                                str(port.rotation_map.get(i, "open"))
                             )
 
                         # Make an element
-                        xml_rotation_map = ET.Element("port_rotation_map", {
-                            "name": port.name
-                        })
+                        xml_rotation_map = ET.Element(
+                            "port_rotation_map", {"name": port.name}
+                        )
                         xml_rotation_map.text = " ".join(rotation)
                         xml_ports.append(xml_rotation_map)
 
             elem.append(xml_ports)
 
         # Recurse
-        keys = self.blocks.keys() #sorted(list(self.blocks.keys()))
+        keys = self.blocks.keys()  #sorted(list(self.blocks.keys()))
         for key in keys:
             xml_block = self.blocks[key].to_etree()
             elem.append(xml_block)
@@ -509,7 +509,7 @@ class Block:
         block = self.get_neighboring_block(conn.driver)
         assert block is not None, (self.instance, conn.driver)
 
-        # Recurse            
+        # Recurse
         return block.find_net_for_port(conn.port, conn.pin)
 
     def get_block_by_path(self, path):
@@ -527,7 +527,7 @@ class Block:
             instance = "{}[{}]".format(parts[0].name, parts[0].index)
             if block.instance != instance:
                 return None
-            
+
             # Check if operating mode matches
             if parts[0].mode != None:
                 if block.mode != parts[0].mode:
@@ -569,6 +569,7 @@ class Block:
 
     def __repr__(self):
         return str(self)
+
 
 # =============================================================================
 

--- a/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/packed_netlist.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+"""
+Utilities for handling VTR packed netlist (.net) data
+
+VPR packed netlist format specification:
+    https://docs.verilogtorouting.org/en/latest/vpr/file_formats/#packed-netlist-format-net
+"""
+import re
+import lxml.etree as ET
+
+from block_path import PathNode
+
+# =============================================================================
+
+
+class Connection:
+    """
+    A class representing a connection of a port pin. For output ports it
+    refers to child/sibling block, port and pin while for input ports it refers
+    to the parent/sibling block, port and pin.
+    """
+
+    # A regex for parsing connection specification
+    REGEX = re.compile(r"(?P<driver>\S+)\.(?P<port>\S+)\[(?P<pin>[0-9]+)\]->"
+                       r"(?P<interconnect>\S+)")
+
+    def __init__(self, driver, port, pin, interconnect):
+        """
+        Basic constructor
+        """
+        self.driver = driver
+        self.port = port
+        self.pin = pin
+        self.interconnect = interconnect
+
+    @staticmethod
+    def from_string(spec):
+        """
+        Parses a specification string. Returns a Connection object
+
+        >>> Connection.from_string("parent.A[3]->interconnect")
+        parent.A[3]->interconnect
+        >>> Connection.from_string("parent.A->interconnect")
+        Traceback (most recent call last):
+        ...
+        AssertionError: parent.A->interconnect
+        >>> Connection.from_string("parent.A[3]")
+        Traceback (most recent call last):
+        ...
+        AssertionError: parent.A[3]
+        >>> Connection.from_string("Something")
+        Traceback (most recent call last):
+        ...
+        AssertionError: Something
+        """
+        assert isinstance(spec, str)
+
+        # Try match
+        match = Connection.REGEX.fullmatch(spec)
+        assert match is not None, spec
+
+        # Extract data
+        return Connection(
+            driver = match.group("driver"),
+            port = match.group("port"),
+            pin = int(match.group("pin")),
+            interconnect = match.group("interconnect")
+        )
+
+    def to_string(self):
+        """
+        Builds a specification string that can be stored in packed netlist
+        """
+        return "{}.{}[{}]->{}".format(
+            self.driver,
+            self.port,
+            self.pin,
+            self.interconnect
+        )
+
+    def __str__(self):
+        return self.to_string()
+
+    def __repr__(self):
+        return self.to_string()
+
+# =============================================================================
+
+
+class Port:
+    """
+    A class representing a block port. Stores port information such as type
+    (direction), bus width and its connections.
+    """
+
+    def __init__(self, name, type, width=1, connections=None):
+        """
+        Basic constructor
+        """
+        self.name = name
+        self.type = type
+        self.width = width
+
+        # Sanity check provided port connections
+        if connections is not None:
+            assert isinstance(connections, dict)
+
+            # Check each entry
+            for pin, conn in connections.items():
+                assert isinstance(pin, int), pin
+                assert pin < self.width, (pin, width)
+                assert isinstance(conn, Connection) or \
+                       isinstance(conn, str), pin
+
+            self.connections = connections
+
+        else:
+            self.connections = {}
+
+        # Rotation map
+        self.rotation_map = None
+
+    @staticmethod
+    def from_etree(elem, type):
+        """
+        Builds a port class from the packed netlist (XML) representation.
+        """
+        assert elem.tag == "port", elem.tag
+        name = elem.attrib["name"]
+
+        conn = elem.text.strip().split()
+        width = len(conn)
+
+        # Remove open connections
+        conn = {i: conn[i] for i in range(width) if conn[i] != "open"}
+
+        # Build connection objects. Do that only for ports that specify a 
+        # connection to another port. Otherwise treat the name as a net name.
+        for key in conn.keys():
+            if "->" in conn[key]:
+                conn[key] = Connection.from_string(conn[key])    
+        
+        return Port(name, type, width, conn)
+
+    def to_etree(self):
+        """
+        Converts the port representation to the packed netlist (XML)
+        representation.
+        """
+
+        # Format connections
+        text = []
+        for i in range(self.width):
+            if i in self.connections:
+                text.append(str(self.connections[i]))
+            else:
+                text.append("open")
+
+        elem = ET.Element("port", attrib={"name": self.name})
+        elem.text = " ".join(text)
+        return elem
+
+    def __str__(self):
+        """
+        Returns a user-readable description string
+        """
+        return "{}[{}:0] ({})".format(
+            self.name,
+            self.width - 1,
+            self.type[0].upper()
+        )
+
+    def __repr__(self):
+        return str(self)
+
+# =============================================================================
+
+
+class Block:
+    """
+    A hierarchical block of a packed netlist.
+    """
+
+    def __init__(self, name, instance, mode=None, parent=None):
+
+        # Basic attributes
+        self.name = name
+        self.instance = instance
+        self.mode = mode
+
+        # Identify the block type. FIXME: Use a regex here
+        self.type = instance.split("[", maxsplit=1)[0]
+
+        # Ports indexed by names
+        self.ports = {}
+
+        # Parent block
+        self.parent = parent
+
+        # Child blocks indexed by instance
+        self.blocks = {}
+
+        # Leaf block attributes and parameters
+        self.attributes = {}
+        self.parameters = {}
+
+    @staticmethod
+    def from_etree(elem):
+        """
+        Builds a block class from the packed netlist (XML) representation.
+        """
+        assert elem.tag == "block", elem.tag
+
+        # Create the block with basic attributes
+        block = Block(
+            name = elem.attrib["name"],
+            instance = elem.attrib["instance"],
+            mode = elem.get("mode", "default")
+        )
+
+        # Parse ports
+        rotation_maps = {}
+        for tag in ["inputs", "outputs", "clocks"]:
+            port_type = tag[:-1]
+
+            xml_ports = elem.find(tag)
+            if xml_ports is not None:
+                for xml_port in xml_ports:
+
+                    # Got a port rotation map
+                    if xml_port.tag == "port_rotation_map":
+                        port_name = xml_port.attrib["name"]
+                        rotation = xml_port.text
+
+                        # Parse the map
+                        rotation_map = {}
+                        for i, j in enumerate(rotation.strip().split()):
+                            if j != "open":
+                                rotation_map[i] = int(j)
+
+                        # Store it to be later associated with a port
+                        rotation_maps[port_name] = rotation_map
+
+                    # Got a port
+                    else:
+                        port = Port.from_etree(xml_port, port_type)
+                        block.ports[port.name] = port
+
+        # Associate rotation maps with ports
+        for port_name, rotation_map in rotation_maps.items():
+            assert port_name in block.ports, port_name
+            block.ports[port_name].rotation_map = rotation_map
+
+        # Recursively parse sub-blocks
+        for xml_block in elem.findall("block"):
+
+            sub_block = Block.from_etree(xml_block)
+
+            sub_block.parent = block
+            block.blocks[sub_block.instance] = sub_block
+
+        # Parse attributes and parameters
+        for tag, data in zip(["attributes", "parameters"], \
+                             [block.attributes, block.parameters]):
+
+            # Find the list
+            xml_list = elem.find(tag)
+            if xml_list is not None:
+
+                # Only a leaf block can have attributes / parameters
+                assert block.is_leaf, "Non-leaf block '{}' with {}".format(
+                    block.instance, tag)
+
+                # Parse
+                sub_tag = tag[:-1]
+                for xml_item in xml_list.findall(sub_tag):
+                    data[xml_item.attrib["name"]] = xml_item.text
+
+        return block
+
+    def to_etree(self):
+        """
+        Converts the block representation to the packed netlist (XML)
+        representation.
+        """
+
+        # Base block element
+        attrib = {
+            "name": self.name,
+            "instance": self.instance,
+        }
+        if not self.is_leaf:
+            attrib["mode"] = self.mode if self.mode is not None else "default"
+
+        elem = ET.Element("block", attrib)
+
+        # If this is an "open" block then skip the remaining tags
+        if self.name == "open":
+            return elem
+
+        # Attributes / parameters
+        if self.is_leaf:
+            for tag, data in zip(["attributes", "parameters"], \
+                                 [self.attributes, self.parameters]):
+
+                xml_list = ET.Element(tag)
+
+                sub_tag = tag[:-1]
+                for key, value in data.items():
+                    xml_item = ET.Element(sub_tag, {"name": key})
+                    xml_item.text = value
+                    xml_list.append(xml_item)
+
+                elem.append(xml_list)
+
+        # Ports
+        for tag in ["inputs", "outputs", "clocks"]:
+            xml_ports = ET.Element(tag)
+            port_type = tag[:-1]
+
+            keys = self.ports.keys() #sorted(list(self.ports[tag].keys()))
+            for key in keys:
+                port = self.ports[key]
+                if port.type == port_type:
+
+                    # Encode port
+                    xml_port = port.to_etree()
+                    xml_ports.append(xml_port)
+
+                    # Rotation map
+                    if port.rotation_map:
+
+                        # Encode
+                        rotation = []
+                        for i in range(port.width):
+                            rotation.append(str(
+                                port.rotation_map.get(i, "open"))
+                            )
+
+                        # Make an element
+                        xml_rotation_map = ET.Element("port_rotation_map", {
+                            "name": port.name
+                        })
+                        xml_rotation_map.text = " ".join(rotation)
+                        xml_ports.append(xml_rotation_map)
+
+            elem.append(xml_ports)
+
+        # Recurse
+        keys = self.blocks.keys() #sorted(list(self.blocks.keys()))
+        for key in keys:
+            xml_block = self.blocks[key].to_etree()
+            elem.append(xml_block)
+
+        return elem
+
+    @property
+    def is_leaf(self):
+        """
+        Returns True when the block is a leaf block
+        """
+        return len(self.blocks) == 0
+
+    @property
+    def is_open(self):
+        """
+        Returns True when the block is open
+        """
+        return self.name == "open"
+
+    @property
+    def is_route_throu(self):
+        """
+        Returns True when the block is a route-throu native LUT
+        """
+
+        # VPR stores route-through LUTs as "open" blocks with mode set to
+        # "wire".
+        return self.is_leaf and self.name == "open" and self.mode == "wire"
+
+    def get_path(self, with_indices=True, with_modes=True, default_modes=True):
+        """
+        Returns the full path to the block. When with_indices is True then
+        index suffixes '[<index>]' are appended to block types. When
+        with_modes is True then mode suffixes '[<mode>]' are appended. The
+        default_modes flag controls appending suffixes for default modes.
+        """
+        path = []
+        block = self
+
+        # Walk towards the tree root
+        while block is not None:
+
+            # Type or type with index (instance)
+            if with_indices:
+                node = block.instance
+            else:
+                node = block.type
+
+            # Mode suffix
+            if not block.is_leaf and with_modes:
+                if block.mode != "default" or default_modes:
+                    node += "[{}]".format(block.mode)
+
+            # Prepend
+            path = [node] + path
+
+            # Go up
+            block = block.parent
+
+        return ".".join(path)
+
+    def rename_cluster(self, name):
+        """
+        Renames this block and all its children except leaf blocks
+        """
+
+        def walk(block):
+
+            if not block.is_leaf and not block.is_open:
+                block.name = name
+
+            for child in block.blocks.values():
+                walk(child)
+
+        walk(self)
+
+    def rename_nets(self, net_map):
+        """
+        Renames all nets and leaf blocks that drive them according to the
+        given map.
+        """
+
+        def walk(block):
+
+            # Rename a leaf block
+            if block.is_leaf and not block.is_open:
+                block.name = net_map.get(block.name, block.name)
+
+            # Rename nets in port connections
+            for port in block.ports.values():
+                for pin, conn in port.connections.items():
+
+                    if isinstance(conn, str):
+                        port.connections[pin] = net_map.get(conn, conn)
+
+            # Recurse
+            for child in block.blocks.values():
+                walk(child)
+
+        walk(self)
+
+    def get_neighboring_block(self, instance):
+        """
+        Returns a neighboring block given in the vicinity of the current block
+        given an instance name. The block can be:
+
+         - This block,
+         - A child,
+         - The parent,
+         - A sibling (the parent's child).         
+        """
+
+        # Strip index. FIXME: Use a regex here.
+        block_type = instance.split("[", maxsplit=1)[0]
+
+        # Check self
+        if self.instance == instance:
+            return self
+
+        # Check children
+        if instance in self.blocks:
+            return self.blocks[instance]
+
+        # Check parent and siblings
+        if self.parent is not None:
+
+            # Parent
+            if self.parent.type == block_type:
+                return self.parent
+
+            # Siblings
+            if instance in self.parent.blocks:
+                return self.parent.blocks[instance]
+
+        return None
+
+    def find_net_for_port(self, port, pin):
+        """
+        Finds net for the given port name and pin index of the block.
+        """
+
+        # Get the port
+        assert port in self.ports, (self.name, self.instance, (port, pin))
+        port = self.ports[port]
+
+        # Unconnected
+        if pin not in port.connections:
+            return None
+
+        # Get the pin connection
+        conn = port.connections[pin]
+
+        # The connection refers to a net directly
+        if isinstance(conn, str):
+            return conn
+
+        # Get driving block
+        block = self.get_neighboring_block(conn.driver)
+        assert block is not None, (self.instance, conn.driver)
+
+        # Recurse            
+        return block.find_net_for_port(conn.port, conn.pin)
+
+    def get_block_by_path(self, path):
+        """
+        Returns a child block given its hierarchical path. The path must not
+        include the current block.
+
+        The path may or may not contain modes. When a mode is given it will
+        be used for matching. The path must contain indices.
+        """
+
+        def walk(block, parts):
+
+            # Check if instance matches
+            instance = "{}[{}]".format(parts[0].name, parts[0].index)
+            if block.instance != instance:
+                return None
+            
+            # Check if operating mode matches
+            if parts[0].mode != None:
+                if block.mode != parts[0].mode:
+                    return None
+
+            # Next
+            parts = parts[1:]
+
+            # No more path parts, this is the block
+            if not parts:
+                return block
+
+            # Find child block by its instance and recurse
+            instance = "{}[{}]".format(parts[0].name, parts[0].index)
+            if instance in block.blocks:
+                return walk(block.blocks[instance], parts)
+
+            return None
+
+        # Prepend self to the path
+        path = "{}[{}]".format(self.instance, self.mode) + "." + path
+
+        # Split and parse the path
+        path = path.split(".")
+        path = [PathNode.from_string(p) for p in path]
+
+        # Find the child
+        return walk(self, path)
+
+    def __str__(self):
+        """
+        Returns a user-readable description string
+        """
+        ref = self.instance
+        if self.mode is not None:
+            ref += "[{}]".format(self.mode)
+        ref += " ({})".format(self.name)
+        return ref
+
+    def __repr__(self):
+        return str(self)
+
+# =============================================================================
+
+
+class PackedNetlist:
+    """
+    A VPR Packed netlist representation.
+
+    The packed netlist is organized as one huge block representing the whole
+    FPGA with all placeable blocks (CLBs) as its children. Here we store the
+    top-level block implicitly so all blocks mentioned in a PackedNetlist
+    instance refer to individual placeable CLBs.
+    """
+
+    def __init__(self):
+        """
+        Basic constructor
+        """
+
+        # Architecture and atom netlist ids
+        self.arch_id = None
+        self.netlist_id = None
+
+        # Top-level block name and instance
+        self.name = None
+        self.instance = None
+
+        # Top-level ports (net names)
+        self.ports = {
+            "inputs": [],
+            "outputs": [],
+            "clocks": [],
+        }
+
+        # CLBs
+        self.blocks = {}
+
+    @staticmethod
+    def from_etree(root):
+        """
+        Reads the packed netlist from the given element tree
+        """
+        assert root.tag == "block", root.tag
+
+        netlist = PackedNetlist()
+        netlist.name = root.attrib["name"]
+        netlist.instance = root.attrib["instance"]
+
+        netlist.arch_id = root.get("architecture_id", None)
+        netlist.netlist_id = root.get("atom_netlist_id", None)
+
+        # Parse top-level ports
+        for tag in ["inputs", "outputs", "clocks"]:
+            xml_ports = root.find(tag)
+            if xml_ports is not None and xml_ports.text:
+                netlist.ports[tag] = xml_ports.text.strip().split()
+
+        # Parse CLBs
+        for xml_block in root.findall("block"):
+            block = Block.from_etree(xml_block)
+            netlist.blocks[block.instance] = block
+
+        return netlist
+
+    def to_etree(self):
+        """
+        Builds an element tree (XML) that represents the packed netlist
+        """
+
+        # Top-level root block
+        attr = {
+            "name": self.name,
+            "instance": self.instance,
+        }
+
+        if self.arch_id is not None:
+            attr["architecture_id"] = self.arch_id
+        if self.netlist_id is not None:
+            attr["atom_netlist_id"] = self.netlist_id
+
+        root = ET.Element("block", attr)
+
+        # Top-level ports
+        for tag in ["inputs", "outputs", "clocks"]:
+            xml_ports = ET.Element(tag)
+            xml_ports.text = " ".join(self.ports[tag])
+            root.append(xml_ports)
+
+        # CLB blocks
+        keys = self.blocks.keys()
+        for key in keys:
+            xml_block = self.blocks[key].to_etree()
+            root.append(xml_block)
+
+        return root

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph.py
@@ -3,11 +3,9 @@
 A set of utils for VTR pb_type rr graphs
 """
 
-import re
 import itertools
 import colorsys
 
-from collections import namedtuple
 from enum import Enum
 
 from block_path import PathNode
@@ -180,9 +178,9 @@ class Graph():
                 # Add edge
                 ic = "direct:{}".format(xml_pbtype.attrib["name"])
                 if parent_node.port_type in [PortType.INPUT, PortType.CLOCK]:
-                    edge = graph.add_edge(parent_node.id, node.id, ic)
+                    graph.add_edge(parent_node.id, node.id, ic)
                 elif parent_node.port_type == PortType.OUTPUT:
-                    edge = graph.add_edge(node.id, parent_node.id, ic)
+                    graph.add_edge(node.id, parent_node.id, ic)
                 else:
                     assert False, parent_node
 
@@ -290,7 +288,7 @@ class Graph():
 
         # Determine where the pb_type is in the hierarchy
         is_leaf = is_leaf_pbtype(xml_pbtype)
-        is_top = get_parent_pb(xml_pbtype) == None
+        is_top = get_parent_pb(xml_pbtype) is None
         assert not (is_top and is_leaf), (xml_pbtype.tag, xml_pbtype.attrib)
 
         # Add nodes
@@ -463,7 +461,7 @@ class Graph():
             for i, net in enumerate(nets):
 
                 h = i / len(nets)
-                l = 0.50
+                l = 0.50  # noqa: E741
                 s = 1.0
 
                 r, g, b = colorsys.hls_to_rgb(h, l, s)
@@ -535,7 +533,7 @@ class Graph():
                 continue
 
             highlight = highlight_nodes is not None and \
-                        node.id in highlight_nodes
+                        node.id in highlight_nodes  # noqa: E127
 
             parts = node.path.split(".")
             label = "{}: {}".format(node.id, ".".join(parts[-2:]))
@@ -570,7 +568,6 @@ class Graph():
         # Add nodes
         for rank, nodes in nodes.items():
             dot.append(" {")
-            #dot.append("  rank=same;")
 
             for node in nodes:
                 dot.append(

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""
+A set of utils for VTR pb_type rr graphs
+"""
+
+import re
+import itertools
+import colorsys
+
+from collections import namedtuple
+from enum import Enum
+
+from block_path import PathNode
+
+from pb_type import PortType
+
+from arch_xml_utils import is_leaf_pbtype
+from arch_xml_utils import get_parent_pb
+from arch_xml_utils import yield_pb_children
+from arch_xml_utils import yield_pins
+
+# =============================================================================
+
+
+class NodeType(Enum):
+    """
+    Type of a pb graph node
+    """
+    PORT = 0
+    SOURCE = 1
+    SINK = 2
+
+
+class Node:
+    """
+    This class represents a node in pb graph. Nodes are associated with port
+    pins.
+    """
+    def __init__(self, id, type, port_type, path, net=None):
+        self.id = id
+        self.type = type
+        self.port_type = port_type
+        self.path = path
+        self.net = net
+
+    def __str__(self):
+        return "id:{:3d}, type:{}, port_type:{}, path:{}, net:{}".format(
+            self.id,
+            self.type,
+            self.port_type,
+            self.path,
+            self.net
+        )
+
+
+class Edge:
+    """
+    This class represents an edge in pb_graph. Edges are associated with
+    interconnect connections.
+    """
+    def __init__(self, src_id, dst_id, ic):
+        self.src_id = src_id
+        self.dst_id = dst_id
+        self.ic = ic
+
+    def __str__(self):
+        return "src_id:{}, dst_id:{}, ic:{}".format(
+            self.src_id,
+            self.dst_id,
+            self.ic
+        )
+
+# =============================================================================
+
+
+class Graph():
+    """
+    Representation of a complex block routing graph.
+
+    This class stores only nodes and edges instead of a hierarchical tree of
+    objects representing blocks (pb_types). Graph nodes are associated with
+    pb_type ports. Each node has a path that uniquely identifies which port
+    it represents.
+    """
+
+    def __init__(self):
+
+        # Nodes by id
+        self.nodes = {}
+        # Edges (assorted)
+        self.edges = []
+
+        # Id of the next node to be added
+        self.next_node_id = 0
+
+    def add_node(self, type, port_type, path, net=None):
+        """
+        Adds a new node. Automatically assings its id
+        """
+        node = Node(
+            id = self.next_node_id,
+            type = type,
+            port_type = port_type,
+            path = path,
+            net = net
+        )
+
+        self.nodes[node.id] = node
+        self.next_node_id += 1
+
+        return node
+
+    def add_edge(self, src_id, dst_id, ic):
+        """
+        Adds a new edge. Checks if the given node ids are valid.
+        """
+        assert src_id in self.nodes, src_id
+        assert dst_id in self.nodes, dst_id
+
+        edge = Edge(
+            src_id = src_id,
+            dst_id = dst_id,
+            ic = ic
+        )
+
+        self.edges.append(edge)
+
+        return edge
+
+    def clear_nets(self):
+        """
+        Removes all net annotations
+        """
+        for node in self.nodes.values():
+            node.net = None
+
+    def edge_net(self, edge):
+        """
+        Returns net associated with the given edge
+
+        Edges do not have explicit net annotations. It is assumed that when
+        an edge binds two nodes that belong to the same net, that edge belongs
+        to that net as well.
+        """
+        src_node = self.nodes[edge.src_id]
+        dst_node = self.nodes[edge.dst_id]
+
+        if src_node.net is None:
+            return None
+        if dst_node.net is None:
+            return None
+
+        if src_node.net != dst_node.net:
+            return None
+
+        return src_node.net
+
+    @staticmethod
+    def from_etree(xml_clb, clb_instance=None):
+        """
+        Builds a routing graph for the given complex block from VPR
+        architecture XML description.
+        """
+        assert xml_clb.tag == "pb_type"        
+
+        # Create the graph
+        graph = Graph()
+
+        # Handler for "lut" pb_types. It creates an additional level of
+        # hierarchy to match the representation in packed netlist.
+        def process_lut(xml_pbtype, up_node_map, path):
+
+            # The parent is actually a leaf so it does not have any modes
+            # However, the mode name must equal to the pb_type name.
+            curr_path = path + "[{}].lut[0]".format(xml_pbtype.attrib["name"])
+
+            # Copy nodes from the parent and connect them 1-to-1
+            for parent_node in up_node_map.values():
+                parent_port = parent_node.path.rsplit(".", maxsplit=1)[-1]
+
+                # Add node
+                node = graph.add_node(
+                    parent_node.type,
+                    parent_node.port_type,
+                    ".".join([curr_path, parent_port])
+                )
+
+                # Add edge
+                ic = "direct:{}".format(xml_pbtype.attrib["name"]) 
+                if parent_node.port_type in [PortType.INPUT, PortType.CLOCK]:
+                    edge = graph.add_edge(
+                        parent_node.id,
+                        node.id,
+                        ic
+                    )
+                elif parent_node.port_type == PortType.OUTPUT:
+                    edge = graph.add_edge(
+                        node.id,
+                        parent_node.id,
+                        ic
+                    )
+                else:
+                    assert False, parent_node
+
+            # Change parent port nodes to PORT
+            for parent_node in up_node_map.values():
+                parent_node.type = NodeType.PORT
+
+        # Recursive build function
+        def process_pbtype(xml_pbtype, up_node_map, path=""):
+            """
+            This function adds nodes for all child pb_type ports and edges
+            connecting them with the parent pb_type ports. The process is
+            repeated for each mode.
+
+            Before the first level of recursion nodes of the top-level pb_type
+            need to be already built.
+            """
+
+            # Identify all modes. If there is none then add the default
+            # implicit one.
+            xml_modes = {x.attrib["name"]: x for x in xml_pbtype.findall("mode")}
+            if not xml_modes:
+                xml_modes = {"default": xml_pbtype}
+
+            # Process each mode
+            for mode, xml_mode in xml_modes.items():
+
+                # Append mode name to the current path
+                curr_path = path +  "[{}]".format(mode)
+
+                # Enumerate childern, build their paths
+                children = []
+                for xml_child, index in yield_pb_children(xml_mode):
+
+                    child_path = ".".join([
+                        curr_path,
+                        "{}[{}]".format(
+                            xml_child.attrib["name"],
+                            index
+                        )
+                    ])
+
+                    children.append((xml_child, child_path,))
+
+                # Build child pb_type nodes
+                dn_node_map = {}
+                for xml_child, child_path in children:
+                    nodes = graph._build_nodes(xml_child, child_path)
+                    dn_node_map.update(nodes)
+
+                    # Special case, a "lut" class leaf pb_type
+                    cls = xml_child.get("class", None)
+                    if cls == "lut":
+                        process_lut(xml_child, nodes, child_path)
+
+                # Build interconnect edges
+                xml_ic = xml_mode.find("interconnect")
+                assert xml_ic is not None
+
+                graph._build_edges(xml_ic, curr_path, up_node_map, dn_node_map)
+
+                # Recurse
+                for xml_child, child_path in children:
+                    if not is_leaf_pbtype(xml_child):
+                        process_pbtype(xml_child, dn_node_map, child_path)
+
+
+        # Set the top-level CLB path
+        if clb_instance is None:
+            path = xml_clb.attrib["name"] + "[0]"
+        else:
+            path = clb_instance
+
+        # Build top-level sources and sinks
+        up_node_map = graph._build_nodes(xml_clb, path)
+
+        # Begin recustion
+        process_pbtype(xml_clb, up_node_map, path)
+
+        return graph
+
+    def _build_nodes(self, xml_pbtype, prefix):
+        """
+        Adds nodes for each pin of the given pb_type. Returns a map of pin
+        names to node ids
+        """
+        node_map = {}
+
+        # Sink/source node type map
+        leaf_node_types = {
+            "input": NodeType.SINK,
+            "clock": NodeType.SINK,
+            "output": NodeType.SOURCE,
+        }
+
+        top_node_types = {
+            "input": NodeType.SOURCE,
+            "clock": NodeType.SOURCE,
+            "output": NodeType.SINK,
+        }
+
+        # Determine where the pb_type is in the hierarchy
+        is_leaf = is_leaf_pbtype(xml_pbtype)
+        is_top = get_parent_pb(xml_pbtype) == None
+        assert not (is_top and is_leaf), (xml_pbtype.tag, xml_pbtype.attrib)
+
+        # Add nodes
+        for xml_port in xml_pbtype:
+
+            if xml_port.tag in ["input", "output", "clock"]:
+                width = int(xml_port.attrib["num_pins"])
+
+                # Determine node type
+                if is_top:
+                    node_type = top_node_types[xml_port.tag]
+                elif is_leaf:
+                    node_type = leaf_node_types[xml_port.tag]
+                else:
+                    node_type = NodeType.PORT
+
+                # Determine node port direction
+                port_type = PortType.from_string(xml_port.tag)
+
+                # Add a node for each pin
+                for i in range(width):
+                    name = "{}[{}]".format(xml_port.attrib["name"], i)
+                    path = ".".join([prefix, name])
+                    node = self.add_node(node_type, port_type, path)
+
+                    node_map[path] = node
+
+        return node_map
+
+    def _build_edges(self, xml_ic, path, up_node_map, dn_node_map):
+        """
+        Builds edges for the given interconnect. Uses node maps to bind
+        port pin names with node ids.
+        """
+
+        # Join node maps
+        node_map = {**up_node_map, **dn_node_map}
+
+        # Get parent pb_type and its name
+        xml_pbtype = get_parent_pb(xml_ic)
+        parent_name = xml_pbtype.attrib["name"]
+
+        # Split the path
+        path_parts = path.split(".")
+
+        # A helper function
+        def get_node_path(pin):
+
+            # Split parts
+            parts = pin.split(".")
+            assert len(parts) == 2, pin
+
+            # Parse the pb_type referred by the pin
+            pin_pbtype = PathNode.from_string(parts[0])
+
+            # This pin refers to the parent
+            if pin_pbtype.name == parent_name:
+                ref_pbtype = PathNode.from_string(path_parts[-1])
+
+                # Fixup pb_type reference name
+                part = "{}[{}]".format(
+                    pin_pbtype.name,
+                    ref_pbtype.index,
+                )
+                parts = path_parts[:-1] + [part] + parts[1:]
+
+            else:
+                parts = path_parts + parts
+
+            # Assemble the full path
+            node_path = ".".join(parts)
+            return node_path
+
+        # Process interconnects
+        for xml_conn in xml_ic:
+
+            # Direct
+            if xml_conn.tag == "direct":
+                inps = list(yield_pins(xml_ic, xml_conn.attrib["input"],  False))
+                outs = list(yield_pins(xml_ic, xml_conn.attrib["output"], False))
+
+                assert len(inps) == len(outs), (
+                    xml_conn.tag,
+                    xml_conn.attrib,
+                    len(inps),
+                    len(outs)
+                )
+
+                # Add edges
+                for inp, out in zip(inps, outs):
+                    inp = get_node_path(inp)
+                    out = get_node_path(out)
+                    
+                    self.add_edge(
+                        src_id = node_map[inp].id,
+                        dst_id = node_map[out].id,
+                        ic = xml_conn.attrib["name"]
+                    )
+
+            # Mux
+            elif xml_conn.tag == "mux":
+                inp_ports = xml_conn.attrib["input"].split()
+
+                # Get output pins, should be only one
+                out_pins = list(yield_pins(xml_ic, xml_conn.attrib["output"], False))
+                assert len(out_pins) == 1, xml_ic.attrib
+
+                # Build edges for each input port
+                for inp_port in inp_ports:
+
+                    # Get input pins, should be only one
+                    inp_pins = list(yield_pins(xml_ic, inp_port, False))
+                    assert len(inp_pins) == 1, xml_conn.attrib
+
+                    # Add edge
+                    inp = get_node_path(inp_pins[0])
+                    out = get_node_path(out_pins[0])
+                    
+                    self.add_edge(
+                        src_id = node_map[inp].id,
+                        dst_id = node_map[out].id,
+                        ic = xml_conn.attrib["name"]
+                    )
+
+            # Complete
+            elif xml_conn.tag == "complete":
+                inp_ports = xml_conn.attrib["input"].split()
+                out_ports = xml_conn.attrib["output"].split()
+
+                # Build lists of all input and all output pins
+                inp_pins = []
+                for inp_port in inp_ports:
+                    inp_pins.extend(list(yield_pins(xml_ic, inp_port, False)))
+
+                out_pins = []
+                for out_port in out_ports:
+                    out_pins.extend(list(yield_pins(xml_ic, out_port, False)))
+
+                # Add edges
+                for inp_pin, out_pin in itertools.product(inp_pins, out_pins):
+                    inp = get_node_path(inp_pin)
+                    out = get_node_path(out_pin)
+                    
+                    self.add_edge(
+                        src_id = node_map[inp].id,
+                        dst_id = node_map[out].id,
+                        ic = xml_conn.attrib["name"]
+                    )
+
+    def dump_dot(self, color_by="type", nets_only=False, highlight_nodes=None):
+        """
+        Returns a string with the graph in DOT format suitable for the
+        Graphviz.
+
+        Nodes can be colored by "type" or "net". When nets_only is True then
+        only nodes and edges that belong to a net are dumped.
+        """
+        dot = []
+
+        # Build net color map
+        if color_by == "net":
+            nets = set([node.net for node in self.nodes.values()]) - set([None])
+            nets = sorted(list(nets))
+
+            net_colors = {}
+            for i, net in enumerate(nets):
+
+                h = i / len(nets)
+                l = 0.50
+                s = 1.0
+
+                r, g, b = colorsys.hls_to_rgb(h, l, s)
+                color = "#{:02X}{:02X}{:02X}".format(
+                    int(r * 255.0),
+                    int(g * 255.0),
+                    int(b * 255.0),
+                )
+
+                net_colors[net] = color
+
+        # Node color
+        def node_color(node, highlight=False):
+
+            if highlight_nodes:
+                if highlight:
+                    return "#FF2020"
+                elif node.net:
+                    return "#808080"
+                else:
+                    return "#C0C0C0"
+
+            # By type
+            if color_by == "type":
+                if node.type == NodeType.SOURCE:
+                    return "#C08080"
+                elif node.type == NodeType.SINK:
+                    return "#8080C0"
+                else:
+                    return "#C0C0C0"
+
+            # By net
+            elif color_by == "net":
+                if node.net is None:
+                    return "#C0C0C0"
+                else:
+                    return net_colors[node.net]
+
+            # Default
+            else:
+                return "#C0C0C0"
+
+        # Edge color
+        def edge_color(edge):
+
+            if color_by == "net":
+                net = self.edge_net(edge)
+                if net:
+                    return net_colors[net]
+                else:
+                    return "#C0C0C0"
+
+            # Default
+            else:
+                return "#C0C0C0"
+
+        # Add header
+        dot.append("digraph g {")
+        dot.append(" rankdir=LR;")
+        dot.append(" ratio=0.5;")
+        dot.append(" splines=false;")
+        dot.append(" node [style=filled];")
+
+        # Build nodes
+        nodes = {}
+        for node in self.nodes.values():
+
+            if nets_only and node.net is None:
+                continue
+
+            highlight = highlight_nodes is not None and \
+                        node.id in highlight_nodes
+
+            parts = node.path.split(".")
+            label = "{}: {}".format(node.id, ".".join(parts[-2:]))
+            color = node_color(node, highlight)
+            rank = 0
+
+            if node.net:
+                xlabel = node.net
+            else:
+                xlabel = ""
+
+            if node.type == NodeType.SOURCE:
+                shape = "diamond"
+            elif node.type == NodeType.SINK:
+                shape = "octagon"
+            else:
+                shape = "ellipse"
+
+            if rank not in nodes:
+                nodes[rank] = []
+
+            nodes[rank].append({
+                "id": node.id,
+                "label": label,
+                "xlabel": xlabel,
+                "color": color,
+                "shape": shape
+            })
+
+        # Add nodes
+        for rank, nodes in nodes.items():
+            dot.append(" {")
+            #dot.append("  rank=same;")
+
+            for node in nodes:
+                dot.append("  node_{} [label=\"{}\",xlabel=\"{}\",fillcolor=\"{}\",shape={}];".format(
+                    node["id"],
+                    node["label"],
+                    node["xlabel"],
+                    node["color"],
+                    node["shape"],
+                ))
+
+            dot.append(" }")
+
+        # Add edges
+        for edge in self.edges:
+
+            if nets_only:
+                if not self.edge_net(edge):
+                    continue
+
+            label = edge.ic 
+            color = edge_color(edge)
+
+            dot.append(" node_{} -> node_{} [label=\"{}\",color=\"{}\"];".format(
+                edge.src_id,
+                edge.dst_id,
+                label,
+                color
+            ))
+
+        # Footer
+        dot.append("}")
+        return "\n".join(dot)

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+A set of utility functions responsible for loading a packed netlist into a
+complex block routing graph and creating a packed netlist from a graph with
+routing information.
+"""
+
+from block_path import PathNode
+
+from pb_rr_graph import Graph
+from pb_rr_graph import NodeType
+
+import packed_netlist
+
+# =============================================================================
+
+
+def get_block_by_path(block, path):
+    """
+    Returns a block given its hierarchical path. The path must be a list of
+    PathNode objects.
+    """
+
+    if len(path) == 0:
+        return block
+
+    # Find instance
+    instance = "{}[{}]".format(path[0].name, path[0].index)
+    if instance in block.blocks:
+        block = block.blocks[instance]
+
+        # Check operating mode
+        if path[0].mode != None:
+            if block.mode != path[0].mode:
+                return None
+
+        # Recurse
+        return get_block_by_path(block, path[1:])
+
+    return None
+
+# =============================================================================
+
+
+def load_clb_nets_into_pb_graph(clb_block, clb_graph):
+    """
+    Loads packed netlist of the given CLB block into its routing graph
+    """
+
+    # Annotate nodes with nets
+    for node in clb_graph.nodes.values():
+    
+        # Disassemble node path parts
+        parts = node.path.split(".")
+        parts = [PathNode.from_string(p) for p in parts]
+
+        # Check if the node belongs to this CLB
+        block_inst = "{}[{}]".format(parts[0].name, parts[0].index)
+        assert block_inst == clb_block.instance, (block_inst, clb_block.instance)
+
+        # Find the block referred to by the node
+        block = get_block_by_path(clb_block, parts[1:-1])
+        if block is None:
+            continue
+
+        # Find a corresponding port in the block
+        node_port = parts[-1]
+        if node_port.name not in block.ports:
+            continue
+        block_port = block.ports[node_port.name]
+
+        # Find a net for the port pin and assign it
+        net = block.find_net_for_port(block_port.name, node_port.index)
+        node.net = net
+
+# =============================================================================
+
+
+def build_packed_netlist_from_pb_graph(clb_graph):
+    """
+    This function builds a packed netlist fragment given an annotated (with
+    nets) CLB graph. The created netlist fragment will be missing information:
+
+      - Atom block names
+      - Atom block attributes and parameters
+
+    The missing information has to be supplied externally as it is not stored
+    within a graph.
+
+    The first step is to create the block hierarchy (without any ports yet).
+    This is done by scanning the graph and creating blocks for nodes that
+    belong to nets. Only those nodes are used here.
+
+    The second stage is open block insertion. Whenever a non-leaf is in use
+    it should have all of its children present. Unused ones should be makred
+    as "open".
+
+    The third stage is adding ports to the blocks and connectivity information.
+    To gather all necessary information all the nodes of the graph are needed.
+
+    The final step is leaf block name assignment. Leaf blocks get their names
+    based on nets they drive. A special case is a block representing an output
+    that doesn't drive anything. Such blocks get names based on their inputs
+    but prefixed with "out:".
+    """
+
+    # Build node connectivity. These two maps holds upstream and downstream
+    # node sets for a given node. They consider active nodes only.
+    nodes_up = {}
+
+    for edge in clb_graph.edges:
+
+        # Check if the edge is active
+        if clb_graph.edge_net(edge) is None:
+            continue
+
+        # Up map
+        if edge.dst_id not in nodes_up:
+            nodes_up[edge.dst_id] = set()
+        nodes_up[edge.dst_id].add((edge.src_id, edge.ic))
+
+    # Create the block hierarchy for nodes that have nets assigned.
+    clb_block = None
+    for node in clb_graph.nodes.values():
+
+        # No net
+        if node.net is None:
+            continue
+
+        # Disassemble node path parts
+        parts = node.path.split(".")
+        parts = [PathNode.from_string(p) for p in parts]
+
+        # Create the root CLB
+        instance = "{}[{}]".format(parts[0].name, parts[0].index)
+        if clb_block is None:
+            clb_block = packed_netlist.Block(
+                name = "clb", # FIXME:
+                instance = instance
+            )
+        else:
+            assert clb_block.instance == instance
+
+        # Follow the path, create blocks
+        parent = clb_block
+        for prev_part, curr_part in zip(parts[0:-2], parts[1:-1]):
+            instance = "{}[{}]".format(curr_part.name, curr_part.index)
+            parent_mode = prev_part.mode
+                
+            # Get an existing block
+            if instance in parent.blocks:
+                block = parent.blocks[instance]
+
+            # Create a new block
+            else:
+                block = packed_netlist.Block(
+                    name = "",
+                    instance = instance,
+                    parent = parent
+                )
+                block.name = "block@{:08X}".format(id(block))
+                parent.blocks[instance] = block
+
+            # Set / verify operating mode of the parent
+            if parent_mode is not None:
+                assert parent.mode in [None, parent_mode], (parent.mode, parent_mode)
+                parent.mode = parent_mode
+
+            # Next level
+            parent = block
+
+    # Add open blocks.
+    for node in clb_graph.nodes.values():
+
+        # Consider only nodes without nets
+        if node.net:
+            continue
+
+        # Disassemble node path parts
+        parts = node.path.split(".")
+        parts = [PathNode.from_string(p) for p in parts]
+
+        if len(parts) < 3:
+            continue
+
+        # Find parent block
+        parent = get_block_by_path(clb_block, parts[1:-2])
+        if not parent:
+            continue
+
+        # Operating mode of the parent must match
+        if parent.mode != parts[-3].mode:
+            continue
+
+        # Check if the parent contains an open block correesponding to this
+        # node.
+        curr_part = parts[-2]
+        instance = "{}[{}]".format(curr_part.name, curr_part.index)
+
+        if instance in parent.blocks:
+            continue
+
+        # Create an open block
+        block = packed_netlist.Block(
+            name = "open",
+            instance = instance,
+            parent = parent
+        )
+        parent.blocks[block.instance] = block
+
+    # Add block ports and their connections
+    for node in clb_graph.nodes.values():
+
+        # Disassemble node path parts
+        parts = node.path.split(".")
+        parts = [PathNode.from_string(p) for p in parts]
+
+        # Find the block. If not found it meas that it is not active and
+        # shouldn't be present in the netlist
+        #path = ["{}[{}]".format(p.name, p.index) for p in parts[1:-1]]
+        block = get_block_by_path(clb_block, parts[1:-1])
+        if block is None:
+            continue
+
+        # The block is open, skip
+        if block.is_open:
+            continue
+
+        # Get the port, add it if not present
+        port_name = parts[-1].name
+        port_type = node.port_type.name.lower()
+        if port_name not in block.ports:
+
+            # The relevant information will be updated as more nodes gets
+            # discovered.
+            port = packed_netlist.Port(
+                name = port_name,
+                type = port_type
+            )
+            block.ports[port_name] = port
+
+        else:
+
+            port = block.ports[port_name]
+            assert port.type == port_type, (port.type, port_type)        
+
+        # Extend the port width if necessary
+        bit_index = parts[-1].index
+        port.width = max(port.width, bit_index + 1)
+
+        # The port is not active, nothing more to be done here
+        if node.net is None:
+            continue
+
+        # Identify driver of the port
+        driver_node = None
+        driver_conn = None
+        if node.id in nodes_up:
+            assert len(nodes_up[node.id]) <= 1, node.path
+            driver_node, driver_conn = next(iter(nodes_up[node.id]))
+
+        # Got a driver, this is an intermediate port
+        if driver_node is not None:
+
+            # Get the driver pb_type and port
+            driver_path = clb_graph.nodes[driver_node].path.split(".")
+            driver_path = [PathNode.from_string(driver_path[i]) for i in [-2, -1]]
+
+            # When a connection refers to the immediate parent do not include
+            # block index suffix
+            driver_instance = driver_path[0].name
+            if block.parent is None or block.parent.type != driver_path[0].name:
+                driver_instance += "[{}]".format(driver_path[0].index)
+
+            # Add the connection
+            port.connections[bit_index] = packed_netlist.Connection(
+                driver_instance,
+                driver_path[1].name,
+                driver_path[1].index,
+                driver_conn
+            )
+
+        # No driver, this is a source pin
+        else:
+            port.connections[bit_index] = node.net
+
+    # Assign names to leaf blocks
+    def leaf_walk(block):
+
+        # A leaf
+        if block.is_leaf and not block.is_open:
+
+            # Identify all output pins that drive nets
+            nets = []
+            for port in block.ports.values():
+                if port.type == "output":
+                    for net in port.connections.values():
+                        if isinstance(net, str):
+                            nets.append(net)
+
+            # No nets driven, this is an output pad
+            if not nets:
+                assert "outpad" in block.ports
+
+                port = block.ports["outpad"]
+                assert port.type == "input", port
+                assert port.width == 1, port
+
+                net = block.find_net_for_port("outpad", 0)
+                nets = ["out:" + net]
+
+            # Build block name and assign it
+            if nets:
+                block.name = "_".join(nets)
+
+        # Recurse
+        for child in block.blocks.values():
+            leaf_walk(child)
+
+    leaf_walk(clb_block)
+
+    # Return the top-level CLB block
+    return clb_block

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
@@ -7,9 +7,6 @@ routing information.
 
 from block_path import PathNode
 
-from pb_rr_graph import Graph
-from pb_rr_graph import NodeType
-
 import packed_netlist
 
 # =============================================================================
@@ -30,7 +27,7 @@ def get_block_by_path(block, path):
         block = block.blocks[instance]
 
         # Check operating mode
-        if path[0].mode != None:
+        if path[0].mode is not None:
             if block.mode != path[0].mode:
                 return None
 
@@ -218,7 +215,6 @@ def build_packed_netlist_from_pb_graph(clb_graph):
 
         # Find the block. If not found it meas that it is not active and
         # shouldn't be present in the netlist
-        #path = ["{}[{}]".format(p.name, p.index) for p in parts[1:-1]]
         block = get_block_by_path(clb_block, parts[1:-1])
         if block is None:
             continue

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_netlist.py
@@ -39,6 +39,7 @@ def get_block_by_path(block, path):
 
     return None
 
+
 # =============================================================================
 
 
@@ -49,14 +50,16 @@ def load_clb_nets_into_pb_graph(clb_block, clb_graph):
 
     # Annotate nodes with nets
     for node in clb_graph.nodes.values():
-    
+
         # Disassemble node path parts
         parts = node.path.split(".")
         parts = [PathNode.from_string(p) for p in parts]
 
         # Check if the node belongs to this CLB
         block_inst = "{}[{}]".format(parts[0].name, parts[0].index)
-        assert block_inst == clb_block.instance, (block_inst, clb_block.instance)
+        assert block_inst == clb_block.instance, (
+            block_inst, clb_block.instance
+        )
 
         # Find the block referred to by the node
         block = get_block_by_path(clb_block, parts[1:-1])
@@ -72,6 +75,7 @@ def load_clb_nets_into_pb_graph(clb_block, clb_graph):
         # Find a net for the port pin and assign it
         net = block.find_net_for_port(block_port.name, node_port.index)
         node.net = net
+
 
 # =============================================================================
 
@@ -135,8 +139,8 @@ def build_packed_netlist_from_pb_graph(clb_graph):
         instance = "{}[{}]".format(parts[0].name, parts[0].index)
         if clb_block is None:
             clb_block = packed_netlist.Block(
-                name = "clb", # FIXME:
-                instance = instance
+                name="clb",  # FIXME:
+                instance=instance
             )
         else:
             assert clb_block.instance == instance
@@ -146,7 +150,7 @@ def build_packed_netlist_from_pb_graph(clb_graph):
         for prev_part, curr_part in zip(parts[0:-2], parts[1:-1]):
             instance = "{}[{}]".format(curr_part.name, curr_part.index)
             parent_mode = prev_part.mode
-                
+
             # Get an existing block
             if instance in parent.blocks:
                 block = parent.blocks[instance]
@@ -154,16 +158,15 @@ def build_packed_netlist_from_pb_graph(clb_graph):
             # Create a new block
             else:
                 block = packed_netlist.Block(
-                    name = "",
-                    instance = instance,
-                    parent = parent
+                    name="", instance=instance, parent=parent
                 )
                 block.name = "block@{:08X}".format(id(block))
                 parent.blocks[instance] = block
 
             # Set / verify operating mode of the parent
             if parent_mode is not None:
-                assert parent.mode in [None, parent_mode], (parent.mode, parent_mode)
+                assert parent.mode in [None, parent_mode
+                                       ], (parent.mode, parent_mode)
                 parent.mode = parent_mode
 
             # Next level
@@ -202,9 +205,7 @@ def build_packed_netlist_from_pb_graph(clb_graph):
 
         # Create an open block
         block = packed_netlist.Block(
-            name = "open",
-            instance = instance,
-            parent = parent
+            name="open", instance=instance, parent=parent
         )
         parent.blocks[block.instance] = block
 
@@ -233,16 +234,13 @@ def build_packed_netlist_from_pb_graph(clb_graph):
 
             # The relevant information will be updated as more nodes gets
             # discovered.
-            port = packed_netlist.Port(
-                name = port_name,
-                type = port_type
-            )
+            port = packed_netlist.Port(name=port_name, type=port_type)
             block.ports[port_name] = port
 
         else:
 
             port = block.ports[port_name]
-            assert port.type == port_type, (port.type, port_type)        
+            assert port.type == port_type, (port.type, port_type)
 
         # Extend the port width if necessary
         bit_index = parts[-1].index
@@ -264,7 +262,9 @@ def build_packed_netlist_from_pb_graph(clb_graph):
 
             # Get the driver pb_type and port
             driver_path = clb_graph.nodes[driver_node].path.split(".")
-            driver_path = [PathNode.from_string(driver_path[i]) for i in [-2, -1]]
+            driver_path = [
+                PathNode.from_string(driver_path[i]) for i in [-2, -1]
+            ]
 
             # When a connection refers to the immediate parent do not include
             # block index suffix
@@ -274,9 +274,7 @@ def build_packed_netlist_from_pb_graph(clb_graph):
 
             # Add the connection
             port.connections[bit_index] = packed_netlist.Connection(
-                driver_instance,
-                driver_path[1].name,
-                driver_path[1].index,
+                driver_instance, driver_path[1].name, driver_path[1].index,
                 driver_conn
             )
 

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+This file implements a simple graph router used for complex block routing
+graphs.
+"""
+
+from pb_rr_graph import Graph, NodeType
+
+# =============================================================================
+
+
+class Net:
+    """
+    This class represents a net for the router. It holds the driver (source)
+    node as well as all sink node ids.
+    """
+
+    def __init__(self, name):
+        self.name = name
+
+        self.source = None
+        self.sinks = set()
+
+        self.is_routed = False
+
+    def __str__(self):
+        return "{}, fanout={}, {}".format(
+            self.name,
+            len(self.sinks),
+            "routed" if self.is_routed else "unrouted"
+        )
+
+# =============================================================================
+
+
+class Router:
+    """
+    Simple graph router.
+
+    Currently the routed does a greedy depth-first routing. Each time a path
+    from a sink to a source is found it gets immediately annotated with nets.
+    """
+
+    def __init__(self, graph):
+        self.graph = graph
+        self.nets = {}
+
+        # Discover nets from the graph
+        self.discover_nets()
+
+    def discover_nets(self):
+        """
+        Scans the graph looking for nets
+        """
+
+        # TODO: For now look for nets only assuming that all of them are
+        # unrouted.
+        sources = {}
+        sinks = {}
+
+        for node in self.graph.nodes.values():
+
+            if node.type not in [NodeType.SOURCE, NodeType.SINK]:
+                continue
+
+            # No net
+            if node.net is None:
+                continue
+
+            # Got a source
+            if node.type == NodeType.SOURCE:
+                assert node.net not in sources, node.net
+                sources[node.net] = node.id
+
+            # Got a sink
+            elif node.type == NodeType.SINK:
+                if node.net not in sinks:
+                    sinks[node.net] = set()
+                sinks[node.net].add(node.id)
+
+        # Make nets
+        nets = set(sinks.keys()) | set(sources.keys())
+        for net_name in nets:
+
+            net = Net(net_name)
+
+            # A net may or may not have a source node. If there is no source
+            # then one will be created during routing when a route reaches a
+            # node of the top-level CLB.
+            if net_name in sources:
+                net.source = sources[net_name]
+
+            # A net may or may not have at leas one sink node. If there are
+            # no sinks then no routing will be done.
+            if net_name in sinks:
+                net.sinks = sinks[net_name]
+
+            self.nets[net_name] = net
+
+        # DEBUG
+        print("  ", "Nets:")
+        keys = sorted(list(self.nets.keys()))
+        for key in keys:
+            print("   ", str(self.nets[key]))
+
+
+    def route_net(self, net, debug=False):
+        """
+        Routes a single net.
+        """
+
+        top_level_sources = set()
+
+        def walk_depth_first(node, curr_route=None):
+
+            # FIXME: Two possible places for optimization:
+            # - create an edge lookup list indexed by dst node ids
+            # - do not copy the current route list for each recursion level
+
+            # Track the route
+            if not curr_route:
+                curr_route = []
+            curr_route.append(node.id)
+
+            # We've hit a node of the same net. Finish.
+            if node.type in [NodeType.SOURCE, NodeType.PORT]:
+                if node.net == net.name:
+                    return curr_route
+
+            # The node is aleady occupied by a different net
+            if node.net is not None:
+                if node.net != net.name:
+                    return None
+
+            # This node is a free source node. If it is a top-level source then
+            # store it.
+            if node.type == NodeType.SOURCE and node.net is None:
+                if node.path.count(".") == 1:
+                    top_level_sources.add(node.id)
+
+            # Check all incoming edges
+            for edge in self.graph.edges:
+                if edge.dst_id == node.id:
+
+                    # Recurse
+                    next_node = self.graph.nodes[edge.src_id]
+                    route = walk_depth_first(next_node, list(curr_route))
+
+                    # We have a route, terminate
+                    if route:
+                        return route
+
+            return None
+
+        # Search for a route
+        print("  ", net.name)
+
+        # This net has no sinks. Remove annotation from the source node
+        if not net.sinks:
+            node = self.graph.nodes[net.source]
+            node.net = None
+
+        # Route all sinks to the source
+        for sink in net.sinks:
+
+            # Find the route
+            node = self.graph.nodes[sink]
+
+            top_level_sources = set()
+            route = walk_depth_first(node)
+
+            # No route found. Check if we have some free top-level ports that
+            # we can use.
+            if not route and top_level_sources:
+
+                # Use the frist one
+                top_node_id = next(iter(top_level_sources))
+                top_node = self.graph.nodes[top_node_id]
+                top_node.net = net.name
+
+                # Retry
+                route = walk_depth_first(node)
+
+            # No route found
+            if not route:
+                print("   ", "No route found!")
+
+                # DEBUG
+                if debug:
+                    with open("unrouted.dot", "w") as fp:
+                        fp.write(self.graph.dump_dot(
+                            color_by="net",
+                            highlight_nodes=set([
+                                net.source,
+                                sink
+                            ])
+                        ))
+
+                # Raise an exception
+                raise RuntimeError("Unroutable net '{}' from {} to {}".format(
+                    net.name,
+                    self.graph.nodes[net.source],
+                    self.graph.nodes[sink]
+                ))
+
+            # Annotate all nodes of the route
+            for node_id in route:
+                self.graph.nodes[node_id].net = net.name
+
+        # Success
+        net.is_routed = True
+
+
+    def route_nets(self, nets=None, debug=False):
+        """
+        Routes net with specified names or all nets if no names are given.
+        """
+        
+        # Use all if explicit list not provided
+        if nets is None:
+            nets = sorted(list(self.nets.keys()))
+
+        # Route nets
+        for net_name in nets:
+            res = self.route_net(self.nets[net_name], debug=debug)

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
@@ -25,10 +25,10 @@ class Net:
 
     def __str__(self):
         return "{}, fanout={}, {}".format(
-            self.name,
-            len(self.sinks),
+            self.name, len(self.sinks),
             "routed" if self.is_routed else "unrouted"
         )
+
 
 # =============================================================================
 
@@ -102,7 +102,6 @@ class Router:
         keys = sorted(list(self.nets.keys()))
         for key in keys:
             print("   ", str(self.nets[key]))
-
 
     def route_net(self, net, debug=False):
         """
@@ -188,20 +187,20 @@ class Router:
                 # DEBUG
                 if debug:
                     with open("unrouted.dot", "w") as fp:
-                        fp.write(self.graph.dump_dot(
-                            color_by="net",
-                            highlight_nodes=set([
-                                net.source,
-                                sink
-                            ])
-                        ))
+                        fp.write(
+                            self.graph.dump_dot(
+                                color_by="net",
+                                highlight_nodes=set([net.source, sink])
+                            )
+                        )
 
                 # Raise an exception
-                raise RuntimeError("Unroutable net '{}' from {} to {}".format(
-                    net.name,
-                    self.graph.nodes[net.source],
-                    self.graph.nodes[sink]
-                ))
+                raise RuntimeError(
+                    "Unroutable net '{}' from {} to {}".format(
+                        net.name, self.graph.nodes[net.source],
+                        self.graph.nodes[sink]
+                    )
+                )
 
             # Annotate all nodes of the route
             for node_id in route:
@@ -210,12 +209,11 @@ class Router:
         # Success
         net.is_routed = True
 
-
     def route_nets(self, nets=None, debug=False):
         """
         Routes net with specified names or all nets if no names are given.
         """
-        
+
         # Use all if explicit list not provided
         if nets is None:
             nets = sorted(list(self.nets.keys()))

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
@@ -4,7 +4,7 @@ This file implements a simple graph router used for complex block routing
 graphs.
 """
 
-from pb_rr_graph import Graph, NodeType
+from pb_rr_graph import NodeType
 
 # =============================================================================
 
@@ -220,4 +220,4 @@ class Router:
 
         # Route nets
         for net_name in nets:
-            res = self.route_net(self.nets[net_name], debug=debug)
+            self.route_net(self.nets[net_name], debug=debug)

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_rr_graph_router.py
@@ -4,6 +4,8 @@ This file implements a simple graph router used for complex block routing
 graphs.
 """
 
+import logging
+
 from pb_rr_graph import NodeType
 
 # =============================================================================
@@ -98,10 +100,10 @@ class Router:
             self.nets[net_name] = net
 
         # DEBUG
-        print("  ", "Nets:")
+        logging.debug("   Nets:")
         keys = sorted(list(self.nets.keys()))
         for key in keys:
-            print("   ", str(self.nets[key]))
+            logging.debug("    " + str(self.nets[key]))
 
     def route_net(self, net, debug=False):
         """
@@ -152,7 +154,7 @@ class Router:
             return None
 
         # Search for a route
-        print("  ", net.name)
+        logging.debug("   " + net.name)
 
         # This net has no sinks. Remove annotation from the source node
         if not net.sinks:
@@ -182,7 +184,7 @@ class Router:
 
             # No route found
             if not route:
-                print("   ", "No route found!")
+                logging.critical("    No route found!")
 
                 # DEBUG
                 if debug:

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_type.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_type.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+Utilities for representing pb_type hierarchy as defined in VPR architecture
+"""
+import re
+from copy import deepcopy
+from enum import Enum
+
+from arch_xml_utils import is_leaf_pbtype
+
+from block_path import PathNode
+
+# =============================================================================
+
+
+class PortType(Enum):
+    """
+    Type and direction of a pb_type port.
+    """
+    UNSPEC = 0
+    INPUT = 1
+    OUTPUT = 2
+    CLOCK = 3
+
+    @staticmethod
+    def from_string(s):
+        """
+        Convert a string to its corresponding enumerated value
+        """
+        s = s.lower()
+
+        if s == "input":
+            return PortType.INPUT
+        elif s == "output":
+            return PortType.OUTPUT
+        elif s == "clock":
+            return PortType.CLOCK
+        else:
+            assert False, s
+
+
+class Port:
+    """
+    A port of pb_type
+    """
+
+    def __init__(self, type, name, width=1, cls=None):
+        """
+        Basic constructor
+        """
+        self.type = type
+        self.name = name
+        self.width = width
+        self.cls = cls
+
+    @staticmethod
+    def from_etree(elem):
+        """
+        Create the object from its ElementTree representation
+        """
+        assert elem.tag in ["input", "output", "clock"], elem.tag
+
+        # Create the port
+        port = Port(
+            type = PortType.from_string(elem.tag),
+            name = elem.attrib["name"],
+            width = int(elem.get("num_pins", "1")),
+            cls = elem.get("port_class", None)
+        )
+
+        return port
+
+    def yield_pins(self, range_spec=None):
+        """
+        Yields pin names given index range specification. If the range is
+        not given then yields all pins.
+        """
+
+        # Selected pins
+        if range_spec is not None:
+
+            # TODO: Compile the regex upfront
+            match = re.fullmatch(
+                r"((?P<i1>[0-9]+):)?(?P<i0>[0-9]+)",
+                range_spec
+            )
+            assert match is not None, range_spec
+
+            i0 = int(match.group("i0"))
+            i1 = int(match.group("i1")) if match.group("i1") else None
+
+            assert i0 < self.width, range_spec
+
+            # Range
+            if i1 is not None:
+                assert i1 < self.width, range_spec
+
+                if i1 > i0:
+                    indices = range(i0, i1+1)
+                elif i1 < i0:
+                    indices = range(i0, i1-1, -1)
+                else:
+                    indices = [i0]
+
+            # Single number
+            else:
+                indices = [i0]
+
+        # All pins
+        else:
+            indices = range(self.width)
+
+        # Yield names
+        for i in indices:
+            yield (self.name, i)
+
+# =============================================================================
+
+
+class Model:
+    """
+    A leaf cell model.
+
+    VPR architecture XML does not store port widths along with models so
+    here we build the list of models from leaf pb_types.
+    """
+
+    def __init__(self, name):
+        self.name = name
+        self.ports = {}
+
+    @property
+    def blif_model(self):
+        """
+        Returns a BLIF model statement for this model.
+        """
+        if self.name[0] != ".":
+            return ".subckt {}".format(self.name)
+        return self.name
+
+    @staticmethod
+    def collect_models(root_pbtype):
+        """
+        Recursively walks over the pb_type hierarchy and collects models
+        """
+
+        models = {}
+
+        def walk(pb_type):
+
+            # This is a mode, recurse
+            if isinstance(pb_type, Mode):
+                for child in pb_type.pb_types.values():
+                    walk(child)
+
+            # This is a pb_type. Make a model if it is a leaf
+            elif isinstance(pb_type, PbType):
+
+                # Not a leaf, recurse for modes
+                if not pb_type.is_leaf:
+                    for mode in pb_type.modes.values():
+                        walk(mode)
+                    return
+
+                # Get BLIF model
+                assert pb_type.blif_model is not None, pb_type.name
+                blif_model = pb_type.blif_model.split(maxsplit=1)[-1]
+
+                # FIXME: Skip built-ins for now
+                if blif_model[0] == ".":
+                    return
+
+                # Already have that one
+                # TODO: Check if ports match!
+                if blif_model in models:
+                    return
+
+                # Build the model
+                model = Model(blif_model)
+                model.ports = deepcopy(pb_type.ports)
+                models[model.name] = model
+
+            else:
+                assert False, type(pb_type)
+
+        # Walk from the given root pb_type and create models
+        walk(root_pbtype)
+        return models
+
+    def __str__(self):
+        string = self.name
+        for port in self.ports.values():
+            string += " {}:{}[{}:0]".format(
+                port.type.name[0].upper(),
+                port.name,
+                port.width - 1
+            )
+        return string
+
+    def __repr__(self):
+        return str(self)
+
+# =============================================================================
+
+
+class PbType:
+    """
+    A pb_type
+    """
+
+    def __init__(self, name, num_pb=1, cls=None):
+        """
+        Basic constructor
+        """
+        self.name = name
+        self.num_pb = num_pb
+        self.cls = cls
+        self.blif_model = None
+
+        # Parent (a Mode or None)
+        self.parent = None
+        # Modes (indexed by name)
+        self.modes = {}
+
+        # Ports (indexed by name)
+        self.ports = {}
+
+    @property
+    def is_leaf(self):
+        """
+        Returns True if this pb_type is a leaf
+        """
+        if "default" in self.modes and len(self.modes) == 1:
+            return len(self.modes["default"].pb_types) == 0
+
+        return False
+
+    @staticmethod
+    def from_etree(elem):
+        """
+        Create the object from its ElementTree representation
+        """
+        assert elem.tag == "pb_type", elem.tag
+
+        # Create the pb_type
+        name = elem.attrib["name"]
+        num_pb = int(elem.get("num_pb", "1"))
+        cls = elem.get("class", None)
+
+        pb_type = PbType(name, num_pb, cls)
+
+        # BLIF model
+        pb_type.blif_model = elem.get("blif_model", None)
+
+        # Identify all modes. If there is none then add the default
+        # implicit one.
+        xml_modes = {x.attrib["name"]: x for x in elem.findall("mode")}
+        if not xml_modes:
+            xml_modes  = {"default": elem}
+
+        # Build modes
+        pb_type.modes = {}
+        for name, xml_mode in xml_modes.items():
+            mode = Mode.from_etree(xml_mode)
+            mode.parent = pb_type
+            pb_type.modes[mode.name] = mode
+
+        # Build ports
+        for xml_port in elem:
+            if xml_port.tag in ["input", "output", "clock"]:
+
+                port = Port.from_etree(xml_port)
+                pb_type.ports[port.name] = port
+
+
+        # This is a native LUT leaf pb_type. Add one more level of hierarchy
+        if is_leaf_pbtype(elem) and cls == "lut":
+
+            # Rename the default mode so that it matches the pb_type name
+            mode = pb_type.modes["default"]
+            mode.name = pb_type.name
+            pb_type.modes = {mode.name: mode}
+
+            # Add a child pb_type named "lut" to the mode
+            child = PbType(name="lut", cls="lut")
+            child.blif_model = ".names"
+            child.parent = mode
+            mode.pb_types[child.name] = child
+
+            # Add a default mode to the child pb_type
+            mode = Mode("default")
+            mode.parent = child
+            child.modes[mode.name] = mode
+
+            # Copy ports from the current pb_type
+            child.ports = deepcopy(pb_type.ports)
+
+        return pb_type
+
+    def yield_port_pins(self, port_spec):
+        """
+        Given a port specification string yields its pin names
+        """
+
+        # TODO: Compile the regex upfront
+        match = re.fullmatch(
+            r"(?P<port>[^\s\[\]\.]+)(\[(?P<bits>[^\s\[\]]+)\])?",
+            port_spec
+        )
+        assert match is not None, port_spec
+
+        port = match.group("port")
+        bits = match.group("bits")
+
+        # Find the port
+        assert port in self.ports, (self.name, port)
+        port = self.ports[port]
+
+        # Yield the bits
+        yield from port.yield_pins(bits)
+        
+
+    def find(self, path):
+        """
+        Finds a pb_type or a mode given its hierarchical path.
+        """
+
+        # Split the path or assume this is an already splitted list.
+        if isinstance(path, str):
+            path = path.split(".")
+            path = [PathNode.from_string(p) for p in path]
+        else:
+            assert isinstance(path, list), type(path)
+
+        # Walk the hierarchy along the path
+        pbtype = self
+        while True:
+
+            # Pop a node from the path
+            part = path[0]
+            path = path[1:]
+
+            # The path node must not have an index
+            assert part.index is None, part
+
+            # Check name
+            if part.name != pbtype.name:
+                break
+
+            # Explicit mode
+            if part.mode is not None:
+                if part.mode not in pbtype.modes:
+                    break
+                mode = pbtype.modes[part.mode]
+
+                # No more path, return the mode
+                if not path:
+                    return mode
+
+            # Mode not given
+            else:
+
+                # No more path, return the pb_type
+                if not path:
+                    return pbtype
+
+                # Get the implicit mode
+                if len(pbtype.modes) > 1:
+                    break
+                mode = next(iter(pbtype.modes.values()))
+
+            # Find the child pb_type
+            part = path[0]
+            if part.name not in mode.pb_types:
+                break
+
+            pbtype = mode.pb_types[part.name]
+
+        # Not found
+        return None
+
+
+class Mode:
+    """
+    A mode of a pb_type
+    """
+
+    def __init__(self, name):
+        """
+        Basic constructor
+        """
+        self.name = name
+
+        # Parent (a PbType or None)
+        self.parent = None
+        # pb_types indexed by names
+        self.pb_types = {}
+
+    def yield_children(self):
+        """
+        Yields all child pb_types and their indices taking into account num_pb.
+        """
+        for child in self.pb_types.values():
+            for i in range(child.num_pb):
+                yield child, i
+
+    @staticmethod
+    def from_etree(elem):
+        """
+        Create the object from its ElementTree representation
+        """
+        assert elem.tag in ["mode", "pb_type"], elem.tag
+
+        # This element refers to a pb_type so it is the default mode
+        if elem.tag == "pb_type":
+            name = "default"
+        else:
+            name = elem.attrib["name"]
+
+        # Create the mode
+        mode = Mode(name)
+
+        # Build child pb_types
+        for xml_pbtype in elem.findall("pb_type"):
+            pb_type = PbType.from_etree(xml_pbtype)
+            pb_type.parent = mode
+            mode.pb_types[pb_type.name] = pb_type
+
+        return mode

--- a/quicklogic/qlf_k4n8/utils/repacker/pb_type.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/pb_type.py
@@ -62,10 +62,10 @@ class Port:
 
         # Create the port
         port = Port(
-            type = PortType.from_string(elem.tag),
-            name = elem.attrib["name"],
-            width = int(elem.get("num_pins", "1")),
-            cls = elem.get("port_class", None)
+            type=PortType.from_string(elem.tag),
+            name=elem.attrib["name"],
+            width=int(elem.get("num_pins", "1")),
+            cls=elem.get("port_class", None)
         )
 
         return port
@@ -81,8 +81,7 @@ class Port:
 
             # TODO: Compile the regex upfront
             match = re.fullmatch(
-                r"((?P<i1>[0-9]+):)?(?P<i0>[0-9]+)",
-                range_spec
+                r"((?P<i1>[0-9]+):)?(?P<i0>[0-9]+)", range_spec
             )
             assert match is not None, range_spec
 
@@ -96,9 +95,9 @@ class Port:
                 assert i1 < self.width, range_spec
 
                 if i1 > i0:
-                    indices = range(i0, i1+1)
+                    indices = range(i0, i1 + 1)
                 elif i1 < i0:
-                    indices = range(i0, i1-1, -1)
+                    indices = range(i0, i1 - 1, -1)
                 else:
                     indices = [i0]
 
@@ -113,6 +112,7 @@ class Port:
         # Yield names
         for i in indices:
             yield (self.name, i)
+
 
 # =============================================================================
 
@@ -191,14 +191,13 @@ class Model:
         string = self.name
         for port in self.ports.values():
             string += " {}:{}[{}:0]".format(
-                port.type.name[0].upper(),
-                port.name,
-                port.width - 1
+                port.type.name[0].upper(), port.name, port.width - 1
             )
         return string
 
     def __repr__(self):
         return str(self)
+
 
 # =============================================================================
 
@@ -256,7 +255,7 @@ class PbType:
         # implicit one.
         xml_modes = {x.attrib["name"]: x for x in elem.findall("mode")}
         if not xml_modes:
-            xml_modes  = {"default": elem}
+            xml_modes = {"default": elem}
 
         # Build modes
         pb_type.modes = {}
@@ -271,7 +270,6 @@ class PbType:
 
                 port = Port.from_etree(xml_port)
                 pb_type.ports[port.name] = port
-
 
         # This is a native LUT leaf pb_type. Add one more level of hierarchy
         if is_leaf_pbtype(elem) and cls == "lut":
@@ -304,8 +302,7 @@ class PbType:
 
         # TODO: Compile the regex upfront
         match = re.fullmatch(
-            r"(?P<port>[^\s\[\]\.]+)(\[(?P<bits>[^\s\[\]]+)\])?",
-            port_spec
+            r"(?P<port>[^\s\[\]\.]+)(\[(?P<bits>[^\s\[\]]+)\])?", port_spec
         )
         assert match is not None, port_spec
 
@@ -318,7 +315,6 @@ class PbType:
 
         # Yield the bits
         yield from port.yield_pins(bits)
-        
 
     def find(self, path):
         """

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -1096,6 +1096,12 @@ def main():
     net_xml = ET.parse(args.net_in, ET.XMLParser(remove_blank_text=True))
     packed_netlist = PackedNetlist.from_etree(net_xml.getroot())
 
+    # Count blocks
+    total_blocks = 0
+    for clb_block in packed_netlist.blocks.values():
+        total_blocks += clb_block.count_leafs()
+    logging.debug(" {} leaf blocks".format(total_blocks))
+
     init_time = time.perf_counter() - init_time
     repack_time = time.perf_counter()
 
@@ -1415,6 +1421,12 @@ def main():
         with open(fname, "w") as fp:
             fp.writelines(placement)
 
+    # Count blocks
+    total_blocks = 0
+    for clb_block in packed_netlist.blocks.values():
+        total_blocks += clb_block.count_leafs()
+
+    # Print statistics
     logging.info("Finished.")
 
     logging.info("")
@@ -1423,6 +1435,7 @@ def main():
     logging.info("Finishing time     : {:.2f}s".format(writeout_time))
     logging.info("Repacked CLBs      : {}".format(repacked_clb_count))
     logging.info("Repacked blocks    : {}".format(repacked_block_count))
+    logging.info("Total blocks       : {}".format(total_blocks))
 
 
 # =============================================================================

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -503,6 +503,9 @@ def annotate_net_endpoints(
                 constrained_nets[constraint.block_type] = set()
             constrained_nets[constraint.block_type].add(constraint.net)
 
+        # Get nets relevant to this block
+        all_nets = block.get_nets()
+
     # Get block path
     if block_path is None:
         block_path = block.get_path()
@@ -539,17 +542,20 @@ def annotate_net_endpoints(
             if key in constraints:
                 constraint = constraints[key]
 
-                # Check if the block type matches
-                if block_type == constraint.block_type:
-                    logging.debug(
-                        "    Constraining net '{}' to port '{}'".format(
-                            constraint.net, port
-                        )
-                    )
+                # The net must be present in the block
+                if constraint.net in all_nets:
 
-                    # Assign the net
-                    node.net = constraint.net
-                    continue
+                    # Check if the block type matches
+                    if block_type == constraint.block_type:
+                        logging.debug(
+                            "    Constraining net '{}' to port '{}'".format(
+                                constraint.net, port
+                            )
+                        )
+
+                        # Assign the net
+                        node.net = constraint.net
+                        continue
 
         # Optionally remap the port
         if port_map is not None:

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -16,6 +16,7 @@ import logging
 import argparse
 import sys
 import os
+import shlex
 import hashlib
 import time
 from collections import namedtuple
@@ -992,6 +993,10 @@ def main():
 
     if args.log is not None:
         logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
+
+    # Re-assemble and log the commandline
+    cmdline = " ".join([shlex.quote(a) for a in sys.argv])
+    logging.debug("command line: {}".format(cmdline))
 
     # Load the VPR architecture
     logging.info("Loading VPR architecture file...")

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -5,7 +5,6 @@ A SymbiFlow implementation of OpenFPGA re-packer.
 
 import argparse
 import os
-import re
 import hashlib
 import time
 from collections import namedtuple
@@ -27,10 +26,6 @@ from pb_rr_graph_netlist import load_clb_nets_into_pb_graph
 from pb_rr_graph_netlist import build_packed_netlist_from_pb_graph
 
 from pb_type import PbType, Model
-
-from arch_xml_utils import is_leaf_pbtype
-from arch_xml_utils import yield_pb_children
-from arch_xml_utils import yield_indices
 
 # =============================================================================
 
@@ -123,7 +118,6 @@ def fixup_route_throu_luts(clb_block):
 
         # Check if we have both input and output
         assert blk_inp and blk_out
-        #print("   ", blk_inp, blk_out)
 
         # Identify the net
         net_inp = block.find_net_for_port(blk_inp.port.name, blk_inp.pin)
@@ -269,7 +263,7 @@ def identify_blocks_to_repack(clb_block, repacking_rules):
 
         # Check if the current block is a LUT
         is_lut = len(block.blocks) == 1 and "lut[0]" in block.blocks and \
-                 block.blocks["lut[0]"].is_leaf
+                 block.blocks["lut[0]"].is_leaf  # noqa: E127
 
         # Check if the block match the path node. Check type and mode
         block_node = PathNode.from_string(block.instance)
@@ -390,7 +384,6 @@ def identify_repack_target_candidates(clb_pbtype, path):
     """
 
     def walk(arch_path, pbtype, pbtype_index, curr_path=None):
-        #print("Walk:", ".".join(arch_path), curr_path)
 
         # Parse the path node
         if arch_path:
@@ -770,7 +763,7 @@ def write_packed_netlist(fname, netlist):
 
     xml_tree = ET.ElementTree(netlist.to_etree())
     xml_data = '<?xml version="1.0"?>\n' \
-             + ET.tostring(xml_tree, pretty_print=True).decode("utf-8")
+             + ET.tostring(xml_tree, pretty_print=True).decode("utf-8")  # noqa: E127
 
     with open(fname, "w") as fp:
         fp.write(xml_data)
@@ -1044,16 +1037,16 @@ def main():
             src_pbtype = clb_pbtype.find(src_path)
             assert src_pbtype is not None, src_path
 
-            # Get the source BLIF model
-            assert src_pbtype.blif_model is not None
-            src_blif_model = src_pbtype.blif_model
+            #            # Get the source BLIF model
+            #            assert src_pbtype.blif_model is not None
+            #            src_blif_model = src_pbtype.blif_model
 
             # Get the destination BLIF model
             assert dst_pbtype.blif_model is not None, dst_pbtype.name
             dst_blif_model = dst_pbtype.blif_model.split(maxsplit=1)[-1]
 
             # Get the model object
-            assert dst_blif_model in models, blif_model
+            assert dst_blif_model in models, dst_blif_model
             model = models[dst_blif_model]
 
             # Find the cell in the netlist
@@ -1069,7 +1062,7 @@ def main():
             leaf_block_names[dst_path] = cell.name
 
             # Repack it
-            repacked_cell = repack_netlist_cell(
+            repack_netlist_cell(
                 eblif,
                 cell,
                 src_block,

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -927,7 +927,7 @@ def main():
     print("Processing CLBs...")    
 
     removed_ios = set()
-    io_block_names = {}
+    leaf_block_names = {}
 
     repacked_clb_count = 0
     repacked_block_count = 0
@@ -1047,10 +1047,9 @@ def main():
             if cell.type in ["$input", "$output"]:
                 removed_ios.add(cell.name)
 
-            # If the cell is an output IOB then store the desired name for the
-            # destination block
-            if cell.type == "$output":
-                io_block_names[dst_path] = cell.name
+            # Store the leaf block name so that it can be restored after
+            # repacking
+            leaf_block_names[dst_path] = cell.name
 
             # Repack it
             repacked_cell = repack_netlist_cell(
@@ -1109,16 +1108,16 @@ def main():
         repacked_clb_block = build_packed_netlist_from_pb_graph(graph) 
         repacked_clb_block.rename_cluster(clb_block.name)
 
-        # Restore names of IO blocks
+        # Restore names of leaf blocks
         for src_block, rule, (dst_path, dst_pbtype) in blocks_to_repack:
-            if dst_path in io_block_names:
+            if dst_path in leaf_block_names:
 
                 search_path = dst_path.split(".", maxsplit=1)[1]
                 dst_block = repacked_clb_block.get_block_by_path(search_path)
                 assert dst_block is not None, dst_path
 
-                name = io_block_names[dst_path]
-                print("  ", "renaming IOB {} to {}".format(dst_block, name))
+                name = leaf_block_names[dst_path]
+                print("  ", "renaming leaf block {} to {}".format(dst_block, name))
                 dst_block.name = name
 
         # Replace the CLB

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 """
 A SymbiFlow implementation of OpenFPGA re-packer.
+
+The repacker utility is responsible for converting a VPR packed netlist
+expressed using "operating" modes of pb_types so that it is expressed using
+cells from physical modes that represent the underlying hardware. For more
+details please refer to the documentation of the OpenFPGA project:
+https://openfpga.readthedocs.io/en/master/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands/#repack
+
+Please refer to the README.md file for more details on the tool operation and
+implementation.
 """
 
 import logging

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -1,0 +1,1233 @@
+#!/usr/bin/env python3
+"""
+A SymbiFlow implementation of OpenFPGA re-packer.
+"""
+
+import argparse
+import os
+import re
+import hashlib
+import time
+from collections import namedtuple
+
+import json
+import lxml.etree as ET
+
+from block_path import PathNode
+
+from eblif_netlist import Eblif, Cell
+import netlist_cleaning
+
+import packed_netlist as pn
+from packed_netlist import PackedNetlist
+from pb_rr_graph import Graph, NodeType
+from pb_rr_graph_router import Router
+
+from pb_rr_graph_netlist import load_clb_nets_into_pb_graph
+from pb_rr_graph_netlist import build_packed_netlist_from_pb_graph
+
+from pb_type import PbType, Model
+
+from arch_xml_utils import is_leaf_pbtype
+from arch_xml_utils import yield_pb_children
+from arch_xml_utils import yield_indices
+
+# =============================================================================
+
+
+class RepackingRule:
+    """
+    A structure for representing repacking rule.
+    """
+    def __init__(self, src, dst, index_map, port_map, mode_bits=None):
+        self.src = src
+        self.dst = dst
+        self.index_map = index_map
+        self.port_map = port_map
+        self.mode_bits = mode_bits
+
+    def remap_pb_type_index(self, index):
+        """
+        Remaps the given source pb_type index to the destination pb_type index
+        """
+        return index * self.index_map[0] + self.index_map[1]
+
+# =============================================================================
+
+
+def fixup_route_throu_luts(clb_block):
+    """
+    This function identifies route-throu LUTs in the packed netlist and
+    replaces them with explicit LUT-1 blocks.
+
+    The function returns a list of net pairs denoting input and output nets of
+    each inserted buffer LUT-1 block.
+    """
+
+    blocks = []
+
+    def walk(block):
+        """
+        Recursively walks over packed netlist and collects route-throu LUTs
+        """
+
+        # This is a leaf block
+        if block.is_leaf:
+            if block.is_route_throu:
+                blocks.append(block)
+
+        # Recurse for all children
+        else:
+            for child in block.blocks.values():
+                walk(child)
+
+    # Collect route-throu LUTs
+    walk(clb_block)
+
+    if not blocks:
+        return []
+
+    # Process blocks
+    new_net_ids = {}
+    net_pairs = []
+
+    for block in blocks:
+        print("  ", block)
+
+        # Idnetify input and output to be routed together. There should be
+        # only one of each.
+        Port = namedtuple("Port", "port pin")
+
+        blk_inp = None
+        blk_out = None
+
+        for port in block.ports.values():
+            for pin, conn in port.connections.items():
+
+                if port.type in ["input", "clock"]:
+                    if blk_inp is None:
+                        blk_inp = Port(port, pin)
+                    else:
+                        assert False
+
+                elif port.type == "output":
+                    if blk_out is None:
+                        blk_out = Port(port, pin)
+                    else:
+                        assert False
+
+                else:
+                    assert False, port.type
+
+        # Check if we have both input and output
+        assert blk_inp and blk_out
+        #print("   ", blk_inp, blk_out)
+
+        # Identify the net
+        net_inp = block.find_net_for_port(blk_inp.port.name, blk_inp.pin)
+        assert net_inp is not None
+
+        # Create a new net to be driven by the route-throu LUT
+        if net_inp not in new_net_ids:
+            new_net_ids[net_inp] = 0
+
+        net_out = net_inp + "$buf{}".format(new_net_ids[net_inp])
+        new_net_ids[net_inp] += 1
+
+        net_pairs.append((net_inp, net_out))
+
+        # Insert the route-throu LUT as an explicit block
+        lut_block = pn.Block(
+            name = net_out,
+            instance = "lut[0]",
+            mode = "default",
+            parent = block
+        )
+        block.blocks[lut_block.instance] = lut_block
+
+        # Add LUT ports with connections
+        lut_block.ports[blk_inp.port.name] = pn.Port(
+            name = blk_inp.port.name,
+            type = blk_inp.port.type,
+            width = blk_inp.port.width,
+            connections = {
+                blk_inp.pin: pn.Connection(
+                    driver = block.type,
+                    port = blk_inp.port.name,
+                    pin = blk_inp.pin,
+                    interconnect = "direct"
+                )
+            }
+        )
+
+        lut_block.ports[blk_out.port.name] = pn.Port(
+            name = blk_out.port.name,
+            type = blk_out.port.type,
+            width = blk_out.port.width,
+            connections = {
+                blk_out.pin: net_out
+            }
+        )
+
+        # Set input port rotation. This will allow to have a simple LUT-1
+        # buffer in the circuit netlist.
+        lut_block.ports[blk_inp.port.name].rotation_map = {
+            blk_inp.pin: 0
+        }
+
+        # Update the block output port to reference the LUT
+        blk_out.port.connections = {
+            blk_out.pin: pn.Connection(
+                driver = lut_block.instance,
+                port = blk_out.port.name,
+                pin = blk_out.pin,
+                interconnect = "direct"
+            )
+        }
+
+        # Update the block mode and name
+        block.name = lut_block.name
+        block.mode = block.type
+
+    return net_pairs
+
+
+def insert_buffers(nets, eblif, clb_block):
+    """
+    For the given list of net pairs the function inserts buffer cells to
+    the circuit netlist.
+    """
+
+    def walk(block, net, collected_blocks):
+
+        # This is a leaf block
+        if block.is_leaf:
+
+            # Check every input port connection, identify driving nets. Store
+            # the block if at least one input is driven by the given net.
+            for port in block.ports.values():
+                if port.type in ["input", "clock"]:
+                    for pin in port.connections:
+                        pin_net = block.find_net_for_port(port.name, pin)
+
+                        if pin_net == net:
+                            collected_blocks.append(block)
+                            return
+
+        # Recurse for all children
+        else:
+            for child in block.blocks.values():
+                walk(child, net, collected_blocks)
+
+    # Insert buffers for each new net
+    for net_inp, net_out in nets:
+
+        # Insert the buffer cell. Here it is a LUT-1 configured as buffer.
+        cell = Cell("$lut")
+        cell.name = net_out
+        cell.ports["lut_in[0]"] = net_inp
+        cell.ports["lut_out"] = net_out
+        cell.init = [0, 1]
+        eblif.cells[cell.name] = cell
+
+        # Collects blocks driven by the output net
+        blocks = []
+        walk(clb_block, net_out, blocks)
+
+        # Remap block cell connections
+        for block in blocks:
+
+            # Find cell for the block
+            cell = eblif.find_cell(block.name)
+            assert cell is not None, block
+
+            # Find a port referencing the input net. Change it to the output
+            # net
+            for port in cell.ports:
+                if cell.ports[port] == net_inp:
+                    cell.ports[port] = net_out
+
+# =============================================================================
+
+
+def identify_blocks_to_repack(clb_block, repacking_rules):
+    """
+    Identifies all blocks in the packed netlist that require re-packing
+    """
+
+    def walk(block, path):
+        """
+        Recursively walk the path and yield matching blocks from the packed
+        netlist
+        """
+
+        # No more path nodes to follow
+        if not path:
+            return
+
+        # The block is "open"
+        if block.is_open:
+            return
+
+        # Check if the current block is a LUT
+        is_lut = len(block.blocks) == 1 and "lut[0]" in block.blocks and \
+                 block.blocks["lut[0]"].is_leaf
+
+        # Check if the block match the path node. Check type and mode
+        block_node = PathNode.from_string(block.instance)
+        block_node.mode = block.mode
+
+        path_node = path[0]
+
+        if block_node.name != path_node.name:
+            return
+
+        if not block.is_leaf:
+            mode = "default" if is_lut else block_node.mode
+            if path_node.mode != mode:
+                return
+
+        # If index is explicitly given check it as well
+        if path_node.index is not None and path_node.index != block_node.index:
+            return
+
+        # This is a leaf block, add it
+        if block.is_leaf and not block.is_open:
+            assert len(path) == 1, (path, block)
+            yield block
+
+        # This is not a leaf block
+        else:
+
+            # Add the implicit LUT hierarchy to the path
+            if is_lut:
+                path.append(PathNode.from_string("lut[0]"))
+
+            # Recurse
+            for child in block.blocks.values():
+                yield from walk(child, path[1:])
+
+    # For each rule
+    blocks_to_repack = []
+    for rule in repacking_rules:
+        print("  ", "checking rule path '{}'...".format(rule.src))
+
+        # Parse the path
+        path = [PathNode.from_string(p) for p in rule.src.split(".")]
+
+        # Substitute non-explicit modes with "default" to match the packed
+        # netlist
+        for part in path:
+            if part.mode is None:
+                part.mode = "default"
+
+        # Walk
+        for block in walk(clb_block, path):
+            print("   ", block)
+
+            # Append to list
+            blocks_to_repack.append((block, rule))
+
+    return blocks_to_repack
+
+
+def fix_block_path(block_path, arch_path, change_mode=True):
+    """
+    Given a hierarchical path without explicit modes and indices adds them to
+    those nodes that match with the block path.
+
+    The last node with matching name and index will have its mode changed to
+    match the given path if change_mode is True.
+    """
+
+    # Get the full path (with indices and modes) to the block
+    block_path = block_path.split(".")
+    arch_path = arch_path.split(".")
+
+    length = min(len(arch_path), len(block_path))
+
+    # Process the path
+    for i in range(length):
+
+        # Parse both path nodes
+        arch_node = PathNode.from_string(arch_path[i])
+        block_node = PathNode.from_string(block_path[i])
+
+        # Name doesn't match
+        if arch_node.name != block_node.name:
+            break
+        # Index doesn't match
+        if arch_node.index is not None and arch_node.index != block_node.index:
+            break
+
+        # Optionally change mode as in the architecture path
+        if change_mode:
+            mode = arch_node.mode if arch_node.mode else "default"
+        else:
+            mode = block_node.mode
+
+        # Fix the node
+        arch_path[i] = str(PathNode(block_node.name, block_node.index, mode))
+
+        # If the mode does not match then break
+        if arch_node.mode is not None and block_node.mode != "default":
+            if arch_node.mode != block_node.mode:
+                break
+
+    # Join the modified path back
+    return ".".join(arch_path)
+
+
+def identify_repack_target_candidates(clb_pbtype, path):
+    """
+    Given a hierarchical path and a root CLB identifies all leaf pb_types that
+    match that path and yields them.
+
+    The path may be "fixed" (having explicit modes and pb indices) up to some
+    depth. When a path node refers to a concrete pb_type then the algorightm
+    follows exactly that path.
+
+    For non-fixed path nodes the algorithm explores all possiblities and yields
+    them.
+    """
+
+    def walk(arch_path, pbtype, pbtype_index, curr_path=None):
+        #print("Walk:", ".".join(arch_path), curr_path)
+
+        # Parse the path node
+        if arch_path:
+            path_node = PathNode.from_string(arch_path[0])
+            arch_path = arch_path[1:]
+
+        # No more path nodes, consider all wildcards
+        else:
+            path_node = PathNode(None, None, None)
+
+        # Check if the name matches
+        pbtype_name = pbtype.name
+        if path_node.name is not None and path_node.name != pbtype_name:
+            return
+
+        # Check if the index matches
+        if path_node.index is not None and path_node.index != pbtype_index:
+            return
+
+        # Initialize the current path if not given
+        if curr_path is None:
+            curr_path = []
+
+        # This is a leaf pb_type. Yield path to it
+        if pbtype.is_leaf:
+            part = "{}[{}]".format(pbtype_name, pbtype_index)
+            yield (".".join(curr_path + [part]), pbtype)
+
+        # Recurse
+        for mode_name, mode in pbtype.modes.items():
+
+            # Check mode if given
+            if path_node.mode is not None and path_node.mode != mode_name:
+                continue
+
+            # Recurse for children
+            for child, i in mode.yield_children():
+
+                # Recurse
+                part = "{}[{}][{}]".format(pbtype_name, pbtype_index, mode_name)          
+                yield from walk(arch_path, child, i, curr_path + [part])
+
+    # Split the path
+    path = path.split(".")
+
+    # Get CLB index from the path
+    part = PathNode.from_string(path[0])
+    clb_index = part.index
+
+    # Begin walk
+    candidates = list(walk(path, clb_pbtype, clb_index))
+    return candidates
+
+
+# =============================================================================
+
+
+def annotate_net_endpoints(clb_graph, block, block_path=None, port_map=None, def_map=None):
+    """
+    This function annotates SOURCE and SINK nodes of the block pointed by
+    block_path with nets of their corresponding ports but from the other given
+    block.
+
+    This essentially does the block re-packing at the packed netlist level.
+    """
+
+    # Invert the port map (is src->dst, we need dst->src)
+    if port_map is not None:
+        inv_port_map = {v:k for k,v in port_map.items()}
+
+    # Get block path
+    if block_path is None:
+        block_path = block.get_path()
+
+    # Remove mode from the last node of the path
+    block_path = [PathNode.from_string(p) for p in block_path.split(".")]
+    block_path[-1].mode = None
+    block_path = ".".join([str(p) for p in block_path])
+
+    # Annotate SOURCE and SINK nodes
+    for node in clb_graph.nodes.values():
+
+        # Consider only SOURCE and SINK nodes
+        if node.type not in [NodeType.SOURCE, NodeType.SINK]:
+            continue
+
+        # Split the node path into block and port
+        path, port = node.path.rsplit(".", maxsplit=1)
+
+        # Check if the node belongs to this CLB
+        if path != block_path:
+            continue
+
+        # Optionally remap the port
+        port = PathNode.from_string(port)
+        if port_map is not None:
+            key = (port.name, port.index)
+            if key in inv_port_map:    
+                name, index = inv_port_map[key]
+                port = PathNode(name, index)
+
+        # Got this port in the source block
+        # Find a net for the port pin of the source block and assign it
+        net = None
+        if port.name in block.ports:
+            net = block.find_net_for_port(port.name, port.index)
+
+        # If the port is unconnected then check if there is a defautil value
+        # in the map
+        if def_map:
+            key = (port.name, port.index)
+            if key in def_map:
+                net = def_map[key]
+
+        # Skip unconnected ports
+        if not net:
+            print("   ", "Port '{}' is unconnected".format(port))
+            continue
+
+        # Assign the net
+        node.net = net
+
+
+def rotate_truth_table(table, rotation_map):
+    """
+    Rotates address bits of the truth table of a LUT given a bit map.
+    Rotation map key refers to the "new" address while its value to the
+    "old" one.
+    """
+
+    # Get LUT width, possibly different than the current
+    width = max(rotation_map.keys()) + 1
+
+    # Rotate
+    new_table = [0 for i in range(2 ** width)]
+    for daddr in range(2 ** width):
+
+        # Remap address bits
+        saddr = 0
+        for i in range(width):
+            if daddr & (1 << i):
+                if i in rotation_map:
+                    j = rotation_map[i]
+                    saddr |= 1 << j
+
+        assert saddr < len(table), (saddr, len(table))
+        new_table[daddr] = table[saddr]
+
+    return new_table
+
+
+def repack_netlist_cell(eblif, cell, block, src_pbtype, model, rule, def_map=None):
+    """
+    This function transforms circuit netlist (BLIF / EBLIF) cells to implement
+    re-packing.
+    """
+
+    # Build a mini-port map for ports of build-in cells (.names, .latch)
+    # this is needed to correlate pb_type ports with model ports.
+    class_map = {}
+    for port in src_pbtype.ports.values():
+        if port.cls is not None:
+            class_map[port.cls] = port.name
+
+    # Get LUT in port if the cell is a LUT
+    lut_in = class_map.get("lut_in", None)
+
+    # Create a new cell
+    repacked_cell = Cell(model.name)
+    repacked_cell.name = cell.name
+
+    # Copy cell data
+    repacked_cell.cname = cell.cname
+    repacked_cell.attributes = cell.attributes
+    repacked_cell.parameters = cell.parameters
+
+    # Remap port connections
+    lut_rotation = {}
+    lut_width = 0
+
+    for port, net in cell.ports.items():
+        port = PathNode.from_string(port)
+
+        # If the port name refers to a port class then remap it
+        port.name = class_map.get(port.name, port.name)
+
+        # Add port index for 1-bit ports
+        if port.index is None:
+            port.index = 0
+
+        org_index = port.index
+
+        # Undo VPR port rotation
+        blk_port = block.ports[port.name]
+        if blk_port.rotation_map:
+            inv_rotation_map = {v:k for k, v in blk_port.rotation_map.items()}
+            port.index = inv_rotation_map[port.index]
+
+        # Remap the port
+        if rule.port_map is not None:
+            key = (port.name, port.index)
+            if key in rule.port_map:    
+                name, index = rule.port_map[key]
+                port = PathNode(name, index)
+
+        # Remove port index for 1-bit ports
+        width = model.ports[port.name].width
+        if width == 1:
+            port.index = None
+
+        repacked_cell.ports[str(port)] = net
+
+        # Update LUT rotation if applicable
+        if port.name == lut_in:
+            assert port.index not in lut_rotation
+            lut_rotation[port.index] = org_index
+            lut_width = width
+
+    # If the cell is a LUT then rotate its truth table. Append the rotated
+    # truth table as a parameter to the repacked cell.
+    if cell.type == "$lut":
+
+        # Build the init parameter
+        init = rotate_truth_table(cell.init, lut_rotation)
+        init = "".join(["1" if x else "0" for x in init][::-1])
+
+        # Pad with 0s to match LUT width
+        assert (1 << lut_width) >= len(init), (lut_width, init)
+        pad_len = (1 << lut_width) - len(init)
+        init = "0" * pad_len + init
+
+        repacked_cell.parameters["LUT"] = init
+
+    # If the rule contains mode bits then append the MODE parameter to the cell
+    if rule.mode_bits:
+        repacked_cell.parameters["MODE"] = rule.mode_bits
+
+    # If the cell is an IOB output cell then set its name via cname. Such cells
+    # do not drive any nets hence VPR cannot name them automatically
+    if cell.type == "$output":
+        repacked_cell.cname = repacked_cell.name
+
+    # Check for unconnected ports that should be tied to some default nets
+    if def_map:
+        for key, net in def_map.items():
+            port = "{}[{}]".format(*key)
+            if port not in repacked_cell.ports:
+                repacked_cell.ports[port] = net
+
+    # Remove the old cell and replace it with the new one
+    del eblif.cells[cell.name]
+    eblif.cells[repacked_cell.name] = repacked_cell
+
+    return repacked_cell
+
+
+def syncrhonize_attributes_and_parameters(eblif, packed_netlist):
+    """
+    Syncrhonizes EBLIF cells attributes and parameters with the packed netlist
+    leaf blocks by copying them.
+    """
+
+    def walk(block):
+
+        # This is a leaf
+        if block.is_leaf and not block.is_open:
+
+            # Find matching cell
+            cell = eblif.find_cell(block.name)
+            assert cell is not None, block
+
+            # Copy attributes and parameters
+            block.attributes = dict(cell.attributes)
+            block.parameters = dict(cell.parameters)
+
+        # Recurse
+        else:
+            for child in block.blocks.values():
+                walk(child)
+
+    # Walk over CLBs
+    for block in packed_netlist.blocks.values():
+        walk(block)
+
+# =============================================================================
+
+
+def load_repacking_rules(json_root):
+    """
+    Loads rules for the repacker from a parsed JSON file
+    """
+
+    # Get the appropriate section
+    json_rules = json_root.get("repacking_rules", None)
+    assert json_rules is not None
+    assert isinstance(json_rules, list), type(json_rules)
+
+    # Convert the rules
+    print(" Repacking rules:")
+
+    rules = []
+    for entry in json_rules:
+        assert isinstance(entry, dict), type(entry)
+
+        rule = RepackingRule(
+            src = entry["src_pbtype"],
+            dst = entry["dst_pbtype"],
+            index_map = entry["index_map"],
+            port_map = entry["port_map"],
+            mode_bits = entry["mode_bits"],
+        )
+        rules.append(rule)
+
+        # DEBUG
+        print(" ", "{} -> {}".format(rule.src, rule.dst))
+
+    return rules
+
+
+def expand_port_maps(rules, clb_pbtypes):
+    """
+    Expands port maps of repacking rules so that they explicitly specify
+    port pins.
+    """
+
+    for rule in rules:
+
+        # Get src and dst pb_types
+        path = [PathNode.from_string(p) for p in rule.src.split(".")]
+        path = [PathNode(p.name, mode=p.mode) for p in path]
+        src_pbtype = clb_pbtypes[path[0].name].find(path)
+        assert src_pbtype, ".".join([str(p) for p in path])
+
+        path = [PathNode.from_string(p) for p in rule.dst.split(".")]
+        path = [PathNode(p.name, mode=p.mode) for p in path]
+        dst_pbtype = clb_pbtypes[path[0].name].find(path)
+        assert dst_pbtype, ".".join([str(p) for p in path])
+
+        # Expand port map
+        port_map = {}
+        for src_port, dst_port in rule.port_map.items():
+
+            # Get pin lists
+            src_pins = list(src_pbtype.yield_port_pins(src_port))
+            dst_pins = list(dst_pbtype.yield_port_pins(dst_port))
+
+            assert len(src_pins) == len(dst_pins), (src_pins, dst_pins)
+
+            # Update port map
+            for src_pin, dst_pin in zip(src_pins, dst_pins):
+                port_map[src_pin] = dst_pin
+
+        rule.port_map = port_map
+
+        # DEBUG
+#        print(" ", rule.src, "->", rule.dst)
+#        for k, v in rule.port_map.items():
+#            print("  ", k, "->", v)
+
+    return rules
+
+# =============================================================================
+
+
+def write_packed_netlist(fname, netlist):
+    """
+    Writes the given packed netlist to an XML file
+    """
+
+    xml_tree = ET.ElementTree(netlist.to_etree())
+    xml_data = '<?xml version="1.0"?>\n' \
+             + ET.tostring(xml_tree, pretty_print=True).decode("utf-8")
+
+    with open(fname, "w") as fp:
+        fp.write(xml_data)
+
+# =============================================================================
+
+
+def main():
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+
+    parser.add_argument(
+        "--vpr-arch",
+        type=str,
+        required=True,
+        help="VPR architecture XML file"
+    )
+    parser.add_argument(
+        "--repacking-rules",
+        type=str,
+        required=True,
+        help="JSON file describing repacking rules"
+    )
+    parser.add_argument(
+        "--eblif-in",
+        type=str,
+        required=True,
+        help="Input circuit netlist in BLIF/EBLIF format"
+    )
+    parser.add_argument(
+        "--net-in",
+        type=str,
+        required=True,
+        help="Input VPR packed netlist (.net)"
+    )
+    parser.add_argument(
+        "--place-in",
+        type=str,
+        default=None,
+        help="Input VPR placement file (.place)"
+    )
+    parser.add_argument(
+        "--eblif-out",
+        type=str,
+        default=None,
+        help="Output circuit netlist BLIF/EBLIF file"
+    )
+    parser.add_argument(
+        "--net-out",
+        type=str,
+        default=None,
+        help="Output VPR packed netlist (.net) file"
+    )
+    parser.add_argument(
+        "--place-out",
+        type=str,
+        default=None,
+        help="Output VPR placement (.place) file"
+    )
+    parser.add_argument(
+        "--absorb_buffer_luts",
+        type=str,
+        default="on",
+        choices=["on", "off"],
+        help="Controls whether buffer LUTs are to be absorbed downstream"
+    )
+    parser.add_argument(
+        "--dump-dot",
+        action="store_true",
+        help="Dump graphviz .dot files for pb_type graphs"
+    )
+    parser.add_argument(
+        "--dump-netlist",
+        action="store_true",
+        help="Dump .eblif files at different stages of EBLIF netlist processing"
+    )
+
+    args = parser.parse_args()
+    init_time = time.perf_counter()
+
+    absorb_buffer_luts = args.absorb_buffer_luts == "on"
+
+    # Load the VPR architecture
+    print("Loading VPR architecture file...")
+    xml_tree = ET.parse(args.vpr_arch, ET.XMLParser(remove_blank_text=True))
+
+    # Get CLBs
+    xml_clbs = xml_tree.getroot().find("complexblocklist").findall("pb_type")
+    xml_clbs = {clb.attrib["name"]: clb for clb in xml_clbs}
+
+    # Build pb_type hierarchy for each CLB
+    print("Building pb_type hierarchy...")
+    clb_pbtypes = {
+        name: PbType.from_etree(elem)
+        for name, elem in xml_clbs.items()
+    }
+
+    # Build a list of models
+    print("Building primitive models...")
+    models = {}
+    for pb_type in clb_pbtypes.values():
+        models.update(Model.collect_models(pb_type))
+
+    # DEBUG
+    keys = sorted(list(models.keys()))
+    for key in keys:
+        print("", str(models[key]))
+
+    # Load the repacking rules
+    print("Loading repacking rules...")
+    with open(args.repacking_rules, "r") as fp:
+        json_root = json.load(fp)
+
+    # Get repacking rules
+    repacking_rules = load_repacking_rules(json_root)
+    # Expand port maps in repacking rules
+    expand_port_maps(repacking_rules, clb_pbtypes)
+
+    # Load the BLIF/EBLIF file
+    print("Loading BLIF/EBLIF circuit netlist...")
+    eblif = Eblif.from_file(args.eblif_in)
+
+    # Convert top-level inputs to cells
+    eblif.convert_ports_to_cells()
+
+    # Optional dump
+    if args.dump_netlist:
+        eblif.to_file("netlist.io_cells.eblif")
+
+    # Clean the netlist
+    print("Cleaning circuit netlist...")
+
+    if absorb_buffer_luts:
+        net_map = netlist_cleaning.absorb_buffer_luts(eblif)
+    else:
+        net_map = {}
+
+#    # DEBUG
+#    keys = sorted(list(eblif.cells.keys()))
+#    for key in keys:
+#        print("", eblif.cells[key].name)
+
+    # Optional dump
+    if args.dump_netlist:
+        eblif.to_file("netlist.cleaned.eblif")
+
+    # Load the packed netlist XML
+    print("Loading VPR packed netlist...")
+    net_xml = ET.parse(args.net_in, ET.XMLParser(remove_blank_text=True))
+    packed_netlist = PackedNetlist.from_etree(net_xml.getroot())
+
+    init_time = time.perf_counter() - init_time
+    repack_time = time.perf_counter()
+
+    # Process netlist CLBs
+    print("Processing CLBs...")    
+
+    removed_ios = set()
+    io_block_names = {}
+
+    repacked_clb_count = 0
+    repacked_block_count = 0
+
+    for clb_block in packed_netlist.blocks.values():
+        print("", clb_block)
+
+        # Remap block and net names
+        clb_block.rename_nets(net_map)
+
+        # Find a corresponding root pb_type (complex block) in the architecture
+        clb_pbtype = clb_pbtypes.get(clb_block.type, None)
+        if clb_pbtype is None:
+            print("ERROR: Complex block type '{}' not found in the VPR arch".format(clb_block.type))
+            exit(-1)
+
+        # Identify and fixup route-throu LUTs
+        print(" ", "Identifying route-throu LUTs...")
+        net_pairs = fixup_route_throu_luts(clb_block)
+        insert_buffers(net_pairs, eblif, clb_block)
+
+        # Identify blocks to repack. Continue to next CLB if there are none
+        print(" ", "Identifying blocks to repack...")
+        blocks_to_repack = identify_blocks_to_repack(clb_block, repacking_rules)
+        if not blocks_to_repack:
+            continue
+
+        # For each block to be repacked identify its destination candidate(s)
+        print(" ", "Identifying repack targets...")
+        iter_list = list(blocks_to_repack)
+        blocks_to_repack = []
+        for block, rule in iter_list:
+
+            # Remap index of the destination block pointed by the path of the
+            # rule.
+            blk_path = block.get_path()
+            blk_path = [PathNode.from_string(p) for p in blk_path.split(".")]
+            dst_path = rule.dst
+            dst_path = [PathNode.from_string(p) for p in dst_path.split(".")]
+
+            if dst_path[-1].index is None:
+                dst_path[-1].index = rule.remap_pb_type_index(
+                    blk_path[-1].index
+                )
+
+            blk_path = ".".join([str(p) for p in blk_path])
+            dst_path = ".".join([str(p) for p in dst_path])
+
+            # Fix the part of the destination block path so that it matches the
+            # path of the block to be remapped
+            arch_path = fix_block_path(blk_path, dst_path)
+
+            # Identify target candidates
+            candidates = identify_repack_target_candidates(clb_pbtype, arch_path)
+            assert candidates, (block, arch_path)
+
+            print("  ", block, "({})".format(rule.src))
+            for path, pbtype_xml in candidates:
+                print("   ", path)
+
+            # No candidates
+            if not candidates:
+                print("ERROR: No repack target found!")
+                exit(-1)
+
+            # There must be only a single repack target per block
+            if len(candidates) > 1:
+                print("ERROR: Multiple repack targets found!")
+                exit(-1)
+
+            # Store concrete correspondence
+            # (packed netlist block, repacking rule, (target path, target pb_type))
+            blocks_to_repack.append((block, rule, candidates[0]))
+
+        if not blocks_to_repack:
+            continue
+
+        # Check for conflicts
+        repack_targets = set()
+        for block, rule, (path, pbtype) in blocks_to_repack:
+
+            if path in repack_targets:
+                print("ERROR: Multiple blocks are to be repacked into '{}'".format(path))
+            repack_targets.add(path)
+
+        # Stats
+        repacked_clb_count += 1
+        repacked_block_count += len(blocks_to_repack)
+
+        # Repack the circuit netlist
+        print(" ", "Repacking circuit netlist...")
+        for src_block, rule, (dst_path, dst_pbtype) in blocks_to_repack:
+            print("  ", src_block)
+
+            # Find the original pb_type
+            src_path = src_block.get_path(with_indices=False)
+            src_pbtype = clb_pbtype.find(src_path)
+            assert src_pbtype is not None, src_path
+
+            # Get the source BLIF model
+            assert src_pbtype.blif_model is not None
+            src_blif_model = src_pbtype.blif_model
+
+            # Get the destination BLIF model
+            assert dst_pbtype.blif_model is not None, dst_pbtype.name
+            dst_blif_model = dst_pbtype.blif_model.split(maxsplit=1)[-1]
+
+            # Get the model object
+            assert dst_blif_model in models, blif_model
+            model = models[dst_blif_model]
+
+            # Find the cell in the netlist
+            assert src_block.name in eblif.cells, src_block.name
+            cell = eblif.cells[src_block.name]
+
+            # If the cell is an IOB then mark the top-level port to be removed
+            if cell.type in ["$input", "$output"]:
+                removed_ios.add(cell.name)
+
+            # If the cell is an output IOB then store the desired name for the
+            # destination block
+            if cell.type == "$output":
+                io_block_names[dst_path] = cell.name
+
+            # Repack it
+            repacked_cell = repack_netlist_cell(
+                eblif,
+                cell,
+                src_block,
+                src_pbtype,
+                model,
+                rule,
+            )
+
+        # Build a pb routing graph for this CLB
+        print(" ", "Building pb_type routing graph...")
+        clb_xml = xml_clbs[clb_block.type]
+        graph = Graph.from_etree(clb_xml, clb_block.instance)
+
+        # Dump original packed netlist graph as graphvis .dot file
+        if args.dump_dot:
+            load_clb_nets_into_pb_graph(clb_block, graph)
+            fname = "graph_original_{}.dot".format(clb_block.instance)
+            with open(fname, "w") as fp:
+                fp.write(graph.dump_dot(color_by="net", nets_only=True))
+            graph.clear_nets()        
+
+        # Annotate source and sinks with nets
+        print(" ", "Annotating net endpoints...")
+
+        # For the CLB
+        print("  ", clb_block)
+        annotate_net_endpoints(graph, clb_block)
+
+        # For repacked leafs
+        for block, rule, (path, dst_pbtype) in blocks_to_repack:
+            print("  ", block)
+
+            # Get the destination BLIF model
+            assert dst_pbtype.blif_model is not None, dst_pbtype.name
+            dst_blif_model = dst_pbtype.blif_model.split(maxsplit=1)[-1]
+
+            # Annotate
+            annotate_net_endpoints(graph, block, path, rule.port_map)
+
+        # Initialize router
+        print(" ", "Initializing router...")
+        router = Router(graph)
+
+        # There has to be at least one net in the block after repacking
+        assert router.nets, "No nets"
+
+        # Route
+        print(" ", "Routing...")
+        router.route_nets(debug=True)
+
+        # Build packed netlist CLB from the graph
+        print(" ", "Rebuilding CLB netlist...")
+        repacked_clb_block = build_packed_netlist_from_pb_graph(graph) 
+        repacked_clb_block.rename_cluster(clb_block.name)
+
+        # Restore names of IO blocks
+        for src_block, rule, (dst_path, dst_pbtype) in blocks_to_repack:
+            if dst_path in io_block_names:
+
+                search_path = dst_path.split(".", maxsplit=1)[1]
+                dst_block = repacked_clb_block.get_block_by_path(search_path)
+                assert dst_block is not None, dst_path
+
+                name = io_block_names[dst_path]
+                print("  ", "renaming IOB {} to {}".format(dst_block, name))
+                dst_block.name = name
+
+        # Replace the CLB
+        packed_netlist.blocks[clb_block.instance] = repacked_clb_block
+
+        # Dump repacked packed netlist graph as graphviz .dot file
+        if args.dump_dot:
+            fname = "graph_repacked_{}.dot".format(clb_block.instance)
+            with open(fname, "w") as fp:
+                fp.write(graph.dump_dot(color_by="net", nets_only=True))
+
+
+    # Remove top-level ports from the packed netlist
+    for name in removed_ios:
+        for tag, ports in packed_netlist.ports.items():
+            if name in ports:
+                ports.remove(name)
+
+    # Optional dump
+    if args.dump_netlist:
+        eblif.to_file("netlist.repacked.eblif")
+        write_packed_netlist("netlist.repacked.net", packed_netlist)
+
+    # Synchronize packed netlist attributes and parameters with EBLIF
+    syncrhonize_attributes_and_parameters(eblif, packed_netlist)
+
+    repack_time = time.perf_counter() - repack_time
+    writeout_time = time.perf_counter()
+
+    # Clean the circuit netlist again. Need to do it here again as LUT buffers
+    # driving top-level inputs couldn't been swept before repacking as it
+    # would cause top-level port renaming.
+    print("Cleaning repacked circuit netlist...")
+    if absorb_buffer_luts:
+
+        net_map = netlist_cleaning.absorb_buffer_luts(eblif)
+
+        # Synchronize packed netlist net names
+        for block in packed_netlist.blocks.values():
+            block.rename_nets(net_map)
+
+    # Optional dump
+    if args.dump_netlist:
+        eblif.to_file("netlist.repacked_and_cleaned.eblif")
+
+    # Convert cells into top-level ports
+    eblif.convert_cells_to_ports()
+
+    # Write the circuit netlist
+    print("Writing EBLIF circuit netlist...")
+    fname = args.eblif_out if args.eblif_out else "repacked.eblif"
+    eblif.to_file(fname, consts=False)
+
+    # Compute SHA256 digest of the EBLIF file and store it in the packed
+    # netlist.
+    with open(fname, "rb") as fp:
+        digest = hashlib.sha256(fp.read()).hexdigest()
+    packed_netlist.netlist_id = "SHA256:" + digest
+
+    # Write the packed netlist
+    print("Writing VPR packed netlist...")
+    net_out_fname = args.net_out if args.net_out else "repacked.net"
+    write_packed_netlist(net_out_fname, packed_netlist)
+
+    writeout_time = time.perf_counter() - writeout_time
+
+    # Read and patch SHA and packed netlist name in the VPR placement file
+    # if given
+    if args.place_in:
+        print("Patching VPR placement file...")
+
+        # Compute .net file digest
+        with open(net_out_fname, "rb") as fp:
+            net_digest = hashlib.sha256(fp.read()).hexdigest()
+
+        # Read placement
+        with open(args.place_in, "r") as fp:
+            placement = fp.readlines()
+
+        # Find the header line
+        for i in range(len(placement)):
+            if placement[i].startswith("Netlist_File:"):
+
+                # Replace the header
+                placement[i] = "Netlist_File: {} Netlist_ID: {}\n".format(
+                    os.path.basename(net_out_fname),
+                    "SHA256:" + net_digest
+                )
+                break
+        else:
+            print(" WARNING the placement file '{}' has no header!".format(
+                args.place_in))
+
+        # Write the patched placement
+        fname = args.place_out if args.place_out else "repacked.place"
+        with open(fname, "w") as fp:
+            fp.writelines(placement)
+
+    print("Finished.")
+
+    print("")
+    print("Initialization time: {:.2f}s".format(init_time))
+    print("Repacking time     : {:.2f}s".format(repack_time))
+    print("Finishing time     : {:.2f}s".format(writeout_time))
+    print("Repacked CLBs      : {}".format(repacked_clb_count))
+    print("Repacked blocks    : {}".format(repacked_block_count))
+
+# =============================================================================
+
+
+if __name__ == "__main__":
+    main()

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -79,7 +79,7 @@ class RepackingConstraint:
 # =============================================================================
 
 
-def fixup_route_throu_luts(clb_block):
+def fixup_route_throu_luts(clb_block, new_net_ids):
     """
     This function identifies route-throu LUTs in the packed netlist and
     replaces them with explicit LUT-1 blocks.
@@ -112,7 +112,6 @@ def fixup_route_throu_luts(clb_block):
         return []
 
     # Process blocks
-    new_net_ids = {}
     net_pairs = []
 
     for block in blocks:
@@ -246,6 +245,7 @@ def insert_buffers(nets, eblif, clb_block):
         cell.ports["lut_in[0]"] = net_inp
         cell.ports["lut_out"] = net_out
         cell.init = [0, 1]
+        assert cell.name not in eblif.cells, cell
         eblif.cells[cell.name] = cell
 
         # Collects blocks driven by the output net
@@ -1111,6 +1111,8 @@ def main():
     removed_ios = set()
     leaf_block_names = {}
 
+    route_through_net_ids = {}
+
     repacked_clb_count = 0
     repacked_block_count = 0
 
@@ -1132,7 +1134,7 @@ def main():
 
         # Identify and fixup route-throu LUTs
         logging.debug("  Identifying route-throu LUTs...")
-        net_pairs = fixup_route_throu_luts(clb_block)
+        net_pairs = fixup_route_throu_luts(clb_block, route_through_net_ids)
         insert_buffers(net_pairs, eblif, clb_block)
 
         # Identify blocks to repack. Continue to next CLB if there are none

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/netlist.golden.eblif
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/netlist.golden.eblif
@@ -1,0 +1,85 @@
+.model top
+.inputs clk
+.outputs led[0] led[1] led[2] led[3]
+.names $false
+.names $true
+1
+.names $undef
+.names cnt[1] cnt[0] $auto$alumacc.cc:485:replace_alu$5.Y[1]
+01 1
+10 1
+.names cnt[2] cnt[1] cnt[0] $auto$alumacc.cc:485:replace_alu$5.Y[2]
+011 1
+100 1
+101 1
+110 1
+.names cnt[3] cnt[2] cnt[1] cnt[0] $auto$alumacc.cc:485:replace_alu$5.Y[3]
+0111 1
+1000 1
+1001 1
+1010 1
+1011 1
+1100 1
+1101 1
+1110 1
+.names led[0] $abc$215$new_n22_ $auto$alumacc.cc:485:replace_alu$5.Y[4]
+01 1
+10 1
+.names cnt[2] cnt[3] cnt[1] cnt[0] $abc$215$new_n22_
+1111 1
+.names led[1] led[0] $abc$215$new_n22_ $auto$alumacc.cc:485:replace_alu$5.Y[5]
+011 1
+100 1
+101 1
+110 1
+.names led[2] $abc$215$new_n25_ $abc$215$new_n22_ $auto$alumacc.cc:485:replace_alu$5.Y[6]
+011 1
+100 1
+101 1
+110 1
+.names led[0] led[1] $abc$215$new_n25_
+11 1
+.names led[3] led[2] $abc$215$new_n25_ $abc$215$new_n22_ $auto$alumacc.cc:485:replace_alu$5.Y[7]
+0111 1
+1000 1
+1001 1
+1010 1
+1011 1
+1100 1
+1101 1
+1110 1
+.names cnt[0] $auto$alumacc.cc:485:replace_alu$5.X[0]
+0 1
+.latch $auto$alumacc.cc:485:replace_alu$5.X[0] cnt[0] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[1] cnt[1] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[2] cnt[2] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[3] cnt[3] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[4] led[0] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[5] led[1] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[6] led[2] re clk 0
+.latch $auto$alumacc.cc:485:replace_alu$5.Y[7] led[3] re clk 0
+.names cnt[1] $auto$alumacc.cc:485:replace_alu$5.X[1]
+1 1
+.names cnt[2] $auto$alumacc.cc:485:replace_alu$5.X[2]
+1 1
+.names cnt[3] $auto$alumacc.cc:485:replace_alu$5.X[3]
+1 1
+.names led[0] $auto$alumacc.cc:485:replace_alu$5.X[4]
+1 1
+.names led[1] $auto$alumacc.cc:485:replace_alu$5.X[5]
+1 1
+.names led[2] $auto$alumacc.cc:485:replace_alu$5.X[6]
+1 1
+.names led[3] $auto$alumacc.cc:485:replace_alu$5.X[7]
+1 1
+.names $auto$alumacc.cc:485:replace_alu$5.X[0] $auto$alumacc.cc:485:replace_alu$5.Y[0]
+1 1
+.names led[0] cnt[4]
+1 1
+.names led[1] cnt[5]
+1 1
+.names led[2] cnt[6]
+1 1
+.names led[3] cnt[7]
+1 1
+.end

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/test_eblif_roundtrip.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/test_eblif_roundtrip.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from eblif_netlist import Eblif
+
+# =============================================================================
+
+def test_netlist_roundtrip():
+
+    basedir = os.path.dirname(__file__)
+    golden_file = os.path.join(basedir, "netlist.golden.eblif")
+
+    # Load and parse the EBLIF file
+    eblif = Eblif.from_file(golden_file)
+
+    with tempfile.TemporaryDirectory() as tempdir:
+
+        # Write the EBLIF back
+        output_file = os.path.join(tempdir, "netlist.output.eblif")
+        eblif.to_file(output_file)
+
+        # Compare the two files
+        with open(golden_file, "r") as fp:
+            golden_data = fp.read().rstrip()
+        with open(output_file, "r") as fp:
+            output_data = fp.read().rstrip()
+
+        assert golden_data == output_data
+

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/test_eblif_roundtrip.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/test_eblif_roundtrip.py
@@ -3,10 +3,8 @@ import os
 import sys
 import tempfile
 
-import pytest
-
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-from eblif_netlist import Eblif
+from eblif_netlist import Eblif  # noqa: E402
 
 # =============================================================================
 

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/test_eblif_roundtrip.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/eblif_roundtrip/test_eblif_roundtrip.py
@@ -10,6 +10,7 @@ from eblif_netlist import Eblif
 
 # =============================================================================
 
+
 def test_netlist_roundtrip():
 
     basedir = os.path.dirname(__file__)
@@ -31,4 +32,3 @@ def test_netlist_roundtrip():
             output_data = fp.read().rstrip()
 
         assert golden_data == output_data
-

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/identity.xsl
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/identity.xsl
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!-- 
+ Copyright (C) 2020  The SymbiFlow Authors.
+
+ Use of this source code is governed by a ISC-style
+ license that can be found in the LICENSE file or at
+ https://opensource.org/licenses/ISC
+
+ SPDX-License-Identifier:   ISC
+-->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output method="xml" indent="yes"/>
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="@*">
+    <xsl:copy/>
+  </xsl:template>
+
+  <xsl:template match="*">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="text()|processing-instruction()">
+    <xsl:copy>
+      <xsl:apply-templates select="text()|processing-instruction()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:param name="strip_comments" select="''" />
+  <xsl:template match="comment()">
+    <xsl:choose>
+      <xsl:when test="$strip_comments"></xsl:when>
+      <xsl:otherwise><xsl:copy /></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/netlist.golden.net
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/netlist.golden.net
@@ -1,0 +1,746 @@
+<?xml version="1.0"?>
+<block name="top.net" instance="FPGA_packed_netlist[0]" architecture_id="SHA256:e4eb21dd40067be5f659dcebb9ade6d70c1a29c93255ad92035a9dccd7d4b2a0" atom_netlist_id="SHA256:907bae6d91adf12dd9385e7cdf495d7ed3f8e56911cf5256c991a11fdd7b9f1f">
+	<inputs>clk</inputs>
+	<outputs>out:led[0] out:led[1] out:led[2] out:led[3]</outputs>
+	<clocks>clk</clocks>
+	<block name="$auto$alumacc.cc:485:replace_alu$5.Y[7]" instance="clb[0]" mode="default">
+		<inputs>
+			<port name="I">cnt[0] cnt[1] open open open open open open open open open open open open open open open open open open open open open open</port>
+			<port name="reg_in">open</port>
+			<port name="sc_in">open</port>
+			<port name="cin">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="O">open open open fle[3].out[0]-&gt;clbouts1 fle[4].out[0]-&gt;clbouts2 fle[5].out[0]-&gt;clbouts2 open fle[7].out[0]-&gt;clbouts2</port>
+			<port name="reg_out">open</port>
+			<port name="sc_out">open</port>
+			<port name="cout">open</port>
+			<port name="cout_copy">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">clk</port>
+		</clocks>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[2]" instance="fle[0]" mode="n1_lut4">
+			<inputs>
+				<port name="in">clb.I[0]-&gt;crossbar_fle[0].in[0] clb.I[1]-&gt;crossbar_fle[0].in[1] fle[0].out[0]-&gt;crossbar_fle[0].in[2] open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[0].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[2]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 fle.in[2]-&gt;direct1 open</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[2]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 ble4.in[2]-&gt;direct1 open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[2]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 lut4.in[2]-&gt;direct:lut4 open</port>
+							<port_rotation_map name="in">2 1 0 open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[2]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="cnt[2]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">cnt[2]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[3]" instance="fle[1]" mode="n1_lut4">
+			<inputs>
+				<port name="in">clb.I[0]-&gt;crossbar_fle[1].in[0] fle[0].out[0]-&gt;crossbar_fle[1].in[1] clb.I[1]-&gt;crossbar_fle[1].in[2] fle[1].out[0]-&gt;crossbar_fle[1].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[1].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[3]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 fle.in[2]-&gt;direct1 fle.in[3]-&gt;direct1</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[3]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 ble4.in[2]-&gt;direct1 ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[3]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 lut4.in[2]-&gt;direct:lut4 lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">3 1 2 0</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[3]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="cnt[3]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">cnt[3]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+		<block name="$abc$215$new_n22_" instance="fle[2]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[1].out[0]-&gt;crossbar_fle[2].in[0] fle[0].out[0]-&gt;crossbar_fle[2].in[1] clb.I[0]-&gt;crossbar_fle[2].in[2] clb.I[1]-&gt;crossbar_fle[2].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="$abc$215$new_n22_" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 fle.in[2]-&gt;direct1 fle.in[3]-&gt;direct1</port>
+				</inputs>
+				<outputs>
+					<port name="out">lut4[0].out[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">open</port>
+				</clocks>
+				<block name="$abc$215$new_n22_" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 ble4.in[2]-&gt;direct1 ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$abc$215$new_n22_" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 lut4.in[2]-&gt;direct:lut4 lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">1 0 3 2</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$abc$215$new_n22_</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="open" instance="ff[0]" />
+			</block>
+		</block>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[4]" instance="fle[3]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[3].out[0]-&gt;crossbar_fle[3].in[0] open open fle[2].out[0]-&gt;crossbar_fle[3].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[3].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[4]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 open open fle.in[3]-&gt;direct1</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[4]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 open open ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[4]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 open open lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">0 open open 1</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[4]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="led[0]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">led[0]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[5]" instance="fle[4]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[4].out[0]-&gt;crossbar_fle[4].in[0] fle[2].out[0]-&gt;crossbar_fle[4].in[1] fle[3].out[0]-&gt;crossbar_fle[4].in[2] open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[4].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[5]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 fle.in[2]-&gt;direct1 open</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[5]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 ble4.in[2]-&gt;direct1 open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[5]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 lut4.in[2]-&gt;direct:lut4 open</port>
+							<port_rotation_map name="in">0 2 1 open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[5]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="led[1]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">led[1]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[6]" instance="fle[5]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[6].out[0]-&gt;crossbar_fle[5].in[0] fle[5].out[0]-&gt;crossbar_fle[5].in[1] open fle[2].out[0]-&gt;crossbar_fle[5].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[5].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[6]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 open fle.in[3]-&gt;direct1</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[6]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 open ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[6]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 open lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">1 0 open 2</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[6]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="led[2]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">led[2]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+		<block name="$abc$215$new_n25_" instance="fle[6]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[3].out[0]-&gt;crossbar_fle[6].in[0] fle[4].out[0]-&gt;crossbar_fle[6].in[1] open open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="$abc$215$new_n25_" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 open open</port>
+				</inputs>
+				<outputs>
+					<port name="out">lut4[0].out[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">open</port>
+				</clocks>
+				<block name="$abc$215$new_n25_" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 open open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$abc$215$new_n25_" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 open open</port>
+							<port_rotation_map name="in">0 1 open open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$abc$215$new_n25_</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="open" instance="ff[0]" />
+			</block>
+		</block>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[7]" instance="fle[7]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[6].out[0]-&gt;crossbar_fle[7].in[0] fle[2].out[0]-&gt;crossbar_fle[7].in[1] fle[7].out[0]-&gt;crossbar_fle[7].in[2] fle[5].out[0]-&gt;crossbar_fle[7].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[7].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[7]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 fle.in[1]-&gt;direct1 fle.in[2]-&gt;direct1 fle.in[3]-&gt;direct1</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[7]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 ble4.in[1]-&gt;direct1 ble4.in[2]-&gt;direct1 ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[7]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 lut4.in[1]-&gt;direct:lut4 lut4.in[2]-&gt;direct:lut4 lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">2 3 0 1</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[7]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="led[3]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">led[3]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+	</block>
+	<block name="$auto$alumacc.cc:485:replace_alu$5.Y[1]" instance="clb[1]" mode="default">
+		<inputs>
+			<port name="I">open open open open open open open open open open open open open open open open open open open open open open open open</port>
+			<port name="reg_in">open</port>
+			<port name="sc_in">open</port>
+			<port name="cin">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="O">open open open open open open fle[6].out[0]-&gt;clbouts2 fle[7].out[0]-&gt;clbouts2</port>
+			<port name="reg_out">open</port>
+			<port name="sc_out">open</port>
+			<port name="cout">open</port>
+			<port name="cout_copy">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">clk</port>
+		</clocks>
+		<block name="open" instance="fle[0]" />
+		<block name="open" instance="fle[1]" />
+		<block name="open" instance="fle[2]" />
+		<block name="open" instance="fle[3]" />
+		<block name="open" instance="fle[4]" />
+		<block name="open" instance="fle[5]" />
+		<block name="$auto$alumacc.cc:485:replace_alu$5.X[0]" instance="fle[6]" mode="n1_lut4">
+			<inputs>
+				<port name="in">open open fle[6].out[0]-&gt;crossbar_fle[6].in[2] open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[6].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.X[0]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">open open fle.in[2]-&gt;direct1 open</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.X[0]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">open open ble4.in[2]-&gt;direct1 open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.X[0]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">open open lut4.in[2]-&gt;direct:lut4 open</port>
+							<port_rotation_map name="in">open open 0 open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.X[0]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="cnt[0]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">cnt[0]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+		<block name="$auto$alumacc.cc:485:replace_alu$5.Y[1]" instance="fle[7]" mode="n1_lut4">
+			<inputs>
+				<port name="in">fle[7].out[0]-&gt;crossbar_fle[7].in[0] open open fle[6].out[0]-&gt;crossbar_fle[7].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">clb.clk[0]-&gt;clb.clk_to_fle[7].clk</port>
+			</clocks>
+			<block name="$auto$alumacc.cc:485:replace_alu$5.Y[1]" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 open open fle.in[3]-&gt;direct1</port>
+				</inputs>
+				<outputs>
+					<port name="out">ff[0].Q[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">fle.clk[0]-&gt;direct3</port>
+				</clocks>
+				<block name="$auto$alumacc.cc:485:replace_alu$5.Y[1]" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 open open ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="$auto$alumacc.cc:485:replace_alu$5.Y[1]" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 open open lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">0 open open 1</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">$auto$alumacc.cc:485:replace_alu$5.Y[1]</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="cnt[1]" instance="ff[0]">
+					<attributes />
+					<parameters />
+					<inputs>
+						<port name="D">lut4[0].out[0]-&gt;direct2</port>
+					</inputs>
+					<outputs>
+						<port name="Q">cnt[1]</port>
+					</outputs>
+					<clocks>
+						<port name="clk">ble4.clk[0]-&gt;direct3</port>
+					</clocks>
+				</block>
+			</block>
+		</block>
+	</block>
+	<block name="out:led[0]" instance="io[2]" mode="outpad">
+		<inputs>
+			<port name="outpad">led[0]</port>
+		</inputs>
+		<outputs>
+			<port name="inpad">open</port>
+		</outputs>
+		<clocks />
+		<block name="out:led[0]" instance="outpad[0]">
+			<attributes />
+			<parameters />
+			<inputs>
+				<port name="outpad">io.outpad[0]-&gt;outpad</port>
+			</inputs>
+			<outputs />
+			<clocks />
+		</block>
+	</block>
+	<block name="out:led[1]" instance="io[3]" mode="outpad">
+		<inputs>
+			<port name="outpad">led[1]</port>
+		</inputs>
+		<outputs>
+			<port name="inpad">open</port>
+		</outputs>
+		<clocks />
+		<block name="out:led[1]" instance="outpad[0]">
+			<attributes />
+			<parameters />
+			<inputs>
+				<port name="outpad">io.outpad[0]-&gt;outpad</port>
+			</inputs>
+			<outputs />
+			<clocks />
+		</block>
+	</block>
+	<block name="out:led[2]" instance="io[4]" mode="outpad">
+		<inputs>
+			<port name="outpad">led[2]</port>
+		</inputs>
+		<outputs>
+			<port name="inpad">open</port>
+		</outputs>
+		<clocks />
+		<block name="out:led[2]" instance="outpad[0]">
+			<attributes />
+			<parameters />
+			<inputs>
+				<port name="outpad">io.outpad[0]-&gt;outpad</port>
+			</inputs>
+			<outputs />
+			<clocks />
+		</block>
+	</block>
+	<block name="out:led[3]" instance="io[5]" mode="outpad">
+		<inputs>
+			<port name="outpad">led[3]</port>
+		</inputs>
+		<outputs>
+			<port name="inpad">open</port>
+		</outputs>
+		<clocks />
+		<block name="out:led[3]" instance="outpad[0]">
+			<attributes />
+			<parameters />
+			<inputs>
+				<port name="outpad">io.outpad[0]-&gt;outpad</port>
+			</inputs>
+			<outputs />
+			<clocks />
+		</block>
+	</block>
+	<block name="clk" instance="io[6]" mode="inpad">
+		<inputs>
+			<port name="outpad">open</port>
+		</inputs>
+		<outputs>
+			<port name="inpad">inpad[0].inpad[0]-&gt;inpad</port>
+		</outputs>
+		<clocks />
+		<block name="clk" instance="inpad[0]">
+			<attributes />
+			<parameters />
+			<inputs />
+			<outputs>
+				<port name="inpad">clk</port>
+			</outputs>
+			<clocks />
+		</block>
+	</block>
+</block>

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/test_netlist_roundtrip.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/test_netlist_roundtrip.py
@@ -12,6 +12,7 @@ import lxml.etree as ET
 
 # =============================================================================
 
+
 def test_netlist_roundtrip():
 
     basedir = os.path.dirname(__file__)
@@ -21,7 +22,7 @@ def test_netlist_roundtrip():
     xslt_file = os.path.join(basedir, "../sort_netlist.xsl")
     xslt = ET.parse(xslt_file)
     xform = ET.XSLT(xslt)
-    
+
     # Load the golden netlist XML
     xml_tree = ET.parse(golden_file, ET.XMLParser(remove_blank_text=True))
 
@@ -56,4 +57,3 @@ def test_netlist_roundtrip():
             output_data = fp.read()
 
         assert golden_data == output_data
-

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/test_netlist_roundtrip.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/test_netlist_roundtrip.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import os
+import sys
+import tempfile
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from packed_netlist import PackedNetlist
+
+import lxml.etree as ET
+
+# =============================================================================
+
+def test_netlist_roundtrip():
+
+    basedir = os.path.dirname(__file__)
+    golden_file = os.path.join(basedir, "netlist.golden.net")
+
+    # Load the XSLT for sorting
+    xslt_file = os.path.join(basedir, "../sort_netlist.xsl")
+    xslt = ET.parse(xslt_file)
+    xform = ET.XSLT(xslt)
+    
+    # Load the golden netlist XML
+    xml_tree = ET.parse(golden_file, ET.XMLParser(remove_blank_text=True))
+
+    with tempfile.TemporaryDirectory() as tempdir:
+
+        # Transform and save the golden file
+        sorted_golden_file = os.path.join(tempdir, "netlist.golden.sorted.net")
+        with open(sorted_golden_file, "w") as fp:
+            et = xform(xml_tree)
+            st = '<?xml version="1.0">\n' \
+                 + ET.tostring(et, pretty_print=True).decode("utf-8")
+            fp.write(st)
+
+        # Build packed netlist
+        netlist = PackedNetlist.from_etree(xml_tree.getroot())
+
+        # Convert the netlist back to element tree
+        xml_tree = ET.ElementTree(netlist.to_etree())
+
+        # Transform and save the output file
+        sorted_output_file = os.path.join(tempdir, "netlist.output.sorted.net")
+        with open(sorted_output_file, "w") as fp:
+            et = xform(xml_tree)
+            st = '<?xml version="1.0">\n' \
+                 + ET.tostring(et, pretty_print=True).decode("utf-8")
+            fp.write(st)
+
+        # Compare the two files
+        with open(sorted_golden_file, "r") as fp:
+            golden_data = fp.read()
+        with open(sorted_output_file, "r") as fp:
+            output_data = fp.read()
+
+        assert golden_data == output_data
+

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/test_netlist_roundtrip.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/packed_netlist_roundtrip/test_netlist_roundtrip.py
@@ -3,12 +3,10 @@ import os
 import sys
 import tempfile
 
-import pytest
+import lxml.etree as ET
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
-from packed_netlist import PackedNetlist
-
-import lxml.etree as ET
+from packed_netlist import PackedNetlist  # noqa: E402
 
 # =============================================================================
 

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/sort_netlist.xsl
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/sort_netlist.xsl
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+ <xsl:include href="identity.xsl" />
+
+  <!-- Sort everything -->
+  <xsl:template match="block">
+    <xsl:copy>     
+
+      <xsl:apply-templates select="@*">
+        <xsl:sort select="name()" order="ascending"/>
+      </xsl:apply-templates>
+
+      <xsl:apply-templates select="attributes"/>
+      <xsl:apply-templates select="parameters"/>
+
+      <xsl:apply-templates select="inputs">
+        <xsl:sort select="@name" order="ascending"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates select="outputs">
+        <xsl:sort select="@name" order="ascending"/>
+      </xsl:apply-templates>
+      <xsl:apply-templates select="clocks">
+        <xsl:sort select="@name" order="ascending"/>
+      </xsl:apply-templates>
+
+      <xsl:apply-templates select="block">
+        <xsl:sort select="@instance" order="ascending"/>
+      </xsl:apply-templates>
+
+      <xsl:apply-templates select="*[not(self::attributes or self::parameters or self::inputs or self::outputs or self::clocks or self::block)]"/>
+
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>
+


### PR DESCRIPTION
The repacking is a step during which so called "operating cells" used by the VPR packer are converted into so called "phsyical cells" used by the physical device architecture. Both cell sets are defined within different models of relevant pb_types in the VPR architecture. The step involves revoking packing and routing of each cluster and then rebuilding it using physical cells only. The conversion is compliant with the `repack` step as deifined in the OpenFPGA project (https://openfpga.readthedocs.io/en/master/manual/openfpga_shell/openfpga_commands/fpga_bitstream_commands/#repack).

Repacking is added to the CMake flow through a new general mechanism of packed netlist patching. One may define an external utility run between VPR placement and VPR routing stages. See `common/cmake/device.cmake` for details. A similar step is added to the flow of the installed toolchain.

The set of rules for the repacker that define operating and physical cell correspondences are stored in a JSON file under the `third_party/qlf_symbiflow_plugins` submodule.

There is currently no format check whether the repacker operates correctly - such a test leveraging Yosys' equivalence checking is being worked on. Besides that there are more low-level tests for parts of the repacker code available under `utils/qlf_k4n8/repacker/tests`.