### PR TITLE
QuickLogic: upstream repacker fixes

### DIFF
--- a/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
+++ b/quicklogic/common/cmake/quicklogic_qlf_arch.cmake
@@ -29,6 +29,10 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
 
   get_target_property_required(QLF_FASM env QLF_FASM)
 
+  if("${FAMILY}" STREQUAL "qlf_k4n8")
+    set(REPACKER_PATH ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/qlf_k4n8/utils/repacker/repack.py)
+  endif()
+
   # Define the architecture
   define_arch(
     FAMILY ${FAMILY}
@@ -57,7 +61,7 @@ function(QUICKLOGIC_DEFINE_QLF_ARCH)
     NO_PLACE_CONSTR
 
     NET_PATCH_TOOL
-      ${symbiflow-arch-defs_SOURCE_DIR}/quicklogic/qlf_k4n8/utils/repacker/repack.py
+      ${REPACKER_PATH}
     NET_PATCH_TOOL_CMD "${CMAKE_COMMAND} -E env \
       PYTHONPATH=${symbiflow-arch-defs_SOURCE_DIR}/utils \
       \${QUIET_CMD} \${PYTHON3} \${NET_PATCH_TOOL} \

--- a/quicklogic/qlf_k4n8/utils/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/utils/CMakeLists.txt
@@ -8,3 +8,5 @@ add_custom_target(all_python_tests
         ${PYTHON3} -m pytest --doctest-modules -vv
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+add_dependencies(all_quicklogic_tests all_python_tests)

--- a/quicklogic/qlf_k4n8/utils/repacker/repack.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/repack.py
@@ -729,10 +729,10 @@ def repack_netlist_cell(
         init = rotate_truth_table(cell.init, lut_rotation)
         init = "".join(["1" if x else "0" for x in init][::-1])
 
-        # Pad with 0s to match LUT width
-        assert (1 << lut_width) >= len(init), (lut_width, init)
-        pad_len = (1 << lut_width) - len(init)
-        init = "0" * pad_len + init
+        # Expand the truth table to match the physical LUT width. Do that by
+        # repeating the lower part of it until the desired length is attained.
+        while (len(init).bit_length() - 1) < lut_width:
+            init = init + init
 
         # Reverse LUT bit order
         init = init[::-1]

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1.eblif
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1.eblif
@@ -1,0 +1,6 @@
+.model top
+.inputs a
+.outputs o
+.names a o
+0 1
+.end

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_0.golden.eblif
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_0.golden.eblif
@@ -1,0 +1,7 @@
+.model top
+.inputs a
+.outputs o
+.subckt frac_lut4_arith in[0]=a lut4_out=o
+.param LUT 1010101010101010
+.param MODE 0
+.end

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_0.net
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_0.net
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<block name="top.net" instance="FPGA_packed_netlist[0]" architecture_id="SHA256:75d400c4d0f05a6b7a7cc26b5315f29d3cbc1d64579f5a3d3b40f77b1deed75c" atom_netlist_id="SHA256:bcfc8354052a41bff85e4c6f44f7a8c3b27a73ca9ed4db64341c3852c6d323c1">
+	<inputs>a</inputs>
+	<outputs>out:o</outputs>
+	<clocks></clocks>
+	<block name="o" instance="clb[0]" mode="default">
+		<inputs>
+			<port name="I">open open open open open open open open open open open open open open a open open open open open open open open open</port>
+			<port name="reg_in">open</port>
+			<port name="sc_in">open</port>
+			<port name="cin">open</port>
+			<port name="lreset">open</port>
+			<port name="reset">open</port>
+			<port name="preset">open</port>
+		</inputs>
+		<outputs>
+			<port name="O">open open open open open open open fle[7].out[0]-&gt;clbouts2</port>
+			<port name="reg_out">open</port>
+			<port name="sc_out">open</port>
+			<port name="cout">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="open" instance="fle[0]" />
+		<block name="open" instance="fle[1]" />
+		<block name="open" instance="fle[2]" />
+		<block name="open" instance="fle[3]" />
+		<block name="open" instance="fle[4]" />
+		<block name="open" instance="fle[5]" />
+		<block name="open" instance="fle[6]" />
+		<block name="o" instance="fle[7]" mode="n1_lut4">
+			<inputs>
+				<port name="in">clb.I[14]-&gt;crossbar_fle[7].in[0] open open open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+				<port name="preset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="o" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">fle.in[0]-&gt;direct1 open open open</port>
+					<port name="reset">open</port>
+					<port name="preset">open</port>
+				</inputs>
+				<outputs>
+					<port name="out">lut4[0].out[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">open</port>
+				</clocks>
+				<block name="o" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">ble4.in[0]-&gt;direct1 open open open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="o" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">lut4.in[0]-&gt;direct:lut4 open open open</port>
+							<port_rotation_map name="in">0 open open open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">o</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="open" instance="ff[0]" />
+			</block>
+		</block>
+	</block>
+	<block name="out:o" instance="io[1]" mode="io_output">
+		<inputs>
+			<port name="f2a_i">o</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">open</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="out:o" instance="io_output[0]" mode="default">
+			<inputs>
+				<port name="f2a_i">io.f2a_i[0]-&gt;io_output-f2a_i</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs />
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="open" instance="ff[0]" />
+			<block name="out:o" instance="outpad[0]">
+				<attributes />
+				<parameters />
+				<inputs>
+					<port name="outpad">io_output.f2a_i[0]-&gt;mux1</port>
+				</inputs>
+				<outputs />
+				<clocks />
+			</block>
+		</block>
+	</block>
+	<block name="a" instance="io[2]" mode="io_input">
+		<inputs>
+			<port name="f2a_i">open</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">io_input[0].a2f_o[0]-&gt;io-a2f_o</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="a" instance="io_input[0]" mode="default">
+			<inputs>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="a2f_o">inpad[0].inpad[0]-&gt;mux2</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="a" instance="inpad[0]">
+				<attributes />
+				<parameters />
+				<inputs />
+				<outputs>
+					<port name="inpad">a</port>
+				</outputs>
+				<clocks />
+			</block>
+			<block name="open" instance="ff[0]" />
+		</block>
+	</block>
+</block>

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_1.golden.eblif
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_1.golden.eblif
@@ -1,0 +1,7 @@
+.model top
+.inputs a
+.outputs o
+.subckt frac_lut4_arith in[1]=a lut4_out=o
+.param LUT 1100110011001100
+.param MODE 0
+.end

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_1.net
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_1.net
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<block name="top.net" instance="FPGA_packed_netlist[0]" architecture_id="SHA256:75d400c4d0f05a6b7a7cc26b5315f29d3cbc1d64579f5a3d3b40f77b1deed75c" atom_netlist_id="SHA256:bcfc8354052a41bff85e4c6f44f7a8c3b27a73ca9ed4db64341c3852c6d323c1">
+	<inputs>a</inputs>
+	<outputs>out:o</outputs>
+	<clocks></clocks>
+	<block name="o" instance="clb[0]" mode="default">
+		<inputs>
+			<port name="I">open open open open open open open open open open open open open open a open open open open open open open open open</port>
+			<port name="reg_in">open</port>
+			<port name="sc_in">open</port>
+			<port name="cin">open</port>
+			<port name="lreset">open</port>
+			<port name="reset">open</port>
+			<port name="preset">open</port>
+		</inputs>
+		<outputs>
+			<port name="O">open open open open open open open fle[7].out[0]-&gt;clbouts2</port>
+			<port name="reg_out">open</port>
+			<port name="sc_out">open</port>
+			<port name="cout">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="open" instance="fle[0]" />
+		<block name="open" instance="fle[1]" />
+		<block name="open" instance="fle[2]" />
+		<block name="open" instance="fle[3]" />
+		<block name="open" instance="fle[4]" />
+		<block name="open" instance="fle[5]" />
+		<block name="open" instance="fle[6]" />
+		<block name="o" instance="fle[7]" mode="n1_lut4">
+			<inputs>
+				<port name="in">open clb.I[14]-&gt;crossbar_fle[7].in[1] open open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+				<port name="preset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="o" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">open fle.in[1]-&gt;direct1 open open</port>
+					<port name="reset">open</port>
+					<port name="preset">open</port>
+				</inputs>
+				<outputs>
+					<port name="out">lut4[0].out[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">open</port>
+				</clocks>
+				<block name="o" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">open ble4.in[1]-&gt;direct1 open open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="o" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">open lut4.in[1]-&gt;direct:lut4 open open</port>
+							<port_rotation_map name="in">open 0 open open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">o</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="open" instance="ff[0]" />
+			</block>
+		</block>
+	</block>
+	<block name="out:o" instance="io[1]" mode="io_output">
+		<inputs>
+			<port name="f2a_i">o</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">open</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="out:o" instance="io_output[0]" mode="default">
+			<inputs>
+				<port name="f2a_i">io.f2a_i[0]-&gt;io_output-f2a_i</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs />
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="open" instance="ff[0]" />
+			<block name="out:o" instance="outpad[0]">
+				<attributes />
+				<parameters />
+				<inputs>
+					<port name="outpad">io_output.f2a_i[0]-&gt;mux1</port>
+				</inputs>
+				<outputs />
+				<clocks />
+			</block>
+		</block>
+	</block>
+	<block name="a" instance="io[2]" mode="io_input">
+		<inputs>
+			<port name="f2a_i">open</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">io_input[0].a2f_o[0]-&gt;io-a2f_o</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="a" instance="io_input[0]" mode="default">
+			<inputs>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="a2f_o">inpad[0].inpad[0]-&gt;mux2</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="a" instance="inpad[0]">
+				<attributes />
+				<parameters />
+				<inputs />
+				<outputs>
+					<port name="inpad">a</port>
+				</outputs>
+				<clocks />
+			</block>
+			<block name="open" instance="ff[0]" />
+		</block>
+	</block>
+</block>

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_2.golden.eblif
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_2.golden.eblif
@@ -1,0 +1,7 @@
+.model top
+.inputs a
+.outputs o
+.subckt frac_lut4_arith in[2]=a lut4_out=o
+.param LUT 1111000011110000
+.param MODE 0
+.end

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_2.net
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_2.net
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<block name="top.net" instance="FPGA_packed_netlist[0]" architecture_id="SHA256:75d400c4d0f05a6b7a7cc26b5315f29d3cbc1d64579f5a3d3b40f77b1deed75c" atom_netlist_id="SHA256:bcfc8354052a41bff85e4c6f44f7a8c3b27a73ca9ed4db64341c3852c6d323c1">
+	<inputs>a</inputs>
+	<outputs>out:o</outputs>
+	<clocks></clocks>
+	<block name="o" instance="clb[0]" mode="default">
+		<inputs>
+			<port name="I">open open open open open open open open open open open open open open a open open open open open open open open open</port>
+			<port name="reg_in">open</port>
+			<port name="sc_in">open</port>
+			<port name="cin">open</port>
+			<port name="lreset">open</port>
+			<port name="reset">open</port>
+			<port name="preset">open</port>
+		</inputs>
+		<outputs>
+			<port name="O">open open open open open open open fle[7].out[0]-&gt;clbouts2</port>
+			<port name="reg_out">open</port>
+			<port name="sc_out">open</port>
+			<port name="cout">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="open" instance="fle[0]" />
+		<block name="open" instance="fle[1]" />
+		<block name="open" instance="fle[2]" />
+		<block name="open" instance="fle[3]" />
+		<block name="open" instance="fle[4]" />
+		<block name="open" instance="fle[5]" />
+		<block name="open" instance="fle[6]" />
+		<block name="o" instance="fle[7]" mode="n1_lut4">
+			<inputs>
+				<port name="in">open open clb.I[14]-&gt;crossbar_fle[7].in[2] open</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+				<port name="preset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="o" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">open open fle.in[2]-&gt;direct1 open</port>
+					<port name="reset">open</port>
+					<port name="preset">open</port>
+				</inputs>
+				<outputs>
+					<port name="out">lut4[0].out[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">open</port>
+				</clocks>
+				<block name="o" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">open open ble4.in[2]-&gt;direct1 open</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="o" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">open open lut4.in[2]-&gt;direct:lut4 open</port>
+							<port_rotation_map name="in">open open 0 open</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">o</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="open" instance="ff[0]" />
+			</block>
+		</block>
+	</block>
+	<block name="out:o" instance="io[1]" mode="io_output">
+		<inputs>
+			<port name="f2a_i">o</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">open</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="out:o" instance="io_output[0]" mode="default">
+			<inputs>
+				<port name="f2a_i">io.f2a_i[0]-&gt;io_output-f2a_i</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs />
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="open" instance="ff[0]" />
+			<block name="out:o" instance="outpad[0]">
+				<attributes />
+				<parameters />
+				<inputs>
+					<port name="outpad">io_output.f2a_i[0]-&gt;mux1</port>
+				</inputs>
+				<outputs />
+				<clocks />
+			</block>
+		</block>
+	</block>
+	<block name="a" instance="io[2]" mode="io_input">
+		<inputs>
+			<port name="f2a_i">open</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">io_input[0].a2f_o[0]-&gt;io-a2f_o</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="a" instance="io_input[0]" mode="default">
+			<inputs>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="a2f_o">inpad[0].inpad[0]-&gt;mux2</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="a" instance="inpad[0]">
+				<attributes />
+				<parameters />
+				<inputs />
+				<outputs>
+					<port name="inpad">a</port>
+				</outputs>
+				<clocks />
+			</block>
+			<block name="open" instance="ff[0]" />
+		</block>
+	</block>
+</block>

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_3.golden.eblif
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_3.golden.eblif
@@ -1,0 +1,7 @@
+.model top
+.inputs a
+.outputs o
+.subckt frac_lut4_arith in[3]=a lut4_out=o
+.param LUT 1111111100000000
+.param MODE 0
+.end

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_3.net
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/lut1_3.net
@@ -1,0 +1,156 @@
+<?xml version="1.0"?>
+<block name="top.net" instance="FPGA_packed_netlist[0]" architecture_id="SHA256:75d400c4d0f05a6b7a7cc26b5315f29d3cbc1d64579f5a3d3b40f77b1deed75c" atom_netlist_id="SHA256:bcfc8354052a41bff85e4c6f44f7a8c3b27a73ca9ed4db64341c3852c6d323c1">
+	<inputs>a</inputs>
+	<outputs>out:o</outputs>
+	<clocks></clocks>
+	<block name="o" instance="clb[0]" mode="default">
+		<inputs>
+			<port name="I">open open open open open open open open open open open open open open a open open open open open open open open open</port>
+			<port name="reg_in">open</port>
+			<port name="sc_in">open</port>
+			<port name="cin">open</port>
+			<port name="lreset">open</port>
+			<port name="reset">open</port>
+			<port name="preset">open</port>
+		</inputs>
+		<outputs>
+			<port name="O">open open open open open open open fle[7].out[0]-&gt;clbouts2</port>
+			<port name="reg_out">open</port>
+			<port name="sc_out">open</port>
+			<port name="cout">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="open" instance="fle[0]" />
+		<block name="open" instance="fle[1]" />
+		<block name="open" instance="fle[2]" />
+		<block name="open" instance="fle[3]" />
+		<block name="open" instance="fle[4]" />
+		<block name="open" instance="fle[5]" />
+		<block name="open" instance="fle[6]" />
+		<block name="o" instance="fle[7]" mode="n1_lut4">
+			<inputs>
+				<port name="in">open open open clb.I[14]-&gt;crossbar_fle[7].in[3]</port>
+				<port name="reg_in">open</port>
+				<port name="sc_in">open</port>
+				<port name="cin">open</port>
+				<port name="reset">open</port>
+				<port name="preset">open</port>
+			</inputs>
+			<outputs>
+				<port name="out">ble4[0].out[0]-&gt;direct2</port>
+				<port name="reg_out">open</port>
+				<port name="sc_out">open</port>
+				<port name="cout">open</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="o" instance="ble4[0]" mode="default">
+				<inputs>
+					<port name="in">open open open fle.in[3]-&gt;direct1</port>
+					<port name="reset">open</port>
+					<port name="preset">open</port>
+				</inputs>
+				<outputs>
+					<port name="out">lut4[0].out[0]-&gt;mux1</port>
+				</outputs>
+				<clocks>
+					<port name="clk">open</port>
+				</clocks>
+				<block name="o" instance="lut4[0]" mode="lut4">
+					<inputs>
+						<port name="in">open open open ble4.in[3]-&gt;direct1</port>
+					</inputs>
+					<outputs>
+						<port name="out">lut[0].out[0]-&gt;direct:lut4</port>
+					</outputs>
+					<clocks />
+					<block name="o" instance="lut[0]">
+						<attributes />
+						<parameters />
+						<inputs>
+							<port name="in">open open open lut4.in[3]-&gt;direct:lut4</port>
+							<port_rotation_map name="in">open open open 0</port_rotation_map>
+						</inputs>
+						<outputs>
+							<port name="out">o</port>
+						</outputs>
+						<clocks />
+					</block>
+				</block>
+				<block name="open" instance="ff[0]" />
+			</block>
+		</block>
+	</block>
+	<block name="out:o" instance="io[1]" mode="io_output">
+		<inputs>
+			<port name="f2a_i">o</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">open</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="out:o" instance="io_output[0]" mode="default">
+			<inputs>
+				<port name="f2a_i">io.f2a_i[0]-&gt;io_output-f2a_i</port>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs />
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="open" instance="ff[0]" />
+			<block name="out:o" instance="outpad[0]">
+				<attributes />
+				<parameters />
+				<inputs>
+					<port name="outpad">io_output.f2a_i[0]-&gt;mux1</port>
+				</inputs>
+				<outputs />
+				<clocks />
+			</block>
+		</block>
+	</block>
+	<block name="a" instance="io[2]" mode="io_input">
+		<inputs>
+			<port name="f2a_i">open</port>
+			<port name="sc_in">open</port>
+			<port name="reset">open</port>
+		</inputs>
+		<outputs>
+			<port name="a2f_o">io_input[0].a2f_o[0]-&gt;io-a2f_o</port>
+			<port name="sc_out">open</port>
+		</outputs>
+		<clocks>
+			<port name="clk">open open open open</port>
+		</clocks>
+		<block name="a" instance="io_input[0]" mode="default">
+			<inputs>
+				<port name="reset">open</port>
+			</inputs>
+			<outputs>
+				<port name="a2f_o">inpad[0].inpad[0]-&gt;mux2</port>
+			</outputs>
+			<clocks>
+				<port name="clk">open</port>
+			</clocks>
+			<block name="a" instance="inpad[0]">
+				<attributes />
+				<parameters />
+				<inputs />
+				<outputs>
+					<port name="inpad">a</port>
+				</outputs>
+				<clocks />
+			</block>
+			<block name="open" instance="ff[0]" />
+		</block>
+	</block>
+</block>

--- a/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/test_lut_padding.py
+++ b/quicklogic/qlf_k4n8/utils/repacker/tests/lut_padding/test_lut_padding.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+import sys
+import os
+import tempfile
+
+import pytest
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+from repack import main as repack_main  # noqa: E402
+
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    "lut_width, lut_inputs", [
+        ("1", "0"),
+        ("1", "1"),
+        ("1", "2"),
+        ("1", "3"),
+    ]
+)
+def test_lut_padding(monkeypatch, lut_width, lut_inputs):
+    """
+    Tests repacking of a single lut with some inputs unconnected. Verifies
+    results against golden references.
+    """
+
+    basedir = os.path.dirname(__file__)
+
+    qlfpga_plugins = os.path.join(
+        basedir, "..", "..", "..", "..", "..", "..", "third_party",
+        "qlfpga-symbiflow-plugins"
+    )
+
+    vpr_arch = os.path.join(
+        qlfpga_plugins, "qlf_k4n8/vpr_arch/UMC22nm_vpr.xml"
+    )
+    repacking_rules = os.path.join(
+        qlfpga_plugins, "qlf_k4n8/vpr_arch/repacking_rules.json"
+    )
+
+    eblif_ref = os.path.join(
+        basedir, "lut{}_{}.golden.eblif".format(lut_width, lut_inputs)
+    )
+    eblif_in = os.path.join(basedir, "lut{}.eblif".format(lut_width))
+    net_in = os.path.join(
+        basedir, "lut{}_{}.net".format(lut_width, lut_inputs)
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+
+        eblif_out = os.path.join(tempdir, "out.eblif")
+        net_out = os.path.join(tempdir, "out.net")
+
+        # Substitute commandline arguments
+        monkeypatch.setattr(
+            "sys.argv", [
+                "repack.py",
+                "--vpr-arch",
+                vpr_arch,
+                "--repacking-rules",
+                repacking_rules,
+                "--eblif-in",
+                eblif_in,
+                "--net-in",
+                net_in,
+                "--eblif-out",
+                eblif_out,
+                "--net-out",
+                net_out,
+            ]
+        )
+
+        # Invoke the repacker
+        repack_main()
+
+        # Compare output with the golden reference
+        with open(eblif_ref, "r") as fp:
+            golden_data = fp.read().rstrip()
+        with open(eblif_out, "r") as fp:
+            output_data = fp.read().rstrip()
+
+        assert golden_data == output_data


### PR DESCRIPTION
This is based on top of #2137, and it will need a rebase after #2137 is merged.

The PR fixes an issue with the repacker around the LUT fasm outputs. It also adds a test to verify that the fix is working as expected.