### PR TITLE
Update the VTR version used

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - litex-hub::symbiflow-yosys-plugins=1.0.0_7_307_gc14d794=20210420_072542
   - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
   - litex-hub::prjxray-db=0.0_248_g2e51ad3=20210312_125539
-  - litex-hub::vtr-optimized=8.0.0_3452_ge7d45e013=20210318_102115
+  - litex-hub::vtr-optimized=8.0.0_3614_gb3b34e77a=20210507_125510
   - litex-hub::yosys=0.9_5266_g0fb4224e=20210301_104249_py37
   - litex-hub::zachjs-sv2v=0.0.5_0025_ge9f9696=20201120_205532
   - cmake


### PR DESCRIPTION
This PR Updates `vtr-optimized` Conda package to a version with genfasm bug fix included.