### PR TITLE
QuickLogic: Update qlf-fasm and yosys-symbiflow-plugins

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "third_party/icestorm"]
 	path = third_party/icestorm
 	url = https://github.com/cliffordwolf/icestorm.git
-[submodule "third_party/fasm"]
-	path = third_party/fasm
-	url = https://github.com/SymbiFlow/fasm.git
 [submodule "third_party/symbiyosys"]
 	path = third_party/symbiyosys
 	url = https://github.com/YosysHQ/SymbiYosys.git

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - litex-hub::icestorm=0.0_0719_g792cef0=20201120_145821
   - litex-hub::iverilog=s20150603_0957_gad862020=20201120_145821
   - litex-hub::openocd=0.10.0_1514_ga8edbd020=20201119_154304
-  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_307_gc14d794=20210420_072542
+  - litex-hub::symbiflow-yosys-plugins=1.0.0_7_338_g93157fb=20210507_125510
   - litex-hub::prjxray-tools=0.1_2842_g6867429c=20210301_104249
   - litex-hub::prjxray-db=0.0_248_g2e51ad3=20210312_125539
   - litex-hub::vtr-optimized=8.0.0_3614_gb3b34e77a=20210507_125510

--- a/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
+++ b/quicklogic/common/toolchain_wrappers/conda_build_install_package.sh
@@ -25,7 +25,7 @@ conda update $CONDA_FLAGS -q conda
 curl https://storage.googleapis.com/symbiflow-arch-defs-install/quicklogic-arch-defs-63c3d8f9.tar.gz --output arch.tar.gz
 tar -C $INSTALL_DIR -xvf arch.tar.gz && rm arch.tar.gz
 conda install $CONDA_FLAGS -c litex-hub/label/main yosys="0.9_5266_g0fb4224e 20210301_104249_py37"
-conda install $CONDA_FLAGS -c litex-hub/label/main symbiflow-yosys-plugins="1.0.0_7_307_gc14d794=20210420_072542"
+conda install $CONDA_FLAGS -c litex-hub/label/main symbiflow-yosys-plugins="1.0.0_7_338_g93157fb=20210507_125510"
 conda install $CONDA_FLAGS -c litex-hub/label/main vtr-optimized="8.0.0_3614_gb3b34e77a 20210507_125510"
 conda install $CONDA_FLAGS -c litex-hub iverilog
 conda install $CONDA_FLAGS -c tfors gtkwave


### PR DESCRIPTION
This PR updates revisions of both mentioned packages which is required for up-to-date `qlf_k4n8` eFPGA support. The updated `qlf_fasm` provides support for default bitstream which is then mutated by a design FASM file. 