### PR TITLE
kokoro: update to jdk 11

### DIFF
--- a/.github/kokoro/steps/hostsetup.sh
+++ b/.github/kokoro/steps/hostsetup.sh
@@ -15,6 +15,7 @@ echo "Host adding PPAs"
 echo "----------------------------------------"
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
 sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ xenial main'
+sudo add-apt-repository ppa:openjdk-r/ppa
 echo "----------------------------------------"
 
 echo
@@ -64,7 +65,8 @@ sudo apt-get install -y \
         python3-yaml \
         virtualenv \
         ninja-build \
-        pixz
+        pixz \
+        openjdk-11-jdk
 
 if [ -z "${BUILD_TOOL}" ]; then
     export BUILD_TOOL=make
@@ -77,6 +79,12 @@ echo "========================================"
 echo "Setting up environment env"
 echo "----------------------------------------"
 (
+	echo " Set JAVA 11 as default"
+	echo "----------------------------------------"
+	sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+	java -version
+	echo "----------------------------------------"
+
 	echo
 	echo " Configuring CMake"
 	echo "----------------------------------------"

--- a/.github/kokoro/steps/rapidwright.sh
+++ b/.github/kokoro/steps/rapidwright.sh
@@ -1,16 +1,9 @@
 #!/bin/bash
 
-RAPIDWRIGHT_TAG="v2020.2.4-beta"
-
 export RAPIDWRIGHT_PATH=$(pwd)/github/$KOKORO_DIR/env/RapidWright
 mkdir -p "${RAPIDWRIGHT_PATH}"
 
-# Using SymbiFlow/RapidWright fork to control ingestion of upstream merges.
 git clone https://github.com/Xilinx/RapidWright.git "${RAPIDWRIGHT_PATH}"
 pushd "${RAPIDWRIGHT_PATH}"
-git checkout $RAPIDWRIGHT_TAG
 make update_jars
-pushd interchange
-make all
-popd
 popd

--- a/.github/kokoro/xc7-vendor.sh
+++ b/.github/kokoro/xc7-vendor.sh
@@ -7,8 +7,8 @@ export CMAKE_FLAGS=-GNinja
 export BUILD_TOOL=ninja
 export XRAY_VIVADO_SETTINGS=/opt/Xilinx/Vivado/2017.2/settings64.sh
 export URAY_VIVADO_SETTINGS=/image/Xilinx/Vivado/2019.2/settings64.sh
-source ${SCRIPT_DIR}/steps/rapidwright.sh
 source ${SCRIPT_DIR}/common.sh
+source ${SCRIPT_DIR}/steps/rapidwright.sh
 source third_party/prjxray/.github/kokoro/steps/xilinx.sh
 source third_party/prjuray/.github/kokoro/steps/xilinx.sh
 echo

--- a/.github/kokoro/xc7a200t-vendor.sh
+++ b/.github/kokoro/xc7a200t-vendor.sh
@@ -7,8 +7,8 @@ export CMAKE_FLAGS=-GNinja
 export BUILD_TOOL=ninja
 export XRAY_VIVADO_SETTINGS=/opt/Xilinx/Vivado/2017.2/settings64.sh
 export URAY_VIVADO_SETTINGS=/image/Xilinx/Vivado/2019.2/settings64.sh
-source ${SCRIPT_DIR}/steps/rapidwright.sh
 source ${SCRIPT_DIR}/common.sh
+source ${SCRIPT_DIR}/steps/rapidwright.sh
 source third_party/prjxray/.github/kokoro/steps/xilinx.sh
 source third_party/prjuray/.github/kokoro/steps/xilinx.sh
 echo


### PR DESCRIPTION
Recent changes to rapidwright seem to require a newer version of jdk