### PR TITLE
Remove file: from environment.yaml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,4 +33,4 @@ dependencies:
   - cython
   - pip
   - pip:
-    - -r file:requirements.txt
+    - -r requirements.txt


### PR DESCRIPTION
This PR removes the `file:` prefix given before `requirements.txt` in `environment.yaml`. The prefix makes conda provide incorrect file path to `pip`.