### PR TITLE
gha: add name and email for the conda lock updating bot

### DIFF
--- a/.github/workflows/update_conda_lock.yml
+++ b/.github/workflows/update_conda_lock.yml
@@ -27,3 +27,5 @@ jobs:
         conda_lock_file:  'conda_lock.yml'
         environment_file: 'environment.yml'
         gh_access_token:  ${{ secrets.GITHUB_TOKEN }}
+        user_email: 'foss-fpga-tools@google.com'
+        user_name: 'SymbiFlow Robot'


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>