### PR TITLE
Added new mmcm test

### DIFF
--- a/xc/xc7/tests/common/basys3_bottom_frequency.pcf
+++ b/xc/xc7/tests/common/basys3_bottom_frequency.pcf
@@ -1,0 +1,10 @@
+# basys3 100 MHz CLK
+set_io clk_100m W5
+
+# sw[1] is the reset switch on the basys3
+set_io rst V17
+
+#leds 0-2 should all blink at the same rate 
+set_io led[0] U16
+set_io led[1] E19
+set_io led[2] U19

--- a/xc/xc7/tests/mmcm/CMakeLists.txt
+++ b/xc/xc7/tests/mmcm/CMakeLists.txt
@@ -60,6 +60,10 @@ add_file_target(FILE mmcm_int_basys3_bottom.v SCANNER_TYPE verilog)
 add_file_target(FILE mmcm_buf_basys3_bottom.v SCANNER_TYPE verilog)
 add_file_target(FILE mmcm_ext_basys3_bottom.v SCANNER_TYPE verilog)
 add_file_target(FILE mmcm_int_frac_basys3_bottom.v SCANNER_TYPE verilog)
+add_file_target(FILE mmcm_int_frac_basys3_bottom.v SCANNER_TYPE verilog)
+
+add_file_target(FILE clock_tester.v SCANNER_TYPE verilog)
+add_file_target(FILE frequency_test.v SCANNER_TYPE verilog)
 
 add_fpga_target(
   NAME mmcm_packing
@@ -101,6 +105,14 @@ add_fpga_target(
   EXPLICIT_ADD_FILE_TARGET
   )
 
+  add_fpga_target(
+  NAME frequency_test
+  BOARD basys3-bottom
+  SOURCES frequency_test.v
+  INPUT_IO_FILE ${COMMON}/basys3_bottom_frequency.pcf
+  EXPLICIT_ADD_FILE_TARGET
+  )
+
 
 add_vivado_target(
   NAME mmcm_packing_vivado
@@ -137,6 +149,13 @@ add_vivado_target(
 add_vivado_target(
   NAME mmcm_int_frac_basys3_vivado
   PARENT_NAME mmcm_int_frac_basys3
+  CLOCK_PINS clk
+  CLOCK_PERIODS 10.0
+  )
+
+add_vivado_target(
+  NAME frequency_test_vivado
+  PARENT_NAME frequency_test
   CLOCK_PINS clk
   CLOCK_PERIODS 10.0
   )

--- a/xc/xc7/tests/mmcm/clock_tester.v
+++ b/xc/xc7/tests/mmcm/clock_tester.v
@@ -1,0 +1,26 @@
+module clock_tester #(
+parameter COUNT = 25000000
+)
+(
+    input  wire clk,        // board oscillator
+    output reg  led    // pixel clock
+    );
+
+    reg [31:0] clk_count = 0; 
+
+    always @(posedge clk) begin
+        if (clk_count == COUNT)begin
+            clk_count <= 0;
+            
+            if(led == 0) begin
+                led <= 1;
+            end
+            else begin
+                led <= 0;
+            end
+        end
+        else begin
+            clk_count <= clk_count + 1;
+        end
+    end
+endmodule

--- a/xc/xc7/tests/mmcm/frequency_test.v
+++ b/xc/xc7/tests/mmcm/frequency_test.v
@@ -1,0 +1,75 @@
+`default_nettype none
+`timescale 1ns / 1ps
+
+module top (
+    input  wire clk_100m,     
+    input  wire rst,     
+    output wire  [2:0] led
+    );
+
+    wire clk_fb_mmcm, clk_fb_pll;         
+    wire clk_out_mmcm, clk_out_pll;        
+    wire locked_mmcm, locked_pll;     
+    wire clk_buff_mmcm, clk_buff_pll;    
+
+    
+    
+    MMCME2_ADV #(
+        .CLKFBOUT_MULT_F(9),
+        .CLKIN1_PERIOD(10.0),
+        .CLKOUT0_DIVIDE_F(36),
+        .CLKOUT1_DIVIDE(1),  
+        .DIVCLK_DIVIDE(1)
+    ) MMCME2_ADV_inst (
+        .CLKIN1(clk_100m),
+        .RST(rst),
+        .CLKOUT0(clk_out_mmcm),
+        .LOCKED(locked_mmcm),
+        .CLKFBOUT(clk_fb_mmcm),
+        .CLKFBIN(clk_fb_mmcm),
+        .CLKOUT0B(),
+        .CLKOUT1(),
+        .CLKOUT1B(),
+        .CLKOUT2(),
+        .CLKOUT2B(),
+        .CLKOUT3(),
+        .CLKOUT3B(),
+        .CLKOUT4(),
+        .CLKOUT5(),
+        .CLKOUT6(),
+        .CLKFBOUTB(),
+        .PWRDWN()
+    );  
+
+    
+    
+ PLLE2_ADV #(
+        .CLKFBOUT_MULT(9),
+        .CLKIN1_PERIOD(10.0),
+        .CLKOUT0_DIVIDE(36),
+        .CLKOUT1_DIVIDE(1),  
+        .DIVCLK_DIVIDE(1)
+    ) PLLE2_ADV_inst (
+        .CLKIN1(clk_100m),
+        .RST(rst),
+        .CLKOUT0(clk_out_pll),
+        .LOCKED(locked_pll),
+        .CLKFBOUT(clk_fb_pll),
+        .CLKFBIN(clk_fb_pll),
+        .CLKOUT1(),
+        .CLKOUT2(),
+        .CLKOUT3(),
+        .CLKOUT4(),
+        .CLKOUT5()
+    );
+    
+
+    BUFG bufg_clk_pll(.I(clk_out_pll), .O(clk_buff_pll));
+    BUFG bufg_clk_mmcm(.I(clk_out_mmcm), .O(clk_buff_mmcm));
+
+
+    clock_tester #(100000000) T0 (clk_100m, led[0]);
+    clock_tester #(25000000) T1 (clk_buff_pll, led[1]);
+    clock_tester #(25000000) T2 (clk_buff_mmcm, led[2]);
+
+endmodule


### PR DESCRIPTION
This PR is meant to test the problem discussed in [issue #2248](https://github.com/SymbiFlow/symbiflow-arch-defs/issues/2248) and tests the timing for the MMCM. The design uses an MMCM, and PLL to drive a 25KHz clock and is meant for a basys3 board. If the design works properly leds 0-2 on the basys should blink at the same rate.  