### PR TITLE
Clarify how to make the demo bitstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To initialize submodules and setup the CMake build system, from the root of the 
 make env
 ```
 
-To build all demo bitstreams there are 3 useful targets:
+To build all demo bitstreams there are 3 useful targets (run these commands in `symbiflow-arch-defs/build`):
 
 ```
 # Build all demo bitstreams, targetting all architectures


### PR DESCRIPTION
Current instructions can mislead people to `make` from the root of the `symbiflow-arch-defs` directory, whereas it should be run in `symbiflow-arch-defs/build`.