### PR TITLE
gh: check statuses: skip latest package update if main CI did not finish

### DIFF
--- a/.github/check-status/check-status.py
+++ b/.github/check-status/check-status.py
@@ -8,6 +8,8 @@ from stdm import get_latest_artifact_url
 gh_ref = environ['GITHUB_REPOSITORY']
 gh_sha = environ['INPUT_SHA']
 
+MAIN_CI = "Architecture Definitions"
+
 print('Getting status of %s @ %s...' % (gh_ref, gh_sha))
 
 status = Github(environ['INPUT_TOKEN']
@@ -18,6 +20,10 @@ for item in status.statuses:
 
 if status.state != 'success':
     print('Status not successful. Skipping...')
+    exit(1)
+
+if not any([item.context == MAIN_CI for item in status.statuses]):
+    print('Main CI has not completed. Skipping...')
     exit(1)
 
 artifacts, _ = get_latest_artifact_url()


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

For some reason, the Kokoro status does not appear as `pending` anymore using the GH API to get a commit's status.

This could cause a potential update of the latest package even though a test fails after the package has been updated, as all the succeeding CI checks trigger the latest package update.

This PR ensures that all CI checks have passed, by adding a check to wait for the main CI (`Architecture Definitions`) to complete, before proceeding with the latest link update.