### PR TITLE
Fixes due to yosys changes

### DIFF
--- a/common/cmake/devices.cmake
+++ b/common/cmake/devices.cmake
@@ -1608,7 +1608,7 @@ function(ADD_FPGA_TARGET)
           PINMAP_FILE=${PINMAP}
           PYTHON3=${PYTHON3}
           ${ADD_FPGA_TARGET_DEFINES}
-          ${QUIET_CMD} ${YOSYS} -p "${COMPLETE_YOSYS_SYNTH_SCRIPT}" -l ${OUT_JSON_SYNTH}.log ${SOURCE_FILES}
+          ${QUIET_CMD} ${YOSYS} -r ${TOP} -p "${COMPLETE_YOSYS_SYNTH_SCRIPT}" -l ${OUT_JSON_SYNTH}.log ${SOURCE_FILES}
       COMMAND
         ${CMAKE_COMMAND} -E touch ${OUT_FASM_EXTRA}
       WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
@@ -2703,7 +2703,9 @@ function(generate_pinmap)
   get_target_property_required(PYTHON3 env PYTHON3)
   get_target_property_required(QUIET_CMD env QUIET_CMD)
 
+  set(NAME ${GENERATE_PINMAP_NAME})
   set(BOARD ${GENERATE_PINMAP_BOARD})
+  set(TOP ${GENERATE_PINMAP_TOP})
   get_target_property_required(DEVICE ${BOARD} DEVICE)
   get_target_property_required(PACKAGE ${BOARD} PACKAGE)
   get_target_property_required(PINMAP_FILE ${BOARD} PINMAP)
@@ -2720,8 +2722,8 @@ function(generate_pinmap)
   endforeach()
 
   add_custom_command(
-    OUTPUT ${GENERATE_PINMAP_NAME}.json
-    COMMAND ${QUIET_CMD} ${YOSYS} -p \"proc $<SEMICOLON> write_json ${CMAKE_CURRENT_BINARY_DIR}/${GENERATE_PINMAP_NAME}.json\" -l ${CMAKE_CURRENT_BINARY_DIR}/${GENERATE_PINMAP_NAME}.json.log ${SOURCE_FILES}
+    OUTPUT ${NAME}.json
+    COMMAND ${QUIET_CMD} ${YOSYS} -r ${TOP} -p \"proc $<SEMICOLON> write_json ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.json\" -l ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.json.log ${SOURCE_FILES}
     DEPENDS
       ${QUIET_CMD}
       ${YOSYS}
@@ -2730,16 +2732,16 @@ function(generate_pinmap)
     )
 
   add_custom_command(
-    OUTPUT ${GENERATE_PINMAP_NAME}
+    OUTPUT ${NAME}
     COMMAND ${PYTHON3} ${CREATE_PINMAP}
-      --design_json ${CMAKE_CURRENT_BINARY_DIR}/${GENERATE_PINMAP_NAME}.json
+      --design_json ${CMAKE_CURRENT_BINARY_DIR}/${NAME}.json
       --pinmap_csv ${PINMAP}
-      --module ${GENERATE_PINMAP_TOP} > ${CMAKE_CURRENT_BINARY_DIR}/${GENERATE_PINMAP_NAME}
+      --module ${TOP} > ${CMAKE_CURRENT_BINARY_DIR}/${NAME}
     DEPENDS
       ${PYTHON3}
       ${CREATE_PINMAP}
       ${PINMAP} ${PINMAP_TARGET}
-      ${GENERATE_PINMAP_NAME}.json
+      ${NAME}.json
     )
 
   add_file_target(FILE ${GENERATE_PINMAP_NAME} GENERATED)

--- a/conda_lock.yml
+++ b/conda_lock.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=4.5=1_gnu
-  - binutils-riscv64-elf=2.34=20211006_163223
+  - binutils-riscv64-elf=2.34=20211213_222451
   - bison=3.7.5=h2531618_1
   - bzip2=1.0.8=h7b6447c_0
   - c-ares=1.17.1=h27cfd23_0
@@ -22,7 +22,7 @@ dependencies:
   - gcc-riscv64-elf-newlib=9.2.0=20201119_154229
   - gcc-riscv64-elf-nostdc=9.2.0=20210923_213204
   - gmp=6.2.1=h2531618_2
-  - gperftools=2.9.1_3_gc259412=20211122_104637
+  - gperftools=2.9.1_5_g003775a=20211214_154543
   - icestorm=0.0_0719_g792cef0=20201120_145821
   - icu=58.2=he6710b0_3
   - importlib-metadata=4.8.2=py37h06a4308_0
@@ -30,7 +30,7 @@ dependencies:
   - iverilog=s20150603_0957_gad862020=20201120_145821
   - krb5=1.19.2=hac12032_0
   - ld_impl_linux-64=2.35.1=h7274673_9
-  - libcurl=7.78.0=h0b77cf5_0
+  - libcurl=7.80.0=h0b77cf5_0
   - libedit=3.1.20210910=h7f8727e_0
   - libev=4.33=h7f8727e_1
   - libffi=3.3=he6710b0_2
@@ -62,8 +62,8 @@ dependencies:
   - perl=5.26.2=h14c3975_0
   - pip=21.2.2=py37h06a4308_0
   - pkg-config=0.29.2=h1bed415_8
-  - prjxray-db=0.0_253_gcd41f08=20211122_104637
-  - prjxray-tools=0.1_2934_g60168e9b=20211122_104637
+  - prjxray-db=0.0_257_g0a0adde=20211214_154543
+  - prjxray-tools=0.1_2936_g4c157493=20211214_154543
   - pycodestyle=2.7.0=pyhd3eb1b0_0
   - pyflakes=2.3.1=pyhd3eb1b0_0
   - pyparsing=3.0.4=pyhd3eb1b0_0
@@ -72,16 +72,16 @@ dependencies:
   - rhash=1.4.1=h3c74f83_1
   - setuptools=58.0.4=py37h06a4308_0
   - sqlite=3.36.0=hc218d9a_0
-  - surelog=0.0_3778_gffd348877=20211122_104637_py37
+  - surelog=0.0_3886_g5d4071e40=20211214_154543_py37
   - swig=4.0.2=h295c915_4
-  - symbiflow-yosys-plugins=1.0.0_7_511_g6c4141c=20211122_104637
+  - symbiflow-yosys-plugins=1.0.0_7_534_g3fb0f3b=20211214_154543
   - tbb=2020.3=hfd86e86_0
   - tk=8.6.11=h1ccaba5_0
   - typing_extensions=3.10.0.2=pyh06a4308_0
-  - vtr-optimized=8.0.0_4986_gf92cfebaf=20211122_104637
+  - vtr-optimized=8.0.0_5030_g6aa520950=20211214_154543
   - wheel=0.37.0=pyhd3eb1b0_1
   - xz=5.2.5=h7b6447c_0
-  - yosys=0.11_48_g113c94384=20211122_104637_py37
+  - yosys=0.12_30_g5dadcc85b=20211214_154543_py37
   - zachjs-sv2v=0.0.5_0025_ge9f9696=20201120_205532
   - zipp=3.6.0=pyhd3eb1b0_0
   - zlib=1.2.11=h7b6447c_3
@@ -96,7 +96,7 @@ dependencies:
     - chardet==4.0.0
     - charset-normalizer==2.0.9
     - colorama==0.4.4
-    - cryptography==36.0.0
+    - cryptography==36.0.1
     - cssselect2==0.4.1
     - cycler==0.11.0
     - defusedxml==0.7.1
@@ -117,10 +117,10 @@ dependencies:
     - jsonmerge==1.8.0
     - jsonschema==4.2.1
     - kiwisolver==1.3.2
-    - lxml==4.6.4
+    - lxml==4.7.1
     - Mako==1.1.6
     - MarkupSafe==2.0.1
-    - matplotlib==3.5.0
+    - matplotlib==3.5.1
     - mccabe==0.6.1
     - numpy==1.21.4
     - okonomiyaki==1.3.2
@@ -149,7 +149,6 @@ dependencies:
     - requests==2.26.0
     - rr-graph @ git+https://github.com/SymbiFlow/symbiflow-rr-graph.git@f0c41b77ad25b3afc438f4a7bff4c2297f6587d5
     - scipy==1.7.3
-    - setuptools-scm==6.3.2
     - simplejson==3.17.6
     - simplesat==0.8.2
     - six==1.16.0
@@ -162,7 +161,6 @@ dependencies:
     - tinyfpgab==1.1.0
     - tinyprog==1.0.21
     - toml==0.10.2
-    - tomli==1.2.2
     - tqdm==4.62.3
     - urllib3==1.26.7
     - webencodings==0.5.1

--- a/quicklogic/qlf_k4n8/tests/synth_flow/rgb2ycrcb/CMakeLists.txt
+++ b/quicklogic/qlf_k4n8/tests/synth_flow/rgb2ycrcb/CMakeLists.txt
@@ -3,7 +3,7 @@ add_file_target(FILE ${CURR_DIR}/rgb2ycrcb.v SCANNER_TYPE verilog)
 
 add_fpga_target(
   NAME rgb2ycrcb_test-umc22-no-adder
-  TOP rgb2ycrcb
+  TOP top
   BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/rgb2ycrcb.v
   EXPLICIT_ADD_FILE_TARGET
@@ -12,7 +12,7 @@ add_fpga_target(
 
 add_fpga_target(
   NAME rgb2ycrcb_test-umc22-adder
-  TOP rgb2ycrcb
+  TOP top
   BOARD qlf_k4n8-qlf_k4n8_umc22_slow_board
   SOURCES ${CURR_DIR}/rgb2ycrcb.v
   EXPLICIT_ADD_FILE_TARGET

--- a/xc/xc7/techmap/cells_map.v
+++ b/xc/xc7/techmap/cells_map.v
@@ -29,6 +29,25 @@ end
 
 endmodule
 
+module FD (output reg Q, input C, D);
+
+parameter [0:0] INIT = 1'b0;
+
+wire CE_SIG;
+wire SR_SIG;
+
+CESR_MUX cesr_mux(
+    .CE(1'b1),
+    .SR(1'b0),
+    .CE_OUT(CE_SIG),
+    .SR_OUT(SR_SIG)
+);
+
+FDRE_ZINI #(.ZINI(!|INIT), .IS_C_INVERTED(|0))
+  _TECHMAP_REPLACE_ (.D(D), .Q(Q), .C(C), .CE(CE_SIG), .R(SR_SIG));
+
+endmodule
+
 module FDRE (output reg Q, input C, CE, D, R);
 
 parameter [0:0] INIT = 1'b0;

--- a/xc/xc7/yosys/synth.tcl
+++ b/xc/xc7/yosys/synth.tcl
@@ -30,8 +30,11 @@ if { $::env(USE_ROI) == "TRUE" } {
     # Overwrite some models (e.g. IBUF with more parameters)
     read_verilog -lib $::env(TECHMAP_PATH)/iobs.v
 
-    # Re-targetting FD to FDREs
-    techmap -map  $::env(TECHMAP_PATH)/retarget.v
+    # TODO: This should eventually end up in upstream Yosys
+    #       as models such as FD are not currently supported
+    #       as being used in old FPGAs (e.g. Spartan6)
+    # Read in unsupported models
+    read_verilog -lib $::env(TECHMAP_PATH)/retarget.v
 
     if { [info exists ::env(TOP)] && $::env(TOP) != "" } {
         hierarchy -check -top $::env(TOP)


### PR DESCRIPTION
The conda lock update revealed a couple of issues with the most recent yosys.

This PR tries to fix these.

1. FD retargetting seems not to be working anymore. Now, the cell to retarget is add as a library module and it gets techmapped after synthesis
2. Yosys introduced `-r <topmodule>` option. This is now added when calling yosys.