### PR TITLE
ci: add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+- package-ecosystem: gitsubmodule
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+  labels:
+  - dependencies
+  - kokoro:force-run
+  - third-party
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99


### PR DESCRIPTION
This PR adds a dependabot configuration file. Dependabot is a built-in service from GitHub which will create PRs for updating GitHub Actions.

It seems that this repo used dependabot-preview, which was disabled some months ago (see #2132). That's because dependabot was an external service which GitHub bought and made it a built-in feature.

Close #2132
Close #2157
Close #2158
Close #2161
Close #2195
Close #2197
Close #2206
Close #2221
Close #2234
Close #2235
Close #2236
