### PR TITLE
xc: cells map: add missing parameter to BUFGCE

### DIFF
--- a/xc/xc7/techmap/cells_map.v
+++ b/xc/xc7/techmap/cells_map.v
@@ -3303,6 +3303,8 @@ module BUFGCE (
   output O,
   );
 
+  parameter SIM_DEVICE = "7SERIES";
+
   BUFGCTRL _TECHMAP_REPLACE_ (
     .O(O),
     .CE0(CE),


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>